### PR TITLE
docs(geometry): align geometry module surfaces

### DIFF
--- a/docs/report/report.tex
+++ b/docs/report/report.tex
@@ -2207,11 +2207,12 @@ It provides \texttt{Vector<S, N>} as the canonical $N$-dimensional vector specie
 \toprule
 \textbf{Mathematical Concept} & \textbf{C++23 construct} & \textbf{Structural \texttt{concept}} \\
 \midrule
-Affine / vector space & \texttt{Vector<S,N>} & --- \\
+Affine / vector space & \texttt{Vector<S,N>} & \texttt{IsAffine} \\
 Inner product $\langle u, v \rangle$ & \texttt{dot(u, v)} & \texttt{IsInnerProductSpace} \\
 Metric space $(X,d)$ & \texttt{distance(a,b)} & \texttt{IsMetricSpace} \\
 Euclidean space & \texttt{norm(v)} / \texttt{distance(a,b)} & \texttt{IsEuclideanSpace} \\
-Hilbert space (complete) & real $\mathbb{R}^N$ & \texttt{IsHilbertSpace} \\
+Finite-dimensional inner-product space & real $\mathbb{R}^N$ & \texttt{IsFiniteDimensionalInnerProductSpace} \\
+Hilbert space (complete) & complete real inner-product space & \texttt{IsHilbertSpace} \\
 \bottomrule
 \end{tabular}
 \end{table}
@@ -2219,7 +2220,7 @@ Hilbert space (complete) & real $\mathbb{R}^N$ & \texttt{IsHilbertSpace} \\
 \section{\texttt{:affine}}
 \label{sec:geometry-affine}
 
-Implements $N$-dimensional vectors with component-wise arithmetic. The affine layer provides translation and scalar action without presupposing a norm.
+Implements $N$-dimensional vectors with component-wise arithmetic. The affine layer provides translation and scalar action without presupposing a norm, and is captured explicitly by \texttt{IsAffine<V,S>}.
 
 \begin{lstlisting}[language=C++, caption={Geometry: affine vector operations (from \texttt{affine\_test.cpp}).}, label={lst:geometry-affine}]
 using Vec2 = Vector<double, 2>;
@@ -2330,7 +2331,7 @@ REQUIRE(identity.num() == 1);
 \section{\texttt{:scalars}}
 \label{sec:numbers-scalars}
 
-Provides the floating-point anchors \texttt{machine\_real\_scalar} and \texttt{machine\_integer} as pre-certified concrete species.
+Provides the floating-point anchors \texttt{machine\_real\_scalar} and \texttt{machine\_integer} as pre-certified concrete species. It also defines the bridge concepts \texttt{IsFloatingScalar}, \texttt{IsIntegralScalar}, and \texttt{IsUnsignedIntegralScalar} to connect concrete machine scalars with the structural ontology.
 
 \section{\texttt{:dual}}
 \label{sec:numbers-dual}

--- a/docs/report/report.tex
+++ b/docs/report/report.tex
@@ -2207,9 +2207,10 @@ It provides \texttt{Vector<S, N>} as the canonical $N$-dimensional vector specie
 \toprule
 \textbf{Mathematical Concept} & \textbf{C++23 construct} & \textbf{Structural \texttt{concept}} \\
 \midrule
-Affine / vector space & \texttt{Vector<S,N>} & \texttt{IsAffine} \\
+Affine / vector space & \texttt{Vector<S,N>} & --- \\
 Inner product $\langle u, v \rangle$ & \texttt{dot(u, v)} & \texttt{IsInnerProductSpace} \\
-Normed space $\|v\|$ & \texttt{norm(v)} & \texttt{IsNormedSpace} \\
+Metric space $(X,d)$ & \texttt{distance(a,b)} & \texttt{IsMetricSpace} \\
+Euclidean space & \texttt{norm(v)} / \texttt{distance(a,b)} & \texttt{IsEuclideanSpace} \\
 Hilbert space (complete) & real $\mathbb{R}^N$ & \texttt{IsHilbertSpace} \\
 \bottomrule
 \end{tabular}

--- a/src/main/modules/dedekind/algebra/modules.cppm
+++ b/src/main/modules/dedekind/algebra/modules.cppm
@@ -39,6 +39,27 @@ namespace dedekind::algebra {
 using namespace dedekind::category;
 
 /**
+ * @concept IsIntegralScalar
+ * @brief Internal bridge for std::integral scalar carriers.
+ */
+export template <typename S>
+concept IsIntegralScalar = std::integral<S>;
+
+/**
+ * @concept IsUnsignedIntegralScalar
+ * @brief Internal bridge for std::unsigned_integral scalar carriers.
+ */
+export template <typename S>
+concept IsUnsignedIntegralScalar = std::unsigned_integral<S>;
+
+/**
+ * @concept IsFloatingScalar
+ * @brief Internal bridge for std::floating_point scalar carriers.
+ */
+export template <typename S>
+concept IsFloatingScalar = std::floating_point<S>;
+
+/**
  * @concept IsSemimodule
  * @brief A commutative additive monoid participating in a Linear Action.
  * @tparam M The module carrier.
@@ -201,7 +222,7 @@ export struct BoolLineMeetAction {
  * @brief Strength-reduced scaling for unsigned 1D vectors.
  * @details Multiplication by powers of two is lowered to left-shift when safe.
  */
-export template <std::unsigned_integral S, typename Tag>
+export template <IsUnsignedIntegralScalar S, typename Tag>
 constexpr OneDimensionalVector<S, Tag> scale_strength_reduced(
     const OneDimensionalVector<S, Tag>& v, S factor) {
   if (factor == S{0}) return OneDimensionalVector<S, Tag>(S{0});

--- a/src/main/modules/dedekind/geometry/affine.cppm
+++ b/src/main/modules/dedekind/geometry/affine.cppm
@@ -31,7 +31,7 @@ concept IsAffine = requires(const V a, const V b, const S s) {
   { a - b } -> std::same_as<V>;
   { a * s } -> std::same_as<V>;
   { s * a } -> std::same_as<V>;
-  requires requires { V::dimension; };
+  { V::dimension };
 };
 
 /**

--- a/src/main/modules/dedekind/geometry/affine.cppm
+++ b/src/main/modules/dedekind/geometry/affine.cppm
@@ -22,12 +22,25 @@ using namespace dedekind::category;
 using namespace dedekind::algebra;
 
 /**
+ * @concept IsAffine
+ * @brief Affine-space witness over scalar carrier S.
+ */
+export template <typename V, typename S>
+concept IsAffine = requires(const V a, const V b, const S s) {
+  { a + b } -> std::same_as<V>;
+  { a - b } -> std::same_as<V>;
+  { a * s } -> std::same_as<V>;
+  { s * a } -> std::same_as<V>;
+  requires requires { V::dimension; };
+};
+
+/**
  * @class Vector
  * @brief An element of a Coordinate Space over a Field F.
  * @tparam F The scalar field (Rational, Real, or Complex).
  * @tparam N The dimension of the space.
  */
-export template <std::floating_point F, std::size_t N>
+export template <IsFloatingScalar F, std::size_t N>
 class Vector {
  public:
   using scalar_type = F;

--- a/src/main/modules/dedekind/geometry/euclidean.cppm
+++ b/src/main/modules/dedekind/geometry/euclidean.cppm
@@ -22,6 +22,7 @@ module;
 export module dedekind.geometry:euclidean;
 
 import :inner_product;
+import dedekind.algebra;
 
 namespace dedekind::geometry {
 
@@ -52,7 +53,7 @@ concept IsEuclideanSpace = IsMetricSpace<V, S> && requires(const V v) {
 /**
  * @brief Canonical Euclidean distance induced by the norm.
  */
-export template <std::floating_point F, std::size_t N>
+export template <dedekind::algebra::IsFloatingScalar F, std::size_t N>
 constexpr F distance(const Vector<F, N>& a, const Vector<F, N>& b) {
   return norm(a - b);
 }

--- a/src/main/modules/dedekind/geometry/euclidean.cppm
+++ b/src/main/modules/dedekind/geometry/euclidean.cppm
@@ -1,5 +1,5 @@
 /**
- * @file ontology:geometry.cppm
+ * @file dedekind/geometry/euclidean.cppm
  * @brief The Study of Distance, Metrics, and Curvature.
  *
  * Copyright 2026 The Dedekind Authors
@@ -15,12 +15,13 @@
 
 module;
 
+#include <cstddef>
 #include <concepts>
 #include <functional>
 
 export module dedekind.geometry:euclidean;
 
-import dedekind.morphologies; // For Vector Spaces and Norms
+import :inner_product;
 
 namespace dedekind::geometry {
 
@@ -47,5 +48,13 @@ concept IsEuclideanSpace = IsMetricSpace<V, S> && requires(const V v) {
   // The Norm (Magnitude) of a single vector.
   { norm(v) } -> std::same_as<S>;
 };
+
+/**
+ * @brief Canonical Euclidean distance induced by the norm.
+ */
+export template <std::floating_point F, std::size_t N>
+constexpr F distance(const Vector<F, N>& a, const Vector<F, N>& b) {
+  return norm(a - b);
+}
 
 }  // namespace dedekind::geometry

--- a/src/main/modules/dedekind/geometry/euclidean.cppm
+++ b/src/main/modules/dedekind/geometry/euclidean.cppm
@@ -17,7 +17,6 @@ module;
 
 #include <concepts>
 #include <cstddef>
-#include <functional>
 
 export module dedekind.geometry:euclidean;
 

--- a/src/main/modules/dedekind/geometry/euclidean.cppm
+++ b/src/main/modules/dedekind/geometry/euclidean.cppm
@@ -15,8 +15,8 @@
 
 module;
 
-#include <cstddef>
 #include <concepts>
+#include <cstddef>
 #include <functional>
 
 export module dedekind.geometry:euclidean;

--- a/src/main/modules/dedekind/geometry/hilbert.cppm
+++ b/src/main/modules/dedekind/geometry/hilbert.cppm
@@ -22,12 +22,13 @@ using namespace dedekind::sequences;
 using namespace dedekind::morphologies;
 
 /**
- * @concept IsEuclideanSpace
- * @brief A finite-dimensional real inner product space.
+ * @concept IsFiniteDimensionalInnerProductSpace
+ * @brief A finite-dimensional real inner-product space.
  */
 export template <typename V, typename R>
-concept IsEuclideanSpace = IsInnerProductSpace<V, R> &&
-                           std::floating_point<R> && requires { V::dimension; };
+concept IsFiniteDimensionalInnerProductSpace =
+    IsInnerProductSpace<V, R> && std::floating_point<R> &&
+    requires { V::dimension; };
 
 /**
  * @concept IsHilbertSpace

--- a/src/main/modules/dedekind/geometry/hilbert.cppm
+++ b/src/main/modules/dedekind/geometry/hilbert.cppm
@@ -10,6 +10,7 @@ module;
 export module dedekind.geometry:hilbert;
 
 import :inner_product;
+import dedekind.algebra;
 import dedekind.order;
 import dedekind.sequences;
 import dedekind.morphologies;
@@ -27,7 +28,7 @@ using namespace dedekind::morphologies;
  */
 export template <typename V, typename R>
 concept IsFiniteDimensionalInnerProductSpace =
-    IsInnerProductSpace<V, R> && std::floating_point<R> &&
+    IsInnerProductSpace<V, R> && dedekind::algebra::IsFloatingScalar<R> &&
     requires { V::dimension; };
 
 /**

--- a/src/main/modules/dedekind/numbers/scalars.cppm
+++ b/src/main/modules/dedekind/numbers/scalars.cppm
@@ -46,6 +46,28 @@ using namespace dedekind::category;
 using namespace dedekind::sets;
 
 /**
+ * @concept IsIntegralScalar
+ * @brief Numbers-layer alias for the algebra scalar bridge concept.
+ */
+export template <typename S>
+concept IsIntegralScalar = dedekind::algebra::IsIntegralScalar<S>;
+
+/**
+ * @concept IsUnsignedIntegralScalar
+ * @brief Numbers-layer alias for the algebra scalar bridge concept.
+ */
+export template <typename S>
+concept IsUnsignedIntegralScalar =
+    dedekind::algebra::IsUnsignedIntegralScalar<S>;
+
+/**
+ * @concept IsFloatingScalar
+ * @brief Numbers-layer alias for the algebra scalar bridge concept.
+ */
+export template <typename S>
+concept IsFloatingScalar = dedekind::algebra::IsFloatingScalar<S>;
+
+/**
  * @concept IsNumbers
  * @brief The Root Category for all Numerical Structures.
  *

--- a/src/test/cpp/modules/dedekind/geometry/affine_test.cpp
+++ b/src/test/cpp/modules/dedekind/geometry/affine_test.cpp
@@ -7,6 +7,8 @@ TEST_CASE("Geometry: Affine Rational Space", "[geometry][affine]") {
   using R = double;
   using Vec2 = Vector<R, 2>;
 
+  SECTION("Affine concept witness") { static_assert(IsAffine<Vec2, R>); }
+
   SECTION("Rational Scaling") {
     Vec2 v{1.0, 1.0};
     R scale = 0.5;

--- a/src/test/cpp/modules/dedekind/geometry/euclidean_test.cpp
+++ b/src/test/cpp/modules/dedekind/geometry/euclidean_test.cpp
@@ -18,7 +18,6 @@ TEST_CASE("Geometry: Euclidean metric structure", "[geometry][euclidean]") {
     Vec2 b{3.0, 4.0};
 
     REQUIRE(distance(a, b) == 5.0);
-    REQUIRE(distance(a, b) == norm(a - b));
   }
 
   SECTION("Distance is symmetric") {

--- a/src/test/cpp/modules/dedekind/geometry/euclidean_test.cpp
+++ b/src/test/cpp/modules/dedekind/geometry/euclidean_test.cpp
@@ -1,0 +1,36 @@
+#include <catch2/catch_test_macros.hpp>
+
+import dedekind.geometry;
+
+using namespace dedekind::geometry;
+
+TEST_CASE("Geometry: Euclidean metric structure", "[geometry][euclidean]") {
+  using R = double;
+  using Vec2 = Vector<R, 2>;
+
+  SECTION("Euclidean vectors satisfy metric and Euclidean concepts") {
+    static_assert(IsMetricSpace<Vec2, R>);
+    static_assert(IsEuclideanSpace<Vec2, R>);
+  }
+
+  SECTION("Distance matches the induced L2 norm") {
+    Vec2 a{0.0, 0.0};
+    Vec2 b{3.0, 4.0};
+
+    REQUIRE(distance(a, b) == 5.0);
+    REQUIRE(distance(a, b) == norm(b - a));
+  }
+
+  SECTION("Distance is symmetric") {
+    Vec2 a{1.0, -2.0};
+    Vec2 b{4.0, 2.0};
+
+    REQUIRE(distance(a, b) == distance(b, a));
+  }
+
+  SECTION("Distance from a point to itself is zero") {
+    Vec2 a{2.0, -1.0};
+
+    REQUIRE(distance(a, a) == 0.0);
+  }
+}

--- a/src/test/cpp/modules/dedekind/geometry/euclidean_test.cpp
+++ b/src/test/cpp/modules/dedekind/geometry/euclidean_test.cpp
@@ -18,7 +18,7 @@ TEST_CASE("Geometry: Euclidean metric structure", "[geometry][euclidean]") {
     Vec2 b{3.0, 4.0};
 
     REQUIRE(distance(a, b) == 5.0);
-    REQUIRE(distance(a, b) == norm(b - a));
+    REQUIRE(distance(a, b) == norm(a - b));
   }
 
   SECTION("Distance is symmetric") {


### PR DESCRIPTION
Closes #137

## Summary
- start the geometry alignment pass on its own branch
- reserve a separate CI lane for geometry code, tests, and documentation updates

## Planned scope
- review exported geometry surfaces and concept usage
- update tests where the current API has drifted
- align inline documentation and partition headers with the implemented module

## Status
- draft PR opened before implementation to keep the workstream isolated