### PR TITLE
feat(sets): revisit set cardinality and ETCS alignment

### DIFF
--- a/src/main/modules/dedekind/sets/boundaries.cppm
+++ b/src/main/modules/dedekind/sets/boundaries.cppm
@@ -34,9 +34,11 @@
  */
 module;
 
+#include <algorithm>
 #include <compare>
 #include <concepts>
 #include <functional>
+#include <limits>
 
 export module dedekind.sets:boundaries;
 
@@ -228,6 +230,46 @@ export using ℕ = NaturalNumbers;
 
 // Canonical ambient-set value used by the sets DSL tests.
 export inline constexpr ℕ N{};
+
+/**
+ * @brief ETCS-aligned upper bound for meet/intersection cardinality.
+ * @details For extensional sets with explicit `upper_bound()`, this is
+ *          `min(bound(A), bound(B))`. For intensional/transfinite species,
+ *          the function returns the maximal finite sentinel.
+ */
+export template <typename S1, typename S2>
+constexpr std::size_t bound_meet(const S1& lhs, const S2& rhs) {
+  if constexpr (requires {
+                  { lhs.upper_bound() } -> std::convertible_to<std::size_t>;
+                  { rhs.upper_bound() } -> std::convertible_to<std::size_t>;
+                }) {
+    return std::min(static_cast<std::size_t>(lhs.upper_bound()),
+                    static_cast<std::size_t>(rhs.upper_bound()));
+  } else {
+    return std::numeric_limits<std::size_t>::max();
+  }
+}
+
+/**
+ * @brief ETCS-aligned upper bound for join/union cardinality.
+ * @details For extensional sets with explicit `upper_bound()`, this is the
+ *          saturating sum `bound(A) + bound(B)`. For intensional/transfinite
+ *          species, the function returns the maximal finite sentinel.
+ */
+export template <typename S1, typename S2>
+constexpr std::size_t bound_join(const S1& lhs, const S2& rhs) {
+  if constexpr (requires {
+                  { lhs.upper_bound() } -> std::convertible_to<std::size_t>;
+                  { rhs.upper_bound() } -> std::convertible_to<std::size_t>;
+                }) {
+    const std::size_t a = static_cast<std::size_t>(lhs.upper_bound());
+    const std::size_t b = static_cast<std::size_t>(rhs.upper_bound());
+    const std::size_t max_v = std::numeric_limits<std::size_t>::max();
+    return (a > max_v - b) ? max_v : a + b;
+  } else {
+    return std::numeric_limits<std::size_t>::max();
+  }
+}
 
 };  // namespace dedekind::sets
 

--- a/src/main/modules/dedekind/sets/boundaries.cppm
+++ b/src/main/modules/dedekind/sets/boundaries.cppm
@@ -234,17 +234,28 @@ export inline constexpr ℕ N{};
 /**
  * @brief ETCS-aligned upper bound for meet/intersection cardinality.
  * @details For extensional sets with explicit `upper_bound()`, this is
- *          `min(bound(A), bound(B))`. For intensional/transfinite species,
- *          the function returns the maximal finite sentinel.
+ *          `min(bound(A), bound(B))`. If exactly one operand provides an
+ *          explicit finite bound, that bound is still a valid upper bound
+ *          for the meet. For fully intensional/transfinite pairs where
+ *          neither side exposes `upper_bound()`, the function returns the
+ *          maximal finite sentinel.
  */
 export template <typename S1, typename S2>
 constexpr std::size_t bound_meet(const S1& lhs, const S2& rhs) {
-  if constexpr (requires {
-                  { lhs.upper_bound() } -> std::convertible_to<std::size_t>;
-                  { rhs.upper_bound() } -> std::convertible_to<std::size_t>;
-                }) {
+  constexpr bool lhs_has_upper_bound = requires {
+    { lhs.upper_bound() } -> std::convertible_to<std::size_t>;
+  };
+  constexpr bool rhs_has_upper_bound = requires {
+    { rhs.upper_bound() } -> std::convertible_to<std::size_t>;
+  };
+
+  if constexpr (lhs_has_upper_bound && rhs_has_upper_bound) {
     return std::min(static_cast<std::size_t>(lhs.upper_bound()),
                     static_cast<std::size_t>(rhs.upper_bound()));
+  } else if constexpr (lhs_has_upper_bound) {
+    return static_cast<std::size_t>(lhs.upper_bound());
+  } else if constexpr (rhs_has_upper_bound) {
+    return static_cast<std::size_t>(rhs.upper_bound());
   } else {
     return std::numeric_limits<std::size_t>::max();
   }

--- a/src/test/cpp/modules/dedekind/sets/boundaries_test.cpp
+++ b/src/test/cpp/modules/dedekind/sets/boundaries_test.cpp
@@ -1,4 +1,5 @@
 #include <catch2/catch_test_macros.hpp>
+#include <limits>
 import dedekind.category;
 import dedekind.sets;
 
@@ -76,5 +77,33 @@ TEST_CASE("Boundaries: The Algebra of Extremality", "[sets][boundaries]") {
 
     CHECK(not_null(7) == true);
     CHECK(not_universe(7) == false);
+  }
+
+  SECTION("Cardinality bounds for extensional sets are computed explicitly") {
+    constexpr SingletonSet<ℤ> s1{1};
+    constexpr SingletonSet<ℤ> s2{2};
+    constexpr Ø<ℤ> empty;
+
+    CHECK(bound_meet(s1, s2) == 1);
+    CHECK(bound_join(s1, s2) == 2);
+
+    CHECK(bound_meet(empty, s1) == 0);
+    CHECK(bound_join(empty, s1) == 1);
+  }
+
+  SECTION("Cardinality bounds for intensional/transfinite sets use sentinel") {
+    constexpr ℕ naturals;
+    const auto max_v = std::numeric_limits<std::size_t>::max();
+
+    CHECK(bound_meet(universe, naturals) == max_v);
+    CHECK(bound_join(universe, naturals) == max_v);
+  }
+
+  SECTION("Identity optimizations remain structurally valid") {
+    constexpr SingletonSet<ℤ> s{42};
+    constexpr Ø<ℤ> empty;
+
+    CHECK(std::is_same_v<decltype(empty | s), SingletonSet<ℤ>>);
+    CHECK(std::is_same_v<decltype(universe & s), SingletonSet<ℤ>>);
   }
 }

--- a/src/test/cpp/modules/dedekind/sets/boundaries_test.cpp
+++ b/src/test/cpp/modules/dedekind/sets/boundaries_test.cpp
@@ -93,10 +93,15 @@ TEST_CASE("Boundaries: The Algebra of Extremality", "[sets][boundaries]") {
 
   SECTION("Cardinality bounds for intensional/transfinite sets use sentinel") {
     constexpr ℕ naturals;
+    constexpr Ø<ℤ> empty;
+    constexpr SingletonSet<ℤ> singleton{7};
     const auto max_v = std::numeric_limits<std::size_t>::max();
 
     CHECK(bound_meet(universe, naturals) == max_v);
     CHECK(bound_join(universe, naturals) == max_v);
+
+    CHECK(bound_meet(empty, naturals) == 0);
+    CHECK(bound_meet(singleton, naturals) == 1);
   }
 
   SECTION("Identity optimizations remain structurally valid") {


### PR DESCRIPTION
Closes #129

First implementation slice:
- align cardinality terminology with ETCS set operations
- add compile-time cardinality bounds for basic set combinators
- test extensional vs intensional behavior and optimization identities