### PR TITLE
draft: issue #160 add drop(path, n) sequence primitive

### DIFF
--- a/src/main/modules/dedekind/sequences/path.cppm
+++ b/src/main/modules/dedekind/sequences/path.cppm
@@ -153,12 +153,12 @@ export template <typename T, typename Cardinality>
   requires(!IsFiniteMagnitude<Cardinality>)
 constexpr auto drop(const Path<T, Cardinality>& path, std::size_t n) {
   // Precondition: n + i must not overflow std::size_t for accessed indices.
-  // For safety in finite scenarios, assert n is reasonable (e.g., < SIZE_MAX/2).
+  // For safety in finite scenarios, assert n is reasonable (e.g., <
+  // SIZE_MAX/2).
   assert(n < std::numeric_limits<std::size_t>::max() / 2 &&
          "drop offset too large; risk of overflow in n + i");
-  return Path<T, Cardinality>{[path, n](std::size_t i) {
-    return path.at(n + i);
-  }};
+  return Path<T, Cardinality>{
+      [path, n](std::size_t i) { return path.at(n + i); }};
 }
 
 export template <typename T, typename Step>

--- a/src/main/modules/dedekind/sequences/path.cppm
+++ b/src/main/modules/dedekind/sequences/path.cppm
@@ -24,9 +24,11 @@
 module;
 
 #include <algorithm>
+#include <cassert>
 #include <concepts>
 #include <cstddef>
 #include <functional>
+#include <limits>
 #include <type_traits>
 #include <utility>
 
@@ -138,10 +140,25 @@ constexpr auto prefix(const Path<T, Cardinality>& path, std::size_t length) {
  * Return the infinite tail of a path, shifted by n indices.
  *
  * drop(path, n) = λi. path(n + i)
+ *
+ * @tparam T The element type.
+ * @tparam Cardinality The cardinality of the input path (must be infinite).
+ * @param path The input path (must have infinite cardinality).
+ * @param n The offset to drop (precondition: n + i must not overflow for all
+ *           accessed indices i).
+ * @return An infinite path with the same cardinality, representing the shifted
+ *         tail.
  */
-export template <typename T>
-constexpr auto drop(const Path<T>& path, std::size_t n) {
-  return Path<T>{[path, n](std::size_t i) { return path.at(n + i); }};
+export template <typename T, typename Cardinality>
+  requires(!IsFiniteMagnitude<Cardinality>)
+constexpr auto drop(const Path<T, Cardinality>& path, std::size_t n) {
+  // Precondition: n + i must not overflow std::size_t for accessed indices.
+  // For safety in finite scenarios, assert n is reasonable (e.g., < SIZE_MAX/2).
+  assert(n < std::numeric_limits<std::size_t>::max() / 2 &&
+         "drop offset too large; risk of overflow in n + i");
+  return Path<T, Cardinality>{[path, n](std::size_t i) {
+    return path.at(n + i);
+  }};
 }
 
 export template <typename T, typename Step>

--- a/src/main/modules/dedekind/sequences/path.cppm
+++ b/src/main/modules/dedekind/sequences/path.cppm
@@ -134,6 +134,16 @@ constexpr auto prefix(const Path<T, Cardinality>& path, std::size_t length) {
   }
 }
 
+/**
+ * Return the infinite tail of a path, shifted by n indices.
+ *
+ * drop(path, n) = λi. path(n + i)
+ */
+export template <typename T>
+constexpr auto drop(const Path<T>& path, std::size_t n) {
+  return Path<T>{[path, n](std::size_t i) { return path.at(n + i); }};
+}
+
 export template <typename T, typename Step>
   requires std::invocable<const std::decay_t<Step>&, const T&> &&
            std::same_as<

--- a/src/test/cpp/modules/dedekind/sequences/path_test.cpp
+++ b/src/test/cpp/modules/dedekind/sequences/path_test.cpp
@@ -43,6 +43,7 @@ TEST_CASE("Sequences: The Path to Continuity",
     const auto tail = drop(path, 5);
 
     static_assert(IsSequence<decltype(tail)>);
+    static_assert(!IsFiniteSequence<decltype(tail)>);
     REQUIRE(tail.at(0) == path.at(5));
     REQUIRE(tail.at(3) == path.at(8));
   }

--- a/src/test/cpp/modules/dedekind/sequences/path_test.cpp
+++ b/src/test/cpp/modules/dedekind/sequences/path_test.cpp
@@ -39,6 +39,30 @@ TEST_CASE("Sequences: The Path to Continuity",
     REQUIRE(first_four.at(3) == 45);
   }
 
+  SECTION("Drop yields an infinite shifted tail") {
+    const auto tail = drop(path, 5);
+
+    static_assert(IsSequence<decltype(tail)>);
+    REQUIRE(tail.at(0) == path.at(5));
+    REQUIRE(tail.at(3) == path.at(8));
+  }
+
+  SECTION("Drop identity at zero offset") {
+    const auto same = drop(path, 0);
+
+    REQUIRE(same.at(0) == path.at(0));
+    REQUIRE(same.at(7) == path.at(7));
+  }
+
+  SECTION("Prefix of drop forms a shifted finite window") {
+    const auto window = prefix(drop(path, 2), 4);
+
+    static_assert(IsFiniteSequence<decltype(window)>);
+    REQUIRE(window.size() == 4u);
+    REQUIRE(window.at(0) == 44);
+    REQUIRE(window.at(3) == 47);
+  }
+
   SECTION("Iterative rules support finite orbit counting") {
     const auto orbit = iterate(1, [](int x) { return x + 1; }, 5);
 


### PR DESCRIPTION
Closes #160

## Execution plan
- [ ] Add `drop(path, n)` to `dedekind.sequences` with signature and semantics `drop(path, n) = λi. path(n + i)`.
- [ ] Ensure the return type remains infinite `Path<T, ℵ_0>` and aligns with existing `Path` conventions.
- [ ] Add unit tests for index-shift behavior (`drop(path, 0)`, `drop(path, n)`, larger offsets).
- [ ] Add composition tests for sliding windows using `prefix(drop(path, i), n)` and related frame patterns.
- [ ] Verify compatibility with the window-frame use cases discussed in #157 and no regression at call sites.
- [ ] Update docs/examples to map SQL frame clauses to `prefix`/`drop` combinations.
- [ ] Run format/lint/tests and capture benchmark or correctness notes in the PR.

## Minimal bootstrap commit
This PR starts with an empty initialization commit to establish branch/PR scaffolding before implementation.