### PR TITLE
Align numeric starters with set-builder template

### DIFF
--- a/src/main/modules/dedekind/category/cartesian.cppm
+++ b/src/main/modules/dedekind/category/cartesian.cppm
@@ -399,6 +399,16 @@ struct Set final {
   }
 };
 
+/**
+ * @brief Explicit alias for the canonical ETCS CCC witness over ambient A.
+ *
+ * @details
+ * This alias exists to reduce naming ambiguity with `dedekind::sets::Set`
+ * (the intensional set-builder DSL species).
+ */
+export template <typename A>
+using CanonicalSetCCC = Set<A>;
+
 // Now we can bless it right next to its definition
 static_assert(IsCartesianClosed<Set<int>>,
               "Verification Failed: Set must be Cartesian Closed.");
@@ -412,7 +422,7 @@ static_assert(IsCartesianClosed<Set<int>>,
  * set concepts to also be category concepts.
  */
 export template <typename A>
-concept HasCanonicalSetCCC = IsCartesianClosed<Set<A>>;
+concept HasCanonicalSetCCC = IsCartesianClosed<CanonicalSetCCC<A>>;
 
 /**
  * @concept IsProductCategory

--- a/src/main/modules/dedekind/numbers/complex.cppm
+++ b/src/main/modules/dedekind/numbers/complex.cppm
@@ -9,7 +9,12 @@ module;
 
 export module dedekind.numbers:complex;
 
+import dedekind.category;
+import dedekind.sets;
+
 namespace dedekind::numbers {
+using namespace dedekind::category;
+using namespace dedekind::sets;
 
 export template <typename C, typename R>
 concept IsComplex = requires(C z) {
@@ -41,5 +46,14 @@ class Complex {
   R re_{};
   R im_{};
 };
+
+export template <typename R = double, typename L = ClassicalLogic,
+                 typename C = ℶ_1>
+using ComplexSetOf = Ω<Complex<R>, L, C>;
+
+export using ComplexSet = ComplexSetOf<>;
+export using ℂ = ComplexSet;
+
+export inline constexpr ℂ C{};
 
 }  // namespace dedekind::numbers

--- a/src/main/modules/dedekind/numbers/dual.cppm
+++ b/src/main/modules/dedekind/numbers/dual.cppm
@@ -15,10 +15,14 @@ module;
 export module dedekind.numbers:dual;
 
 import dedekind.algebra;
+import dedekind.category;
+import dedekind.sets;
 
 namespace dedekind::numbers {
 
 using namespace dedekind::algebra;
+using namespace dedekind::category;
+using namespace dedekind::sets;
 
 /**
  * @class Dual
@@ -54,5 +58,14 @@ class Dual {
  * Deferred while Dual witnesses are being retargeted to the active ring
  * contracts.
  */
+
+export template <typename F = double, typename L = ClassicalLogic,
+                 typename C = ℶ_1>
+using DualSetOf = Ω<Dual<F>, L, C>;
+
+export using DualSet = DualSetOf<>;
+export using 𝔻 = DualSet;
+
+export inline constexpr 𝔻 D{};
 
 }  // namespace dedekind::numbers

--- a/src/main/modules/dedekind/numbers/integer.cppm
+++ b/src/main/modules/dedekind/numbers/integer.cppm
@@ -6,9 +6,14 @@ module;
 
 #include <concepts>
 
-export module dedekind.numbers:integers;
+export module dedekind.numbers:integer;
+
+import dedekind.category;
+import dedekind.sets;
 
 namespace dedekind::numbers {
+using namespace dedekind::category;
+using namespace dedekind::sets;
 
 export template <typename T>
 concept IsReflectiveSpecies = std::regular<T> && requires(T a) {
@@ -70,5 +75,13 @@ concept Continuum_ℝ = IsReal<E> && IsContinuous<E>;
 
 export template <typename M, typename E, typename R>
 concept Algebra_ℂ = IsComplex<E, R>;
+
+export template <typename L = ClassicalLogic, typename C = ℵ_0>
+using IntegerSetOf = Ω<int, L, C>;
+
+export using IntegerSet = IntegerSetOf<>;
+export using ℤ = IntegerSet;
+
+export inline constexpr ℤ Z{};
 
 }  // namespace dedekind::numbers

--- a/src/main/modules/dedekind/numbers/numbers.cppm
+++ b/src/main/modules/dedekind/numbers/numbers.cppm
@@ -25,7 +25,7 @@ export module dedekind.numbers;
 /** @section Discrete_Foundations (Level -1 & 0) */
 export import :booleans;  // Truth<L> and Ω
 export import :naturals;  // ℕ (Unsigned species)
-export import :integers;  // ℤ (Signed species)
+export import :integer;   // ℤ (Signed species)
 
 /** @section Algebraic_Extensions (Level 3 & 8) */
 export import :rational;  // ℚ (The Quotient Field)

--- a/src/main/modules/dedekind/numbers/rational.cppm
+++ b/src/main/modules/dedekind/numbers/rational.cppm
@@ -12,7 +12,12 @@ module;
 
 export module dedekind.numbers:rational;
 
+import dedekind.category;
+import dedekind.sets;
+
 namespace dedekind::numbers {
+using namespace dedekind::category;
+using namespace dedekind::sets;
 
 /**
  * @class Rational
@@ -93,5 +98,14 @@ class Rational {
 
 // Proof: The inverse of 2/3 is 3/2.
 static_assert((Rational<int>(2, 3).inverse().num() == 3));
+
+export template <std::signed_integral Z = int, typename L = ClassicalLogic,
+                 typename C = ℵ_0>
+using RationalSetOf = Ω<Rational<Z>, L, C>;
+
+export using RationalSet = RationalSetOf<>;
+export using ℚ = RationalSet;
+
+export inline constexpr ℚ Q{};
 
 }  // namespace dedekind::numbers

--- a/src/main/modules/dedekind/numbers/real.cppm
+++ b/src/main/modules/dedekind/numbers/real.cppm
@@ -10,7 +10,12 @@ module;
 
 export module dedekind.numbers:real;
 
+import dedekind.category;
+import dedekind.sets;
+
 namespace dedekind::numbers {
+using namespace dedekind::category;
+using namespace dedekind::sets;
 
 export template <typename Q>
   requires std::regular<Q>
@@ -45,5 +50,14 @@ class Real {
  private:
   Q value_{};
 };
+
+export template <typename Q = double, typename L = ClassicalLogic,
+                 typename C = ℶ_1>
+using RealSetOf = Ω<Real<Q>, L, C>;
+
+export using RealSet = RealSetOf<>;
+export using ℝ = RealSet;
+
+export inline constexpr ℝ R{};
 
 }  // namespace dedekind::numbers

--- a/src/main/modules/dedekind/sets/boundaries.cppm
+++ b/src/main/modules/dedekind/sets/boundaries.cppm
@@ -203,10 +203,14 @@ static_assert(dedekind::category::IsSet<decltype(ambient_set<int>(Ø<int>{}))>,
 
 // Transitional alias used by tests and set-builder examples.
 // ETCS-level natural-number witnesses may replace this direct alias later.
-export using NaturalNumbers = Ω<int>;
+export template <typename L = ClassicalLogic, typename C = ℵ_0>
+using NaturalNumbersOf = Ω<int, L, C>;
 
-// Canonical symbol used by the sets DSL tests.
-export inline constexpr NaturalNumbers ℕ{};
+export using NaturalNumbers = NaturalNumbersOf<>;
+export using ℕ = NaturalNumbers;
+
+// Canonical ambient-set value used by the sets DSL tests.
+export inline constexpr ℕ N{};
 
 };  // namespace dedekind::sets
 

--- a/src/main/modules/dedekind/sets/mereology.cppm
+++ b/src/main/modules/dedekind/sets/mereology.cppm
@@ -392,7 +392,15 @@ struct SetMetadata<
   using Cardinality = typename S::cardinality_type;
 };
 
-/** @brief ETCS alignment bridge: a sets-side species can be lifted to IsSet. */
+/**
+ * @brief ETCS alignment bridge: lift a `dedekind::sets` species into a
+ * `dedekind::category::IsSet` object.
+ *
+ * @details
+ * This is the explicit seam between:
+ * - `dedekind::sets::Set<...>`: intensional set-builder DSL species.
+ * - `dedekind::category::Set<...>`: canonical CCC/category witness.
+ */
 template <typename S>
 concept IsETCSLiftedSet = requires(const S s) {
   requires dedekind::category::IsSet<

--- a/src/test/cpp/modules/dedekind/numbers/dual_test.cpp
+++ b/src/test/cpp/modules/dedekind/numbers/dual_test.cpp
@@ -6,15 +6,15 @@ import dedekind.numbers;
 using namespace dedekind::numbers;
 
 TEST_CASE("Analysis: Dual Numbers and Differentiation", "[numbers][dual]") {
-  using R = double;
-  using D = Dual<R>;
+  using Scalar = double;
+  using DualValue = Dual<Scalar>;
 
   SECTION("Automatic Differentiation: f(x) = x²") {
     // Seed: x = 3, dx = 1
-    D x{3.0, 1.0};
+    DualValue x{3.0, 1.0};
 
     // Compute f(x) = x * x
-    D res = x * x;
+    DualValue res = x * x;
 
     // f(3) = 9
     REQUIRE(res.value() == 9.0);

--- a/src/test/cpp/modules/dedekind/numbers/rational_test.cpp
+++ b/src/test/cpp/modules/dedekind/numbers/rational_test.cpp
@@ -14,10 +14,10 @@ TEST_CASE("Numbers: Rational Simplification", "[numbers][rational]") {
 }
 
 TEST_CASE("Numbers: The Rational Field", "[numbers][field]") {
-  using ℚ = Rational<int>;
+  using RationalValue = Rational<int>;
 
   SECTION("Multiplicative Identity: (a/b) * (b/a) = 1") {
-    ℚ a(3, 4);
+    RationalValue a(3, 4);
     auto a_inv = a.inverse();  // 4/3
 
     auto identity = a * a_inv;
@@ -28,8 +28,8 @@ TEST_CASE("Numbers: The Rational Field", "[numbers][field]") {
   }
 
   SECTION("Division Morphism") {
-    ℚ a(1, 2);
-    ℚ b(1, 4);
+    RationalValue a(1, 2);
+    RationalValue b(1, 4);
 
     // (1/2) / (1/4) = 2
     auto res = a / b;
@@ -39,6 +39,6 @@ TEST_CASE("Numbers: The Rational Field", "[numbers][field]") {
 
   SECTION("Zero-Denominator Protection") {
     // Reciprocal of zero must throw
-    REQUIRE_THROWS_AS(ℚ(0, 1).inverse(), std::domain_error);
+    REQUIRE_THROWS_AS(RationalValue(0, 1).inverse(), std::domain_error);
   }
 }

--- a/src/test/cpp/modules/dedekind/numbers/starters_test.cpp
+++ b/src/test/cpp/modules/dedekind/numbers/starters_test.cpp
@@ -1,0 +1,109 @@
+#include <catch2/catch_test_macros.hpp>
+
+import dedekind.category;
+import dedekind.numbers;
+import dedekind.sets;
+
+using namespace dedekind::category;
+using namespace dedekind::numbers;
+using namespace dedekind::sets;
+
+TEST_CASE("Numbers: canonical starter symbols", "[numbers][starter]") {
+  STATIC_CHECK(std::same_as<ℕ, NaturalNumbers>);
+  STATIC_CHECK(std::same_as<decltype(N), const ℕ>);
+
+  STATIC_CHECK(std::same_as<ℤ, IntegerSet>);
+  STATIC_CHECK(std::same_as<decltype(Z), const ℤ>);
+
+  STATIC_CHECK(std::same_as<ℚ, RationalSet>);
+  STATIC_CHECK(std::same_as<decltype(Q), const ℚ>);
+
+  STATIC_CHECK(std::same_as<ℝ, RealSet>);
+  STATIC_CHECK(std::same_as<decltype(R), const ℝ>);
+
+  STATIC_CHECK(std::same_as<ℂ, ComplexSet>);
+  STATIC_CHECK(std::same_as<decltype(C), const ℂ>);
+
+  STATIC_CHECK(std::same_as<𝔻, DualSet>);
+  STATIC_CHECK(std::same_as<decltype(D), const 𝔻>);
+}
+
+TEST_CASE("Numbers: starter universes construct from ambient values",
+          "[numbers][starter][sets]") {
+  constexpr auto n = var<ℕ>;
+  constexpr auto naturals = Set{n % N};
+  static_assert(naturals(7) == Ternary::True);
+
+  constexpr auto z = var<ℤ>;
+  constexpr auto integers = Set{z % Z};
+  static_assert(integers(-7) == Ternary::True);
+
+  constexpr auto q = var<ℚ>;
+  constexpr auto rationals = Set{q % Q};
+  static_assert(rationals(Rational<int>{1, 2}) == Ternary::True);
+
+  constexpr auto r = var<ℝ>;
+  constexpr auto reals = Set{r % R};
+  static_assert(reals(Real<double>{1.25}) == Ternary::True);
+
+  constexpr auto c = var<ℂ>;
+  constexpr auto complexes = Set{c % C};
+  static_assert(complexes(Complex<double>{1.0, 2.0}) == Ternary::True);
+
+  constexpr auto d = var<𝔻>;
+  constexpr auto duals = Set{d % D};
+  static_assert(duals(Dual<double>{1.0, 1.0}) == Ternary::True);
+}
+
+TEST_CASE("Numbers: starter universes satisfy lattice identities",
+          "[numbers][starter][algebra]") {
+  {
+    constexpr auto n = var<ℕ>;
+    const auto U = Set{n % N};
+    const auto O = !U;
+    CHECK((U | O)(7) == Ternary::True);
+    CHECK((U & O)(7) == Ternary::False);
+    CHECK((U | O)(-3) == Ternary::True);
+    CHECK((U & O)(-3) == Ternary::False);
+  }
+
+  {
+    constexpr auto z = var<ℤ>;
+    const auto U = Set{z % Z};
+    const auto O = !U;
+    CHECK((U | O)(4) == Ternary::True);
+    CHECK((U & O)(4) == Ternary::False);
+  }
+
+  {
+    constexpr auto q = var<ℚ>;
+    const auto U = Set{q % Q};
+    const auto O = !U;
+    CHECK((U | O)(Rational<int>{1, 3}) == Ternary::True);
+    CHECK((U & O)(Rational<int>{1, 3}) == Ternary::False);
+  }
+
+  {
+    constexpr auto r = var<ℝ>;
+    const auto U = Set{r % R};
+    const auto O = !U;
+    CHECK((U | O)(Real<double>{2.0}) == Ternary::True);
+    CHECK((U & O)(Real<double>{2.0}) == Ternary::False);
+  }
+
+  {
+    constexpr auto c = var<ℂ>;
+    const auto U = Set{c % C};
+    const auto O = !U;
+    CHECK((U | O)(Complex<double>{1.0, -1.0}) == Ternary::True);
+    CHECK((U & O)(Complex<double>{1.0, -1.0}) == Ternary::False);
+  }
+
+  {
+    constexpr auto d = var<𝔻>;
+    const auto U = Set{d % D};
+    const auto O = !U;
+    CHECK((U | O)(Dual<double>{3.0, 1.0}) == Ternary::True);
+    CHECK((U & O)(Dual<double>{3.0, 1.0}) == Ternary::False);
+  }
+}

--- a/src/test/cpp/modules/dedekind/numbers/symolic_test.cpp
+++ b/src/test/cpp/modules/dedekind/numbers/symolic_test.cpp
@@ -8,8 +8,8 @@ using namespace dedekind::numbers;
 using namespace dedekind::category;
 
 TEST_CASE("Numbers: Symbolic Checkpoint", "[numbers][symbolic]") {
-  using R = Real<double>;
-  using C = Complex<R>;
+  using RealValue = Real<double>;
+  using ComplexValue = Complex<RealValue>;
 
   SECTION("Sqrt2 symbolic anchor") {
     const auto root2 = Sqrt2_Symbolic<double>();
@@ -22,9 +22,9 @@ TEST_CASE("Numbers: Symbolic Checkpoint", "[numbers][symbolic]") {
   }
 
   SECTION("Complex arithmetic over Real wrapper") {
-    const C a{R{1.0}, R{2.0}};
-    const C b{R{3.0}, R{4.0}};
-    const C s = a + b;
+    const ComplexValue a{RealValue{1.0}, RealValue{2.0}};
+    const ComplexValue b{RealValue{3.0}, RealValue{4.0}};
+    const ComplexValue s = a + b;
     REQUIRE(s.real().resolve() == 4.0);
     REQUIRE(s.imag().resolve() == 6.0);
   }

--- a/src/test/cpp/modules/dedekind/sets/category_integration_test.cpp
+++ b/src/test/cpp/modules/dedekind/sets/category_integration_test.cpp
@@ -34,9 +34,9 @@ TEST_CASE("Sets+Category: singleton and comprehension predicates satisfy ETCS",
   CHECK(atom_set.χ(42) == true);
   CHECK(atom_set.χ(7) == false);
 
-  auto x = var<NaturalNumbers>;
-  const auto positive = Set{x % ℕ | (x > 0)};
-  const auto bounded = Set{x % ℕ | (x <= 10)};
+  auto x = var<ℕ>;
+  const auto positive = Set{x % N | (x > 0)};
+  const auto bounded = Set{x % N | (x <= 10)};
 
   const auto positive_set = ambient_set<int>(positive);
   const auto bounded_set = ambient_set<int>(bounded);
@@ -50,4 +50,22 @@ TEST_CASE("Sets+Category: singleton and comprehension predicates satisfy ETCS",
   CHECK(positive_set.χ(-5) == Ternary::False);
   CHECK(support.χ(5) == Ternary::True);
   CHECK(support.χ(50) == Ternary::False);
+}
+
+TEST_CASE("Sets+Category: Set naming boundary is explicit",
+          "[sets][category][etcs][alignment]") {
+  auto x = var<ℕ>;
+  const auto positive = Set{x % N | (x > 0)};
+
+  // `sets::Set` (DSL species) and `category::Set` (CCC witness) are distinct.
+  STATIC_CHECK(!std::same_as<decltype(positive),
+                             dedekind::category::CanonicalSetCCC<int>>);
+  STATIC_CHECK(dedekind::category::HasCanonicalSetCCC<int>);
+
+  // Bridge through ETCS object construction.
+  const auto positive_set = ambient_set<int>(positive);
+  STATIC_CHECK(dedekind::category::IsSetInCanonicalCCC<decltype(positive_set)>);
+
+  CHECK(positive_set.χ(3) == Ternary::True);
+  CHECK(positive_set.χ(-3) == Ternary::False);
 }

--- a/src/test/cpp/modules/dedekind/sets/expressions_test.cpp
+++ b/src/test/cpp/modules/dedekind/sets/expressions_test.cpp
@@ -17,18 +17,18 @@ TEST_CASE("Dedekind MVP: Basic Membership and Symbols", "[sets]") {
     REQUIRE(finite(2) == false);
 
     // Should be Set<int, TernaryLogic> (because ℕ is transfinite)
-    auto infinite = Set{x % ℕ | (x > 0)};
+    auto infinite = Set{x % N | (x > 0)};
     REQUIRE(infinite(5) == Ternary::True);
     REQUIRE(infinite(-5) == Ternary::False);
   }
 }
 
 TEST_CASE("Dedekind Identities: Extremal Collapse", "[sets][identities]") {
-  auto x = var<NaturalNumbers>;
+  auto x = var<ℕ>;
 
   SECTION("Identity: Set{Ω} is Ω") {
     // The terminal object should remain terminal
-    auto U = Set{ℕ};
+    auto U = Set{N};
 
     // It must satisfy the 'Total Presence' axiom
     static_assert(std::is_same_v<decltype(U)::logic_species, TernaryLogic>);
@@ -38,7 +38,7 @@ TEST_CASE("Dedekind Identities: Extremal Collapse", "[sets][identities]") {
 
   SECTION("Contradiction: {x ∈ ℕ | x > 10 ∧ x < 5} is ∅") {
     // Here we combine the symbolic predicates
-    auto S = Set{x % ℕ | (x > 10 && x < 5)};
+    auto S = Set{x % N | (x > 10 && x < 5)};
 
     // For a non-trivial polish, we verify it is 'Total Absence'
     REQUIRE(S(0) == Ternary::False);
@@ -47,44 +47,7 @@ TEST_CASE("Dedekind Identities: Extremal Collapse", "[sets][identities]") {
   }
 
   SECTION("Tautology: {x ∈ ℕ | x > 10 ∨ x <= 10} is Ω") {
-    auto S = Set{x % ℕ | (x > 10 || x <= 10)};
+    auto S = Set{x % N | (x > 10 || x <= 10)};
     REQUIRE(S(7) == Ternary::True);
   }
-}
-
-TEST_CASE("Dedekind Boolean Sets: Concrete Algebraic Starter",
-          "[sets][boolean][algebra]") {
-  auto b = var<Ω<bool, ClassicalLogic, Finite>>;
-
-  // Two concrete subsets of the boolean universe.
-  auto truthy = Set{b % Ω<bool, ClassicalLogic, Finite>{} | (b == true)};
-  auto falsy = Set{b % Ω<bool, ClassicalLogic, Finite>{} | (b == false)};
-
-  // Partition check: each value belongs to exactly one side.
-  REQUIRE(truthy(true));
-  REQUIRE_FALSE(truthy(false));
-  REQUIRE_FALSE(falsy(true));
-  REQUIRE(falsy(false));
-
-  // Boolean algebra laws over the concrete universe {false, true}.
-  auto top = truthy | falsy;
-  auto bottom = truthy & falsy;
-
-  REQUIRE(top(true));
-  REQUIRE(top(false));
-  REQUIRE_FALSE(bottom(true));
-  REQUIRE_FALSE(bottom(false));
-
-  auto not_truthy = !truthy;
-  REQUIRE_FALSE(not_truthy(true));
-  REQUIRE(not_truthy(false));
-
-  // Absorption: A ∨ (A ∧ B) = A and A ∧ (A ∨ B) = A
-  auto absorb_join = truthy | (truthy & falsy);
-  auto absorb_meet = truthy & (truthy | falsy);
-
-  REQUIRE(absorb_join(true) == truthy(true));
-  REQUIRE(absorb_join(false) == truthy(false));
-  REQUIRE(absorb_meet(true) == truthy(true));
-  REQUIRE(absorb_meet(false) == truthy(false));
 }


### PR DESCRIPTION
- Rename numbers partition :integers -> :integer
- Standardize numeric starter symbols to type/value pairs: ℕ/N, ℤ/Z, ℚ/Q, ℝ/R, ℂ/C, 𝔻/D
- Add parametric starter aliases for naturals and numeric ambient sets
- Clarify category:Set vs sets:Set boundary with CanonicalSetCCC alias
- Strengthen sets/category bridge docs and integration tests
- Remove redundant boolean starter test from expressions_test
- Add numbers starter tests proving algebraic-set/lattice behavior
- Update number tests to avoid symbol shadowing under -Wshadow