### PR TITLE
feat(topology,sequences): iterate on topology and sequences modules

### DIFF
--- a/src/main/modules/dedekind/sequences/ranges.cppm
+++ b/src/main/modules/dedekind/sequences/ranges.cppm
@@ -37,6 +37,7 @@ module;
 
 #include <concepts>
 #include <cstddef>
+#include <cstdint>
 
 export module dedekind.sequences:ranges;
 
@@ -138,9 +139,14 @@ class IntegerInterval
    * @details Computes the number of integers in the interval exactly.
    */
   constexpr std::size_t size() const noexcept {
-    const T elo = (Lower == Boundary::Closed) ? lo_ : T(lo_ + T(1));
-    const T ehi = (Upper == Boundary::Open) ? T(hi_ - T(1)) : hi_;
-    return (ehi >= elo) ? static_cast<std::size_t>(ehi - elo + T(1)) : 0u;
+    // Use int64_t to avoid signed overflow / unsigned wrap when adjusting
+    // the bounds by ±1 for open boundaries.
+    using W = std::int64_t;
+    const W wlo = static_cast<W>(lo_);
+    const W whi = static_cast<W>(hi_);
+    const W elo = (Lower == Boundary::Closed) ? wlo : wlo + W(1);
+    const W ehi = (Upper == Boundary::Open) ? whi - W(1) : whi;
+    return (ehi >= elo) ? static_cast<std::size_t>(ehi - elo + W(1)) : 0u;
   }
 
   /**
@@ -154,9 +160,13 @@ class IntegerInterval
    * @return A Path<T> whose first size() elements enumerate the interval.
    */
   constexpr auto as_sequence() const {
-    const T start = (Lower == Boundary::Closed) ? lo_ : T(lo_ + T(1));
+    // Use int64_t for the same reason as size(): avoid signed overflow /
+    // unsigned wrap when the lower boundary is open.
+    using W = std::int64_t;
+    const W start = (Lower == Boundary::Closed) ? static_cast<W>(lo_)
+                                                : static_cast<W>(lo_) + W(1);
     return Path<T>{[start](std::size_t i) {
-      return static_cast<T>(start + static_cast<T>(i));
+      return static_cast<T>(start + static_cast<W>(i));
     }};
   }
 

--- a/src/main/modules/dedekind/sequences/ranges.cppm
+++ b/src/main/modules/dedekind/sequences/ranges.cppm
@@ -1,0 +1,200 @@
+/**
+ * @file dedekind/sequences/ranges.cppm
+ * @partition :ranges
+ * @brief Level 2.6: The Integer Interval — A Serendipitous Bridge.
+ *
+ * @copyright 2026 The Dedekind Authors
+ * Licensed under the Apache License, Version 2.0.
+ *
+ * @section Serendipity: The Triple Nature of the Integer Interval
+ * For any integral type T, the integer interval [a, b) is simultaneously:
+ *
+ *   1. **A Sequence** (IsTerminalSet via as_sequence()):
+ *      The injective enumeration f(i) = a + i, f: ℕ → T.
+ *
+ *   2. **A Set with unique elements:**
+ *      f is injective ⟹ no element appears twice (set axiom holds).
+ *
+ *   3. **A Convex Set** (IsConvex):
+ *      x ∈ [a,b), y ∈ [a,b), x ≤ z ≤ y  ⟹  z ∈ [a,b).
+ *      It is the integer analog of a topological interval.
+ *
+ * @details
+ * IntegerInterval<T, Lower, Upper, L> reifies this triple nature within the
+ * dedekind framework:
+ *   - IsPredicate / IsConvex:      Domain = T, Codomain = Ω,
+ *                                  operator()(T) → Ω.
+ *   - IsCountableSet / IsTerminalSet: as_sequence() → Path<T>, size().
+ *   - Uniqueness:                  formalized as a static_assert on
+ *                                  injectivity of the sequence generator.
+ *
+ * The default boundary convention [lo, hi) mirrors std::ranges::iota_view
+ * and standard C++ iterator practice.
+ *
+ * Wikipedia: Integer lattice, Convex set, Injective function
+ */
+module;
+
+#include <concepts>
+#include <cstddef>
+
+export module dedekind.sequences:ranges;
+
+import dedekind.category;
+import dedekind.sets;
+import dedekind.topology;
+import :net;
+import :path;
+
+namespace dedekind::sequences {
+using namespace dedekind::category;
+using namespace dedekind::topology;
+
+/**
+ * @concept IsConvexEnumerable
+ * @brief A convex set that is also finitely enumerable (a terminal set).
+ *
+ * @details This concept captures the serendipitous combination found in
+ * integer intervals: they are topologically convex (no holes) AND finitely
+ * enumerable (a terminal countable set). Integer intervals are the canonical
+ * witness for this concept.
+ *
+ * @see IntegerInterval
+ */
+export template <typename S>
+concept IsConvexEnumerable = IsConvex<S> && IsTerminalSet<S>;
+
+namespace detail {
+
+/**
+ * @brief Boundary tag mixin for the open/closed corners of IntegerInterval.
+ * Mirrors the convention in dedekind::topology::detail::IntervalBoundaryTag.
+ */
+template <Boundary Lower, Boundary Upper>
+struct IntegerIntervalBoundaryMixin {};
+
+template <>
+struct IntegerIntervalBoundaryMixin<Boundary::Open, Boundary::Open> {
+  using is_open_tag = void;
+};
+
+template <>
+struct IntegerIntervalBoundaryMixin<Boundary::Closed, Boundary::Closed> {
+  using is_closed_tag = void;
+};
+
+}  // namespace detail
+
+/**
+ * @class IntegerInterval
+ * @brief The integer interval — serendipitously a sequence, a set, and a
+ * convex set.
+ *
+ * @tparam T      An integral type (the element species).
+ * @tparam Lower  Boundary policy for the lower bound (default: Closed).
+ * @tparam Upper  Boundary policy for the upper bound (default: Open).
+ * @tparam L      The subobject classifier logic (default: ClassicalLogic).
+ *
+ * @note The default [lo, hi) is the integer analog of std::ranges::iota_view.
+ *
+ * @par Triple nature (static assertions in the test suite)
+ * | Property     | Concept              | Witness                     |
+ * |:-------------|:---------------------|:----------------------------|
+ * | Convex set   | IsConvex             | is_convex_v registration    |
+ * | Unique elems | —                    | injectivity of as_sequence()|
+ * | Finite seq   | IsTerminalSet        | size() + as_sequence()      |
+ * | All three    | IsConvexEnumerable   | combination                 |
+ */
+export template <std::integral T, Boundary Lower = Boundary::Closed,
+                 Boundary Upper = Boundary::Open, typename L = ClassicalLogic>
+class IntegerInterval
+    : public detail::IntegerIntervalBoundaryMixin<Lower, Upper> {
+ public:
+  using Domain = T;
+  using Codomain = typename L::Ω;
+
+  static constexpr Boundary lower_boundary = Lower;
+  static constexpr Boundary upper_boundary = Upper;
+
+  constexpr IntegerInterval(T lo, T hi) : lo_(lo), hi_(hi) {}
+
+  /**
+   * @brief Characteristic morphism χ: T → Ω (the predicate / set view).
+   * @details Is x a member of this interval?
+   */
+  constexpr Codomain operator()(const T& x) const noexcept {
+    if constexpr (Lower == Boundary::Closed && Upper == Boundary::Open)
+      return (x >= lo_ && x < hi_) ? L::True : L::False;
+    else if constexpr (Lower == Boundary::Closed && Upper == Boundary::Closed)
+      return (x >= lo_ && x <= hi_) ? L::True : L::False;
+    else if constexpr (Lower == Boundary::Open && Upper == Boundary::Open)
+      return (x > lo_ && x < hi_) ? L::True : L::False;
+    else  // Open, Closed
+      return (x > lo_ && x <= hi_) ? L::True : L::False;
+  }
+
+  /**
+   * @brief Cardinality of the interval as a finite set.
+   * @details Computes the number of integers in the interval exactly.
+   */
+  constexpr std::size_t size() const noexcept {
+    const T elo = (Lower == Boundary::Closed) ? lo_ : T(lo_ + T(1));
+    const T ehi = (Upper == Boundary::Open) ? T(hi_ - T(1)) : hi_;
+    return (ehi >= elo) ? static_cast<std::size_t>(ehi - elo + T(1)) : 0u;
+  }
+
+  /**
+   * @brief Sequence view: the injective enumeration f(i) = lo + i.
+   *
+   * @details
+   * The generator is injective: i ≠ j ⟹ f(i) ≠ f(j). This witnesses
+   * the uniqueness (set) property of the integer interval. Callers
+   * should read at most size() terms to stay within the interval.
+   *
+   * @return A Path<T> whose first size() elements enumerate the interval.
+   */
+  constexpr auto as_sequence() const {
+    const T start = (Lower == Boundary::Closed) ? lo_ : T(lo_ + T(1));
+    return Path<T>{[start](std::size_t i) {
+      return static_cast<T>(start + static_cast<T>(i));
+    }};
+  }
+
+  constexpr T lower_bound() const noexcept { return lo_; }
+  constexpr T upper_bound() const noexcept { return hi_; }
+
+ private:
+  T lo_, hi_;
+};
+
+}  // namespace dedekind::sequences
+
+// --- Trait registrations (re-open peer namespaces, mirroring the pattern in
+//     dedekind::topology::interval.cppm) ---
+
+namespace dedekind::topology {
+
+/**
+ * @brief Register IntegerInterval as a convex set.
+ * @details An integer interval is a contiguous lattice segment with no holes,
+ *          satisfying the topological definition of convexity over ℤ.
+ */
+export template <std::integral T, Boundary Lower, Boundary Upper, typename L>
+inline constexpr bool
+    is_convex_v<dedekind::sequences::IntegerInterval<T, Lower, Upper, L>> =
+        true;
+
+}  // namespace dedekind::topology
+
+namespace dedekind::category {
+
+/** @brief Register IntegerInterval in the species atlas. */
+export template <std::integral T, dedekind::topology::Boundary Lower,
+                 dedekind::topology::Boundary Upper, typename L>
+struct SpeciesTraits<dedekind::sequences::IntegerInterval<T, Lower, Upper, L>> {
+  using Domain = T;
+  using Codomain = typename L::Ω;
+  using cardinality_type = dedekind::sets::Finite;
+};
+
+}  // namespace dedekind::category

--- a/src/main/modules/dedekind/sequences/sequences.cppm
+++ b/src/main/modules/dedekind/sequences/sequences.cppm
@@ -10,3 +10,4 @@ export module dedekind.sequences;
 export import :net;
 export import :limits;
 export import :path;
+export import :ranges;

--- a/src/main/modules/dedekind/topology/interval.cppm
+++ b/src/main/modules/dedekind/topology/interval.cppm
@@ -164,6 +164,95 @@ inline constexpr bool is_convex_v<Ray<T, D, B, L>> = true;
 export template <typename T, Boundary Lower, Boundary Upper, typename L>
 inline constexpr bool is_convex_v<Interval<T, Lower, Upper, L>> = true;
 
+/**
+ * @class HalfSpace
+ * @brief A runtime-direction Ray — the general form of a half-space.
+ *
+ * @details
+ * While Ray<T,D,B,L> encodes direction at compile time, HalfSpace<T,B,L>
+ * stores direction at runtime. This makes it the natural witness for the
+ * IsRay<R,T> concept, which requires a single type R to produce both
+ * upward and downward half-spaces through static factory methods:
+ *
+ *   HalfSpace<T>::upward_from(pivot)   — { x | x > pivot }  (Open)
+ *   HalfSpace<T>::downward_from(pivot) — { x | x < pivot }  (Open)
+ *
+ * The two types are complementary:
+ *   - Ray<T,D,B,L>  — compile-time direction; no runtime overhead.
+ *   - HalfSpace<T,B,L> — runtime direction; satisfies IsRay<R,T>.
+ *
+ * Both satisfy IsHalfSpace.
+ *
+ * @tparam T The element species (must be totally ordered).
+ * @tparam B The boundary policy (Open or Closed).
+ * @tparam L The subobject classifier logic.
+ */
+export template <IsTotallyOrdered T, Boundary B = Boundary::Open,
+                 typename L = ClassicalLogic>
+class HalfSpace : public detail::BoundaryTag<B> {
+ public:
+  using Domain = T;
+  using Codomain = typename L::Ω;
+  using is_ray_tag = void;
+
+  template <typename Op>
+  static constexpr bool is_associative_v = true;
+  template <typename Op>
+  static constexpr bool is_idempotent_v = true;
+
+  /** @brief Factory: { x | x > pivot } or { x | x >= pivot }. */
+  static constexpr HalfSpace upward_from(T pivot) {
+    return HalfSpace{pivot, Direction::Upward};
+  }
+  /** @brief Factory: { x | x < pivot } or { x | x <= pivot }. */
+  static constexpr HalfSpace downward_from(T pivot) {
+    return HalfSpace{pivot, Direction::Downward};
+  }
+
+  /** @brief Construct from a compile-time Ray (direction preserving). */
+  template <Direction D>
+  constexpr explicit HalfSpace(const Ray<T, D, B, L>& ray)
+      : pivot_(ray.pivot()), dir_(D) {}
+
+  constexpr T pivot() const { return pivot_; }
+  constexpr Direction direction() const { return dir_; }
+
+  /** @brief Characteristic morphism χ: T → Ω. */
+  constexpr Codomain operator()(const T& x) const noexcept {
+    if (dir_ == Direction::Upward)
+      return (B == Boundary::Open ? x > pivot_ : x >= pivot_) ? L::True
+                                                              : L::False;
+    else
+      return (B == Boundary::Open ? x < pivot_ : x <= pivot_) ? L::True
+                                                              : L::False;
+  }
+
+  /** @brief Intersection: yields the stricter of two same-direction halves. */
+  friend constexpr HalfSpace operator&(const HalfSpace& a, const HalfSpace& b) {
+    if (a.dir_ == Direction::Upward)
+      return HalfSpace{std::max(a.pivot_, b.pivot_), Direction::Upward};
+    else
+      return HalfSpace{std::min(a.pivot_, b.pivot_), Direction::Downward};
+  }
+
+  /** @brief Union: yields the looser of two same-direction halves. */
+  friend constexpr HalfSpace operator|(const HalfSpace& a, const HalfSpace& b) {
+    if (a.dir_ == Direction::Upward)
+      return HalfSpace{std::min(a.pivot_, b.pivot_), Direction::Upward};
+    else
+      return HalfSpace{std::max(a.pivot_, b.pivot_), Direction::Downward};
+  }
+
+ private:
+  constexpr HalfSpace(T pivot, Direction d) : pivot_(pivot), dir_(d) {}
+
+  T pivot_;
+  Direction dir_;
+};
+
+export template <typename T, Boundary B, typename L>
+inline constexpr bool is_convex_v<HalfSpace<T, B, L>> = true;
+
 /** @section Formal_Verification
  * Deferred while topology interval contracts are being retargeted to the
  * current category/sets concept split.
@@ -212,5 +301,37 @@ template <typename T, dedekind::topology::Direction D,
           dedekind::topology::Boundary B, typename L>
 inline constexpr bool
     is_idempotent_v<dedekind::topology::Ray<T, D, B, L>, std::bit_or<>> = true;
+
+/** @section HalfSpace_Harmony */
+
+export template <typename T, dedekind::topology::Boundary B, typename L>
+struct SpeciesTraits<dedekind::topology::HalfSpace<T, B, L>> {
+  using species = ClassicalLogic;
+  using Domain = T;
+  using Codomain = T;
+
+  static constexpr auto cardinality =
+      std::integral<T> ? CardinalityTag::Countable : CardinalityTag::Continuum;
+};
+
+template <typename T, dedekind::topology::Boundary B, typename L>
+inline constexpr bool
+    is_associative_v<dedekind::topology::HalfSpace<T, B, L>, std::bit_and<>> =
+        true;
+
+template <typename T, dedekind::topology::Boundary B, typename L>
+inline constexpr bool
+    is_idempotent_v<dedekind::topology::HalfSpace<T, B, L>, std::bit_and<>> =
+        true;
+
+template <typename T, dedekind::topology::Boundary B, typename L>
+inline constexpr bool
+    is_associative_v<dedekind::topology::HalfSpace<T, B, L>, std::bit_or<>> =
+        true;
+
+template <typename T, dedekind::topology::Boundary B, typename L>
+inline constexpr bool
+    is_idempotent_v<dedekind::topology::HalfSpace<T, B, L>, std::bit_or<>> =
+        true;
 
 }  // namespace dedekind::category

--- a/src/main/modules/dedekind/topology/interval.cppm
+++ b/src/main/modules/dedekind/topology/interval.cppm
@@ -21,6 +21,7 @@
  * @dependency :topology, :order, :mereology
  */
 module;
+#include <cassert>
 #include <concepts>
 #include <functional>
 export module dedekind.topology:interval;
@@ -218,7 +219,7 @@ class HalfSpace : public detail::BoundaryTag<B> {
   constexpr Direction direction() const { return dir_; }
 
   /** @brief Characteristic morphism χ: T → Ω. */
-  constexpr Codomain operator()(const T& x) const noexcept {
+  constexpr Codomain operator()(const T& x) const {
     if (dir_ == Direction::Upward)
       return (B == Boundary::Open ? x > pivot_ : x >= pivot_) ? L::True
                                                               : L::False;

--- a/src/test/cpp/modules/dedekind/sequences/integer_interval_test.cpp
+++ b/src/test/cpp/modules/dedekind/sequences/integer_interval_test.cpp
@@ -1,0 +1,97 @@
+#include <catch2/catch_test_macros.hpp>
+
+import dedekind.sequences;
+import dedekind.topology;
+import dedekind.category;
+
+using namespace dedekind::sequences;
+using namespace dedekind::topology;
+using namespace dedekind::category;
+
+// Default: closed–open [lo, hi)
+using II = IntegerInterval<int>;
+// Fully closed [lo, hi]
+using CI = IntegerInterval<int, Boundary::Closed, Boundary::Closed>;
+
+TEST_CASE("IntegerInterval: the serendipitous bridge",
+          "[sequences][topology]") {
+  /**
+   * The serendipitous finding: an integer interval is simultaneously
+   *   1. A convex set    (IsConvex)
+   *   2. A set with unique elements  (injectivity of as_sequence())
+   *   3. A finite enumerable set     (IsTerminalSet)
+   * All three combine into IsConvexEnumerable.
+   */
+
+  SECTION("Axiomatic: the triple property") {
+    // 1. Convex set
+    static_assert(IsConvex<II>);
+    // 2. Finite enumerable set
+    static_assert(IsTerminalSet<II>);
+    // 3. The serendipitous combination
+    static_assert(IsConvexEnumerable<II>);
+
+    // Closed variant satisfies the same triple
+    static_assert(IsConvexEnumerable<CI>);
+  }
+
+  SECTION("Predicate view: set membership χ: ℤ → bool") {
+    II interval{1, 5};  // [1, 5): contains 1,2,3,4
+
+    REQUIRE(interval(1));   // lower bound included (Closed)
+    REQUIRE(interval(4));   // last element included
+    REQUIRE(!interval(5));  // upper bound excluded (Open)
+    REQUIRE(!interval(0));  // below lower bound
+  }
+
+  SECTION("Size: finite cardinality as a set") {
+    REQUIRE(II{1, 5}.size() == 4u);  // {1,2,3,4}
+    REQUIRE(II{0, 1}.size() == 1u);  // {0}
+    REQUIRE(II{3, 3}.size() == 0u);  // empty (lo == hi in half-open)
+    REQUIRE(II{5, 3}.size() == 0u);  // empty (inverted)
+
+    REQUIRE(CI{1, 5}.size() == 5u);  // {1,2,3,4,5}
+    REQUIRE(CI{3, 3}.size() == 1u);  // {3} — single element
+  }
+
+  SECTION("Sequence view: injective enumeration f(i) = lo + i") {
+    II interval{1, 5};
+    auto seq = interval.as_sequence();
+
+    static_assert(IsSequence<decltype(seq)>);
+
+    REQUIRE(seq.at(0) == 1);  // f(0) = 1
+    REQUIRE(seq.at(3) == 4);  // f(3) = 4
+  }
+
+  SECTION("Uniqueness: injective generator witnesses the set axiom") {
+    II interval{1, 5};
+    auto seq = interval.as_sequence();
+
+    // i ≠ j implies f(i) ≠ f(j) for all i,j < size()
+    for (std::size_t i = 0; i < interval.size(); ++i)
+      for (std::size_t j = i + 1; j < interval.size(); ++j)
+        REQUIRE(seq.at(i) != seq.at(j));
+  }
+
+  SECTION("Closed interval [1, 5]: all boundary policies") {
+    CI interval{1, 5};  // [1, 5]
+
+    REQUIRE(interval(1));   // lower bound included
+    REQUIRE(interval(5));   // upper bound included (Closed)
+    REQUIRE(!interval(6));  // above upper bound
+    REQUIRE(!interval(0));  // below lower bound
+
+    auto seq = interval.as_sequence();
+    REQUIRE(seq.at(0) == 1);
+    REQUIRE(seq.at(4) == 5);  // 5th element (0-indexed) of {1,2,3,4,5}
+  }
+
+  SECTION("Boundary accessors") {
+    II interval{2, 7};
+    REQUIRE(interval.lower_bound() == 2);
+    REQUIRE(interval.upper_bound() == 7);
+    static_assert(II::lower_boundary == Boundary::Closed);
+    static_assert(II::upper_boundary == Boundary::Open);
+  }
+}

--- a/src/test/cpp/modules/dedekind/topology/shapes_test.cpp
+++ b/src/test/cpp/modules/dedekind/topology/shapes_test.cpp
@@ -65,6 +65,48 @@ TEST_CASE("Topology: Rules of Continuity Coverage", "[topology][continuity]") {
     static_assert(IsHalfSpace<typename UnitInterval::upper_ray_type>);
   }
 
+  SECTION("HalfSpace: the general runtime-direction ray") {
+    using HS = HalfSpace<ℝ>;
+
+    // HalfSpace satisfies both IsHalfSpace and IsRay
+    static_assert(IsHalfSpace<HS>);
+    static_assert(IsRay<HS, ℝ>);
+    static_assert(IsConvex<HS>);
+
+    // Factory methods produce both orientations from a single type
+    constexpr auto up = HS::upward_from(3);
+    constexpr auto down = HS::downward_from(3);
+
+    // { x | x > 3 }
+    REQUIRE(!up(2));
+    REQUIRE(!up(3));  // Open boundary
+    REQUIRE(up(4));
+
+    // { x | x < 3 }
+    REQUIRE(down(2));
+    REQUIRE(!down(3));  // Open boundary
+    REQUIRE(!down(4));
+
+    // Construct from a compile-time Ray
+    UnitRay compile_time_ray{5};
+    HS runtime_ray{compile_time_ray};
+    REQUIRE(!runtime_ray(4));
+    REQUIRE(runtime_ray(6));
+
+    // Intersection tightens the bound
+    auto hs1 = HS::upward_from(2);
+    auto hs2 = HS::upward_from(5);
+    auto inter = hs1 & hs2;
+    REQUIRE(!inter(4));
+    REQUIRE(inter(6));
+
+    using ClosedHS = HalfSpace<ℝ, Boundary::Closed>;
+    static_assert(IsHalfSpace<ClosedHS>);
+    static_assert(IsClosed<ClosedHS>);
+    constexpr auto closed_up = ClosedHS::upward_from(3);
+    static_assert(closed_up(3) == dedekind::category::ClassicalLogic::True);
+  }
+
   SECTION("Intersection Laws: The Convex Magma") {
     static_assert(is_convex_v<UnitRay>);
     static_assert((std::same_as<decltype(std::declval<UnitRay>() &


### PR DESCRIPTION
Closes #133
Closes #134

Planned work:
- #133: Revisit topology module following boundary/interval additions in #131/#132; align concepts with ETCS, add literature references, improve doc coverage, check idiomatic test usage
- #134: Iterate on sequences module; reify std::vector as a finite sequence, check std::ranges compliance, align concept signatures with upstream ETCS/category concepts