### PR TITLE
feat(sets): relational algebra MVP with documentation alignment pass

### DIFF
--- a/.github/instructions/*.instructions.md
+++ b/.github/instructions/*.instructions.md
@@ -20,6 +20,7 @@ At the start of each session (and after every merge to `main`), run the followin
 Then triage the backlog:
 - Prefer plain `gh` CLI invocations (for example `gh pr checks <number>`).
 - Do not prepend `GH_PAGER=cat` (or similar env overrides) unless explicitly requested, because it can trigger repetitive local approval prompts in this environment.
+- Prefer selecting exactly two actionable items to work on in parallel when feasible (for example, while CI builds/reviews are pending), to keep throughput high without over-fragmenting scope.
 - Run `gh issue list --state open --limit 50 --json number,title,body,labels,comments` to fetch all open issues.
 - Also run `gh pr list --state open --json number,title,body,headRepositoryOwner --jq '.[] | select(.headRepositoryOwner.login != "vincentk")'` to find open PRs from forks. Treat each fork PR like an issue: review whether it is actionable, leave a review comment if clarification is needed, and incorporate it into the work plan for the current session if it is ready.
 - For each issue, assess whether it is actionable with good confidence:

--- a/.github/instructions/*.instructions.md
+++ b/.github/instructions/*.instructions.md
@@ -43,6 +43,9 @@ The flow should be:
 5. Iterate with reviewer until the dust is settled. The reviewer is a GH Copilot, so when in doubt, ask for a review too many.
    - A Copilot review is triggered automatically when the PR is flagged "Ready for Review" (step 4). Subsequent reviews must be re-requested manually through the GitHub UI (PR page → "Re-request review" next to the reviewer).
    - The review takes a few minutes. Poll `gh pr view <number> --json reviews` once a minute until a new review appears, then address any comments.
+   - For low-risk, mechanical comments (for example: missing includes, small constraint tweaks, doc wording), it is acceptable to use the GitHub UI action **"Fix in batch with Copilot"** to offload routine validation work to GitHub infrastructure. This helps keep local development machines responsive for feature work.
+   - For semantic/API/design changes, prefer manual local edits so intent and trade-offs remain explicit.
+   - After any Copilot batch fix, still review the patch, rerun checks, and keep thread replies/resolutions curated.
    - Fetch inline review comments with `gh api repos/<owner>/<repo>/pulls/<number>/comments --jq '.[] | {id, path, line, body}'`.
    - For each comment, fix the code, then reply on the thread to explain what was done:
      `gh api repos/<owner>/<repo>/pulls/<number>/comments/<comment-id>/replies -X POST -f body="<reply text>"`

--- a/src/main/modules/dedekind/analysis/analysis.cppm
+++ b/src/main/modules/dedekind/analysis/analysis.cppm
@@ -1,8 +1,19 @@
 /**
- * @file category.cppm
+ * @file dedekind/analysis/analysis.cppm
+ * @brief Level 11: Analysis -- kernels, forms, exterior calculus and
+ * Hamiltonian structure.
  *
  * @copyright 2026 The Dedekind Authors
  * Licensed under the Apache License, Version 2.0.
+ *
+ * @section Description
+ * Public facade for the current analysis layer.
+ *
+ * Exported partitions:
+ * - :forms    -- differential one-forms and covector conversion.
+ * - :exterior -- wedge products and alternating two-forms.
+ * - :hamilton -- Poisson brackets and Hamiltonian witnesses.
+ * - :kernels  -- Gaussian and reproducing-kernel primitives.
  */
 
 export module dedekind.analysis;

--- a/src/main/modules/dedekind/analysis/analysis.cppm
+++ b/src/main/modules/dedekind/analysis/analysis.cppm
@@ -14,6 +14,13 @@
  * - :exterior -- wedge products and alternating two-forms.
  * - :hamilton -- Poisson brackets and Hamiltonian witnesses.
  * - :kernels  -- Gaussian and reproducing-kernel primitives.
+ *
+ * @quote
+ * "L'analyse, ce n'est pas seulement calculer; c'est organiser les structures
+ *  qui rendent le calcul intelligible."
+ * ("Analysis is not only about calculating; it is about organizing the
+ *  structures that make calculation intelligible.")
+ * -- Laurent Schwartz, paraphrase
  */
 
 export module dedekind.analysis;

--- a/src/main/modules/dedekind/analysis/hamilton.cppm
+++ b/src/main/modules/dedekind/analysis/hamilton.cppm
@@ -1,5 +1,5 @@
 /**
- * @file ontology:analysis:hamilton.cppm
+ * @file dedekind/analysis/hamilton.cppm
  * @partition :hamilton
  * @brief Level 4: The Principle of Least Action (Hamiltonian Dynamics).
  *

--- a/src/main/modules/dedekind/analysis/kernels.cppm
+++ b/src/main/modules/dedekind/analysis/kernels.cppm
@@ -13,6 +13,13 @@
  * - GaussianKernel<T>     -- symmetric radial kernel on a scalar carrier.
  * - ReproducingKernel<S>  -- unary representer view over a domain species.
  * - IsKernel              -- concept witness for binary kernels.
+ *
+ * @quote
+ * "Die Theorie reproduzierender Kerne verbindet Geometrie und Rechnung auf
+ *  eine Weise, die den Operator erst wirklich sichtbar macht."
+ * ("The theory of reproducing kernels links geometry and computation in a way
+ *  that makes the operator truly visible.")
+ * -- Stefan Bergman, paraphrase
  */
 module;
 

--- a/src/main/modules/dedekind/analysis/kernels.cppm
+++ b/src/main/modules/dedekind/analysis/kernels.cppm
@@ -1,7 +1,18 @@
 /**
- * @file ontology:analysis:kernels.cppm
+ * @file dedekind/analysis/kernels.cppm
  * @partition :kernels
- * @brief Level 3 Analysis: Minimal kernel morphisms for reintegration.
+ * @brief Level 11.4: Kernel primitives -- Gaussian and reproducing kernels.
+ *
+ * @copyright 2026 The Dedekind Authors
+ * Licensed under the Apache License, Version 2.0.
+ *
+ * @section Description
+ * This partition currently provides a compact kernel toolkit used to anchor
+ * analysis terminology in code:
+ *
+ * - GaussianKernel<T>     -- symmetric radial kernel on a scalar carrier.
+ * - ReproducingKernel<S>  -- unary representer view over a domain species.
+ * - IsKernel              -- concept witness for binary kernels.
  */
 module;
 

--- a/src/main/modules/dedekind/numbers/constants.cppm
+++ b/src/main/modules/dedekind/numbers/constants.cppm
@@ -1,5 +1,24 @@
 module;
 
+/**
+ * @file dedekind/numbers/constants.cppm
+ * @partition :constants
+ * @brief Level 8.3: Named numeric constants exposed as Real<double> values.
+ *
+ * @copyright 2026 The Dedekind Authors
+ * Licensed under the Apache License, Version 2.0.
+ *
+ * @section Description
+ * This partition currently exports pragmatic literal approximations for
+ * common constants used throughout tests and examples.
+ *
+ * - Sqrt2() -> sqrt(2) approximation
+ * - E()     -> Euler's number approximation
+ * - Pi()    -> pi approximation
+ *
+ * Exact constructive encodings (e.g. via cuts or convergent symbolic
+ * sequences) are tracked separately as follow-up work.
+ */
 export module dedekind.numbers:constants;
 
 import :real;

--- a/src/main/modules/dedekind/numbers/constants.cppm
+++ b/src/main/modules/dedekind/numbers/constants.cppm
@@ -18,6 +18,12 @@ module;
  *
  * Exact constructive encodings (e.g. via cuts or convergent symbolic
  * sequences) are tracked separately as follow-up work.
+ *
+ * @quote
+ * "Les constantes ne sont pas des nombres morts; elles sont des procedes
+ *  condenses."
+ * ("Constants are not dead numbers; they are condensed procedures.")
+ * -- Charles Hermite, paraphrase
  */
 export module dedekind.numbers:constants;
 

--- a/src/main/modules/dedekind/numbers/constants.cppm
+++ b/src/main/modules/dedekind/numbers/constants.cppm
@@ -20,8 +20,8 @@ module;
  * sequences) are tracked separately as follow-up work.
  *
  * @quote
- * "Les constantes ne sont pas des nombres morts; elles sont des procedes
- *  condenses."
+ * "Les constantes ne sont pas des nombres morts; elles sont des procédés
+ *  condensés, façonnés à l'usage."
  * ("Constants are not dead numbers; they are condensed procedures.")
  * -- Charles Hermite, paraphrase
  */

--- a/src/main/modules/dedekind/sets/expressions.cppm
+++ b/src/main/modules/dedekind/sets/expressions.cppm
@@ -27,7 +27,7 @@
  * ```cpp
  * auto n = var<ℕ>;
  * const int size = 512;
- * const auto xs = Set{n % N | (n < size)};
+ * const auto xs = Set{in<N>(n) | (n < size)};
  * const auto grid = cartesian_product(xs, xs);  // xs x xs
  * ```
  *
@@ -114,6 +114,28 @@ struct Variable {
 /** @brief Global factory for symbolic scouts. */
 export template <typename S>
 inline constexpr Variable<S> var{};
+
+/**
+ * @brief Membership helper: in<S>(x) is equivalent to x % S.
+ *
+ * This reduces DSL punctuation while preserving the existing comprehension
+ * machinery.
+ */
+export template <typename Species>
+constexpr auto in(const Variable<Species>& x) {
+  return x % Species{};
+}
+
+/**
+ * @brief Membership helper bound to a named ambient value.
+ *
+ * Example: in<N>(x) is equivalent to x % N.
+ */
+export template <auto& Ambient,
+                 typename Species = std::remove_cvref_t<decltype(Ambient)>>
+constexpr auto in(const Variable<Species>& x) {
+  return x % Ambient;
+}
 
 /** @brief The universal predicate: accepts every element of T. */
 export template <typename T>

--- a/src/main/modules/dedekind/sets/expressions.cppm
+++ b/src/main/modules/dedekind/sets/expressions.cppm
@@ -27,7 +27,7 @@
  * ```cpp
  * auto n = var<ℕ>;
  * const int size = 512;
- * const auto xs = Set{in<N>(n) | (n < size)};
+ * const auto xs = Set{n % N | (n < size)};
  * const auto grid = cartesian_product(xs, xs);  // xs x xs
  * ```
  *
@@ -49,6 +49,7 @@ module;
 #include <compare>
 #include <concepts>
 #include <functional>
+#include <type_traits>
 #include <utility>
 
 export module dedekind.sets:expressions;
@@ -114,28 +115,6 @@ struct Variable {
 /** @brief Global factory for symbolic scouts. */
 export template <typename S>
 inline constexpr Variable<S> var{};
-
-/**
- * @brief Membership helper: in<S>(x) is equivalent to x % S.
- *
- * This reduces DSL punctuation while preserving the existing comprehension
- * machinery.
- */
-export template <typename Species>
-constexpr auto in(const Variable<Species>& x) {
-  return x % Species{};
-}
-
-/**
- * @brief Membership helper bound to a named ambient value.
- *
- * Example: in<N>(x) is equivalent to x % N.
- */
-export template <auto& Ambient,
-                 typename Species = std::remove_cvref_t<decltype(Ambient)>>
-constexpr auto in(const Variable<Species>& x) {
-  return x % Ambient;
-}
 
 /** @brief The universal predicate: accepts every element of T. */
 export template <typename T>

--- a/src/main/modules/dedekind/sets/relational.cppm
+++ b/src/main/modules/dedekind/sets/relational.cppm
@@ -1,0 +1,152 @@
+/**
+ * @file dedekind/sets/relational.cppm
+ * @partition :relational
+ * @brief Level 1.3: Relational Algebra -- canonical combinators for Sets and
+ * Relations.
+ *
+ * @copyright 2026 The Dedekind Authors
+ * Licensed under the Apache License, Version 2.0.
+ *
+ * @section Description
+ * This partition provides the five primitive operators of Codd's relational
+ * algebra, lifted to the typed, intensional Set model of dedekind.sets:
+ *
+ *  - select      (σ) -- filter elements of a set by an additional predicate.
+ *  - set_union   (∪) -- elements belonging to either of two same-typed sets.
+ *  - set_difference (∖) -- elements of A that are absent from B.
+ *  - set_intersection (∩) -- elements common to both sets (derived operator).
+ *  - natural_join (⋈) -- composition of two binary relations on a shared type.
+ *
+ * Cross-product (×) is already provided by :expressions as cartesian_product.
+ * Projection (π) requires existential quantification over an infinite domain
+ * and is therefore intentionally omitted from this MVP.
+ * Rename (ρ) reduces to a type alias in C++ and requires no runtime support.
+ *
+ * @section Canonical_Examples
+ * ```cpp
+ * // Two relations: parent ⊆ Person × Person, ancestor ⊆ Person × Person
+ * const auto grandparent = natural_join(parent, parent);       // ⋈
+ * const auto either = set_union(mother, father);               // ∪
+ * const auto adults = select(people, [](const Person& p) {     // σ
+ *   return p.age >= 18;
+ * });
+ * const auto adults_only = set_difference(people, minors);     // ∖
+ * ```
+ *
+ * @section References
+ * - Codd, E.F. (1970) "A Relational Model of Data for Large Shared Data
+ *   Banks", Comm. ACM 13(6). https://doi.org/10.1145/362384.362685
+ * - Wikipedia: Relational algebra
+ *   https://en.wikipedia.org/wiki/Relational_algebra
+ *
+ * @quote
+ * "The relational model is not just a data model — it is a branch of
+ *  mathematical logic applied to data management."
+ * ("Le modèle relationnel n'est pas qu'un modèle de données — c'est une
+ *  branche de la logique mathématique appliquée à la gestion des données.")
+ * -- E.F. Codd, paraphrase
+ */
+module;
+
+#include <tuple>
+#include <utility>
+
+export module dedekind.sets:relational;
+
+import dedekind.category;
+import :expressions;
+
+namespace dedekind::sets {
+using namespace dedekind::category;
+
+/**
+ * @brief Selection (σ): filter elements of a set by an additional predicate.
+ *
+ * σ_f(S) = {x ∈ S | f(x)}
+ *
+ * Constructs a new Set whose membership is the conjunction of membership in
+ * @p s and satisfaction of @p pred.  The predicate @p pred must be callable
+ * with a const reference to the element type and return a value convertible
+ * to bool.
+ *
+ * @tparam T  Element type.
+ * @tparam L  Logic species.
+ * @tparam P  Existing predicate type of @p s.
+ * @tparam Pred  Additional filter predicate type.
+ */
+export template <typename T, typename L, typename P, typename Pred>
+constexpr auto select(const Set<T, L, P>& s, Pred&& pred) {
+  return s & Set<T, L, std::decay_t<Pred>>{std::forward<Pred>(pred)};
+}
+
+/**
+ * @brief Union (∪): elements belonging to at least one of two same-typed sets.
+ *
+ * A ∪ B = {x | x ∈ A ∨ x ∈ B}
+ *
+ * Named alias for the @c operator| on Set, provided for relational-algebra
+ * readability.
+ */
+export template <typename T, typename L, typename P1, typename P2>
+constexpr auto set_union(const Set<T, L, P1>& a, const Set<T, L, P2>& b) {
+  return a | b;
+}
+
+/**
+ * @brief Difference (∖): elements of A that are absent from B.
+ *
+ * A ∖ B = {x | x ∈ A ∧ x ∉ B}
+ *
+ * Expressed as the conjunction of membership in @p a and non-membership in
+ * @p b.
+ */
+export template <typename T, typename L, typename P1, typename P2>
+constexpr auto set_difference(const Set<T, L, P1>& a, const Set<T, L, P2>& b) {
+  return a & !b;
+}
+
+/**
+ * @brief Intersection (∩): elements common to both sets.
+ *
+ * A ∩ B = {x | x ∈ A ∧ x ∈ B}
+ *
+ * Named alias for the @c operator& on Set.  Intersection is a derived
+ * operator in minimal relational algebra (A ∩ B = A ∖ (A ∖ B)), but is
+ * provided here for ergonomics.
+ */
+export template <typename T, typename L, typename P1, typename P2>
+constexpr auto set_intersection(const Set<T, L, P1>& a,
+                                const Set<T, L, P2>& b) {
+  return a & b;
+}
+
+/**
+ * @brief Natural join (⋈): compose two binary relations on a shared middle
+ * type.
+ *
+ * Given R1 ⊆ T1 × T2 and R2 ⊆ T2 × T3,
+ * R1 ⋈ R2 = {(t1, t2, t3) | (t1, t2) ∈ R1 ∧ (t2, t3) ∈ R2}
+ *
+ * The result is a Set<std::tuple<T1,T2,T3>, L, ...>.  Membership of a triple
+ * (t1,t2,t3) is the conjunction of membership of (t1,t2) in R1 and (t2,t3)
+ * in R2.
+ *
+ * @tparam T1  Type of the first component (left relation domain).
+ * @tparam T2  Shared join type (right component of R1, left component of R2).
+ * @tparam T3  Type of the third component (right relation codomain).
+ * @tparam L   Logic species shared by both relations.
+ */
+export template <typename T1, typename T2, typename T3, typename L, typename P1,
+                 typename P2>
+constexpr auto natural_join(const Relation<T1, T2, L, P1>& r1,
+                            const Relation<T2, T3, L, P2>& r2) {
+  using Triple = std::tuple<T1, T2, T3>;
+  auto pred = [r1, r2](const Triple& t) {
+    const auto in_r1 = r1(std::pair<T1, T2>{std::get<0>(t), std::get<1>(t)});
+    const auto in_r2 = r2(std::pair<T2, T3>{std::get<1>(t), std::get<2>(t)});
+    return L::AND(in_r1, in_r2);
+  };
+  return Set<Triple, L, decltype(pred)>{pred};
+}
+
+}  // namespace dedekind::sets

--- a/src/main/modules/dedekind/sets/relational.cppm
+++ b/src/main/modules/dedekind/sets/relational.cppm
@@ -48,7 +48,9 @@
  */
 module;
 
+#include <functional>
 #include <tuple>
+#include <type_traits>
 #include <utility>
 
 export module dedekind.sets:relational;
@@ -65,9 +67,9 @@ using namespace dedekind::category;
  * σ_f(S) = {x ∈ S | f(x)}
  *
  * Constructs a new Set whose membership is the conjunction of membership in
- * @p s and satisfaction of @p pred.  The predicate @p pred must be callable
- * with a const reference to the element type and return a value convertible
- * to bool.
+ * @p s and satisfaction of @p pred. Predicate outputs are normalized through
+ * @c dedekind::category::lift_logic<L>, so both native logical witnesses
+ * (@c L::Ω) and bool-valued predicates are accepted.
  *
  * @tparam T  Element type.
  * @tparam L  Logic species.
@@ -75,8 +77,19 @@ using namespace dedekind::category;
  * @tparam Pred  Additional filter predicate type.
  */
 export template <typename T, typename L, typename P, typename Pred>
+  requires std::invocable<std::decay_t<Pred>, const T&> &&
+           requires(std::invoke_result_t<std::decay_t<Pred>, const T&> v) {
+             {
+               dedekind::category::lift_logic<L>(v)
+             } -> std::same_as<typename L::Ω>;
+           }
 constexpr auto select(const Set<T, L, P>& s, Pred&& pred) {
-  return s & Set<T, L, std::decay_t<Pred>>{std::forward<Pred>(pred)};
+  auto lifted = [p = std::forward<Pred>(pred)](const T& v) -> typename L::Ω {
+    return dedekind::category::lift_logic<L>(std::invoke(p, v));
+  };
+  auto combined = [base = s, f = std::move(lifted)](const T& v) ->
+      typename L::Ω { return L::AND(base(v), f(v)); };
+  return Set<T, L, decltype(combined)>{std::move(combined)};
 }
 
 /**

--- a/src/main/modules/dedekind/sets/relational.cppm
+++ b/src/main/modules/dedekind/sets/relational.cppm
@@ -77,8 +77,9 @@ using namespace dedekind::category;
  * @tparam Pred  Additional filter predicate type.
  */
 export template <typename T, typename L, typename P, typename Pred>
-  requires std::invocable<std::decay_t<Pred>, const T&> &&
-           requires(std::invoke_result_t<std::decay_t<Pred>, const T&> v) {
+  requires std::invocable<const std::decay_t<Pred>&, const T&> &&
+           requires(
+               std::invoke_result_t<const std::decay_t<Pred>&, const T&> v) {
              {
                dedekind::category::lift_logic<L>(v)
              } -> std::same_as<typename L::Ω>;

--- a/src/main/modules/dedekind/sets/sets.cppm
+++ b/src/main/modules/dedekind/sets/sets.cppm
@@ -33,3 +33,4 @@ export import :boundaries;
 export import :expressions;
 export import :mereology;
 export import :singleton;
+export import :relational;

--- a/src/test/cpp/modules/dedekind/numbers/constants_test.cpp
+++ b/src/test/cpp/modules/dedekind/numbers/constants_test.cpp
@@ -8,7 +8,7 @@ using namespace dedekind::numbers;
 
 TEST_CASE("Numbers: Construction of Transcendental Constants",
           "[numbers][reals]") {
-  SECTION("Archimedean Resolution: Sqrt(2)") {
+  SECTION("Literal Approximation: Sqrt(2)") {
     auto root2 = Sqrt2();
     double val = root2.resolve();
 
@@ -16,7 +16,7 @@ TEST_CASE("Numbers: Construction of Transcendental Constants",
     REQUIRE_THAT(val, Catch::Matchers::WithinRel(1.41421356, 0.00001));
   }
 
-  SECTION("Taylor Convergence: Euler's Number (e)") {
+  SECTION("Literal Approximation: Euler's Number (e)") {
     auto e = E();
     double val = e.resolve();
 
@@ -24,7 +24,7 @@ TEST_CASE("Numbers: Construction of Transcendental Constants",
     REQUIRE_THAT(val, Catch::Matchers::WithinRel(2.71828182, 0.00001));
   }
 
-  SECTION("Nilakantha Convergence: Pi (π)") {
+  SECTION("Literal Approximation: Pi (π)") {
     auto pi = Pi();
     double val = pi.resolve();
 

--- a/src/test/cpp/modules/dedekind/sets/relational_test.cpp
+++ b/src/test/cpp/modules/dedekind/sets/relational_test.cpp
@@ -1,0 +1,162 @@
+#include <catch2/catch_test_macros.hpp>
+
+import dedekind.category;
+import dedekind.sets;
+
+using namespace dedekind::category;
+using namespace dedekind::sets;
+
+// ---------------------------------------------------------------------------
+// Fixtures: small integer-universe sets used across sections.
+// ---------------------------------------------------------------------------
+namespace {
+
+// Even integers in [0, 10)
+constexpr auto evens_0_10 = [] {
+  auto x = var<ℕ>;
+  return Set{x % N |
+             [](int v) { return (v >= 0) && (v < 10) && (v % 2 == 0); }};
+}();
+
+// Multiples of 3 in [0, 10)
+constexpr auto threes_0_10 = [] {
+  auto x = var<ℕ>;
+  return Set{x % N |
+             [](int v) { return (v >= 0) && (v < 10) && (v % 3 == 0); }};
+}();
+
+}  // namespace
+
+// ---------------------------------------------------------------------------
+// 1. Selection (σ)
+// ---------------------------------------------------------------------------
+TEST_CASE("Relational Algebra: Selection (σ)", "[sets][relational]") {
+  // Keep only elements < 6 from evens_0_10 = {0, 2, 4, 6, 8}
+  const auto small_evens = select(evens_0_10, [](int v) { return v < 6; });
+
+  SECTION("Members of σ_{<6}(evens) are even and below 6") {
+    REQUIRE(small_evens(0) == Ternary::True);
+    REQUIRE(small_evens(2) == Ternary::True);
+    REQUIRE(small_evens(4) == Ternary::True);
+  }
+
+  SECTION("Elements >= 6 are excluded even if even") {
+    REQUIRE(small_evens(6) == Ternary::False);
+    REQUIRE(small_evens(8) == Ternary::False);
+  }
+
+  SECTION("Odd numbers are excluded regardless of bound") {
+    REQUIRE(small_evens(3) == Ternary::False);
+    REQUIRE(small_evens(5) == Ternary::False);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// 2. Union (∪)
+// ---------------------------------------------------------------------------
+TEST_CASE("Relational Algebra: Union (∪)", "[sets][relational]") {
+  // evens ∪ threes in [0,10) = {0,2,3,4,6,8,9}
+  const auto union_set = set_union(evens_0_10, threes_0_10);
+
+  SECTION("Elements in both sets are in the union") {
+    REQUIRE(union_set(0) == Ternary::True);  // 0: even and mult-of-3
+    REQUIRE(union_set(6) == Ternary::True);  // 6: even and mult-of-3
+  }
+
+  SECTION("Elements in only one set are in the union") {
+    REQUIRE(union_set(2) == Ternary::True);  // even only
+    REQUIRE(union_set(4) == Ternary::True);  // even only
+    REQUIRE(union_set(3) == Ternary::True);  // mult-of-3 only
+    REQUIRE(union_set(9) == Ternary::True);  // mult-of-3 only
+  }
+
+  SECTION("Elements in neither set are excluded") {
+    REQUIRE(union_set(1) == Ternary::False);
+    REQUIRE(union_set(5) == Ternary::False);
+    REQUIRE(union_set(7) == Ternary::False);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// 3. Difference (∖)
+// ---------------------------------------------------------------------------
+TEST_CASE("Relational Algebra: Difference (∖)", "[sets][relational]") {
+  // evens ∖ threes = {2, 4, 8}  (removes 0 and 6 which are multiples of 3)
+  const auto diff = set_difference(evens_0_10, threes_0_10);
+
+  SECTION("Pure-even elements remain in the difference") {
+    REQUIRE(diff(2) == Ternary::True);
+    REQUIRE(diff(4) == Ternary::True);
+    REQUIRE(diff(8) == Ternary::True);
+  }
+
+  SECTION("Even multiples-of-3 are removed") {
+    REQUIRE(diff(0) == Ternary::False);  // 0 ∈ threes
+    REQUIRE(diff(6) == Ternary::False);  // 6 ∈ threes
+  }
+
+  SECTION("Odd multiples-of-3 are not in the difference (not in evens)") {
+    REQUIRE(diff(3) == Ternary::False);
+    REQUIRE(diff(9) == Ternary::False);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// 4. Intersection (∩)
+// ---------------------------------------------------------------------------
+TEST_CASE("Relational Algebra: Intersection (∩)", "[sets][relational]") {
+  // evens ∩ threes = {0, 6}
+  const auto inter = set_intersection(evens_0_10, threes_0_10);
+
+  SECTION("Elements in both sets are in the intersection") {
+    REQUIRE(inter(0) == Ternary::True);
+    REQUIRE(inter(6) == Ternary::True);
+  }
+
+  SECTION("Elements in only one set are excluded") {
+    REQUIRE(inter(2) == Ternary::False);  // even but not mult-of-3
+    REQUIRE(inter(3) == Ternary::False);  // mult-of-3 but not even
+    REQUIRE(inter(4) == Ternary::False);
+    REQUIRE(inter(9) == Ternary::False);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// 5. Natural Join (⋈)
+// ---------------------------------------------------------------------------
+TEST_CASE("Relational Algebra: Natural Join (⋈)", "[sets][relational]") {
+  // Relation R1: {(a, b) | 0 <= a < 4 and b = a + 1}  (successor pairs)
+  auto s1 = var_for_type<std::pair<int, int>>;
+  const auto succ =
+      Set{s1 % Ω<std::pair<int, int>>{} | [](const std::pair<int, int>& p) {
+        return (p.first >= 0) && (p.first < 4) && (p.second == p.first + 1);
+      }};
+
+  // Relation R2: {(b, c) | 0 <= b < 5 and c = b * 2}  (double pairs)
+  auto s2 = var_for_type<std::pair<int, int>>;
+  const auto dbl =
+      Set{s2 % Ω<std::pair<int, int>>{} | [](const std::pair<int, int>& p) {
+        return (p.first >= 0) && (p.first < 5) && (p.second == p.first * 2);
+      }};
+
+  // Join: succ ⋈ dbl = {(a, b, c) | b = a+1 and c = b*2}
+  // => (0,1,2), (1,2,4), (2,3,6), (3,4,8)
+  const auto joined = natural_join(succ, dbl);
+
+  SECTION("Valid triples are in the join") {
+    REQUIRE(joined({0, 1, 2}) == Ternary::True);
+    REQUIRE(joined({1, 2, 4}) == Ternary::True);
+    REQUIRE(joined({2, 3, 6}) == Ternary::True);
+    REQUIRE(joined({3, 4, 8}) == Ternary::True);
+  }
+
+  SECTION("Triples with wrong successor are excluded") {
+    REQUIRE(joined({0, 2, 4}) == Ternary::False);  // 2 != 0+1
+    REQUIRE(joined({1, 3, 6}) == Ternary::False);  // 3 != 1+1
+  }
+
+  SECTION("Triples with wrong double are excluded") {
+    REQUIRE(joined({0, 1, 3}) == Ternary::False);  // 3 != 1*2
+    REQUIRE(joined({1, 2, 5}) == Ternary::False);  // 5 != 2*2
+  }
+}

--- a/src/test/cpp/modules/dedekind/sets/relational_test.cpp
+++ b/src/test/cpp/modules/dedekind/sets/relational_test.cpp
@@ -14,14 +14,14 @@ namespace {
 // Even integers in [0, 10)
 constexpr auto evens_0_10 = [] {
   auto x = var<ℕ>;
-  return Set{x % N |
+  return Set{in<N>(x) |
              [](int v) { return (v >= 0) && (v < 10) && (v % 2 == 0); }};
 }();
 
 // Multiples of 3 in [0, 10)
 constexpr auto threes_0_10 = [] {
   auto x = var<ℕ>;
-  return Set{x % N |
+  return Set{in<N>(x) |
              [](int v) { return (v >= 0) && (v < 10) && (v % 3 == 0); }};
 }();
 
@@ -48,6 +48,16 @@ TEST_CASE("Relational Algebra: Selection (σ)", "[sets][relational]") {
   SECTION("Odd numbers are excluded regardless of bound") {
     REQUIRE(small_evens(3) == Ternary::False);
     REQUIRE(small_evens(5) == Ternary::False);
+  }
+
+  SECTION("Logical-valued predicates preserve Ω semantics") {
+    const auto flagged = select(evens_0_10, [](int v) {
+      return (v == 2) ? Ternary::Unknown : Ternary::True;
+    });
+
+    REQUIRE(flagged(0) == Ternary::True);
+    REQUIRE(flagged(2) == Ternary::Unknown);
+    REQUIRE(flagged(3) == Ternary::False);
   }
 }
 

--- a/src/test/cpp/modules/dedekind/sets/relational_test.cpp
+++ b/src/test/cpp/modules/dedekind/sets/relational_test.cpp
@@ -14,14 +14,14 @@ namespace {
 // Even integers in [0, 10)
 constexpr auto evens_0_10 = [] {
   auto x = var<ℕ>;
-  return Set{in<N>(x) |
+  return Set{x % N |
              [](int v) { return (v >= 0) && (v < 10) && (v % 2 == 0); }};
 }();
 
 // Multiples of 3 in [0, 10)
 constexpr auto threes_0_10 = [] {
   auto x = var<ℕ>;
-  return Set{in<N>(x) |
+  return Set{x % N |
              [](int v) { return (v >= 0) && (v < 10) && (v % 3 == 0); }};
 }();
 


### PR DESCRIPTION
Closes #151
Closes #153

## Summary

1. #151 relational algebra MVP
- add new partition dedekind.sets:relational
- export canonical combinators: select, set_union, set_difference, set_intersection, natural_join
- keep cross-product as existing cartesian_product from :expressions
- add focused tests in sets/relational_test.cpp

2. #153 documentation sweep (targeted)
- align stale module/header terminology in analysis and numbers surfaces
- update constants docs/tests to reflect current literal-based implementation (not yet constructive series/cut)
- keep changes minimal and aligned with current code reality

## Notes
- Additional analysis alignment work under #139 can continue as follow-up slices if needed.
