### PR TITLE
feat: embedding tower N->Z->Q->R->C with IsMonicArrow and in_via

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,5 @@ docs/paper/*.out
 docs/paper/*.toc
 docs/paper/*.run.xml
 **/*.synctex.gz
+
+build_ci/**

--- a/src/main/modules/dedekind/category/etcs.cppm
+++ b/src/main/modules/dedekind/category/etcs.cppm
@@ -112,6 +112,24 @@ constexpr auto set_complement(const S& s) {
   return classify<A>(!s.χ);
 }
 
+/** @brief ETCS membership: x ∈ S evaluated via χ_S(x). */
+export template <typename S>
+  requires IsSubobject<S, typename S::Ambient>
+constexpr auto in(const typename S::Ambient& x, const S& s) {
+  return s.χ(x);
+}
+
+/**
+ * @brief Membership through an embedding arrow e: X -> A, then χ_S.
+ * @details Evaluates x ∈_e S as χ_S(e(x)).
+ */
+export template <typename S, IsArrow E>
+  requires IsSubobject<S, typename S::Ambient> &&
+           std::same_as<Cod<E>, typename S::Ambient>
+constexpr auto in_via(const Dom<E>& x, E&& embedding, const S& s) {
+  return s.χ(std::forward<E>(embedding)(x));
+}
+
 /** @brief Lattice alias: meet = intersection. */
 export template <typename S1, typename S2>
   requires IsCompatibleSetPair<S1, S2>

--- a/src/main/modules/dedekind/category/morphism.cppm
+++ b/src/main/modules/dedekind/category/morphism.cppm
@@ -606,4 +606,32 @@ constexpr auto operator>>(T&& value, const Arrow& f) ->
   return f(std::forward<T>(value));
 }
 
+/**
+ * @brief User-declared monicity witness for an arrow type.
+ * @details Injectivity cannot be verified at compile time in general.
+ *          Users specialize this to `true` to declare that a given arrow
+ *          is injective (i.e., a monomorphism in the category of sets).
+ *          The compiler trusts the declaration; no runtime proof is required.
+ *
+ *          This mirrors `is_kleene_associative_v` in the partial algebra layer.
+ */
+export template <typename E>
+inline constexpr bool is_monic_arrow_v = false;
+
+/**
+ * @concept IsMonicArrow
+ * @brief An arrow declared to be a monomorphism (ι: A ↣ B).
+ * @details A monic arrow is injective: if e(x) == e(y) then x == y.
+ *          The user declares monicity via `is_monic_arrow_v<E> = true`.
+ */
+export template <typename E>
+concept IsMonicArrow = IsArrow<E> && is_monic_arrow_v<E>;
+
+// Identity arrows are always monic.
+template <typename T>
+inline constexpr bool is_monic_arrow_v<Identity<T>> = true;
+
+static_assert(IsMonicArrow<Identity<int>>,
+              "Identity must be recognised as a monic arrow.");
+
 }  // namespace dedekind::category

--- a/src/main/modules/dedekind/numbers/complex.cppm
+++ b/src/main/modules/dedekind/numbers/complex.cppm
@@ -17,8 +17,16 @@ namespace dedekind::numbers {
 using namespace dedekind::category;
 using namespace dedekind::sets;
 
+export template <typename S>
+concept IsComplexScalar = requires(S a, S b) {
+  S{};
+  { a + b } -> std::same_as<S>;
+  { a - b } -> std::same_as<S>;
+  { a * b } -> std::same_as<S>;
+};
+
 export template <typename R>
-  requires std::regular<R>
+  requires IsComplexScalar<R>
 class Complex {
  public:
   using scalar_type = R;
@@ -43,12 +51,23 @@ class Complex {
 };
 
 /**
+ * @brief Machine realization arrow ℝ ↪ ℂ: Real<R> → Complex<R>.
+ * @details Every real x embeds as the complex number (x + 0i).
+ *          This is the current machine model lift of R → C.
+ */
+export template <IsRealCarrier R = machine_real_scalar>
+inline constexpr auto embed_ℝ_ℂ = arrow<Real<R>, Complex<R>>(
+    [](const Real<R>& r) noexcept { return Complex<R>{r.resolve(), R{}}; });
+
+/**
  * @brief Characteristic morphism for ℂ: the complex numbers.
  * Accepts native Complex<R> and all embedded predecessors
- * (Real<R>, Rational<int>, int, unsigned, Ternary).
+ * (Real<R>, Rational<I>, int, unsigned, Ternary).
  */
-export template <std::floating_point R = double, typename L = ClassicalLogic,
+export template <typename R = machine_real_scalar,
+                 IsInteger I = machine_integer, typename L = ClassicalLogic,
                  typename C = ℶ_1>
+  requires IsComplexScalar<R>
 struct ComplexesOf {
   using Domain = Complex<R>;
   using Codomain = typename L::Ω;
@@ -60,17 +79,16 @@ struct ComplexesOf {
     return L::True;
   }
 
-  // Direct parent: embed Real<R> into ℂ (canonical x -> x + 0i).
+  // Direct parent: embed Real<R> into ℂ via the canonical arrow.
   constexpr typename L::Ω operator()(const Real<R>& r) const {
-    return operator()(
-        Complex<R>{static_cast<R>(r.resolve()), static_cast<R>(0)});
+    return operator()(embed_ℝ_ℂ<R>(r));
   }
 
   // Delegate non-parent ancestors to ambient ℝ.
   template <typename T>
     requires(!std::same_as<T, Complex<R>> && !std::same_as<T, Real<R>>)
   constexpr typename L::Ω operator()(const T& x) const {
-    return dedekind::numbers::R(x);
+    return dedekind::numbers::RealsOf<machine_real_scalar, I>{}(x);
   }
 };
 
@@ -78,16 +96,6 @@ export using ComplexSet = ComplexesOf<>;
 export using ℂ = ComplexSet;
 
 export inline constexpr ℂ C{};
-
-/**
- * @brief Canonical embedding ℝ ↪ ℂ: Real<double> → Complex<double>.
- * @details Every real x embeds as the complex number (x + 0i).
- *          This is the canonical ring monomorphism R → C.
- */
-export inline constexpr auto embed_ℝ_ℂ =
-    arrow<Real<double>, Complex<double>>([](const Real<double>& r) noexcept {
-      return Complex<double>{r.resolve(), 0.0};
-    });
 
 }  // namespace dedekind::numbers
 
@@ -100,6 +108,6 @@ struct SpeciesTraits<dedekind::numbers::Complex<R>> {
 
 template <>
 inline constexpr bool
-    is_monic_arrow_v<std::decay_t<decltype(dedekind::numbers::embed_ℝ_ℂ)>> =
+    is_monic_arrow_v<std::decay_t<decltype(dedekind::numbers::embed_ℝ_ℂ<>)>> =
         true;
 }  // namespace dedekind::category

--- a/src/main/modules/dedekind/numbers/complex.cppm
+++ b/src/main/modules/dedekind/numbers/complex.cppm
@@ -17,12 +17,6 @@ namespace dedekind::numbers {
 using namespace dedekind::category;
 using namespace dedekind::sets;
 
-export template <typename C, typename R>
-concept IsComplex = requires(C z) {
-  { z.real() } -> std::same_as<R>;
-  { z.imag() } -> std::same_as<R>;
-};
-
 export template <typename R>
   requires std::regular<R>
 class Complex {
@@ -48,11 +42,39 @@ class Complex {
   R im_{};
 };
 
+/**
+ * @brief Characteristic morphism for ℂ: the complex numbers.
+ * Accepts native Complex<R> and all embedded predecessors
+ * (Real<double>, Rational<int>, int, unsigned, Ternary).
+ */
 export template <typename R = double, typename L = ClassicalLogic,
                  typename C = ℶ_1>
-using ComplexSetOf = Ω<Complex<R>, L, C>;
+struct ComplexesOf {
+  using Domain = Complex<R>;
+  using Codomain = typename L::Ω;
+  using logic_species = L;
+  using cardinality_type = C;
 
-export using ComplexSet = ComplexSetOf<>;
+  // Native Complex<R>: always a member of ℂ
+  constexpr typename L::Ω operator()(const Complex<R>&) const {
+    return L::True;
+  }
+
+  // Embedded Real<double> (canonical x -> x + 0i)
+  constexpr typename L::Ω operator()(const Real<double>& r) const {
+    return operator()(
+        Complex<R>{static_cast<R>(r.resolve()), static_cast<R>(0)});
+  }
+
+  // Delegate non-parent ancestors to ambient ℝ.
+  template <typename T>
+    requires(!std::same_as<T, Complex<R>> && !std::same_as<T, Real<double>>)
+  constexpr typename L::Ω operator()(const T& x) const {
+    return dedekind::numbers::R(x);
+  }
+};
+
+export using ComplexSet = ComplexesOf<>;
 export using ℂ = ComplexSet;
 
 export inline constexpr ℂ C{};
@@ -62,7 +84,7 @@ export inline constexpr ℂ C{};
  * @details Every real x embeds as the complex number (x + 0i).
  *          This is the canonical ring monomorphism R → C.
  */
-export inline constexpr auto embed_R_C =
+export inline constexpr auto embed_ℝ_ℂ =
     arrow<Real<double>, Complex<double>>([](const Real<double>& r) noexcept {
       return Complex<double>{r.resolve(), 0.0};
     });
@@ -78,6 +100,6 @@ struct SpeciesTraits<dedekind::numbers::Complex<R>> {
 
 template <>
 inline constexpr bool
-    is_monic_arrow_v<std::decay_t<decltype(dedekind::numbers::embed_R_C)>> =
+    is_monic_arrow_v<std::decay_t<decltype(dedekind::numbers::embed_ℝ_ℂ)>> =
         true;
 }  // namespace dedekind::category

--- a/src/main/modules/dedekind/numbers/complex.cppm
+++ b/src/main/modules/dedekind/numbers/complex.cppm
@@ -45,9 +45,9 @@ class Complex {
 /**
  * @brief Characteristic morphism for ℂ: the complex numbers.
  * Accepts native Complex<R> and all embedded predecessors
- * (Real<double>, Rational<int>, int, unsigned, Ternary).
+ * (Real<R>, Rational<int>, int, unsigned, Ternary).
  */
-export template <typename R = double, typename L = ClassicalLogic,
+export template <std::floating_point R = double, typename L = ClassicalLogic,
                  typename C = ℶ_1>
 struct ComplexesOf {
   using Domain = Complex<R>;
@@ -60,15 +60,15 @@ struct ComplexesOf {
     return L::True;
   }
 
-  // Embedded Real<double> (canonical x -> x + 0i)
-  constexpr typename L::Ω operator()(const Real<double>& r) const {
+  // Direct parent: embed Real<R> into ℂ (canonical x -> x + 0i).
+  constexpr typename L::Ω operator()(const Real<R>& r) const {
     return operator()(
         Complex<R>{static_cast<R>(r.resolve()), static_cast<R>(0)});
   }
 
   // Delegate non-parent ancestors to ambient ℝ.
   template <typename T>
-    requires(!std::same_as<T, Complex<R>> && !std::same_as<T, Real<double>>)
+    requires(!std::same_as<T, Complex<R>> && !std::same_as<T, Real<R>>)
   constexpr typename L::Ω operator()(const T& x) const {
     return dedekind::numbers::R(x);
   }

--- a/src/main/modules/dedekind/numbers/complex.cppm
+++ b/src/main/modules/dedekind/numbers/complex.cppm
@@ -11,6 +11,7 @@ export module dedekind.numbers:complex;
 
 import dedekind.category;
 import dedekind.sets;
+import :real;
 
 namespace dedekind::numbers {
 using namespace dedekind::category;
@@ -56,4 +57,27 @@ export using ℂ = ComplexSet;
 
 export inline constexpr ℂ C{};
 
+/**
+ * @brief Canonical embedding ℝ ↪ ℂ: Real<double> → Complex<double>.
+ * @details Every real x embeds as the complex number (x + 0i).
+ *          This is the canonical ring monomorphism R → C.
+ */
+export inline constexpr auto embed_R_C =
+    arrow<Real<double>, Complex<double>>([](const Real<double>& r) noexcept {
+      return Complex<double>{r.resolve(), 0.0};
+    });
+
 }  // namespace dedekind::numbers
+
+namespace dedekind::category {
+template <typename R>
+struct SpeciesTraits<dedekind::numbers::Complex<R>> {
+  using Domain = dedekind::numbers::Complex<R>;
+  using machine_type = dedekind::numbers::Complex<R>;
+};
+
+template <>
+inline constexpr bool
+    is_monic_arrow_v<std::decay_t<decltype(dedekind::numbers::embed_R_C)>> =
+        true;
+}  // namespace dedekind::category

--- a/src/main/modules/dedekind/numbers/integer.cppm
+++ b/src/main/modules/dedekind/numbers/integer.cppm
@@ -84,4 +84,43 @@ export using ℤ = IntegerSet;
 
 export inline constexpr ℤ Z{};
 
+/**
+ * @brief Canonical embedding ℕ ↪ ℤ: unsigned int → int.
+ * @details The natural numbers embed into the integers via the unsigned→signed
+ *          widening conversion. This is injective for values that fit in int;
+ *          large unsigned values may overflow, so the domain is conventionally
+ *          restricted to values ≤ INT_MAX when used with certified arithmetic.
+ */
+export inline constexpr auto embed_N_Z = arrow<unsigned, int>(
+    [](const unsigned& x) noexcept { return static_cast<int>(x); });
+
+/**
+ * @brief Canonical embedding K3 ↪ ℤ: Ternary → int.
+ * @details Maps False -> -1, Unknown -> 0, True -> 1.
+ */
+export inline constexpr auto embed_K3_Z =
+    arrow<Ternary, int>([](const Ternary& t) noexcept {
+      switch (t) {
+        case Ternary::False:
+          return -1;
+        case Ternary::Unknown:
+          return 0;
+        case Ternary::True:
+          return 1;
+      }
+      return 0;
+    });
+
 }  // namespace dedekind::numbers
+
+namespace dedekind::category {
+template <>
+inline constexpr bool
+    is_monic_arrow_v<std::decay_t<decltype(dedekind::numbers::embed_N_Z)>> =
+        true;
+
+template <>
+inline constexpr bool
+    is_monic_arrow_v<std::decay_t<decltype(dedekind::numbers::embed_K3_Z)>> =
+        true;
+}  // namespace dedekind::category

--- a/src/main/modules/dedekind/numbers/integer.cppm
+++ b/src/main/modules/dedekind/numbers/integer.cppm
@@ -10,6 +10,7 @@ export module dedekind.numbers:integer;
 
 import dedekind.category;
 import dedekind.sets;
+import :naturals;
 
 namespace dedekind::numbers {
 using namespace dedekind::category;
@@ -76,10 +77,45 @@ concept Continuum_ℝ = IsReal<E> && IsContinuous<E>;
 export template <typename M, typename E, typename R>
 concept Algebra_ℂ = IsComplex<E, R>;
 
+/**
+ * @brief Characteristic morphism for ℤ: the integers.
+ * Accepts native int and all embedded predecessors (unsigned, Ternary).
+ */
 export template <typename L = ClassicalLogic, typename C = ℵ_0>
-using IntegerSetOf = Ω<int, L, C>;
+struct IntegersOf {
+  using Domain = int;
+  using Codomain = typename L::Ω;
+  using logic_species = L;
+  using cardinality_type = C;
 
-export using IntegerSet = IntegerSetOf<>;
+  // Native int: always a member of ℤ
+  constexpr typename L::Ω operator()(int) const { return L::True; }
+
+  // Embedded unsigned (via embed_ℕ_ℤ)
+  constexpr typename L::Ω operator()(unsigned n) const {
+    return operator()(static_cast<int>(n));
+  }
+
+  // Embedded Ternary (via embed_K3_ℤ)
+  constexpr typename L::Ω operator()(Ternary t) const {
+    switch (t) {
+      case Ternary::False:
+        return operator()(-1);
+      case Ternary::Unknown:
+        return operator()(0);
+      case Ternary::True:
+        return operator()(1);
+    }
+    return L::False;
+  }
+
+  // Embedded bool (via embed_𝔹_ℕ → embed_ℕ_ℤ)
+  constexpr typename L::Ω operator()(bool b) const {
+    return operator()(embed_𝔹_ℕ(b));
+  }
+};
+
+export using IntegerSet = IntegersOf<>;
 export using ℤ = IntegerSet;
 
 export inline constexpr ℤ Z{};
@@ -91,14 +127,14 @@ export inline constexpr ℤ Z{};
  *          large unsigned values may overflow, so the domain is conventionally
  *          restricted to values ≤ INT_MAX when used with certified arithmetic.
  */
-export inline constexpr auto embed_N_Z = arrow<unsigned, int>(
+export inline constexpr auto embed_ℕ_ℤ = arrow<unsigned, int>(
     [](const unsigned& x) noexcept { return static_cast<int>(x); });
 
 /**
  * @brief Canonical embedding K3 ↪ ℤ: Ternary → int.
  * @details Maps False -> -1, Unknown -> 0, True -> 1.
  */
-export inline constexpr auto embed_K3_Z =
+export inline constexpr auto embed_K3_ℤ =
     arrow<Ternary, int>([](const Ternary& t) noexcept {
       switch (t) {
         case Ternary::False:
@@ -116,11 +152,11 @@ export inline constexpr auto embed_K3_Z =
 namespace dedekind::category {
 template <>
 inline constexpr bool
-    is_monic_arrow_v<std::decay_t<decltype(dedekind::numbers::embed_N_Z)>> =
+    is_monic_arrow_v<std::decay_t<decltype(dedekind::numbers::embed_ℕ_ℤ)>> =
         true;
 
 template <>
 inline constexpr bool
-    is_monic_arrow_v<std::decay_t<decltype(dedekind::numbers::embed_K3_Z)>> =
+    is_monic_arrow_v<std::decay_t<decltype(dedekind::numbers::embed_K3_ℤ)>> =
         true;
 }  // namespace dedekind::category

--- a/src/main/modules/dedekind/numbers/naturals.cppm
+++ b/src/main/modules/dedekind/numbers/naturals.cppm
@@ -70,7 +70,7 @@ concept Monoid_ℕ = IsNatural<E> && requires(const M& m) {
  * @brief Canonical embedding 𝔹 ↪ ℕ: bool → unsigned.
  * @details False maps to 0, True maps to 1.
  */
-export inline constexpr auto embed_B_N =
+export inline constexpr auto embed_𝔹_ℕ =
     arrow<bool, unsigned>([](const bool& b) noexcept { return b ? 1u : 0u; });
 
 };  // namespace dedekind::numbers
@@ -78,6 +78,6 @@ export inline constexpr auto embed_B_N =
 namespace dedekind::category {
 template <>
 inline constexpr bool
-    is_monic_arrow_v<std::decay_t<decltype(dedekind::numbers::embed_B_N)>> =
+    is_monic_arrow_v<std::decay_t<decltype(dedekind::numbers::embed_𝔹_ℕ)>> =
         true;
 }  // namespace dedekind::category

--- a/src/main/modules/dedekind/numbers/naturals.cppm
+++ b/src/main/modules/dedekind/numbers/naturals.cppm
@@ -66,4 +66,18 @@ concept Monoid_ℕ = IsNatural<E> && requires(const M& m) {
   { m.cardinality() } -> std::same_as<std::size_t>;
 };
 
+/**
+ * @brief Canonical embedding 𝔹 ↪ ℕ: bool → unsigned.
+ * @details False maps to 0, True maps to 1.
+ */
+export inline constexpr auto embed_B_N =
+    arrow<bool, unsigned>([](const bool& b) noexcept { return b ? 1u : 0u; });
+
 };  // namespace dedekind::numbers
+
+namespace dedekind::category {
+template <>
+inline constexpr bool
+    is_monic_arrow_v<std::decay_t<decltype(dedekind::numbers::embed_B_N)>> =
+        true;
+}  // namespace dedekind::category

--- a/src/main/modules/dedekind/numbers/rational.cppm
+++ b/src/main/modules/dedekind/numbers/rational.cppm
@@ -14,6 +14,7 @@ export module dedekind.numbers:rational;
 
 import dedekind.category;
 import dedekind.sets;
+import :integer;
 
 namespace dedekind::numbers {
 using namespace dedekind::category;
@@ -99,11 +100,37 @@ class Rational {
 // Proof: The inverse of 2/3 is 3/2.
 static_assert((Rational<int>(2, 3).inverse().num() == 3));
 
-export template <std::signed_integral Z = int, typename L = ClassicalLogic,
+/**
+ * @brief Characteristic morphism for ℚ: the rationals.
+ * Accepts native Rational<int> and delegates predecessor checks through ℤ.
+ */
+export template <std::signed_integral I = int, typename L = ClassicalLogic,
                  typename C = ℵ_0>
-using RationalSetOf = Ω<Rational<Z>, L, C>;
+struct RationalsOf {
+  using Domain = Rational<I>;
+  using Codomain = typename L::Ω;
+  using logic_species = L;
+  using cardinality_type = C;
 
-export using RationalSet = RationalSetOf<>;
+  // Native Rational<int>: always a member of ℚ
+  constexpr typename L::Ω operator()(const Rational<I>&) const {
+    return L::True;
+  }
+
+  // Direct parent: embed int into ℚ.
+  constexpr typename L::Ω operator()(int z) const {
+    return operator()(Rational<I>{static_cast<I>(z), static_cast<I>(1)});
+  }
+
+  // Delegate non-parent ancestors to ambient ℤ.
+  template <typename T>
+    requires(!std::same_as<T, Rational<I>> && !std::same_as<T, int>)
+  constexpr typename L::Ω operator()(const T& x) const {
+    return dedekind::numbers::Z(x);
+  }
+};
+
+export using RationalSet = RationalsOf<>;
 export using ℚ = RationalSet;
 
 export inline constexpr ℚ Q{};
@@ -113,7 +140,7 @@ export inline constexpr ℚ Q{};
  * @details Every integer n embeds as the fraction n/1.
  *          This is the standard ring homomorphism Z → Q.
  */
-export inline constexpr auto embed_Z_Q = arrow<int, Rational<int>>(
+export inline constexpr auto embed_ℤ_ℚ = arrow<int, Rational<int>>(
     [](const int& n) noexcept { return Rational<int>{n, 1}; });
 
 }  // namespace dedekind::numbers
@@ -127,6 +154,6 @@ struct SpeciesTraits<dedekind::numbers::Rational<Z>> {
 
 template <>
 inline constexpr bool
-    is_monic_arrow_v<std::decay_t<decltype(dedekind::numbers::embed_Z_Q)>> =
+    is_monic_arrow_v<std::decay_t<decltype(dedekind::numbers::embed_ℤ_ℚ)>> =
         true;
 }  // namespace dedekind::category

--- a/src/main/modules/dedekind/numbers/rational.cppm
+++ b/src/main/modules/dedekind/numbers/rational.cppm
@@ -20,11 +20,14 @@ namespace dedekind::numbers {
 using namespace dedekind::category;
 using namespace dedekind::sets;
 
+// Canonical machine realization for the integer carrier.
+export using machine_integer = int;
+
 /**
  * @class Rational
  * @brief The Field of Fractions over an Integral Domain Z.
  */
-export template <std::signed_integral Z>
+export template <IsInteger Z>
 class Rational {
  public:
   using Domain = Z;
@@ -98,13 +101,13 @@ class Rational {
 /** @section Formal_Verification */
 
 // Proof: The inverse of 2/3 is 3/2.
-static_assert((Rational<int>(2, 3).inverse().num() == 3));
+static_assert((Rational<machine_integer>(2, 3).inverse().num() == 3));
 
 /**
  * @brief Characteristic morphism for ℚ: the rationals.
- * Accepts native Rational<int> and delegates predecessor checks through ℤ.
+ * Accepts native Rational<I> and delegates predecessor checks through ℤ.
  */
-export template <std::signed_integral I = int, typename L = ClassicalLogic,
+export template <IsInteger I = machine_integer, typename L = ClassicalLogic,
                  typename C = ℵ_0>
 struct RationalsOf {
   using Domain = Rational<I>;
@@ -112,19 +115,19 @@ struct RationalsOf {
   using logic_species = L;
   using cardinality_type = C;
 
-  // Native Rational<int>: always a member of ℚ
+  // Native Rational<I>: always a member of ℚ
   constexpr typename L::Ω operator()(const Rational<I>&) const {
     return L::True;
   }
 
-  // Direct parent: embed int into ℚ.
-  constexpr typename L::Ω operator()(int z) const {
+  // Direct parent: embed machine integer into ℚ.
+  constexpr typename L::Ω operator()(machine_integer z) const {
     return operator()(Rational<I>{static_cast<I>(z), static_cast<I>(1)});
   }
 
   // Delegate non-parent ancestors to ambient ℤ.
   template <typename T>
-    requires(!std::same_as<T, Rational<I>> && !std::same_as<T, int>)
+    requires(!std::same_as<T, Rational<I>> && !std::same_as<T, machine_integer>)
   constexpr typename L::Ω operator()(const T& x) const {
     return dedekind::numbers::Z(x);
   }
@@ -136,17 +139,20 @@ export using ℚ = RationalSet;
 export inline constexpr ℚ Q{};
 
 /**
- * @brief Canonical embedding ℤ ↪ ℚ: int → Rational<int>.
+ * @brief Machine realization arrow ℤ ↪ ℚ: machine_integer → Rational<I>.
  * @details Every integer n embeds as the fraction n/1.
- *          This is the standard ring homomorphism Z → Q.
+ *          This is the current machine model lift of Z → Q.
  */
-export inline constexpr auto embed_ℤ_ℚ = arrow<int, Rational<int>>(
-    [](const int& n) noexcept { return Rational<int>{n, 1}; });
+export template <IsInteger I = machine_integer>
+inline constexpr auto embed_ℤ_ℚ =
+    arrow<machine_integer, Rational<I>>([](const machine_integer& n) noexcept {
+      return Rational<I>{static_cast<I>(n), static_cast<I>(1)};
+    });
 
 }  // namespace dedekind::numbers
 
 namespace dedekind::category {
-template <std::signed_integral Z>
+template <dedekind::numbers::IsInteger Z>
 struct SpeciesTraits<dedekind::numbers::Rational<Z>> {
   using Domain = dedekind::numbers::Rational<Z>;
   using machine_type = dedekind::numbers::Rational<Z>;
@@ -154,6 +160,6 @@ struct SpeciesTraits<dedekind::numbers::Rational<Z>> {
 
 template <>
 inline constexpr bool
-    is_monic_arrow_v<std::decay_t<decltype(dedekind::numbers::embed_ℤ_ℚ)>> =
+    is_monic_arrow_v<std::decay_t<decltype(dedekind::numbers::embed_ℤ_ℚ<>)>> =
         true;
 }  // namespace dedekind::category

--- a/src/main/modules/dedekind/numbers/rational.cppm
+++ b/src/main/modules/dedekind/numbers/rational.cppm
@@ -108,4 +108,25 @@ export using ℚ = RationalSet;
 
 export inline constexpr ℚ Q{};
 
+/**
+ * @brief Canonical embedding ℤ ↪ ℚ: int → Rational<int>.
+ * @details Every integer n embeds as the fraction n/1.
+ *          This is the standard ring homomorphism Z → Q.
+ */
+export inline constexpr auto embed_Z_Q = arrow<int, Rational<int>>(
+    [](const int& n) noexcept { return Rational<int>{n, 1}; });
+
 }  // namespace dedekind::numbers
+
+namespace dedekind::category {
+template <std::signed_integral Z>
+struct SpeciesTraits<dedekind::numbers::Rational<Z>> {
+  using Domain = dedekind::numbers::Rational<Z>;
+  using machine_type = dedekind::numbers::Rational<Z>;
+};
+
+template <>
+inline constexpr bool
+    is_monic_arrow_v<std::decay_t<decltype(dedekind::numbers::embed_Z_Q)>> =
+        true;
+}  // namespace dedekind::category

--- a/src/main/modules/dedekind/numbers/real.cppm
+++ b/src/main/modules/dedekind/numbers/real.cppm
@@ -52,11 +52,36 @@ class Real {
   Q value_{};
 };
 
-export template <typename Q = double, typename L = ClassicalLogic,
+/**
+ * @brief Characteristic morphism for ℝ: the real numbers.
+ * Accepts native Real<double> and delegates predecessor checks through ℚ.
+ */
+export template <typename S = double, typename L = ClassicalLogic,
                  typename C = ℶ_1>
-using RealSetOf = Ω<Real<Q>, L, C>;
+struct RealsOf {
+  using Domain = Real<S>;
+  using Codomain = typename L::Ω;
+  using logic_species = L;
+  using cardinality_type = C;
 
-export using RealSet = RealSetOf<>;
+  // Native Real<Q>: always a member of ℝ
+  constexpr typename L::Ω operator()(const Real<S>&) const { return L::True; }
+
+  // Direct parent: embed Rational<int> into ℝ.
+  constexpr typename L::Ω operator()(const Rational<int>& q) const {
+    return operator()(
+        Real<S>{static_cast<S>(q.num()) / static_cast<S>(q.den())});
+  }
+
+  // Delegate non-parent ancestors to ambient ℚ.
+  template <typename T>
+    requires(!std::same_as<T, Real<S>> && !std::same_as<T, Rational<int>>)
+  constexpr typename L::Ω operator()(const T& x) const {
+    return dedekind::numbers::Q(x);
+  }
+};
+
+export using RealSet = RealsOf<>;
 export using ℝ = RealSet;
 
 export inline constexpr ℝ R{};
@@ -67,7 +92,7 @@ export inline constexpr ℝ R{};
  *          The embedding is exact for rationals representable in double;
  *          rounding is acknowledged by the ℶ_1 cardinality of ℝ.
  */
-export inline constexpr auto embed_Q_R =
+export inline constexpr auto embed_ℚ_ℝ =
     arrow<Rational<int>, Real<double>>([](const Rational<int>& q) noexcept {
       return Real<double>{static_cast<double>(q.num()) /
                           static_cast<double>(q.den())};
@@ -84,6 +109,6 @@ struct SpeciesTraits<dedekind::numbers::Real<Q>> {
 
 template <>
 inline constexpr bool
-    is_monic_arrow_v<std::decay_t<decltype(dedekind::numbers::embed_Q_R)>> =
+    is_monic_arrow_v<std::decay_t<decltype(dedekind::numbers::embed_ℚ_ℝ)>> =
         true;
 }  // namespace dedekind::category

--- a/src/main/modules/dedekind/numbers/real.cppm
+++ b/src/main/modules/dedekind/numbers/real.cppm
@@ -54,9 +54,9 @@ class Real {
 
 /**
  * @brief Characteristic morphism for ℝ: the real numbers.
- * Accepts native Real<double> and delegates predecessor checks through ℚ.
+ * Accepts native Real<S> and delegates predecessor checks through ℚ.
  */
-export template <typename S = double, typename L = ClassicalLogic,
+export template <std::floating_point S = double, typename L = ClassicalLogic,
                  typename C = ℶ_1>
 struct RealsOf {
   using Domain = Real<S>;

--- a/src/main/modules/dedekind/numbers/real.cppm
+++ b/src/main/modules/dedekind/numbers/real.cppm
@@ -12,6 +12,7 @@ export module dedekind.numbers:real;
 
 import dedekind.category;
 import dedekind.sets;
+import :rational;
 
 namespace dedekind::numbers {
 using namespace dedekind::category;
@@ -60,4 +61,29 @@ export using ℝ = RealSet;
 
 export inline constexpr ℝ R{};
 
+/**
+ * @brief Canonical embedding ℚ ↪ ℝ: Rational<int> → Real<double>.
+ * @details Converts a rational p/q to the closest IEEE 754 double.
+ *          The embedding is exact for rationals representable in double;
+ *          rounding is acknowledged by the ℶ_1 cardinality of ℝ.
+ */
+export inline constexpr auto embed_Q_R =
+    arrow<Rational<int>, Real<double>>([](const Rational<int>& q) noexcept {
+      return Real<double>{static_cast<double>(q.num()) /
+                          static_cast<double>(q.den())};
+    });
+
 }  // namespace dedekind::numbers
+
+namespace dedekind::category {
+template <typename Q>
+struct SpeciesTraits<dedekind::numbers::Real<Q>> {
+  using Domain = dedekind::numbers::Real<Q>;
+  using machine_type = dedekind::numbers::Real<Q>;
+};
+
+template <>
+inline constexpr bool
+    is_monic_arrow_v<std::decay_t<decltype(dedekind::numbers::embed_Q_R)>> =
+        true;
+}  // namespace dedekind::category

--- a/src/main/modules/dedekind/numbers/real.cppm
+++ b/src/main/modules/dedekind/numbers/real.cppm
@@ -18,8 +18,20 @@ namespace dedekind::numbers {
 using namespace dedekind::category;
 using namespace dedekind::sets;
 
-export template <typename Q>
-  requires std::regular<Q>
+// Canonical machine realization for the real scalar carrier.
+export using machine_real_scalar = double;
+
+export template <typename S>
+concept IsRealCarrier = requires(S a, S b) {
+  S{};
+  { a + b } -> std::same_as<S>;
+  { a - b } -> std::same_as<S>;
+  { a * b } -> std::same_as<S>;
+  { a / b } -> std::same_as<S>;
+  { a < b } -> std::convertible_to<bool>;
+};
+
+export template <IsRealCarrier Q>
 class Real {
  public:
   using Domain = Q;
@@ -44,6 +56,10 @@ class Real {
     return Real{a.value_ * b.value_};
   }
 
+  friend constexpr Real operator-(const Real& a, const Real& b) {
+    return Real{a.value_ - b.value_};
+  }
+
   friend constexpr Real operator/(const Real& a, const Real& b) {
     return Real{a.value_ / b.value_};
   }
@@ -53,10 +69,22 @@ class Real {
 };
 
 /**
+ * @brief Machine realization arrow ℚ ↪ ℝ: Rational<I> → Real<S>.
+ * @details Converts a rational p/q to the closest IEEE 754 value of type S.
+ */
+export template <IsInteger I = machine_integer,
+                 IsRealCarrier S = machine_real_scalar>
+inline constexpr auto embed_ℚ_ℝ =
+    arrow<Rational<I>, Real<S>>([](const Rational<I>& q) noexcept {
+      return Real<S>{static_cast<S>(q.num()) / static_cast<S>(q.den())};
+    });
+
+/**
  * @brief Characteristic morphism for ℝ: the real numbers.
  * Accepts native Real<S> and delegates predecessor checks through ℚ.
  */
-export template <std::floating_point S = double, typename L = ClassicalLogic,
+export template <IsRealCarrier S = machine_real_scalar,
+                 IsInteger I = machine_integer, typename L = ClassicalLogic,
                  typename C = ℶ_1>
 struct RealsOf {
   using Domain = Real<S>;
@@ -64,20 +92,19 @@ struct RealsOf {
   using logic_species = L;
   using cardinality_type = C;
 
-  // Native Real<Q>: always a member of ℝ
+  // Native Real<S>: always a member of ℝ
   constexpr typename L::Ω operator()(const Real<S>&) const { return L::True; }
 
-  // Direct parent: embed Rational<int> into ℝ.
-  constexpr typename L::Ω operator()(const Rational<int>& q) const {
-    return operator()(
-        Real<S>{static_cast<S>(q.num()) / static_cast<S>(q.den())});
+  // Direct parent: embed Rational<I> into ℝ via the canonical arrow.
+  constexpr typename L::Ω operator()(const Rational<I>& q) const {
+    return operator()(embed_ℚ_ℝ<I, S>(q));
   }
 
   // Delegate non-parent ancestors to ambient ℚ.
   template <typename T>
-    requires(!std::same_as<T, Real<S>> && !std::same_as<T, Rational<int>>)
+    requires(!std::same_as<T, Real<S>> && !std::same_as<T, Rational<I>>)
   constexpr typename L::Ω operator()(const T& x) const {
-    return dedekind::numbers::Q(x);
+    return dedekind::numbers::RationalsOf<I>{}(x);
   }
 };
 
@@ -85,18 +112,6 @@ export using RealSet = RealsOf<>;
 export using ℝ = RealSet;
 
 export inline constexpr ℝ R{};
-
-/**
- * @brief Canonical embedding ℚ ↪ ℝ: Rational<int> → Real<double>.
- * @details Converts a rational p/q to the closest IEEE 754 double.
- *          The embedding is exact for rationals representable in double;
- *          rounding is acknowledged by the ℶ_1 cardinality of ℝ.
- */
-export inline constexpr auto embed_ℚ_ℝ =
-    arrow<Rational<int>, Real<double>>([](const Rational<int>& q) noexcept {
-      return Real<double>{static_cast<double>(q.num()) /
-                          static_cast<double>(q.den())};
-    });
 
 }  // namespace dedekind::numbers
 
@@ -109,6 +124,6 @@ struct SpeciesTraits<dedekind::numbers::Real<Q>> {
 
 template <>
 inline constexpr bool
-    is_monic_arrow_v<std::decay_t<decltype(dedekind::numbers::embed_ℚ_ℝ)>> =
+    is_monic_arrow_v<std::decay_t<decltype(dedekind::numbers::embed_ℚ_ℝ<>)>> =
         true;
 }  // namespace dedekind::category

--- a/src/main/modules/dedekind/sets/boundaries.cppm
+++ b/src/main/modules/dedekind/sets/boundaries.cppm
@@ -218,6 +218,9 @@ struct NaturalNumbersOf {
   constexpr typename L::Ω operator()(U) const {
     return L::True;
   }
+
+  // Embedded bool (via embed_𝔹_ℕ → unsigned): landing in ℕ
+  constexpr typename L::Ω operator()(bool) const { return L::True; }
 };
 
 export using NaturalNumbers = NaturalNumbersOf<>;

--- a/src/main/modules/dedekind/sets/boundaries.cppm
+++ b/src/main/modules/dedekind/sets/boundaries.cppm
@@ -204,7 +204,21 @@ static_assert(dedekind::category::IsSet<decltype(ambient_set<int>(Ø<int>{}))>,
 // Transitional alias used by tests and set-builder examples.
 // ETCS-level natural-number witnesses may replace this direct alias later.
 export template <typename L = ClassicalLogic, typename C = ℵ_0>
-using NaturalNumbersOf = Ω<int, L, C>;
+struct NaturalNumbersOf {
+  using Domain = int;
+  using Codomain = typename L::Ω;
+  using logic_species = L;
+  using cardinality_type = C;
+
+  constexpr typename L::Ω operator()(int x) const {
+    return x >= 0 ? L::True : L::False;
+  }
+
+  template <std::unsigned_integral U>
+  constexpr typename L::Ω operator()(U) const {
+    return L::True;
+  }
+};
 
 export using NaturalNumbers = NaturalNumbersOf<>;
 export using ℕ = NaturalNumbers;

--- a/src/main/modules/dedekind/sets/expressions.cppm
+++ b/src/main/modules/dedekind/sets/expressions.cppm
@@ -101,6 +101,10 @@ class Set {
   constexpr Set(Comprehension<B, P> cp) : predicate_(std::move(cp.predicate)) {}
 
   template <typename B>
+    requires std::same_as<T, typename B::Domain> && std::same_as<Predicate, B>
+  constexpr Set(MembershipBinding<B> b) : predicate_(b.base) {}
+
+  template <typename B>
     requires std::same_as<T, typename B::Domain> &&
              std::same_as<Predicate, UniversalPredicate<T>> &&
              requires { typename B::is_universal_boundary; }
@@ -145,6 +149,11 @@ class Set {
 export template <typename B, typename P>
 Set(Comprehension<B, P>)
     -> Set<typename B::Domain, typename NaturalLogic<B>::type, P>;
+
+export template <typename S>
+  requires(!requires { typename S::is_universal_boundary; })
+Set(MembershipBinding<S>)
+    -> Set<typename S::Domain, typename NaturalLogic<S>::type, S>;
 
 export template <typename S>
   requires requires { typename S::is_universal_boundary; }

--- a/src/test/cpp/modules/dedekind/category/etcs_test.cpp
+++ b/src/test/cpp/modules/dedekind/category/etcs_test.cpp
@@ -132,3 +132,23 @@ TEST_CASE("ETCS: Boolean algebra over bool ambient",
     CHECK(set_intersection(p, set_union(p, q)).χ(x) == p.χ(x));
   }
 }
+
+TEST_CASE("ETCS: embedding-mediated membership avoids subset claims",
+          "[category][etcs][embedding][membership]") {
+  const auto integers = ambient_set<int>([](const int&) { return true; });
+  const auto naturals = ambient_set<int>([](const int& x) { return x >= 0; });
+
+  // Identity embedding int -> int as the carrier inclusion into Z's ambient.
+  const auto embed_int_in_Z = arrow<int, int>([](const int& x) { return x; });
+
+  CHECK(in_via(7, embed_int_in_Z, integers) == true);
+  CHECK(in_via(-7, embed_int_in_Z, integers) == true);
+
+  // Canonical widening embedding unsigned -> int for N-membership checks.
+  const auto embed_unsigned_in_N = arrow<unsigned, int>(
+      [](const unsigned& x) { return static_cast<int>(x); });
+
+  CHECK(in(-1, naturals) == false);
+  CHECK(in(7, naturals) == true);
+  CHECK(in_via(7u, embed_unsigned_in_N, naturals) == true);
+}

--- a/src/test/cpp/modules/dedekind/numbers/starters_test.cpp
+++ b/src/test/cpp/modules/dedekind/numbers/starters_test.cpp
@@ -33,6 +33,8 @@ TEST_CASE("Numbers: starter universes construct from ambient values",
   constexpr auto n = var<ℕ>;
   constexpr auto naturals = Set{n % N};
   static_assert(naturals(7) == Ternary::True);
+  static_assert(naturals(-7) == Ternary::False);
+  static_assert(naturals(7u) == Ternary::True);
 
   constexpr auto z = var<ℤ>;
   constexpr auto integers = Set{z % Z};

--- a/src/test/cpp/modules/dedekind/numbers/tower_test.cpp
+++ b/src/test/cpp/modules/dedekind/numbers/tower_test.cpp
@@ -1,0 +1,168 @@
+/**
+ * @file tower_test.cpp
+ * @brief The numerical tower: embedding-mediated membership through ℕ ↪ ℤ ↪ ℚ ↪
+ * ℝ ↪ ℂ.
+ *
+ * @section Design_Note
+ * We deliberately model inclusions as *embedding arrows* rather than subset
+ * declarations.  This avoids closure / totality commitments: each embedding
+ * e: X -> Y is a user-declared monic arrow; membership in Y is tested via
+ * χ_Y(e(x)), not by asserting X ⊆ Y in a categorical sense.
+ *
+ * See: etcs.cppm — `in_via(x, e, S)` for the underlying primitive.
+ */
+#include <catch2/catch_test_macros.hpp>
+
+import dedekind.category;
+import dedekind.numbers;
+import dedekind.sets;
+
+using namespace dedekind::category;
+using namespace dedekind::numbers;
+using namespace dedekind::sets;
+
+// ---------------------------------------------------------------------------
+// Compile-time monicity declarations are honoured
+// ---------------------------------------------------------------------------
+
+static_assert(IsMonicArrow<Identity<int>>);
+static_assert(IsMonicArrow<std::decay_t<decltype(embed_B_N)>>);
+static_assert(IsMonicArrow<std::decay_t<decltype(embed_N_Z)>>);
+static_assert(IsMonicArrow<std::decay_t<decltype(embed_K3_Z)>>);
+static_assert(IsMonicArrow<std::decay_t<decltype(embed_Z_Q)>>);
+static_assert(IsMonicArrow<std::decay_t<decltype(embed_Q_R)>>);
+static_assert(IsMonicArrow<std::decay_t<decltype(embed_R_C)>>);
+
+// ---------------------------------------------------------------------------
+// Arrow types are correct (compile-time)
+// ---------------------------------------------------------------------------
+
+static_assert(std::same_as<Dom<std::decay_t<decltype(embed_B_N)>>, bool>);
+static_assert(std::same_as<Cod<std::decay_t<decltype(embed_B_N)>>, unsigned>);
+
+static_assert(std::same_as<Dom<std::decay_t<decltype(embed_N_Z)>>, unsigned>);
+static_assert(std::same_as<Cod<std::decay_t<decltype(embed_N_Z)>>, int>);
+
+static_assert(std::same_as<Dom<std::decay_t<decltype(embed_K3_Z)>>, Ternary>);
+static_assert(std::same_as<Cod<std::decay_t<decltype(embed_K3_Z)>>, int>);
+
+static_assert(std::same_as<Dom<std::decay_t<decltype(embed_Z_Q)>>, int>);
+static_assert(
+    std::same_as<Cod<std::decay_t<decltype(embed_Z_Q)>>, Rational<int>>);
+
+static_assert(
+    std::same_as<Dom<std::decay_t<decltype(embed_Q_R)>>, Rational<int>>);
+static_assert(
+    std::same_as<Cod<std::decay_t<decltype(embed_Q_R)>>, Real<double>>);
+
+static_assert(
+    std::same_as<Dom<std::decay_t<decltype(embed_R_C)>>, Real<double>>);
+static_assert(
+    std::same_as<Cod<std::decay_t<decltype(embed_R_C)>>, Complex<double>>);
+
+static_assert(IsSpecies<Rational<int>>);
+static_assert(IsSpecies<Real<double>>);
+static_assert(IsSpecies<Complex<double>>);
+
+// ---------------------------------------------------------------------------
+// 𝔹 ↪ ℕ
+// ---------------------------------------------------------------------------
+
+TEST_CASE("Tower: 𝔹 ↪ ℕ via embed_B_N", "[numbers][tower][embedding]") {
+  const auto naturals_u =
+      ambient_set<unsigned>([](const unsigned&) { return true; });
+
+  CHECK(embed_B_N(false) == 0u);
+  CHECK(embed_B_N(true) == 1u);
+
+  CHECK(in_via(false, embed_B_N, naturals_u) == true);
+  CHECK(in_via(true, embed_B_N, naturals_u) == true);
+}
+
+// ---------------------------------------------------------------------------
+// ℕ ↪ ℤ
+// ---------------------------------------------------------------------------
+
+TEST_CASE("Tower: ℕ ↪ ℤ via embed_N_Z", "[numbers][tower][embedding]") {
+  // Unsigned naturals always embed into integers successfully.
+  const auto integers = ambient_set<int>([](const int&) { return true; });
+
+  CHECK(in_via(0u, embed_N_Z, integers) == true);
+  CHECK(in_via(42u, embed_N_Z, integers) == true);
+  CHECK(in_via(1000u, embed_N_Z, integers) == true);
+
+  // Membership in the naturals set respects sign.
+  CHECK(N(0) == true);
+  CHECK(N(7) == true);
+  CHECK(N(-1) == false);
+
+  // Unsigned values are always natural.
+  CHECK(N(0u) == true);
+  CHECK(N(42u) == true);
+}
+
+// ---------------------------------------------------------------------------
+// K3 ↪ ℤ
+// ---------------------------------------------------------------------------
+
+TEST_CASE("Tower: K3 ↪ ℤ via embed_K3_Z", "[numbers][tower][embedding]") {
+  const auto integers = ambient_set<int>([](const int&) { return true; });
+
+  CHECK(embed_K3_Z(Ternary::False) == -1);
+  CHECK(embed_K3_Z(Ternary::Unknown) == 0);
+  CHECK(embed_K3_Z(Ternary::True) == 1);
+
+  CHECK(in_via(Ternary::False, embed_K3_Z, integers) == true);
+  CHECK(in_via(Ternary::Unknown, embed_K3_Z, integers) == true);
+  CHECK(in_via(Ternary::True, embed_K3_Z, integers) == true);
+}
+
+// ---------------------------------------------------------------------------
+// ℤ ↪ ℚ
+// ---------------------------------------------------------------------------
+
+TEST_CASE("Tower: ℤ ↪ ℚ via embed_Z_Q", "[numbers][tower][embedding]") {
+  // Embedding preserves value: n -> n/1.
+  CHECK(embed_Z_Q(3).num() == 3);
+  CHECK(embed_Z_Q(3).den() == 1);
+  CHECK(embed_Z_Q(-5).num() == -5);
+}
+
+// ---------------------------------------------------------------------------
+// ℚ ↪ ℝ
+// ---------------------------------------------------------------------------
+
+TEST_CASE("Tower: ℚ ↪ ℝ via embed_Q_R", "[numbers][tower][embedding]") {
+  // Embedding preserves value: 3/1 -> 3.0.
+  CHECK(embed_Q_R(Rational<int>{3, 1}).resolve() == 3.0);
+  CHECK(embed_Q_R(Rational<int>{1, 2}).resolve() == 0.5);
+  CHECK(embed_Q_R(Rational<int>{-7, 4}).resolve() == -1.75);
+}
+
+// ---------------------------------------------------------------------------
+// ℝ ↪ ℂ
+// ---------------------------------------------------------------------------
+
+TEST_CASE("Tower: ℝ ↪ ℂ via embed_R_C", "[numbers][tower][embedding]") {
+  // Embedding: imaginary part is always 0.
+  CHECK(embed_R_C(Real<double>{3.0}).real() == 3.0);
+  CHECK(embed_R_C(Real<double>{3.0}).imag() == 0.0);
+  CHECK(embed_R_C(Real<double>{-2.5}).real() == -2.5);
+  CHECK(embed_R_C(Real<double>{-2.5}).imag() == 0.0);
+}
+
+// ---------------------------------------------------------------------------
+// Composed tower: unsigned ↪ ℤ ↪ ℚ ↪ ℝ ↪ ℂ  (via >> composition)
+// ---------------------------------------------------------------------------
+
+TEST_CASE("Tower: composed chain unsigned -> ℤ -> ℚ -> ℝ -> ℂ",
+          "[numbers][tower][embedding][composition]") {
+  const auto embed_N_Q = embed_N_Z >> embed_Z_Q;
+  const auto embed_N_R = embed_N_Q >> embed_Q_R;
+  const auto embed_N_C = embed_N_R >> embed_R_C;
+
+  // 3 travels the full chain and arrives in ℂ as (3 + 0i).
+  const auto result = embed_N_C(3u);
+  CHECK(result.real() == 3.0);
+  CHECK(result.imag() == 0.0);
+}

--- a/src/test/cpp/modules/dedekind/numbers/tower_test.cpp
+++ b/src/test/cpp/modules/dedekind/numbers/tower_test.cpp
@@ -25,13 +25,13 @@ using namespace dedekind::sets;
 // Compile-time monicity declarations are honoured
 // ---------------------------------------------------------------------------
 
-static_assert(IsMonicArrow<Identity<int>>);
+static_assert(IsMonicArrow<Identity<machine_integer>>);
 static_assert(IsMonicArrow<std::decay_t<decltype(embed_𝔹_ℕ)>>);
 static_assert(IsMonicArrow<std::decay_t<decltype(embed_ℕ_ℤ)>>);
 static_assert(IsMonicArrow<std::decay_t<decltype(embed_K3_ℤ)>>);
-static_assert(IsMonicArrow<std::decay_t<decltype(embed_ℤ_ℚ)>>);
-static_assert(IsMonicArrow<std::decay_t<decltype(embed_ℚ_ℝ)>>);
-static_assert(IsMonicArrow<std::decay_t<decltype(embed_ℝ_ℂ)>>);
+static_assert(IsMonicArrow<std::decay_t<decltype(embed_ℤ_ℚ<>)>>);
+static_assert(IsMonicArrow<std::decay_t<decltype(embed_ℚ_ℝ<>)>>);
+static_assert(IsMonicArrow<std::decay_t<decltype(embed_ℝ_ℂ<>)>>);
 
 // ---------------------------------------------------------------------------
 // Arrow types are correct (compile-time)
@@ -41,28 +41,31 @@ static_assert(std::same_as<Dom<std::decay_t<decltype(embed_𝔹_ℕ)>>, bool>);
 static_assert(std::same_as<Cod<std::decay_t<decltype(embed_𝔹_ℕ)>>, unsigned>);
 
 static_assert(std::same_as<Dom<std::decay_t<decltype(embed_ℕ_ℤ)>>, unsigned>);
-static_assert(std::same_as<Cod<std::decay_t<decltype(embed_ℕ_ℤ)>>, int>);
+static_assert(
+    std::same_as<Cod<std::decay_t<decltype(embed_ℕ_ℤ)>>, machine_integer>);
 
 static_assert(std::same_as<Dom<std::decay_t<decltype(embed_K3_ℤ)>>, Ternary>);
-static_assert(std::same_as<Cod<std::decay_t<decltype(embed_K3_ℤ)>>, int>);
-
-static_assert(std::same_as<Dom<std::decay_t<decltype(embed_ℤ_ℚ)>>, int>);
 static_assert(
-    std::same_as<Cod<std::decay_t<decltype(embed_ℤ_ℚ)>>, Rational<int>>);
+    std::same_as<Cod<std::decay_t<decltype(embed_K3_ℤ)>>, machine_integer>);
 
 static_assert(
-    std::same_as<Dom<std::decay_t<decltype(embed_ℚ_ℝ)>>, Rational<int>>);
-static_assert(
-    std::same_as<Cod<std::decay_t<decltype(embed_ℚ_ℝ)>>, Real<double>>);
+    std::same_as<Dom<std::decay_t<decltype(embed_ℤ_ℚ<>)>>, machine_integer>);
+static_assert(std::same_as<Cod<std::decay_t<decltype(embed_ℤ_ℚ<>)>>,
+                           Rational<machine_integer>>);
 
-static_assert(
-    std::same_as<Dom<std::decay_t<decltype(embed_ℝ_ℂ)>>, Real<double>>);
-static_assert(
-    std::same_as<Cod<std::decay_t<decltype(embed_ℝ_ℂ)>>, Complex<double>>);
+static_assert(std::same_as<Dom<std::decay_t<decltype(embed_ℚ_ℝ<>)>>,
+                           Rational<machine_integer>>);
+static_assert(std::same_as<Cod<std::decay_t<decltype(embed_ℚ_ℝ<>)>>,
+                           Real<machine_real_scalar>>);
 
-static_assert(IsSpecies<Rational<int>>);
-static_assert(IsSpecies<Real<double>>);
-static_assert(IsSpecies<Complex<double>>);
+static_assert(std::same_as<Dom<std::decay_t<decltype(embed_ℝ_ℂ<>)>>,
+                           Real<machine_real_scalar>>);
+static_assert(std::same_as<Cod<std::decay_t<decltype(embed_ℝ_ℂ<>)>>,
+                           Complex<machine_real_scalar>>);
+
+static_assert(IsSpecies<Rational<machine_integer>>);
+static_assert(IsSpecies<Real<machine_real_scalar>>);
+static_assert(IsSpecies<Complex<machine_real_scalar>>);
 
 // ---------------------------------------------------------------------------
 // 𝔹 ↪ ℕ
@@ -123,9 +126,9 @@ TEST_CASE("Tower: K3 ↪ ℤ via embed_K3_ℤ", "[numbers][tower][embedding]") {
 
 TEST_CASE("Tower: ℤ ↪ ℚ via embed_ℤ_ℚ", "[numbers][tower][embedding]") {
   // Embedding preserves value: n -> n/1.
-  CHECK(embed_ℤ_ℚ(3).num() == 3);
-  CHECK(embed_ℤ_ℚ(3).den() == 1);
-  CHECK(embed_ℤ_ℚ(-5).num() == -5);
+  CHECK(embed_ℤ_ℚ<>(3).num() == 3);
+  CHECK(embed_ℤ_ℚ<>(3).den() == 1);
+  CHECK(embed_ℤ_ℚ<>(-5).num() == -5);
 }
 
 // ---------------------------------------------------------------------------
@@ -134,9 +137,9 @@ TEST_CASE("Tower: ℤ ↪ ℚ via embed_ℤ_ℚ", "[numbers][tower][embedding]")
 
 TEST_CASE("Tower: ℚ ↪ ℝ via embed_ℚ_ℝ", "[numbers][tower][embedding]") {
   // Embedding preserves value: 3/1 -> 3.0.
-  CHECK(embed_ℚ_ℝ(Rational<int>{3, 1}).resolve() == 3.0);
-  CHECK(embed_ℚ_ℝ(Rational<int>{1, 2}).resolve() == 0.5);
-  CHECK(embed_ℚ_ℝ(Rational<int>{-7, 4}).resolve() == -1.75);
+  CHECK(embed_ℚ_ℝ<>(Rational<machine_integer>{3, 1}).resolve() == 3.0);
+  CHECK(embed_ℚ_ℝ<>(Rational<machine_integer>{1, 2}).resolve() == 0.5);
+  CHECK(embed_ℚ_ℝ<>(Rational<machine_integer>{-7, 4}).resolve() == -1.75);
 }
 
 // ---------------------------------------------------------------------------
@@ -145,10 +148,10 @@ TEST_CASE("Tower: ℚ ↪ ℝ via embed_ℚ_ℝ", "[numbers][tower][embedding]")
 
 TEST_CASE("Tower: ℝ ↪ ℂ via embed_ℝ_ℂ", "[numbers][tower][embedding]") {
   // Embedding: imaginary part is always 0.
-  CHECK(embed_ℝ_ℂ(Real<double>{3.0}).real() == 3.0);
-  CHECK(embed_ℝ_ℂ(Real<double>{3.0}).imag() == 0.0);
-  CHECK(embed_ℝ_ℂ(Real<double>{-2.5}).real() == -2.5);
-  CHECK(embed_ℝ_ℂ(Real<double>{-2.5}).imag() == 0.0);
+  CHECK(embed_ℝ_ℂ<>(Real<machine_real_scalar>{3.0}).real() == 3.0);
+  CHECK(embed_ℝ_ℂ<>(Real<machine_real_scalar>{3.0}).imag() == 0.0);
+  CHECK(embed_ℝ_ℂ<>(Real<machine_real_scalar>{-2.5}).real() == -2.5);
+  CHECK(embed_ℝ_ℂ<>(Real<machine_real_scalar>{-2.5}).imag() == 0.0);
 }
 
 // ---------------------------------------------------------------------------
@@ -157,9 +160,9 @@ TEST_CASE("Tower: ℝ ↪ ℂ via embed_ℝ_ℂ", "[numbers][tower][embedding]")
 
 TEST_CASE("Tower: composed chain unsigned -> ℤ -> ℚ -> ℝ -> ℂ",
           "[numbers][tower][embedding][composition]") {
-  const auto embed_ℕ_ℚ = embed_ℕ_ℤ >> embed_ℤ_ℚ;
-  const auto embed_ℕ_ℝ = embed_ℕ_ℚ >> embed_ℚ_ℝ;
-  const auto embed_ℕ_ℂ = embed_ℕ_ℝ >> embed_ℝ_ℂ;
+  const auto embed_ℕ_ℚ = embed_ℕ_ℤ >> embed_ℤ_ℚ<>;
+  const auto embed_ℕ_ℝ = embed_ℕ_ℚ >> embed_ℚ_ℝ<>;
+  const auto embed_ℕ_ℂ = embed_ℕ_ℝ >> embed_ℝ_ℂ<>;
 
   // 3 travels the full chain and arrives in ℂ as (3 + 0i).
   const auto result = embed_ℕ_ℂ(3u);
@@ -178,13 +181,13 @@ TEST_CASE("Stress: Im(K3->ℤ) intersect positive-real ℂ",
   const int z_unknown = embed_K3_ℤ(Ternary::Unknown);
   const int z_true = embed_K3_ℤ(Ternary::True);
 
-  const auto embed_ℤ_ℂ = embed_ℤ_ℚ >> embed_ℚ_ℝ >> embed_ℝ_ℂ;
+  const auto embed_ℤ_ℂ = embed_ℤ_ℚ<> >> embed_ℚ_ℝ<> >> embed_ℝ_ℂ<>;
 
   const auto c_false = embed_ℤ_ℂ(z_false);
   const auto c_unknown = embed_ℤ_ℂ(z_unknown);
   const auto c_true = embed_ℤ_ℂ(z_true);
 
-  const auto has_positive_real = [](const Complex<double>& z) {
+  const auto has_positive_real = [](const Complex<machine_real_scalar>& z) {
     return z.real() > 0.0;
   };
 

--- a/src/test/cpp/modules/dedekind/numbers/tower_test.cpp
+++ b/src/test/cpp/modules/dedekind/numbers/tower_test.cpp
@@ -26,39 +26,39 @@ using namespace dedekind::sets;
 // ---------------------------------------------------------------------------
 
 static_assert(IsMonicArrow<Identity<int>>);
-static_assert(IsMonicArrow<std::decay_t<decltype(embed_B_N)>>);
-static_assert(IsMonicArrow<std::decay_t<decltype(embed_N_Z)>>);
-static_assert(IsMonicArrow<std::decay_t<decltype(embed_K3_Z)>>);
-static_assert(IsMonicArrow<std::decay_t<decltype(embed_Z_Q)>>);
-static_assert(IsMonicArrow<std::decay_t<decltype(embed_Q_R)>>);
-static_assert(IsMonicArrow<std::decay_t<decltype(embed_R_C)>>);
+static_assert(IsMonicArrow<std::decay_t<decltype(embed_𝔹_ℕ)>>);
+static_assert(IsMonicArrow<std::decay_t<decltype(embed_ℕ_ℤ)>>);
+static_assert(IsMonicArrow<std::decay_t<decltype(embed_K3_ℤ)>>);
+static_assert(IsMonicArrow<std::decay_t<decltype(embed_ℤ_ℚ)>>);
+static_assert(IsMonicArrow<std::decay_t<decltype(embed_ℚ_ℝ)>>);
+static_assert(IsMonicArrow<std::decay_t<decltype(embed_ℝ_ℂ)>>);
 
 // ---------------------------------------------------------------------------
 // Arrow types are correct (compile-time)
 // ---------------------------------------------------------------------------
 
-static_assert(std::same_as<Dom<std::decay_t<decltype(embed_B_N)>>, bool>);
-static_assert(std::same_as<Cod<std::decay_t<decltype(embed_B_N)>>, unsigned>);
+static_assert(std::same_as<Dom<std::decay_t<decltype(embed_𝔹_ℕ)>>, bool>);
+static_assert(std::same_as<Cod<std::decay_t<decltype(embed_𝔹_ℕ)>>, unsigned>);
 
-static_assert(std::same_as<Dom<std::decay_t<decltype(embed_N_Z)>>, unsigned>);
-static_assert(std::same_as<Cod<std::decay_t<decltype(embed_N_Z)>>, int>);
+static_assert(std::same_as<Dom<std::decay_t<decltype(embed_ℕ_ℤ)>>, unsigned>);
+static_assert(std::same_as<Cod<std::decay_t<decltype(embed_ℕ_ℤ)>>, int>);
 
-static_assert(std::same_as<Dom<std::decay_t<decltype(embed_K3_Z)>>, Ternary>);
-static_assert(std::same_as<Cod<std::decay_t<decltype(embed_K3_Z)>>, int>);
+static_assert(std::same_as<Dom<std::decay_t<decltype(embed_K3_ℤ)>>, Ternary>);
+static_assert(std::same_as<Cod<std::decay_t<decltype(embed_K3_ℤ)>>, int>);
 
-static_assert(std::same_as<Dom<std::decay_t<decltype(embed_Z_Q)>>, int>);
+static_assert(std::same_as<Dom<std::decay_t<decltype(embed_ℤ_ℚ)>>, int>);
 static_assert(
-    std::same_as<Cod<std::decay_t<decltype(embed_Z_Q)>>, Rational<int>>);
-
-static_assert(
-    std::same_as<Dom<std::decay_t<decltype(embed_Q_R)>>, Rational<int>>);
-static_assert(
-    std::same_as<Cod<std::decay_t<decltype(embed_Q_R)>>, Real<double>>);
+    std::same_as<Cod<std::decay_t<decltype(embed_ℤ_ℚ)>>, Rational<int>>);
 
 static_assert(
-    std::same_as<Dom<std::decay_t<decltype(embed_R_C)>>, Real<double>>);
+    std::same_as<Dom<std::decay_t<decltype(embed_ℚ_ℝ)>>, Rational<int>>);
 static_assert(
-    std::same_as<Cod<std::decay_t<decltype(embed_R_C)>>, Complex<double>>);
+    std::same_as<Cod<std::decay_t<decltype(embed_ℚ_ℝ)>>, Real<double>>);
+
+static_assert(
+    std::same_as<Dom<std::decay_t<decltype(embed_ℝ_ℂ)>>, Real<double>>);
+static_assert(
+    std::same_as<Cod<std::decay_t<decltype(embed_ℝ_ℂ)>>, Complex<double>>);
 
 static_assert(IsSpecies<Rational<int>>);
 static_assert(IsSpecies<Real<double>>);
@@ -68,28 +68,28 @@ static_assert(IsSpecies<Complex<double>>);
 // 𝔹 ↪ ℕ
 // ---------------------------------------------------------------------------
 
-TEST_CASE("Tower: 𝔹 ↪ ℕ via embed_B_N", "[numbers][tower][embedding]") {
+TEST_CASE("Tower: 𝔹 ↪ ℕ via embed_𝔹_ℕ", "[numbers][tower][embedding]") {
   const auto naturals_u =
       ambient_set<unsigned>([](const unsigned&) { return true; });
 
-  CHECK(embed_B_N(false) == 0u);
-  CHECK(embed_B_N(true) == 1u);
+  CHECK(embed_𝔹_ℕ(false) == 0u);
+  CHECK(embed_𝔹_ℕ(true) == 1u);
 
-  CHECK(in_via(false, embed_B_N, naturals_u) == true);
-  CHECK(in_via(true, embed_B_N, naturals_u) == true);
+  CHECK(in_via(false, embed_𝔹_ℕ, naturals_u) == true);
+  CHECK(in_via(true, embed_𝔹_ℕ, naturals_u) == true);
 }
 
 // ---------------------------------------------------------------------------
 // ℕ ↪ ℤ
 // ---------------------------------------------------------------------------
 
-TEST_CASE("Tower: ℕ ↪ ℤ via embed_N_Z", "[numbers][tower][embedding]") {
+TEST_CASE("Tower: ℕ ↪ ℤ via embed_ℕ_ℤ", "[numbers][tower][embedding]") {
   // Unsigned naturals always embed into integers successfully.
   const auto integers = ambient_set<int>([](const int&) { return true; });
 
-  CHECK(in_via(0u, embed_N_Z, integers) == true);
-  CHECK(in_via(42u, embed_N_Z, integers) == true);
-  CHECK(in_via(1000u, embed_N_Z, integers) == true);
+  CHECK(in_via(0u, embed_ℕ_ℤ, integers) == true);
+  CHECK(in_via(42u, embed_ℕ_ℤ, integers) == true);
+  CHECK(in_via(1000u, embed_ℕ_ℤ, integers) == true);
 
   // Membership in the naturals set respects sign.
   CHECK(N(0) == true);
@@ -105,50 +105,50 @@ TEST_CASE("Tower: ℕ ↪ ℤ via embed_N_Z", "[numbers][tower][embedding]") {
 // K3 ↪ ℤ
 // ---------------------------------------------------------------------------
 
-TEST_CASE("Tower: K3 ↪ ℤ via embed_K3_Z", "[numbers][tower][embedding]") {
+TEST_CASE("Tower: K3 ↪ ℤ via embed_K3_ℤ", "[numbers][tower][embedding]") {
   const auto integers = ambient_set<int>([](const int&) { return true; });
 
-  CHECK(embed_K3_Z(Ternary::False) == -1);
-  CHECK(embed_K3_Z(Ternary::Unknown) == 0);
-  CHECK(embed_K3_Z(Ternary::True) == 1);
+  CHECK(embed_K3_ℤ(Ternary::False) == -1);
+  CHECK(embed_K3_ℤ(Ternary::Unknown) == 0);
+  CHECK(embed_K3_ℤ(Ternary::True) == 1);
 
-  CHECK(in_via(Ternary::False, embed_K3_Z, integers) == true);
-  CHECK(in_via(Ternary::Unknown, embed_K3_Z, integers) == true);
-  CHECK(in_via(Ternary::True, embed_K3_Z, integers) == true);
+  CHECK(in_via(Ternary::False, embed_K3_ℤ, integers) == true);
+  CHECK(in_via(Ternary::Unknown, embed_K3_ℤ, integers) == true);
+  CHECK(in_via(Ternary::True, embed_K3_ℤ, integers) == true);
 }
 
 // ---------------------------------------------------------------------------
 // ℤ ↪ ℚ
 // ---------------------------------------------------------------------------
 
-TEST_CASE("Tower: ℤ ↪ ℚ via embed_Z_Q", "[numbers][tower][embedding]") {
+TEST_CASE("Tower: ℤ ↪ ℚ via embed_ℤ_ℚ", "[numbers][tower][embedding]") {
   // Embedding preserves value: n -> n/1.
-  CHECK(embed_Z_Q(3).num() == 3);
-  CHECK(embed_Z_Q(3).den() == 1);
-  CHECK(embed_Z_Q(-5).num() == -5);
+  CHECK(embed_ℤ_ℚ(3).num() == 3);
+  CHECK(embed_ℤ_ℚ(3).den() == 1);
+  CHECK(embed_ℤ_ℚ(-5).num() == -5);
 }
 
 // ---------------------------------------------------------------------------
 // ℚ ↪ ℝ
 // ---------------------------------------------------------------------------
 
-TEST_CASE("Tower: ℚ ↪ ℝ via embed_Q_R", "[numbers][tower][embedding]") {
+TEST_CASE("Tower: ℚ ↪ ℝ via embed_ℚ_ℝ", "[numbers][tower][embedding]") {
   // Embedding preserves value: 3/1 -> 3.0.
-  CHECK(embed_Q_R(Rational<int>{3, 1}).resolve() == 3.0);
-  CHECK(embed_Q_R(Rational<int>{1, 2}).resolve() == 0.5);
-  CHECK(embed_Q_R(Rational<int>{-7, 4}).resolve() == -1.75);
+  CHECK(embed_ℚ_ℝ(Rational<int>{3, 1}).resolve() == 3.0);
+  CHECK(embed_ℚ_ℝ(Rational<int>{1, 2}).resolve() == 0.5);
+  CHECK(embed_ℚ_ℝ(Rational<int>{-7, 4}).resolve() == -1.75);
 }
 
 // ---------------------------------------------------------------------------
 // ℝ ↪ ℂ
 // ---------------------------------------------------------------------------
 
-TEST_CASE("Tower: ℝ ↪ ℂ via embed_R_C", "[numbers][tower][embedding]") {
+TEST_CASE("Tower: ℝ ↪ ℂ via embed_ℝ_ℂ", "[numbers][tower][embedding]") {
   // Embedding: imaginary part is always 0.
-  CHECK(embed_R_C(Real<double>{3.0}).real() == 3.0);
-  CHECK(embed_R_C(Real<double>{3.0}).imag() == 0.0);
-  CHECK(embed_R_C(Real<double>{-2.5}).real() == -2.5);
-  CHECK(embed_R_C(Real<double>{-2.5}).imag() == 0.0);
+  CHECK(embed_ℝ_ℂ(Real<double>{3.0}).real() == 3.0);
+  CHECK(embed_ℝ_ℂ(Real<double>{3.0}).imag() == 0.0);
+  CHECK(embed_ℝ_ℂ(Real<double>{-2.5}).real() == -2.5);
+  CHECK(embed_ℝ_ℂ(Real<double>{-2.5}).imag() == 0.0);
 }
 
 // ---------------------------------------------------------------------------
@@ -157,12 +157,42 @@ TEST_CASE("Tower: ℝ ↪ ℂ via embed_R_C", "[numbers][tower][embedding]") {
 
 TEST_CASE("Tower: composed chain unsigned -> ℤ -> ℚ -> ℝ -> ℂ",
           "[numbers][tower][embedding][composition]") {
-  const auto embed_N_Q = embed_N_Z >> embed_Z_Q;
-  const auto embed_N_R = embed_N_Q >> embed_Q_R;
-  const auto embed_N_C = embed_N_R >> embed_R_C;
+  const auto embed_ℕ_ℚ = embed_ℕ_ℤ >> embed_ℤ_ℚ;
+  const auto embed_ℕ_ℝ = embed_ℕ_ℚ >> embed_ℚ_ℝ;
+  const auto embed_ℕ_ℂ = embed_ℕ_ℝ >> embed_ℝ_ℂ;
 
   // 3 travels the full chain and arrives in ℂ as (3 + 0i).
-  const auto result = embed_N_C(3u);
+  const auto result = embed_ℕ_ℂ(3u);
   CHECK(result.real() == 3.0);
   CHECK(result.imag() == 0.0);
+}
+
+// ---------------------------------------------------------------------------
+// Stress test: Im(K3 -> ℤ) ∩ { z in ℂ | Re(z) > 0 }
+// ---------------------------------------------------------------------------
+
+TEST_CASE("Stress: Im(K3->ℤ) intersect positive-real ℂ",
+          "[numbers][tower][embedding][intersection]") {
+  // Image of K3 in ℤ under canonical embedding: {-1, 0, 1}.
+  const int z_false = embed_K3_ℤ(Ternary::False);
+  const int z_unknown = embed_K3_ℤ(Ternary::Unknown);
+  const int z_true = embed_K3_ℤ(Ternary::True);
+
+  const auto embed_ℤ_ℂ = embed_ℤ_ℚ >> embed_ℚ_ℝ >> embed_ℝ_ℂ;
+
+  const auto c_false = embed_ℤ_ℂ(z_false);
+  const auto c_unknown = embed_ℤ_ℂ(z_unknown);
+  const auto c_true = embed_ℤ_ℂ(z_true);
+
+  const auto has_positive_real = [](const Complex<double>& z) {
+    return z.real() > 0.0;
+  };
+
+  CHECK(has_positive_real(c_false) == false);
+  CHECK(has_positive_real(c_unknown) == false);
+  CHECK(has_positive_real(c_true) == true);
+
+  // Therefore the intersection is exactly {1 + 0i}.
+  CHECK(c_true.real() == 1.0);
+  CHECK(c_true.imag() == 0.0);
 }

--- a/src/test/cpp/modules/dedekind/sets/expressions_test.cpp
+++ b/src/test/cpp/modules/dedekind/sets/expressions_test.cpp
@@ -26,14 +26,13 @@ TEST_CASE("Dedekind MVP: Basic Membership and Symbols", "[sets]") {
 TEST_CASE("Dedekind Identities: Extremal Collapse", "[sets][identities]") {
   auto x = var<ℕ>;
 
-  SECTION("Identity: Set{Ω} is Ω") {
-    // The terminal object should remain terminal
+  SECTION("Identity: Set{N} is N") {
+    // Naturals remain stable when materialized through Set{...}.
     auto U = Set{N};
 
-    // It must satisfy the 'Total Presence' axiom
     static_assert(std::is_same_v<decltype(U)::logic_species, TernaryLogic>);
     REQUIRE(U(42) == Ternary::True);
-    REQUIRE(U(-1) == Ternary::True);
+    REQUIRE(U(-1) == Ternary::False);
   }
 
   SECTION("Contradiction: {x ∈ ℕ | x > 10 ∧ x < 5} is ∅") {


### PR DESCRIPTION
Numeric prototypical tower embedding 𝔹->ℕ->ℤ ->ℚ->ℝ->ℂ with `IsMonicArrow` and `in_via`.


Implemented a semantic split between pure composition and machine realization in the numeric tower.

- Kept ETCS composition/membership generic (`in_via` unchanged).
- Made tower lifts explicit as machine-model realization arrows (not abstractly exact inclusions).
- Introduced model-facing carrier aliases and Dedekind-named carrier concepts so template heads express intent without hard-coding machine primitives in constraints.
- Parameterized predecessor carriers through the tower chain so realizations can vary without changing composition logic.
- Preserved current defaults and behavior for the existing machine model.

Net effect: composition is clean and generic; realization is explicit and honest about approximation/model dependence. This should provide a stable base for either:

- a richer abstract tower later, or
- a primary machine-tower track grounded in `:numeric` and `:partial`.