### PR TITLE
feat(sets): revisit half-spaces and intervals

### DIFF
--- a/src/main/modules/dedekind/topology/interval.cppm
+++ b/src/main/modules/dedekind/topology/interval.cppm
@@ -37,17 +37,48 @@ using namespace dedekind::sets;
 using namespace dedekind::order;
 
 export enum class Direction { Upward, Downward };
+export enum class Boundary { Open, Closed };
+
+namespace detail {
+
+template <Boundary B>
+struct BoundaryTag {};
+
+template <>
+struct BoundaryTag<Boundary::Open> {
+  using is_open_tag = void;
+};
+
+template <>
+struct BoundaryTag<Boundary::Closed> {
+  using is_closed_tag = void;
+};
+
+template <Boundary Lower, Boundary Upper>
+struct IntervalBoundaryTag {};
+
+template <>
+struct IntervalBoundaryTag<Boundary::Open, Boundary::Open> {
+  using is_open_tag = void;
+};
+
+template <>
+struct IntervalBoundaryTag<Boundary::Closed, Boundary::Closed> {
+  using is_closed_tag = void;
+};
+
+}  // namespace detail
 
 /**
  * @class Ray
  * @brief A Half-Space satisfying the Idempotent Semigroupoid laws.
  */
-export template <IsTotallyOrdered T, Direction D, typename L = ClassicalLogic>
-class Ray {
+export template <IsTotallyOrdered T, Direction D, Boundary B = Boundary::Open,
+                 typename L = ClassicalLogic>
+class Ray : public detail::BoundaryTag<B> {
  public:
   using Domain = T;
   using Codomain = typename L::Ω;
-  using is_open_tag = void;
   using is_ray_tag = void;
 
   /** @section Algebraic_Axioms */
@@ -64,9 +95,11 @@ class Ray {
   /** @section Logic: Characteristic Function */
   constexpr auto operator()(const T& x) const {
     if constexpr (D == Direction::Upward)
-      return x > pivot_ ? L::True : L::False;
+      return (B == Boundary::Open ? x > pivot_ : x >= pivot_) ? L::True
+                                                              : L::False;
     else
-      return x < pivot_ ? L::True : L::False;
+      return (B == Boundary::Open ? x < pivot_ : x <= pivot_) ? L::True
+                                                              : L::False;
   }
 
   /** @section Algebraic_Laws: The Rhyme of the Lattice */
@@ -101,14 +134,14 @@ class Ray {
  * @class Interval
  * @brief The "Molecule" formed by the intersection of two Rays.
  */
-export template <IsTotallyOrdered T, typename L = ClassicalLogic>
-class Interval {
+export template <IsTotallyOrdered T, Boundary Lower = Boundary::Open,
+                 Boundary Upper = Boundary::Open, typename L = ClassicalLogic>
+class Interval : public detail::IntervalBoundaryTag<Lower, Upper> {
  public:
   using Domain = T;
   using Codomain = typename L::Ω;
-  using is_open_tag = void;
-  using lower_ray_type = Ray<T, Direction::Upward, L>;
-  using upper_ray_type = Ray<T, Direction::Downward, L>;
+  using lower_ray_type = Ray<T, Direction::Upward, Lower, L>;
+  using upper_ray_type = Ray<T, Direction::Downward, Upper, L>;
 
   constexpr Interval(T low, T high) : lower_(low), upper_(high) {}
 
@@ -116,6 +149,8 @@ class Interval {
 
   constexpr T lower_bound() const { return lower_.pivot(); }
   constexpr T upper_bound() const { return upper_.pivot(); }
+  static constexpr Boundary lower_boundary = Lower;
+  static constexpr Boundary upper_boundary = Upper;
 
  private:
   lower_ray_type lower_;
@@ -123,11 +158,11 @@ class Interval {
 };
 
 /** @section Trait_Registration */
-export template <typename T, Direction D, typename L>
-inline constexpr bool is_convex_v<Ray<T, D, L>> = true;
+export template <typename T, Direction D, Boundary B, typename L>
+inline constexpr bool is_convex_v<Ray<T, D, B, L>> = true;
 
-export template <typename T, typename L>
-inline constexpr bool is_convex_v<Interval<T, L>> = true;
+export template <typename T, Boundary Lower, Boundary Upper, typename L>
+inline constexpr bool is_convex_v<Interval<T, Lower, Upper, L>> = true;
 
 /** @section Formal_Verification
  * Deferred while topology interval contracts are being retargeted to the
@@ -143,8 +178,9 @@ inline constexpr bool is_convex_v<Interval<T, L>> = true;
  */
 namespace dedekind::category {
 
-export template <typename T, dedekind::topology::Direction D>
-struct SpeciesTraits<dedekind::topology::Ray<T, D>> {
+export template <typename T, dedekind::topology::Direction D,
+                 dedekind::topology::Boundary B, typename L>
+struct SpeciesTraits<dedekind::topology::Ray<T, D, B, L>> {
   using species = ClassicalLogic;
   using Domain = T;
   using Codomain = T;
@@ -156,20 +192,25 @@ struct SpeciesTraits<dedekind::topology::Ray<T, D>> {
 /** @section Mereological_Harmony */
 
 // We must explicitly register the Lattice Axioms for IsSet to resolve.
-template <typename T, dedekind::topology::Direction D>
+template <typename T, dedekind::topology::Direction D,
+          dedekind::topology::Boundary B, typename L>
 inline constexpr bool
-    is_associative_v<dedekind::topology::Ray<T, D>, std::bit_and<>> = true;
+    is_associative_v<dedekind::topology::Ray<T, D, B, L>, std::bit_and<>> =
+        true;
 
-template <typename T, dedekind::topology::Direction D>
+template <typename T, dedekind::topology::Direction D,
+          dedekind::topology::Boundary B, typename L>
 inline constexpr bool
-    is_idempotent_v<dedekind::topology::Ray<T, D>, std::bit_and<>> = true;
+    is_idempotent_v<dedekind::topology::Ray<T, D, B, L>, std::bit_and<>> = true;
 
-template <typename T, dedekind::topology::Direction D>
+template <typename T, dedekind::topology::Direction D,
+          dedekind::topology::Boundary B, typename L>
 inline constexpr bool
-    is_associative_v<dedekind::topology::Ray<T, D>, std::bit_or<>> = true;
+    is_associative_v<dedekind::topology::Ray<T, D, B, L>, std::bit_or<>> = true;
 
-template <typename T, dedekind::topology::Direction D>
+template <typename T, dedekind::topology::Direction D,
+          dedekind::topology::Boundary B, typename L>
 inline constexpr bool
-    is_idempotent_v<dedekind::topology::Ray<T, D>, std::bit_or<>> = true;
+    is_idempotent_v<dedekind::topology::Ray<T, D, B, L>, std::bit_or<>> = true;
 
 }  // namespace dedekind::category

--- a/src/test/cpp/modules/dedekind/topology/shapes_test.cpp
+++ b/src/test/cpp/modules/dedekind/topology/shapes_test.cpp
@@ -13,16 +13,26 @@ TEST_CASE("Topology: Rules of Continuity Coverage", "[topology][continuity]") {
   using ℝ = int;
   using UnitRay = Ray<ℝ, Direction::Upward>;
   using UnitInterval = Interval<ℝ>;
+  using ClosedUnitRay = Ray<ℝ, Direction::Upward, Boundary::Closed>;
+  using ClosedUnitInterval = Interval<ℝ, Boundary::Closed, Boundary::Closed>;
+  using LeftClosedInterval = Interval<ℝ, Boundary::Closed, Boundary::Open>;
 
   SECTION("The Skin and Body: IsOpen Verification") {
     // Rays and Open Intervals must carry the is_open_tag
     static_assert(IsOpen<UnitRay>, "Topology: Ray must be an Open set.");
     static_assert(IsOpen<UnitInterval>,
                   "Topology: Interval must be an Open set.");
+    static_assert(IsClosed<ClosedUnitRay>,
+                  "Topology: closed ray must satisfy IsClosed.");
+    static_assert(IsClosed<ClosedUnitInterval>,
+                  "Topology: closed interval must satisfy IsClosed.");
+    static_assert(!IsOpen<ClosedUnitInterval>,
+                  "Topology: closed interval should not satisfy IsOpen.");
 
     // Verify they are recognized as Convex (No holes)
     static_assert(IsConvex<UnitRay>);
     static_assert(IsConvex<UnitInterval>);
+    static_assert(IsConvex<ClosedUnitInterval>);
   }
 
   SECTION("Neighborhoods: The Space Around a Point") {
@@ -60,5 +70,46 @@ TEST_CASE("Topology: Rules of Continuity Coverage", "[topology][continuity]") {
     static_assert((std::same_as<decltype(std::declval<UnitRay>() &
                                          std::declval<UnitRay>()),
                                 UnitRay>));
+  }
+
+  SECTION("Boundary semantics for open and closed intervals") {
+    UnitInterval open_interval(0, 3);
+    ClosedUnitInterval closed_interval(0, 3);
+    LeftClosedInterval left_closed_interval(0, 3);
+
+    CHECK(open_interval(0) == dedekind::category::ClassicalLogic::False);
+    CHECK(open_interval(1) == dedekind::category::ClassicalLogic::True);
+    CHECK(open_interval(3) == dedekind::category::ClassicalLogic::False);
+
+    CHECK(closed_interval(0) == dedekind::category::ClassicalLogic::True);
+    CHECK(closed_interval(3) == dedekind::category::ClassicalLogic::True);
+    CHECK(closed_interval(4) == dedekind::category::ClassicalLogic::False);
+
+    CHECK(left_closed_interval(0) == dedekind::category::ClassicalLogic::True);
+    CHECK(left_closed_interval(3) == dedekind::category::ClassicalLogic::False);
+
+    constexpr ClosedUnitInterval constexpr_closed(0, 2);
+    static_assert(constexpr_closed(0) ==
+                  dedekind::category::ClassicalLogic::True);
+    static_assert(constexpr_closed(2) ==
+                  dedekind::category::ClassicalLogic::True);
+    static_assert(constexpr_closed(3) ==
+                  dedekind::category::ClassicalLogic::False);
+  }
+
+  SECTION("Intervals compose as predicates in set-builder notation") {
+    using namespace dedekind::category;
+    using namespace dedekind::sets;
+
+    auto x = var<Ω<int>>;
+    UnitInterval open_mid(0, 3);
+
+    auto in_open_mid = Set{x % Ω<int>{} | [open_mid](const int& value) {
+      return open_mid(value);
+    }};
+
+    CHECK(in_open_mid(1) == Ternary::True);
+    CHECK(in_open_mid(0) == Ternary::False);
+    CHECK(in_open_mid(3) == Ternary::False);
   }
 }


### PR DESCRIPTION
Closes #131

Draft plan:
- audit existing half-space/interval definitions and convex-set linkage
- align terminology and behavior with ETCS-style set predicates
- add focused tests for set-builder usage and open/closed bound behavior
- evaluate compile-time-friendly bound-check optimizations where type information is available