### PR TITLE
feat(geometry): covectors and outer products

### DIFF
--- a/.github/instructions/*.instructions.md
+++ b/.github/instructions/*.instructions.md
@@ -26,6 +26,8 @@ Then triage the backlog:
   - **Already resolved**: close with `gh issue close <number> --comment "..."` citing the PR that addressed it.
 - Name the branch after the selected issue numbers, e.g. `feat/issues-40-121`.
 
+**Never push directly to `main`.** All work must go through a feature branch and a PR. Direct pushes to `main` are not permitted.
+
 The flow should be:
 1. pick up one or more issues.
 2. create branch and immediately open a draft PR referencing the issues — even before any code is written. This makes it visible what is being worked on and aligns with the CI reference build from the start.

--- a/src/main/modules/dedekind/analysis/forms.cppm
+++ b/src/main/modules/dedekind/analysis/forms.cppm
@@ -40,4 +40,20 @@ struct OneForm {
   }
 };
 
+/**
+ * @brief Convert a OneForm to its Covector (row-vector) representation.
+ *
+ * A OneForm<F,N> and a Covector<F,N> (= LinearMap<F,1,N>) are two
+ * representations of the same linear functional F^N -> F.  This function
+ * constructs the Covector whose single row holds the OneForm's components,
+ * making the bijection explicit.
+ */
+export template <std::floating_point F, std::size_t N>
+constexpr Covector<F, N> to_covector(const OneForm<F, N>& w) {
+  Covector<F, N> result;
+  for (std::size_t j = 0; j < N; ++j)
+    result.set_coefficient(0, j, w.components[j]);
+  return result;
+}
+
 }  // namespace dedekind::analysis

--- a/src/main/modules/dedekind/geometry/linear_map.cppm
+++ b/src/main/modules/dedekind/geometry/linear_map.cppm
@@ -159,4 +159,30 @@ constexpr LinearMap<F, Rows, Cols> zero_linear_map() {
   return LinearMap<F, Rows, Cols>{};
 }
 
+/**
+ * @brief Covector: a linear functional F^N -> F, represented as a row vector.
+ *
+ * A covector (dual vector / linear functional) is canonically a
+ * LinearMap<F, 1, N>: it maps a column vector to a length-1 column vector
+ * whose single entry is the inner product of the row with the argument.
+ */
+export template <std::floating_point F, std::size_t N>
+using Covector = LinearMap<F, 1, N>;
+
+/**
+ * @brief Outer product u ⊗ v : F^N -> F^M.
+ *
+ * Constructs the rank-1 linear map whose (i,j) coefficient is u[i]*v[j].
+ * Applied to a vector w, it yields dot(v,w) * u (the dyadic product).
+ */
+export template <std::floating_point F, std::size_t M, std::size_t N>
+constexpr LinearMap<F, M, N> outer(const Vector<F, M>& u,
+                                   const Vector<F, N>& v) {
+  LinearMap<F, M, N> result;
+  for (std::size_t i = 0; i < M; ++i)
+    for (std::size_t j = 0; j < N; ++j)
+      result.set_coefficient(i, j, u[i] * v[j]);
+  return result;
+}
+
 }  // namespace dedekind::geometry

--- a/src/test/cpp/modules/dedekind/analysis/forms_test.cpp
+++ b/src/test/cpp/modules/dedekind/analysis/forms_test.cpp
@@ -1,0 +1,32 @@
+#include <catch2/catch_test_macros.hpp>
+
+import dedekind.analysis;
+import dedekind.geometry;
+
+using namespace dedekind::analysis;
+using namespace dedekind::geometry;
+
+TEST_CASE("Analysis: OneForm and Covector", "[analysis][forms][covector]") {
+  using R = double;
+  using Vec2 = Vector<R, 2>;
+
+  OneForm<R, 2> w{{3.0, -1.0}};
+  Vec2 v{2.0, 4.0};
+
+  SECTION("OneForm evaluates via dot product") {
+    // w(v) = 3*2 + (-1)*4 = 2.0
+    REQUIRE(w(v) == 2.0);
+  }
+
+  SECTION("to_covector agrees with OneForm evaluation") {
+    auto cov = to_covector(w);
+    // cov(v) returns Vector<R,1>; its single entry must match w(v)
+    REQUIRE(cov(v)[0] == w(v));
+  }
+
+  SECTION("to_covector round-trips component-wise") {
+    auto cov = to_covector(w);
+    REQUIRE(cov.coefficient(0, 0) == w.components[0]);
+    REQUIRE(cov.coefficient(0, 1) == w.components[1]);
+  }
+}

--- a/src/test/cpp/modules/dedekind/geometry/linear_map_test.cpp
+++ b/src/test/cpp/modules/dedekind/geometry/linear_map_test.cpp
@@ -72,3 +72,38 @@ TEST_CASE("Geometry: Linear Map MVP", "[geometry][linear-map]") {
     REQUIRE((zero_linear_map<R, 2, 2>()(v)) == Vec2{});
   }
 }
+
+TEST_CASE("Geometry: Covectors and Outer Products",
+          "[geometry][covector][outer]") {
+  using R = double;
+  using Vec2 = Vector<R, 2>;
+  using Vec3 = Vector<R, 3>;
+
+  SECTION("Covector alias is LinearMap<F,1,N>") {
+    static_assert(std::same_as<Covector<R, 2>, LinearMap<R, 1, 2>>);
+    Covector<R, 2> cov{{{3.0, -1.0}}};
+    Vec2 v{2.0, 4.0};
+    // cov(v)[0] = 3*2 + (-1)*4 = 2.0
+    REQUIRE(cov(v)[0] == 2.0);
+  }
+
+  SECTION("Outer product has rank-1 coefficient formula u[i]*v[j]") {
+    Vec3 u{1.0, 2.0, 3.0};
+    Vec2 v{4.0, 5.0};
+    auto p = outer(u, v);
+    static_assert(std::same_as<decltype(p), LinearMap<R, 3, 2>>);
+    REQUIRE(p.coefficient(0, 0) == 4.0);   // u[0]*v[0]
+    REQUIRE(p.coefficient(0, 1) == 5.0);   // u[0]*v[1]
+    REQUIRE(p.coefficient(1, 0) == 8.0);   // u[1]*v[0]
+    REQUIRE(p.coefficient(2, 1) == 15.0);  // u[2]*v[1]
+  }
+
+  SECTION("Outer product satisfies (u⊗v)(w) = dot(v,w)·u") {
+    Vec2 u{1.0, 2.0};
+    Vec2 v{3.0, 4.0};
+    Vec2 w{1.0, 1.0};
+    auto p = outer(u, v);
+    // dot(v, w) = 3 + 4 = 7; result should be 7*u
+    REQUIRE(p(w) == 7.0 * u);
+  }
+}


### PR DESCRIPTION
Closes #127
Closes #128

Implements covectors (linear functionals) as `LinearMap<F,1,N>` and outer products as rank-1 linear maps.