### PR TITLE
partial: issue #150 spectral-norm benchmark prototype

### DIFF
--- a/src/main/modules/dedekind/sequences/path.cppm
+++ b/src/main/modules/dedekind/sequences/path.cppm
@@ -144,21 +144,19 @@ constexpr auto prefix(const Path<T, Cardinality>& path, std::size_t length) {
  * @tparam T The element type.
  * @tparam Cardinality The cardinality of the input path (must be infinite).
  * @param path The input path (must have infinite cardinality).
- * @param n The offset to drop (precondition: n + i must not overflow for all
- *           accessed indices i).
+ * @param n The offset to drop. Precondition: for each accessed index i, the
+ *          sum n + i must be representable in std::size_t.
  * @return An infinite path with the same cardinality, representing the shifted
  *         tail.
  */
 export template <typename T, typename Cardinality>
   requires(!IsFiniteMagnitude<Cardinality>)
 constexpr auto drop(const Path<T, Cardinality>& path, std::size_t n) {
-  // Precondition: n + i must not overflow std::size_t for accessed indices.
-  // For safety in finite scenarios, assert n is reasonable (e.g., <
-  // SIZE_MAX/2).
-  assert(n < std::numeric_limits<std::size_t>::max() / 2 &&
-         "drop offset too large; risk of overflow in n + i");
-  return Path<T, Cardinality>{
-      [path, n](std::size_t i) { return path.at(n + i); }};
+  return Path<T, Cardinality>{[path, n](std::size_t i) {
+    assert(i <= std::numeric_limits<std::size_t>::max() - n &&
+           "drop index overflow: n + i exceeds size_t");
+    return path.at(n + i);
+  }};
 }
 
 export template <typename T, typename Step>

--- a/src/test/cpp/modules/dedekind/numbers/spectral_norm_benchmark_test.cpp
+++ b/src/test/cpp/modules/dedekind/numbers/spectral_norm_benchmark_test.cpp
@@ -1,40 +1,113 @@
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/matchers/catch_matchers_floating_point.hpp>
+
 #include <chrono>
 #include <cmath>
 #include <cstddef>
-#include <span>
+#include <concepts>
+#include <type_traits>
 #include <vector>
+
+import dedekind.numbers;
+import dedekind.sequences;
+
+using namespace dedekind::numbers;
+using namespace dedekind::sequences;
 
 namespace {
 
-// Benchmarks Game spectral-norm matrix entry:
-// A(i,j) = 1 / ( ((i+j)(i+j+1)/2) + i + 1 )
-constexpr double spectral_entry(std::size_t i, std::size_t j) {
-  const std::size_t ij = i + j;
-  const double denom =
-      (static_cast<double>(ij) * static_cast<double>(ij + 1) * 0.5) +
-      static_cast<double>(i) + 1.0;
-  return 1.0 / denom;
+template <typename S>
+using DenseVector = std::vector<S>;
+
+template <typename S>
+concept RationalLike = requires(S x) {
+  typename S::Domain;
+  { x.num() } -> std::same_as<typename S::Domain>;
+  { x.den() } -> std::same_as<typename S::Domain>;
+};
+
+template <typename S>
+constexpr auto lift_real(double x) {
+  if constexpr (std::floating_point<S>) {
+    return static_cast<S>(x);
+  } else if constexpr (requires { typename S::scalar_type; S{typename S::scalar_type{}, typename S::scalar_type{}}; }) {
+    using R = typename S::scalar_type;
+    return S{static_cast<R>(x), R{}};
+  }
 }
 
-void apply_A(std::span<const double> in, std::span<double> out) {
+template <typename S>
+constexpr auto scalar_zero() {
+  if constexpr (RationalLike<S>) {
+    return S{typename S::Domain{0}, typename S::Domain{1}};
+  } else {
+    return lift_real<S>(0.0);
+  }
+}
+
+template <typename S>
+constexpr auto scalar_one() {
+  if constexpr (RationalLike<S>) {
+    return S{typename S::Domain{1}, typename S::Domain{1}};
+  } else {
+    return lift_real<S>(1.0);
+  }
+}
+
+template <typename S>
+double project_real(const S& x) {
+  // FIXME(https://github.com/vincentk/dedekind/issues/138): Replace this
+  // bridge with a production scalar-to-machine-real projection morphism.
+  if constexpr (std::floating_point<S>) {
+    return static_cast<double>(x);
+  } else if constexpr (requires { x.real(); }) {
+    return static_cast<double>(x.real());
+  } else if constexpr (RationalLike<S>) {
+    return static_cast<double>(x.num()) / static_cast<double>(x.den());
+  } else {
+    return static_cast<double>(x);
+  }
+}
+
+template <typename S>
+auto as_sequence(const DenseVector<S>& data) {
+  return FinitePath<S>{[&data](std::size_t i) { return data.at(i); },
+                       data.size()};
+}
+
+// Benchmarks Game spectral-norm matrix entry:
+// A(i,j) = 1 / ( ((i+j)(i+j+1)/2) + i + 1 )
+template <typename S>
+constexpr auto spectral_entry(std::size_t i, std::size_t j) {
+  const std::size_t ij = i + j;
+  const std::size_t denom = ((ij * (ij + 1u)) / 2u) + i + 1u;
+
+  if constexpr (RationalLike<S>) {
+    return S{typename S::Domain{1}, static_cast<typename S::Domain>(denom)};
+  } else {
+    return lift_real<S>(1.0 / static_cast<double>(denom));
+  }
+}
+
+template <typename S>
+void apply_A(const FinitePath<S>& in, DenseVector<S>& out) {
   const std::size_t n = in.size();
   for (std::size_t i = 0; i < n; ++i) {
-    double sum = 0.0;
+    auto sum = scalar_zero<S>();
     for (std::size_t j = 0; j < n; ++j) {
-      sum += spectral_entry(i, j) * in[j];
+      sum = sum + (spectral_entry<S>(i, j) * in.at(j));
     }
     out[i] = sum;
   }
 }
 
-void apply_At(std::span<const double> in, std::span<double> out) {
+template <typename S>
+void apply_At(const FinitePath<S>& in, DenseVector<S>& out) {
   const std::size_t n = in.size();
   for (std::size_t i = 0; i < n; ++i) {
-    double sum = 0.0;
+    auto sum = scalar_zero<S>();
     for (std::size_t j = 0; j < n; ++j) {
-      sum += spectral_entry(j, i) * in[j];
+      sum = sum + (spectral_entry<S>(j, i) * in.at(j));
     }
     out[i] = sum;
   }
@@ -42,33 +115,39 @@ void apply_At(std::span<const double> in, std::span<double> out) {
 
 // Extraction seam for #164: operator composition is isolated here and receives
 // explicit workspace storage rather than allocating internally.
-void apply_AtA(std::span<const double> in, std::span<double> out,
-               std::span<double> workspace) {
-  apply_A(in, workspace);
-  apply_At(workspace, out);
+template <typename S>
+void apply_AtA(const DenseVector<S>& in, DenseVector<S>& out,
+               DenseVector<S>& workspace) {
+  apply_A(as_sequence(in), workspace);
+  apply_At(as_sequence(workspace), out);
 }
 
-double dot(std::span<const double> lhs, std::span<const double> rhs) {
+template <typename S>
+double inner_product_energy(const DenseVector<S>& lhs,
+                            const DenseVector<S>& rhs) {
   const std::size_t n = lhs.size();
   double sum = 0.0;
   for (std::size_t i = 0; i < n; ++i) {
-    sum += lhs[i] * rhs[i];
+    sum += project_real(lhs[i] * rhs[i]);
   }
   return sum;
 }
 
+template <typename S>
 double spectral_norm(std::size_t n, std::size_t power_iterations = 10u) {
-  std::vector<double> u(n, 1.0);
-  std::vector<double> v(n, 0.0);
-  std::vector<double> tmp(n, 0.0);
+  if (n == 0u) return 0.0;
+
+  DenseVector<S> u(n, scalar_one<S>());
+  DenseVector<S> v(n, scalar_zero<S>());
+  DenseVector<S> tmp(n, scalar_zero<S>());
 
   for (std::size_t i = 0; i < power_iterations; ++i) {
     apply_AtA(u, v, tmp);
     apply_AtA(v, u, tmp);
   }
 
-  const double vBv = dot(u, v);
-  const double vv = dot(v, v);
+  const double vBv = inner_product_energy(u, v);
+  const double vv = inner_product_energy(v, v);
   return std::sqrt(vBv / vv);
 }
 
@@ -76,17 +155,22 @@ double spectral_norm(std::size_t n, std::size_t power_iterations = 10u) {
 
 TEST_CASE("Numbers: spectral norm benchmark kernels", "[numbers][spectral]") {
   SECTION("Matrix entry formula matches canonical values") {
-    REQUIRE(spectral_entry(0u, 0u) == 1.0);
-    REQUIRE(spectral_entry(0u, 1u) == 0.5);
-    REQUIRE(spectral_entry(1u, 0u) == (1.0 / 3.0));
-    REQUIRE(spectral_entry(1u, 1u) == 0.2);
+    REQUIRE(project_real(spectral_entry<double>(0u, 0u)) == 1.0);
+    REQUIRE(project_real(spectral_entry<double>(0u, 1u)) == 0.5);
+    REQUIRE(project_real(spectral_entry<double>(1u, 0u)) == (1.0 / 3.0));
+    REQUIRE(project_real(spectral_entry<double>(1u, 1u)) == 0.2);
   }
 
   SECTION("Power iteration tracks known benchmark values") {
-    REQUIRE_THAT(spectral_norm(10u),
-                 Catch::Matchers::WithinAbs(1.271844019, 1e-9));
-    REQUIRE_THAT(spectral_norm(100u),
-                 Catch::Matchers::WithinAbs(1.274219991, 1e-9));
+    REQUIRE_THAT(spectral_norm<double>(10u),
+                 Catch::Matchers::WithinRel(1.271844019, 1e-8));
+    REQUIRE_THAT(spectral_norm<double>(100u),
+                 Catch::Matchers::WithinRel(1.274219991, 1e-8));
+  }
+
+  SECTION("Scalar-generic pipeline also supports complex carriers") {
+    REQUIRE_THAT(spectral_norm<Complex<double>>(10u),
+                 Catch::Matchers::WithinRel(1.271844019, 1e-8));
   }
 }
 
@@ -94,7 +178,7 @@ TEST_CASE("Numbers: spectral norm benchmark-style run",
           "[numbers][spectral][.stress][.benchmark]") {
   const std::size_t n = 500u;
   const auto t0 = std::chrono::steady_clock::now();
-  const double result = spectral_norm(n);
+  const double result = spectral_norm<double>(n);
   const auto t1 = std::chrono::steady_clock::now();
 
   const auto elapsed_ms =
@@ -102,5 +186,5 @@ TEST_CASE("Numbers: spectral norm benchmark-style run",
 
   INFO("n=" << n << ", elapsed_ms=" << elapsed_ms << ", value=" << result);
 
-  REQUIRE_THAT(result, Catch::Matchers::WithinAbs(1.274224116, 1e-9));
+  REQUIRE_THAT(result, Catch::Matchers::WithinRel(1.274224116, 1e-8));
 }

--- a/src/test/cpp/modules/dedekind/numbers/spectral_norm_benchmark_test.cpp
+++ b/src/test/cpp/modules/dedekind/numbers/spectral_norm_benchmark_test.cpp
@@ -1,0 +1,106 @@
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_floating_point.hpp>
+
+#include <chrono>
+#include <cmath>
+#include <cstddef>
+#include <span>
+#include <vector>
+
+namespace {
+
+// Benchmarks Game spectral-norm matrix entry:
+// A(i,j) = 1 / ( ((i+j)(i+j+1)/2) + i + 1 )
+constexpr double spectral_entry(std::size_t i, std::size_t j) {
+  const std::size_t ij = i + j;
+  const double denom =
+      (static_cast<double>(ij) * static_cast<double>(ij + 1) * 0.5) +
+      static_cast<double>(i) + 1.0;
+  return 1.0 / denom;
+}
+
+void apply_A(std::span<const double> in, std::span<double> out) {
+  const std::size_t n = in.size();
+  for (std::size_t i = 0; i < n; ++i) {
+    double sum = 0.0;
+    for (std::size_t j = 0; j < n; ++j) {
+      sum += spectral_entry(i, j) * in[j];
+    }
+    out[i] = sum;
+  }
+}
+
+void apply_At(std::span<const double> in, std::span<double> out) {
+  const std::size_t n = in.size();
+  for (std::size_t i = 0; i < n; ++i) {
+    double sum = 0.0;
+    for (std::size_t j = 0; j < n; ++j) {
+      sum += spectral_entry(j, i) * in[j];
+    }
+    out[i] = sum;
+  }
+}
+
+// Extraction seam for #164: operator composition is isolated here and receives
+// explicit workspace storage rather than allocating internally.
+void apply_AtA(std::span<const double> in, std::span<double> out,
+               std::span<double> workspace) {
+  apply_A(in, workspace);
+  apply_At(workspace, out);
+}
+
+double dot(std::span<const double> lhs, std::span<const double> rhs) {
+  const std::size_t n = lhs.size();
+  double sum = 0.0;
+  for (std::size_t i = 0; i < n; ++i) {
+    sum += lhs[i] * rhs[i];
+  }
+  return sum;
+}
+
+double spectral_norm(std::size_t n, std::size_t power_iterations = 10u) {
+  std::vector<double> u(n, 1.0);
+  std::vector<double> v(n, 0.0);
+  std::vector<double> tmp(n, 0.0);
+
+  for (std::size_t i = 0; i < power_iterations; ++i) {
+    apply_AtA(u, v, tmp);
+    apply_AtA(v, u, tmp);
+  }
+
+  const double vBv = dot(u, v);
+  const double vv = dot(v, v);
+  return std::sqrt(vBv / vv);
+}
+
+}  // namespace
+
+TEST_CASE("Numbers: spectral norm benchmark kernels", "[numbers][spectral]") {
+  SECTION("Matrix entry formula matches canonical values") {
+    REQUIRE(spectral_entry(0u, 0u) == 1.0);
+    REQUIRE(spectral_entry(0u, 1u) == 0.5);
+    REQUIRE(spectral_entry(1u, 0u) == (1.0 / 3.0));
+    REQUIRE(spectral_entry(1u, 1u) == 0.2);
+  }
+
+  SECTION("Power iteration tracks known benchmark values") {
+    REQUIRE_THAT(spectral_norm(10u), Catch::Matchers::WithinAbs(1.271844019, 1e-9));
+    REQUIRE_THAT(spectral_norm(100u),
+                 Catch::Matchers::WithinAbs(1.274219991, 1e-9));
+  }
+}
+
+TEST_CASE("Numbers: spectral norm benchmark-style run",
+          "[numbers][spectral][.stress][.benchmark]") {
+  const std::size_t n = 500u;
+  const auto t0 = std::chrono::steady_clock::now();
+  const double result = spectral_norm(n);
+  const auto t1 = std::chrono::steady_clock::now();
+
+  const auto elapsed_ms =
+      std::chrono::duration_cast<std::chrono::milliseconds>(t1 - t0).count();
+
+  INFO("n=" << n << ", elapsed_ms=" << elapsed_ms << ", value=" << result);
+
+  REQUIRE_THAT(result, Catch::Matchers::WithinAbs(1.274224116, 1e-9));
+}

--- a/src/test/cpp/modules/dedekind/numbers/spectral_norm_benchmark_test.cpp
+++ b/src/test/cpp/modules/dedekind/numbers/spectral_norm_benchmark_test.cpp
@@ -1,6 +1,5 @@
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/matchers/catch_matchers_floating_point.hpp>
-
 #include <chrono>
 #include <cmath>
 #include <cstddef>
@@ -84,7 +83,8 @@ TEST_CASE("Numbers: spectral norm benchmark kernels", "[numbers][spectral]") {
   }
 
   SECTION("Power iteration tracks known benchmark values") {
-    REQUIRE_THAT(spectral_norm(10u), Catch::Matchers::WithinAbs(1.271844019, 1e-9));
+    REQUIRE_THAT(spectral_norm(10u),
+                 Catch::Matchers::WithinAbs(1.271844019, 1e-9));
     REQUIRE_THAT(spectral_norm(100u),
                  Catch::Matchers::WithinAbs(1.274219991, 1e-9));
   }

--- a/src/test/cpp/modules/dedekind/numbers/spectral_norm_benchmark_test.cpp
+++ b/src/test/cpp/modules/dedekind/numbers/spectral_norm_benchmark_test.cpp
@@ -1,10 +1,10 @@
+#include <cassert>
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/matchers/catch_matchers_floating_point.hpp>
 #include <chrono>
 #include <cmath>
 #include <concepts>
 #include <cstddef>
-#include <type_traits>
 #include <vector>
 
 import dedekind.numbers;
@@ -14,6 +14,9 @@ using namespace dedekind::numbers;
 using namespace dedekind::sequences;
 
 namespace {
+
+template <typename>
+inline constexpr bool dependent_false_v = false;
 
 template <typename S>
 using DenseVector = std::vector<S>;
@@ -36,6 +39,11 @@ constexpr auto lift_real(double x) {
                        }) {
     using R = typename S::scalar_type;
     return S{static_cast<R>(x), R{}};
+  } else {
+    static_assert(dependent_false_v<S>,
+                  "lift_real<S> requires either a floating-point scalar or a"
+                  " complex-like scalar with `scalar_type` and two-argument"
+                  " construction");
   }
 }
 
@@ -95,6 +103,7 @@ constexpr auto spectral_entry(std::size_t i, std::size_t j) {
 template <typename S>
 void apply_A(const FinitePath<S>& in, DenseVector<S>& out) {
   const std::size_t n = in.size();
+  assert(out.size() == n && "apply_A: output vector size must match input");
   for (std::size_t i = 0; i < n; ++i) {
     auto sum = scalar_zero<S>();
     for (std::size_t j = 0; j < n; ++j) {
@@ -107,6 +116,7 @@ void apply_A(const FinitePath<S>& in, DenseVector<S>& out) {
 template <typename S>
 void apply_At(const FinitePath<S>& in, DenseVector<S>& out) {
   const std::size_t n = in.size();
+  assert(out.size() == n && "apply_At: output vector size must match input");
   for (std::size_t i = 0; i < n; ++i) {
     auto sum = scalar_zero<S>();
     for (std::size_t j = 0; j < n; ++j) {
@@ -121,6 +131,10 @@ void apply_At(const FinitePath<S>& in, DenseVector<S>& out) {
 template <typename S>
 void apply_AtA(const DenseVector<S>& in, DenseVector<S>& out,
                DenseVector<S>& workspace) {
+  assert(out.size() == in.size() &&
+         "apply_AtA: output vector size must match input");
+  assert(workspace.size() == in.size() &&
+         "apply_AtA: workspace vector size must match input");
   apply_A(as_sequence(in), workspace);
   apply_At(as_sequence(workspace), out);
 }
@@ -128,6 +142,8 @@ void apply_AtA(const DenseVector<S>& in, DenseVector<S>& out,
 template <typename S>
 double inner_product_energy(const DenseVector<S>& lhs,
                             const DenseVector<S>& rhs) {
+  assert(lhs.size() == rhs.size() &&
+         "inner_product_energy: input vector sizes must match");
   const std::size_t n = lhs.size();
   double sum = 0.0;
   for (std::size_t i = 0; i < n; ++i) {
@@ -139,6 +155,7 @@ double inner_product_energy(const DenseVector<S>& lhs,
 template <typename S>
 double spectral_norm(std::size_t n, std::size_t power_iterations = 10u) {
   if (n == 0u) return 0.0;
+  if (power_iterations == 0u) return 0.0;
 
   DenseVector<S> u(n, scalar_one<S>());
   DenseVector<S> v(n, scalar_zero<S>());
@@ -158,10 +175,14 @@ double spectral_norm(std::size_t n, std::size_t power_iterations = 10u) {
 
 TEST_CASE("Numbers: spectral norm benchmark kernels", "[numbers][spectral]") {
   SECTION("Matrix entry formula matches canonical values") {
-    REQUIRE(project_real(spectral_entry<double>(0u, 0u)) == 1.0);
-    REQUIRE(project_real(spectral_entry<double>(0u, 1u)) == 0.5);
-    REQUIRE(project_real(spectral_entry<double>(1u, 0u)) == (1.0 / 3.0));
-    REQUIRE(project_real(spectral_entry<double>(1u, 1u)) == 0.2);
+    REQUIRE_THAT(project_real(spectral_entry<double>(0u, 0u)),
+                 Catch::Matchers::WithinRel(1.0, 1e-12));
+    REQUIRE_THAT(project_real(spectral_entry<double>(0u, 1u)),
+                 Catch::Matchers::WithinRel(0.5, 1e-12));
+    REQUIRE_THAT(project_real(spectral_entry<double>(1u, 0u)),
+                 Catch::Matchers::WithinRel(1.0 / 3.0, 1e-12));
+    REQUIRE_THAT(project_real(spectral_entry<double>(1u, 1u)),
+                 Catch::Matchers::WithinRel(0.2, 1e-12));
   }
 
   SECTION("Power iteration tracks known benchmark values") {

--- a/src/test/cpp/modules/dedekind/numbers/spectral_norm_benchmark_test.cpp
+++ b/src/test/cpp/modules/dedekind/numbers/spectral_norm_benchmark_test.cpp
@@ -1,10 +1,9 @@
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/matchers/catch_matchers_floating_point.hpp>
-
 #include <chrono>
 #include <cmath>
-#include <cstddef>
 #include <concepts>
+#include <cstddef>
 #include <type_traits>
 #include <vector>
 
@@ -30,7 +29,11 @@ template <typename S>
 constexpr auto lift_real(double x) {
   if constexpr (std::floating_point<S>) {
     return static_cast<S>(x);
-  } else if constexpr (requires { typename S::scalar_type; S{typename S::scalar_type{}, typename S::scalar_type{}}; }) {
+  } else if constexpr (requires {
+                         typename S::scalar_type;
+                         S{typename S::scalar_type{},
+                           typename S::scalar_type{}};
+                       }) {
     using R = typename S::scalar_type;
     return S{static_cast<R>(x), R{}};
   }


### PR DESCRIPTION
Partially addresses #150.

This PR delivers a working spectral-norm benchmark prototype with deterministic checks and forward-compatible operator seams, but does **not** fully close #150 yet.

What is included:
- Spectral norm benchmark kernel and benchmark-style stress case.
- Sequence-oriented operator decomposition (`A`, `A^T`, `A^T A`) with explicit workspace flow.
- Regression checks for canonical benchmark values.

What remains before full #150 closure:
- Replace local scalar-to-machine-real bridge with a production projection morphism (tracked in #138).
- Fold reusable operator abstractions into matrix-core APIs (tracked in #164), then consume them from this benchmark.

Issue links:
- #150 (partial fulfillment)
- #138
- #164