### PR TITLE
feat(#181): Jacobian contract, flat tangent/cotangent bundles, make as canonical build interface

### DIFF
--- a/.github/instructions/*.instructions.md
+++ b/.github/instructions/*.instructions.md
@@ -23,7 +23,9 @@ Then triage the backlog:
 - Prefer plain `gh` CLI invocations (for example `gh pr checks <number>`).
 - When available, prefer repository `make` wrappers for CI/PR status checks:
   `make ci-main`, `make pr-status`, `make pr-checks`, `make pr-watch`, `make pr-sync`.
-- Prefer standardized command-line utilities (especially `gh`, `git`, `cmake`, `ctest`, `make`) over general-purpose scripts for automation work, to reduce approval friction and keep command intents auditable.
+- Commands in this environment may require explicit approval, so prefer standardized command-line utilities (especially `gh`, `git`, `cmake`, `ctest`, `make`) over free-flow Python or shell scripts for automation work; this keeps command intent auditable and easier to approve.
+- If a housekeeping utility is still needed beyond the standardized commands and existing `make` targets, request it interactively first. If approved, place it under `.github/copilot/housekeeping` rather than inlining an ad-hoc script in the session.
+- If such a utility is required, propose it as a reusable checked-in implementation with a clear interface and narrow purpose, so review noise stays manageable and future sessions can reuse the same approved path.
 - Do not prepend `GH_PAGER=cat` (or similar env overrides) unless explicitly requested, because it can trigger repetitive local approval prompts in this environment.
 - Prefer selecting exactly two actionable items to work on in parallel when feasible (for example, while CI builds/reviews are pending), to keep throughput high without over-fragmenting scope.
 - Run `gh issue list --state open --limit 50 --json number,title,body,labels,comments` to fetch all open issues.

--- a/.github/instructions/*.instructions.md
+++ b/.github/instructions/*.instructions.md
@@ -21,6 +21,8 @@ At the start of each session (and after every merge to `main`), run the followin
 
 Then triage the backlog:
 - Prefer plain `gh` CLI invocations (for example `gh pr checks <number>`).
+- When available, prefer repository `make` wrappers for CI/PR status checks:
+  `make ci-main`, `make pr-status`, `make pr-checks`, `make pr-watch`, `make pr-sync`.
 - Prefer standardized command-line utilities (especially `gh`, `git`, `cmake`, `ctest`, `make`) over general-purpose scripts for automation work, to reduce approval friction and keep command intents auditable.
 - Do not prepend `GH_PAGER=cat` (or similar env overrides) unless explicitly requested, because it can trigger repetitive local approval prompts in this environment.
 - Prefer selecting exactly two actionable items to work on in parallel when feasible (for example, while CI builds/reviews are pending), to keep throughput high without over-fragmenting scope.

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -30,24 +30,13 @@ jobs:
         sudo apt-get install -y biber doxygen graphviz texlive-latex-base texlive-latex-extra texlive-bibtex-extra texlive-pictures texlive-plain-generic texlive-fonts-recommended
 
     - name: Check Code Formatting
-      run: find src -name "*.cpp" -o -name "*.cppm" | xargs clang-format-21 --dry-run --Werror
-
-    - name: Configure CMake
-      # Note: CMAKE_CXX_COMPILER is required to use a recent clang.
-      # Note: CMAKE_CXX_SCAN_FOR_MODULES is required for clang to find the module interfaces.
-      # Note: Ninja is required for CMAKE_CXX_SCAN_FOR_MODULES to work.
-      # Note: CMAKE_BUILD_TYPE=Release is required for the code to compile at all, due to the use of concepts and modules.
-      # Note: DEDEKIND_RUNTIME_COVERAGE_BRIDGES=ON improves coverage attribution
-      # for numeric bridge wrappers during Codecov runs.
-      run: cmake -S . -B build -G Ninja -DCMAKE_CXX_COMPILER=clang++-21 -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_SCAN_FOR_MODULES=ON -DDEDEKIND_RUNTIME_COVERAGE_BRIDGES=ON -DDEDEKIND_ENABLE_DOUBLE_REAL_PROXY=ON
+      run: make format-check CLANG_FORMAT=clang-format-21
 
     - name: Build & Run Tests
-      run: |
-        cmake --build build
-        ctest --test-dir build --output-on-failure -V
+      run: make test CXX=clang++-21 CC=clang-21 CMAKE_EXTRA_ARGS="-DDEDEKIND_RUNTIME_COVERAGE_BRIDGES=ON"
 
     - name: Process Coverage Data
-      run: cmake --build build --target generate_coverage
+      run: make coverage CXX=clang++-21 CC=clang-21 CMAKE_EXTRA_ARGS="-DDEDEKIND_RUNTIME_COVERAGE_BRIDGES=ON"
 
     - name: Upload to Codecov
       uses: codecov/codecov-action@v5
@@ -60,12 +49,10 @@ jobs:
     # --- CONDITIONAL DEPLOYMENT STEPS ---
     
     - name: Build Doxygen Documentation
-      run: |
-        cmake --build build --target docs
+      run: make doxygen CXX=clang++-21 CC=clang-21 CMAKE_EXTRA_ARGS="-DDEDEKIND_RUNTIME_COVERAGE_BRIDGES=ON"
 
     - name: Check Report Compilation
-      run: |
-        make -C docs/report ci-check
+      run: make report
 
     - name: Build Publishable Report
       if: github.ref == 'refs/heads/main' && github.event_name == 'push'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,6 +51,9 @@ Thank you for your interest in contributing!
    freely — you do not need to confirm that the code compiles or tests pass locally before
    pushing.  The CI build is the authoritative reference; use it to offload compilation and
    test validation so local development stays unblocked.
+- This project intentionally follows an optimistic concurrency model: contributors can
+   continue shipping small draft-PR checkpoints while CI validates correctness in parallel,
+   which improves overall throughput and reduces workstation idle/blocking time.
 - Before pushing, run `make format` or install the managed hook with `make install-hooks`.
 - Check the PR's CI status regularly while iterating — not necessarily before every push,
    but frequently enough to catch failures early before they compound.  Large divergences

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,7 +40,8 @@ Thank you for your interest in contributing!
 
 - The `Makefile` is the **preferred** build interface; use `make <target>` rather than
    raw `cmake`/`ninja`/`ctest` commands whenever an equivalent target exists.
-   Available targets: `compile`, `test`, `format`, `coverage`, `doxygen`, `clean`, `install-hooks`.
+   Available targets: `compile`, `test`, `format`, `coverage`, `doxygen`, `clean`, `install-hooks`,
+   `ci-main`, `pr-status`, `pr-checks`, `pr-watch`, `pr-sync`.
 - Treat the GitHub CI build as the reference build for the project.  Local builds are useful,
    but merge readiness is determined by the PR checks.
 - Workflow model note: this project intentionally uses an optimistic concurrency
@@ -66,6 +67,8 @@ Thank you for your interest in contributing!
    push small checkpoints, but verify the reference build state first so failures do not
    compound into large divergences. If a check fails, read the workflow logs and address
    the failure before continuing with unrelated work.
+   Suggested command flow:
+   `make pr-sync` (refresh branch + current PR state), then push, then `make pr-watch`.
 - After a green CI run, also check the Codecov report for regressions before marking the PR ready.
 - Mark the PR **Ready for Review** only once **all CI checks show green**.  A draft PR
    with failing CI should never be marked ready.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,6 +50,10 @@ Thank you for your interest in contributing!
   `make pr-sync` runs fetch/status/PR-check snapshot before a push.
 - Treat the GitHub CI build as the reference build for the project.  Local builds are useful,
    but merge readiness is determined by the PR checks.
+- **Net result:** the CI pipeline now uses the same `make` targets as contributors do locally
+   (`make test`, `make coverage`, `make doxygen`, `make report`).  The only thing a contributor
+   strictly needs to run locally is `git push`; GitHub Actions handles the heavy compilation,
+   test execution, coverage processing, and documentation builds on every push.
 - Workflow model note: this project intentionally uses an optimistic concurrency
    model rather than a pessimistic one. In practice, CI is more authoritative
    than local builds, and a small temporary divergence between local and CI

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,10 +50,13 @@ Thank you for your interest in contributing!
   `make pr-sync` runs fetch/status/PR-check snapshot before a push.
 - Treat the GitHub CI build as the reference build for the project.  Local builds are useful,
    but merge readiness is determined by the PR checks.
-- **Net result:** the CI pipeline now uses the same `make` targets as contributors do locally
-   (`make test`, `make coverage`, `make doxygen`, `make report`).  The only thing a contributor
-   strictly needs to run locally is `git push`; GitHub Actions handles the heavy compilation,
-   test execution, coverage processing, and documentation builds on every push.
+- **Net result:** the CI pipeline uses the same `make` targets as contributors do locally
+   (`make test`, `make coverage`, `make doxygen`, `make report`).  For routine development,
+   the only thing a contributor strictly needs to run locally is `git push`; GitHub Actions
+   handles the heavy compilation, test execution, coverage processing, and documentation
+   builds on every push.  Local builds remain necessary when debugging non-trivial build
+   failures or investigating toolchain-specific issues that cannot be diagnosed from CI logs
+   alone.
 - Workflow model note: this project intentionally uses an optimistic concurrency
    model rather than a pessimistic one. In practice, CI is more authoritative
    than local builds, and a small temporary divergence between local and CI

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,8 +10,11 @@ Thank you for your interest in contributing!
    you invest time in an implementation.
 3. **Create a branch** named after the issue(s) you are addressing, e.g.
    `feat/issues-40-121`.
-4. **Implement and test** your changes.  Use the `Makefile` targets — they are the
-   canonical interface for both local development and CI:
+4. **Implement your changes** and push to a draft PR early and often — you do not need
+   to verify that the code compiles or tests pass locally before each push.  The CI build
+   is the reference build; offloading compilation and test execution to CI is explicitly
+   encouraged so local development is not blocked by slow or unavailable toolchains.
+   Use the `Makefile` targets when a local build is convenient:
    ```bash
    make compile   # configure (first run) and build everything
    make test      # build then run the full CTest suite
@@ -29,8 +32,9 @@ Thank you for your interest in contributing!
    ```
    The `pre-push` hook runs `make format` and aborts the push if it had to rewrite files,
    so you can review and commit the formatting changes explicitly.
-6. **Open a pull request** against `main` from your fork branch.  Draft PRs are welcome
-   early; mark it ready for review once CI is green.
+6. **Open a draft PR** against `main` early — even before the implementation is complete.
+   Push incremental checkpoints freely; the draft status signals work-in-progress.
+   Mark the PR **Ready for Review** only once **all CI checks are green**.
 
 ## Development workflow
 
@@ -43,13 +47,16 @@ Thank you for your interest in contributing!
 - Keep the README small and stable.  Only update it when something is plainly wrong or deeply
    misleading; routine progress belongs in the report and inline documentation.
 - Prefer plain `gh` CLI commands when working with issues, pull requests, and CI.
-- Open a draft PR early, even before the implementation is complete, so the work is visible and
-   the reference CI starts running immediately.
+- Open a draft PR early, even before the implementation is complete.  Push checkpoints
+   freely — you do not need to confirm that the code compiles or tests pass locally before
+   pushing.  The CI build is the authoritative reference; use it to offload compilation and
+   test validation so local development stays unblocked.
 - Before pushing, run `make format` or install the managed hook with `make install-hooks`.
-- Poll PR checks regularly during development.  If a check fails, inspect the failed workflow
-   logs before making further changes.
+- Check the PR's CI status regularly while iterating.  If a check fails, read the workflow
+   logs and address the failure before continuing with unrelated work.
 - After a green CI run, also check the Codecov report for regressions before marking the PR ready.
-- Once CI is green and coverage looks acceptable, mark the PR ready for review.
+- Mark the PR **Ready for Review** only once **all CI checks show green**.  A draft PR
+   with failing CI should never be marked ready.
 
 ## Review workflow
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,6 +43,10 @@ Thank you for your interest in contributing!
    Available targets: `compile`, `test`, `format`, `coverage`, `doxygen`, `clean`, `install-hooks`.
 - Treat the GitHub CI build as the reference build for the project.  Local builds are useful,
    but merge readiness is determined by the PR checks.
+- Workflow model note: this project intentionally uses an optimistic concurrency
+   model rather than a pessimistic one. In practice, CI is more authoritative
+   than local builds, and a small temporary divergence between local and CI
+   status is acceptable while iterating on draft PR checkpoints.
 - Before starting new work, check that the most recent `main` branch CI run is green.
 - Keep the README small and stable.  Only update it when something is plainly wrong or deeply
    misleading; routine progress belongs in the report and inline documentation.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,6 +42,12 @@ Thank you for your interest in contributing!
    raw `cmake`/`ninja`/`ctest` commands whenever an equivalent target exists.
    Available targets: `compile`, `test`, `format`, `coverage`, `doxygen`, `clean`, `install-hooks`,
    `ci-main`, `pr-status`, `pr-checks`, `pr-watch`, `pr-sync`.
+- Contributor workflow helper targets:
+  `make ci-main` checks recent `main` branch CI runs.
+  `make pr-status` shows PR metadata for the current branch.
+  `make pr-checks` snapshots current PR check state.
+  `make pr-watch` blocks until PR checks complete.
+  `make pr-sync` runs fetch/status/PR-check snapshot before a push.
 - Treat the GitHub CI build as the reference build for the project.  Local builds are useful,
    but merge readiness is determined by the PR checks.
 - Workflow model note: this project intentionally uses an optimistic concurrency

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,8 +40,8 @@ Thank you for your interest in contributing!
 
 - The `Makefile` is the **preferred** build interface; use `make <target>` rather than
    raw `cmake`/`ninja`/`ctest` commands whenever an equivalent target exists.
-   Available targets: `compile`, `test`, `format`, `coverage`, `doxygen`, `clean`, `install-hooks`,
-   `ci-main`, `pr-status`, `pr-checks`, `pr-watch`, `pr-sync`.
+   Available targets: `compile`, `test`, `format`, `format-check`, `coverage`, `doxygen`, `report`,
+   `clean`, `install-hooks`, `ci-main`, `pr-status`, `pr-checks`, `pr-watch`, `pr-sync`.
 - Contributor workflow helper targets:
   `make ci-main` checks recent `main` branch CI runs.
   `make pr-status` shows PR metadata for the current branch.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,12 +10,15 @@ Thank you for your interest in contributing!
    you invest time in an implementation.
 3. **Create a branch** named after the issue(s) you are addressing, e.g.
    `feat/issues-40-121`.
-4. **Implement and test** your changes.  The project builds with CMake + Ninja:
+4. **Implement and test** your changes.  Use the `Makefile` targets — they are the
+   canonical interface for both local development and CI:
    ```bash
-   cmake -B build -G Ninja
-   cmake --build build
-   ctest --test-dir build --output-on-failure
+   make compile   # configure (first run) and build everything
+   make test      # build then run the full CTest suite
    ```
+   The `Makefile` selects the correct compiler (`clang++` from LLVM) and passes
+   all required CMake flags automatically, including `DEDEKIND_ENABLE_DOUBLE_REAL_PROXY=ON`
+   which is needed for tests that use `double` as the scalar type.
 5. **Format** before committing — the CI will reject unformatted code:
    ```bash
    make format   # runs clang-format-21 on all *.cpp / *.cppm files
@@ -31,6 +34,9 @@ Thank you for your interest in contributing!
 
 ## Development workflow
 
+- The `Makefile` is the **preferred** build interface; use `make <target>` rather than
+   raw `cmake`/`ninja`/`ctest` commands whenever an equivalent target exists.
+   Available targets: `compile`, `test`, `format`, `coverage`, `doxygen`, `clean`, `install-hooks`.
 - Treat the GitHub CI build as the reference build for the project.  Local builds are useful,
    but merge readiness is determined by the PR checks.
 - Before starting new work, check that the most recent `main` branch CI run is green.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -55,11 +55,10 @@ Thank you for your interest in contributing!
    continue shipping small draft-PR checkpoints while CI validates correctness in parallel,
    which improves overall throughput and reduces workstation idle/blocking time.
 - Before pushing, run `make format` or install the managed hook with `make install-hooks`.
-- Check the PR's CI status regularly while iterating — not necessarily before every push,
-   but frequently enough to catch failures early before they compound.  Large divergences
-   between the local state and the reference build are harder to diagnose and fix.
-   If a check fails, read the workflow logs and address the failure before continuing with
-   unrelated work.
+- Check the PR's CI status before each push to keep optimistic concurrency tight:
+   push small checkpoints, but verify the reference build state first so failures do not
+   compound into large divergences. If a check fails, read the workflow logs and address
+   the failure before continuing with unrelated work.
 - After a green CI run, also check the Codecov report for regressions before marking the PR ready.
 - Mark the PR **Ready for Review** only once **all CI checks show green**.  A draft PR
    with failing CI should never be marked ready.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,6 +36,28 @@ Thank you for your interest in contributing!
    Push incremental checkpoints freely; the draft status signals work-in-progress.
    Mark the PR **Ready for Review** only once **all CI checks are green**.
 
+## Workflow at a glance
+
+The intended UX is:
+
+1. **Edit** source files locally — no local build required.
+2. **Format** with `make format` (or let the pre-push hook do it).
+3. **Push** — `git push` is the only command you strictly need to run.
+4. **CI takes over** — GitHub Actions compiles with clang-21, runs all tests,
+   collects coverage, builds Doxygen docs, and checks the LaTeX report.
+   Your workstation stays idle and cool.
+5. **Check progress** with `make pr-checks` or `make pr-watch` while CI runs.
+6. **Iterate** — if CI flags a failure, read the workflow logs, fix locally,
+   push again.  Repeat until green.
+7. **Mark ready** — once all CI checks are green, mark the PR ready for review.
+
+**When local builds are needed:** non-trivial build failures or toolchain-specific
+issues that cannot be diagnosed from CI logs alone warrant a local `make compile`
+or `make test`.  This should be the exception, not the routine.
+
+The goal is to keep the contributor's focus on the mathematics and the code, not
+on build management.
+
 ## Development workflow
 
 - The `Makefile` is the **preferred** build interface; use `make <target>` rather than

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,6 +47,9 @@ Thank you for your interest in contributing!
    model rather than a pessimistic one. In practice, CI is more authoritative
    than local builds, and a small temporary divergence between local and CI
    status is acceptable while iterating on draft PR checkpoints.
+- Motivation: this model is not only about throughput; it also mitigates
+   "works on my laptop" failures by treating CI as the reproducible baseline
+   and local environments as potentially non-reproducible.
 - Before starting new work, check that the most recent `main` branch CI run is green.
 - Keep the README small and stable.  Only update it when something is plainly wrong or deeply
    misleading; routine progress belongs in the report and inline documentation.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,13 +63,14 @@ on build management.
 - The `Makefile` is the **preferred** build interface; use `make <target>` rather than
    raw `cmake`/`ninja`/`ctest` commands whenever an equivalent target exists.
    Available targets: `compile`, `test`, `format`, `format-check`, `coverage`, `doxygen`, `report`,
-   `clean`, `install-hooks`, `ci-main`, `pr-status`, `pr-checks`, `pr-watch`, `pr-sync`, `pr-review-unresolved`.
+   `clean`, `install-hooks`, `ci-main`, `pr-status`, `pr-checks`, `pr-watch`, `pr-sync`, `pr-review-comments`, `pr-review-unresolved`.
 - Contributor workflow helper targets:
   `make ci-main` checks recent `main` branch CI runs.
   `make pr-status` shows PR metadata for the current branch.
   `make pr-checks` snapshots current PR check state.
   `make pr-watch` blocks until PR checks complete.
   `make pr-sync` runs fetch/status/PR-check snapshot before a push.
+  `make pr-review-comments` lists inline review comments on the current PR (or `PR=<number>`).
   `make pr-review-unresolved` scans unresolved review threads on the current PR (or `make pr-review-unresolved PR=<number>`).
 - Treat the GitHub CI build as the reference build for the project.  Local builds are useful,
    but merge readiness is determined by the PR checks.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -52,8 +52,11 @@ Thank you for your interest in contributing!
    pushing.  The CI build is the authoritative reference; use it to offload compilation and
    test validation so local development stays unblocked.
 - Before pushing, run `make format` or install the managed hook with `make install-hooks`.
-- Check the PR's CI status regularly while iterating.  If a check fails, read the workflow
-   logs and address the failure before continuing with unrelated work.
+- Check the PR's CI status regularly while iterating — not necessarily before every push,
+   but frequently enough to catch failures early before they compound.  Large divergences
+   between the local state and the reference build are harder to diagnose and fix.
+   If a check fails, read the workflow logs and address the failure before continuing with
+   unrelated work.
 - After a green CI run, also check the Codecov report for regressions before marking the PR ready.
 - Mark the PR **Ready for Review** only once **all CI checks show green**.  A draft PR
    with failing CI should never be marked ready.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,13 +63,14 @@ on build management.
 - The `Makefile` is the **preferred** build interface; use `make <target>` rather than
    raw `cmake`/`ninja`/`ctest` commands whenever an equivalent target exists.
    Available targets: `compile`, `test`, `format`, `format-check`, `coverage`, `doxygen`, `report`,
-   `clean`, `install-hooks`, `ci-main`, `pr-status`, `pr-checks`, `pr-watch`, `pr-sync`.
+   `clean`, `install-hooks`, `ci-main`, `pr-status`, `pr-checks`, `pr-watch`, `pr-sync`, `pr-review-unresolved`.
 - Contributor workflow helper targets:
   `make ci-main` checks recent `main` branch CI runs.
   `make pr-status` shows PR metadata for the current branch.
   `make pr-checks` snapshots current PR check state.
   `make pr-watch` blocks until PR checks complete.
   `make pr-sync` runs fetch/status/PR-check snapshot before a push.
+  `make pr-review-unresolved` scans unresolved review threads on the current PR (or `make pr-review-unresolved PR=<number>`).
 - Treat the GitHub CI build as the reference build for the project.  Local builds are useful,
    but merge readiness is determined by the PR checks.
 - **Net result:** the CI pipeline uses the same `make` targets as contributors do locally
@@ -112,6 +113,8 @@ on build management.
 
 - Resolve review comments and threads explicitly; do not leave unresolved conversations behind
    when preparing a PR for merge.
+- Run `make pr-review-unresolved` before marking a PR ready; this target exits non-zero when unresolved
+  review threads are found.
 - For low-risk mechanical fixes, batching routine changes is acceptable; for semantic or API
    changes, prefer manual edits so the trade-offs remain explicit.
 - After pushing follow-up commits, re-request review so the latest state is reviewed.

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ FILTER_GVPR  := $(DOCS_DIR)/figures/filter.gvpr
 DOT_FILE     := $(DOCS_DIR)/figures/dedekind_module_dependencies.dot
 
 .PHONY: all clean compile test coverage format format-check install-hooks doxygen dot doc report \
-	ci-main pr-status pr-checks pr-watch pr-sync
+	ci-main pr-status pr-checks pr-watch pr-sync pr-review-unresolved
 
 all: compile
 
@@ -78,6 +78,35 @@ pr-sync:
 	git status -sb
 	gh pr view --json number,title,state,isDraft,url
 	gh pr checks || true
+
+# Scan unresolved review threads on the current PR (or PR=<number>).
+pr-review-unresolved:
+	@PR_NUM="$(PR)"; \
+	if [ -z "$$PR_NUM" ]; then \
+		PR_NUM="$$(gh pr view --json number --jq .number)"; \
+	fi; \
+	REPO="$$(gh repo view --json nameWithOwner --jq .nameWithOwner)"; \
+	OWNER="$${REPO%/*}"; \
+	NAME="$${REPO#*/}"; \
+	echo "Scanning unresolved review threads for PR #$$PR_NUM ($$REPO)..."; \
+	COUNT="$$(gh api graphql \
+		-F owner="$$OWNER" \
+		-F name="$$NAME" \
+		-F number="$$PR_NUM" \
+		-f query='query($$owner:String!, $$name:String!, $$number:Int!) { repository(owner: $$owner, name: $$name) { pullRequest(number: $$number) { reviewThreads(first: 100) { nodes { isResolved path line comments(first: 1) { nodes { author { login } } } } } } } }' \
+		--jq '.data.repository.pullRequest.reviewThreads.nodes | map(select(.isResolved == false)) | length')"; \
+	if [ "$$COUNT" -eq 0 ]; then \
+		echo "OK: no unresolved review threads."; \
+	else \
+		echo "Found $$COUNT unresolved review thread(s):"; \
+		gh api graphql \
+			-F owner="$$OWNER" \
+			-F name="$$NAME" \
+			-F number="$$PR_NUM" \
+			-f query='query($$owner:String!, $$name:String!, $$number:Int!) { repository(owner: $$owner, name: $$name) { pullRequest(number: $$number) { reviewThreads(first: 100) { nodes { isResolved path line comments(first: 1) { nodes { author { login } } } } } } } }' \
+			--jq '.data.repository.pullRequest.reviewThreads.nodes | map(select(.isResolved == false)) | .[] | "- " + (.path // "<unknown>") + ":" + ((.line // 0) | tostring) + " by @" + (.comments.nodes[0].author.login // "unknown")'; \
+		exit 1; \
+	fi
 
 doxygen: $(BUILD_DIR)/CMakeCache.txt
 	cmake --build $(BUILD_DIR) --target docs

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ FILTER_GVPR  := $(DOCS_DIR)/figures/filter.gvpr
 DOT_FILE     := $(DOCS_DIR)/figures/dedekind_module_dependencies.dot
 
 .PHONY: all clean compile test coverage format format-check install-hooks doxygen dot doc report \
-	ci-main pr-status pr-checks pr-watch pr-sync pr-review-unresolved
+	ci-main pr-status pr-checks pr-watch pr-sync pr-review-comments pr-review-unresolved
 
 all: compile
 
@@ -78,6 +78,17 @@ pr-sync:
 	git status -sb
 	gh pr view --json number,title,state,isDraft,url
 	gh pr checks || true
+
+# List inline PR review comments for the current PR (or PR=<number>).
+pr-review-comments:
+	@PR_NUM="$(PR)"; \
+	if [ -z "$$PR_NUM" ]; then \
+		PR_NUM="$$(gh pr view --json number --jq .number)"; \
+	fi; \
+	REPO="$$(gh repo view --json nameWithOwner --jq .nameWithOwner)"; \
+	echo "Listing review comments for PR #$$PR_NUM ($$REPO)..."; \
+	gh api repos/$$REPO/pulls/$$PR_NUM/comments \
+		--jq '.[] | "- " + .path + ":" + (.line|tostring) + " :: " + (.body | gsub("\\n"; " "))'
 
 # Scan unresolved review threads on the current PR (or PR=<number>).
 pr-review-unresolved:

--- a/Makefile
+++ b/Makefile
@@ -4,15 +4,17 @@
 
 # Project Variables
 BUILD_DIR    := build
-LLVM_ROOT    := /usr/local/opt/llvm
-CXX          := $(LLVM_ROOT)/bin/clang++
-CC           := $(LLVM_ROOT)/bin/clang
+LLVM_ROOT    ?= /usr/local/opt/llvm
+CXX          ?= $(LLVM_ROOT)/bin/clang++
+CC           ?= $(LLVM_ROOT)/bin/clang
+CLANG_FORMAT ?= $(LLVM_ROOT)/bin/clang-format
+CMAKE_EXTRA_ARGS ?=
 DOCS_DIR     := docs/report
 DOCS_MAIN    := report
 FILTER_GVPR  := $(DOCS_DIR)/figures/filter.gvpr
 DOT_FILE     := $(DOCS_DIR)/figures/dedekind_module_dependencies.dot
 
-.PHONY: all clean compile test coverage format install-hooks doxygen dot doc \
+.PHONY: all clean compile test coverage format format-check install-hooks doxygen dot doc report \
 	ci-main pr-status pr-checks pr-watch pr-sync
 
 all: compile
@@ -28,7 +30,8 @@ $(BUILD_DIR)/CMakeCache.txt:
 		-DCMAKE_C_COMPILER=$(CC) \
 		-DCMAKE_CXX_SCAN_FOR_MODULES=ON \
 		-DCMAKE_BUILD_TYPE=Release \
-		-DDEDEKIND_ENABLE_DOUBLE_REAL_PROXY=ON
+		-DDEDEKIND_ENABLE_DOUBLE_REAL_PROXY=ON \
+		$(CMAKE_EXTRA_ARGS)
 
 compile: $(BUILD_DIR)/CMakeCache.txt
 	cmake --build $(BUILD_DIR)
@@ -47,7 +50,10 @@ coverage: compile
 
 
 format:
-	find src -name "*.cpp" -o -name "*.cppm" | xargs $(LLVM_ROOT)/bin/clang-format -i
+	find src -name "*.cpp" -o -name "*.cppm" | xargs $(CLANG_FORMAT) -i
+
+format-check:
+	find src -name "*.cpp" -o -name "*.cppm" | xargs $(CLANG_FORMAT) --dry-run --Werror
 
 install-hooks:
 	git config core.hooksPath .githooks
@@ -75,6 +81,9 @@ pr-sync:
 
 doxygen: $(BUILD_DIR)/CMakeCache.txt
 	cmake --build $(BUILD_DIR) --target docs
+
+report:
+	$(MAKE) -C $(DOCS_DIR) ci-check
 
 # Generate build dependency graph without breaking the Ninja build
 dot: $(BUILD_DIR)/CMakeCache.txt

--- a/Makefile
+++ b/Makefile
@@ -20,12 +20,14 @@ clean:
 	rm -rf $(BUILD_DIR)
 
 # Minimal config: Only tell CMake which compiler to use.
+# Note: DEDEKIND_ENABLE_DOUBLE_REAL_PROXY=ON is required for tests that use double as the scalar type.
 $(BUILD_DIR)/CMakeCache.txt:
 	cmake -S . -B $(BUILD_DIR) -G Ninja \
 		-DCMAKE_CXX_COMPILER=$(CXX) \
 		-DCMAKE_C_COMPILER=$(CC) \
 		-DCMAKE_CXX_SCAN_FOR_MODULES=ON \
-		-DCMAKE_BUILD_TYPE=Release
+		-DCMAKE_BUILD_TYPE=Release \
+		-DDEDEKIND_ENABLE_DOUBLE_REAL_PROXY=ON
 
 compile: $(BUILD_DIR)/CMakeCache.txt
 	cmake --build $(BUILD_DIR)

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,8 @@ DOCS_MAIN    := report
 FILTER_GVPR  := $(DOCS_DIR)/figures/filter.gvpr
 DOT_FILE     := $(DOCS_DIR)/figures/dedekind_module_dependencies.dot
 
-.PHONY: all clean compile test coverage format install-hooks
+.PHONY: all clean compile test coverage format install-hooks doxygen dot doc \
+	ci-main pr-status pr-checks pr-watch pr-sync
 
 all: compile
 
@@ -52,6 +53,25 @@ install-hooks:
 	git config core.hooksPath .githooks
 	chmod +x .githooks/pre-push
 	@echo "Installed repo hooks from .githooks/"
+
+# CI/PR workflow helpers (optimistic concurrency loop)
+ci-main:
+	gh run list --branch main --limit 5
+
+pr-status:
+	gh pr view --json number,title,state,isDraft,url
+
+pr-checks:
+	gh pr checks || true
+
+pr-watch:
+	gh pr checks --watch || true
+
+pr-sync:
+	git fetch --prune
+	git status -sb
+	gh pr view --json number,title,state,isDraft,url
+	gh pr checks || true
 
 doxygen: $(BUILD_DIR)/CMakeCache.txt
 	cmake --build $(BUILD_DIR) --target docs

--- a/Makefile
+++ b/Makefile
@@ -22,8 +22,9 @@ all: compile
 clean:
 	rm -rf $(BUILD_DIR)
 
-# Minimal config: Only tell CMake which compiler to use.
-# Note: DEDEKIND_ENABLE_DOUBLE_REAL_PROXY=ON is required for tests that use double as the scalar type.
+# Project configure step: select the LLVM toolchain, enable C++ module
+# scanning, use a Release build, and opt into the double-as-real proxy needed
+# by the current finite-dimensional test suite.
 $(BUILD_DIR)/CMakeCache.txt:
 	cmake -S . -B $(BUILD_DIR) -G Ninja \
 		-DCMAKE_CXX_COMPILER=$(CXX) \

--- a/README.md
+++ b/README.md
@@ -39,8 +39,10 @@ make test
 > | `make compile` | Configure (if needed) and build all targets |
 > | `make test` | Build then run the full test suite via CTest |
 > | `make format` | Auto-format all `*.cpp` / `*.cppm` sources with `clang-format` |
+> | `make format-check` | Verify formatting without modifying files |
 > | `make coverage` | Build, run tests, and produce an LLVM coverage report |
 > | `make doxygen` | Build Doxygen API docs into `build/docs/` |
+> | `make report` | Fast report compile check (`docs/report` `ci-check`) |
 > | `make clean` | Remove the `build/` directory |
 > | `make install-hooks` | Install the pre-push git hook |
 >

--- a/README.md
+++ b/README.md
@@ -43,11 +43,9 @@ make test
 > | `make doxygen` | Build Doxygen API docs into `build/docs/` |
 > | `make clean` | Remove the `build/` directory |
 > | `make install-hooks` | Install the pre-push git hook |
-> | `make ci-main` | Show recent CI runs for `main` |
-> | `make pr-status` | Show PR metadata for the current branch |
-> | `make pr-checks` | Show check status for the current branch PR |
-> | `make pr-watch` | Watch PR checks until completion |
-> | `make pr-sync` | Refresh git/PR status snapshot before a push |
+>
+> For contributor workflow helpers (`make ci-main`, `make pr-status`,
+> `make pr-checks`, `make pr-watch`, `make pr-sync`), see `CONTRIBUTING.md`.
 
 ### Architecture
 

--- a/README.md
+++ b/README.md
@@ -26,10 +26,23 @@ static_assert( SmellsLike<ℝ, DedekindCompleteField> );
 git clone https://github.com/vincentk/dedekind && cd dedekind
 
 # Build and run the formal verification (test) suite
-cmake -B build -G Ninja
-cmake --build build
-ctest --test-dir build --output-on-failure
+make compile
+make test
 ```
+
+> **Note:** The `Makefile` wraps CMake/Ninja and selects the correct compiler and flags automatically.
+> It is the **preferred** interface for local development and is also used in CI.
+> Run `make` (or `make all`) to see available targets:
+>
+> | Target | Description |
+> |---|---|
+> | `make compile` | Configure (if needed) and build all targets |
+> | `make test` | Build then run the full test suite via CTest |
+> | `make format` | Auto-format all `*.cpp` / `*.cppm` sources with `clang-format` |
+> | `make coverage` | Build, run tests, and produce an LLVM coverage report |
+> | `make doxygen` | Build Doxygen API docs into `build/docs/` |
+> | `make clean` | Remove the `build/` directory |
+> | `make install-hooks` | Install the pre-push git hook |
 
 ### Architecture
 

--- a/README.md
+++ b/README.md
@@ -43,6 +43,11 @@ make test
 > | `make doxygen` | Build Doxygen API docs into `build/docs/` |
 > | `make clean` | Remove the `build/` directory |
 > | `make install-hooks` | Install the pre-push git hook |
+> | `make ci-main` | Show recent CI runs for `main` |
+> | `make pr-status` | Show PR metadata for the current branch |
+> | `make pr-checks` | Show check status for the current branch PR |
+> | `make pr-watch` | Watch PR checks until completion |
+> | `make pr-sync` | Refresh git/PR status snapshot before a push |
 
 ### Architecture
 

--- a/issue_186_body.md
+++ b/issue_186_body.md
@@ -1,0 +1,17 @@
+## Problem
+Current Jacobian contract covers classical differentiability with explicit Jacobian witnesses. This works well for smooth maps and piecewise maps away from kink points, but not at non-differentiable locations (e.g. Heaviside at 0, call payoff max(S-K,0) at S=K).
+
+## Desired scope
+- Introduce concepts for piecewise differentiability over regions/cells
+- Add generalized derivative abstractions at kinks (subdifferential / Clarke-style set-valued derivative, or explicit one-sided derivative witnesses)
+- Keep compatibility with existing `DifferentiableMap` and `differential_at` APIs
+- Support compositional pipelines of piecewise/nonsmooth maps (closure under composition), so users can build smooth approximations from piecewise primitives (e.g., sigmoid-like approximations).
+- Add examples/tests for Heaviside, ReLU, and option payoff families
+
+## Notes
+This is intentionally scoped as a follow-up so #181 can stay focused on the finite-dimensional smooth Jacobian contract.
+
+## Related
+- #181
+- #184
+- #185

--- a/issue_186_body_after.md
+++ b/issue_186_body_after.md
@@ -1,0 +1,25 @@
+## Problem
+Current Jacobian contract covers classical differentiability with explicit Jacobian witnesses. This works well for smooth maps and piecewise maps away from kink points, but not at non-differentiable locations (e.g. Heaviside at 0, call payoff max(S-K,0) at S=K).
+
+## Desired scope
+- Introduce concepts for piecewise differentiability over regions/cells
+- Add generalized derivative abstractions at kinks (subdifferential / Clarke-style set-valued derivative, or explicit one-sided derivative witnesses)
+- Keep compatibility with existing `DifferentiableMap` and `differential_at` APIs
+- Support compositional pipelines of piecewise/nonsmooth maps (closure under composition), so users can build smooth approximations from piecewise primitives (e.g., sigmoid-like approximations).
+- Add examples/tests for Heaviside, ReLU, and option payoff families
+
+## Acceptance criteria
+- Supports nonsmooth and piecewise mappings on both discrete and continuous carriers: N -> N and R -> R.
+- Supports compositional closure for these mappings (piecewise with piecewise, piecewise with smooth), including sigmoid-like approximation pipelines.
+- Provides a lifting/composition rule from 1D mappings to higher-dimensional product spaces, with explicit examples/tests for N^2 and R^3.
+- Preserves compatibility with existing DifferentiableMap and differential_at contracts where classical differentiability holds.
+- Includes tests covering behavior at regular points and documented behavior at kink/non-differentiable points.
+
+## Notes
+This is intentionally scoped as a follow-up so #181 can stay focused on the finite-dimensional smooth Jacobian contract.
+
+## Related
+- #181
+- #184
+- #185
+

--- a/issue_186_body_updated.md
+++ b/issue_186_body_updated.md
@@ -1,0 +1,24 @@
+## Problem
+Current Jacobian contract covers classical differentiability with explicit Jacobian witnesses. This works well for smooth maps and piecewise maps away from kink points, but not at non-differentiable locations (e.g. Heaviside at 0, call payoff max(S-K,0) at S=K).
+
+## Desired scope
+- Introduce concepts for piecewise differentiability over regions/cells
+- Add generalized derivative abstractions at kinks (subdifferential / Clarke-style set-valued derivative, or explicit one-sided derivative witnesses)
+- Keep compatibility with existing `DifferentiableMap` and `differential_at` APIs
+- Support compositional pipelines of piecewise/nonsmooth maps (closure under composition), so users can build smooth approximations from piecewise primitives (e.g., sigmoid-like approximations).
+- Add examples/tests for Heaviside, ReLU, and option payoff families
+
+## Acceptance criteria
+- Supports nonsmooth and piecewise mappings on both discrete and continuous carriers: N -> N and R -> R.
+- Supports compositional closure for these mappings (piecewise with piecewise, piecewise with smooth), including sigmoid-like approximation pipelines.
+- Provides a lifting/composition rule from 1D mappings to higher-dimensional product spaces, with explicit examples/tests for N^2 and R^3.
+- Preserves compatibility with existing DifferentiableMap and differential_at contracts where classical differentiability holds.
+- Includes tests covering behavior at regular points and documented behavior at kink/non-differentiable points.
+
+## Notes
+This is intentionally scoped as a follow-up so #181 can stay focused on the finite-dimensional smooth Jacobian contract.
+
+## Related
+- #181
+- #184
+- #185

--- a/src/main/modules/dedekind/analysis/forms.cppm
+++ b/src/main/modules/dedekind/analysis/forms.cppm
@@ -36,7 +36,7 @@ concept IsDifferentialForm = requires(W w, V v) {
  * @class OneForm
  * @brief The cotangent vector (The 'Gradient' components).
  */
-export template <std::floating_point F, std::size_t N>
+export template <IsMatrixScalar F, std::size_t N>
 struct OneForm {
   Vector<F, N> components;
 
@@ -54,11 +54,25 @@ struct OneForm {
  * constructs the Covector whose single row holds the OneForm's components,
  * making the bijection explicit.
  */
-export template <std::floating_point F, std::size_t N>
+export template <IsMatrixScalar F, std::size_t N>
 constexpr Covector<F, N> to_covector(const OneForm<F, N>& w) {
   Covector<F, N> result;
   for (std::size_t j = 0; j < N; ++j)
     result.set_coefficient(0, j, w.components[j]);
+  return result;
+}
+
+/**
+ * @brief Convert a Covector to its OneForm representation.
+ *
+ * This is the inverse view of to_covector for the current dense row-vector
+ * representation of linear functionals.
+ */
+export template <IsMatrixScalar F, std::size_t N>
+constexpr OneForm<F, N> from_covector(const Covector<F, N>& cov) {
+  OneForm<F, N> result{};
+  for (std::size_t j = 0; j < N; ++j)
+    result.components[j] = cov.coefficient(0, j);
   return result;
 }
 

--- a/src/main/modules/dedekind/geometry/linear_map.cppm
+++ b/src/main/modules/dedekind/geometry/linear_map.cppm
@@ -59,6 +59,7 @@ module;
 #include <concepts>
 #include <cstddef>
 #include <initializer_list>
+#include <utility>
 
 export module dedekind.geometry:linear_map;
 
@@ -359,6 +360,104 @@ export template <IsMatrixScalar F, std::size_t N>
 using Covector = LinearMap<F, 1, N>;
 
 /**
+ * @class DifferentiableMap
+ * @brief A finite-dimensional map paired with an exact Jacobian witness.
+ *
+ * This is the first differentiation contract in Dedekind's finite-dimensional
+ * geometry layer. It packages:
+ * - a primal map F^DomainDim -> F^CodomainDim
+ * - an exact Jacobian oracle returning LinearMap<F, CodomainDim, DomainDim>
+ *
+ * The Jacobian is therefore a concrete Fr\'echet derivative witness in the
+ * existing LinearMap carrier.
+ */
+export template <IsMatrixScalar F, std::size_t DomainDim,
+                 std::size_t CodomainDim, typename ValueFn, typename JacobianFn>
+  requires requires(const ValueFn& value, const JacobianFn& jacobian,
+                    const Vector<F, DomainDim>& x) {
+    { value(x) } -> std::same_as<Vector<F, CodomainDim>>;
+    { jacobian(x) } -> std::same_as<LinearMap<F, CodomainDim, DomainDim>>;
+  }
+class DifferentiableMap {
+ public:
+  using scalar_type = F;
+  using Domain = Vector<F, DomainDim>;
+  using Codomain = Vector<F, CodomainDim>;
+  using Jacobian = LinearMap<F, CodomainDim, DomainDim>;
+
+  static constexpr std::size_t domain_dimension = DomainDim;
+  static constexpr std::size_t codomain_dimension = CodomainDim;
+
+  constexpr DifferentiableMap(ValueFn value, JacobianFn jacobian)
+      : value_(std::move(value)), jacobian_(std::move(jacobian)) {}
+
+  constexpr Codomain operator()(const Domain& x) const { return value_(x); }
+
+  constexpr Jacobian jacobian_at(const Domain& x) const { return jacobian_(x); }
+
+ private:
+  [[no_unique_address]] ValueFn value_;
+  [[no_unique_address]] JacobianFn jacobian_;
+};
+
+/**
+ * @concept HasJacobianAt
+ * @brief Map-like object exposing an exact finite-dimensional Jacobian.
+ */
+export template <typename Map>
+concept HasJacobianAt =
+    requires(const Map& map, const typename Map::Domain& x) {
+      typename Map::scalar_type;
+      typename Map::Domain;
+      typename Map::Codomain;
+      typename Map::Jacobian;
+      { map(x) } -> std::same_as<typename Map::Codomain>;
+      { map.jacobian_at(x) } -> std::same_as<typename Map::Jacobian>;
+    };
+
+/**
+ * @brief Construct a finite-dimensional differentiable map from primal and
+ * Jacobian callables.
+ */
+export template <IsMatrixScalar F, std::size_t DomainDim,
+                 std::size_t CodomainDim, typename ValueFn, typename JacobianFn>
+constexpr auto make_differentiable_map(ValueFn value, JacobianFn jacobian) {
+  return DifferentiableMap<F, DomainDim, CodomainDim, ValueFn, JacobianFn>{
+      std::move(value), std::move(jacobian)};
+}
+
+/**
+ * @brief Return the Jacobian of a finite-dimensional differentiable map.
+ */
+export template <HasJacobianAt Map>
+constexpr auto jacobian_at(const Map& map, const typename Map::Domain& x) ->
+    typename Map::Jacobian {
+  return map.jacobian_at(x);
+}
+
+/**
+ * @brief Return the Fr\'echet derivative of a finite-dimensional map.
+ *
+ * In the current finite-dimensional slice, this coincides with the Jacobian.
+ */
+export template <HasJacobianAt Map>
+constexpr auto frechet_derivative_at(const Map& map,
+                                     const typename Map::Domain& x) ->
+    typename Map::Jacobian {
+  return jacobian_at(map, x);
+}
+
+/**
+ * @brief Return the scalar-valued differential as a covector.
+ */
+export template <HasJacobianAt Map>
+  requires(Map::codomain_dimension == 1)
+constexpr Covector<typename Map::scalar_type, Map::domain_dimension>
+differential_at(const Map& map, const typename Map::Domain& x) {
+  return jacobian_at(map, x);
+}
+
+/**
  * @brief Outer product u ⊗ v : F^N -> F^M.
  *
  * Constructs the rank-1 linear map whose (i,j) coefficient is u[i]*v[j].
@@ -419,5 +518,77 @@ constexpr LinearMap<F, M, N> outer(const Vector<F, M>& u,
  */
 export template <std::size_t Rows, std::size_t Cols>
 using RealMatrix = LinearMap<double, Rows, Cols>;
+
+// ============================================================================
+// Tangent and Cotangent Space Aliases (flat ℝ^N case)
+// ============================================================================
+//
+// For the Euclidean space F^N (a flat manifold), the tangent space at every
+// point is canonically isomorphic to F^N itself (the tangent bundle is
+// trivial).  Similarly, the cotangent space at every point is (F^N)* ≅ F^N.
+//
+// These aliases give semantic names to those canonical identifications.
+// They serve as preparation for a future non-flat manifold abstraction
+// (see FIXME below) where the tangent/cotangent spaces are no longer globally
+// trivialized but depend on the base-point and atlas chart.
+//
+// FIXME(https://github.com/vincentk/dedekind/issues/185): Replace these
+// flat-space aliases with proper manifold/atlas/chart concepts once
+// non-trivial manifold structure is introduced.
+
+/**
+ * @brief TangentVector at a point in F^N.
+ *
+ * For the flat manifold F^N, the tangent space T_p(F^N) ≅ F^N for every
+ * base-point p.  The alias makes the geometric role explicit without
+ * introducing any new data.
+ */
+export template <IsMatrixScalar F, std::size_t N>
+using TangentVector = Vector<F, N>;
+
+/**
+ * @brief CotangentVector at a point in F^N.
+ *
+ * The cotangent space T*_p(F^N) ≅ (F^N)* is the dual of the tangent space.
+ * In the finite-dimensional flat case this is canonically represented as a
+ * row vector (Covector), i.e. a LinearMap<F, 1, N>.
+ */
+export template <IsMatrixScalar F, std::size_t N>
+using CotangentVector = Covector<F, N>;
+
+/**
+ * @struct TangentBundlePoint
+ * @brief A point in the tangent bundle T(F^N) = F^N × F^N.
+ *
+ * Packages a base-point with a tangent vector at that point.  For the flat
+ * manifold F^N the bundle is trivially the product; in a non-flat setting
+ * (future issue) this struct would generalise to an atlas-chart-local section.
+ */
+export template <IsMatrixScalar F, std::size_t N>
+struct TangentBundlePoint {
+  Vector<F, N> base;          ///< Base point p ∈ F^N
+  TangentVector<F, N> fiber;  ///< Tangent vector v ∈ T_p(F^N) ≅ F^N
+
+  friend constexpr bool operator==(const TangentBundlePoint&,
+                                   const TangentBundlePoint&) = default;
+};
+
+/**
+ * @struct CotangentBundlePoint
+ * @brief A point in the cotangent bundle T*(F^N) = F^N × (F^N)*.
+ *
+ * Packages a base-point with a cotangent vector (covector) at that point.
+ * The cotangent bundle is dual to the tangent bundle; sections of T*M
+ * are exactly the differential 1-forms (see analysis:forms for the OneForm
+ * view of these objects).
+ */
+export template <IsMatrixScalar F, std::size_t N>
+struct CotangentBundlePoint {
+  Vector<F, N> base;            ///< Base point p ∈ F^N
+  CotangentVector<F, N> fiber;  ///< Cotangent vector ω ∈ T*_p(F^N) ≅ (F^N)*
+
+  friend constexpr bool operator==(const CotangentBundlePoint&,
+                                   const CotangentBundlePoint&) = default;
+};
 
 }  // namespace dedekind::geometry

--- a/src/main/modules/dedekind/geometry/linear_map.cppm
+++ b/src/main/modules/dedekind/geometry/linear_map.cppm
@@ -360,21 +360,29 @@ constexpr LinearMap<F, Rows, Cols> zero_linear_map() {
  *
  * Covectors form the **dual module** Hom_F(V, F), where V = F^N.
  * When F is a field, the dual module is isomorphic to V itself.
+ *
+ * FIXME(https://github.com/vincentk/dedekind/issues/185): Generalize this
+ * alias from the current extensional finite-dimensional carrier to a
+ * first-class dimension/cardinality witness once the geometry layer is lifted
+ * beyond `LinearMap<F, 1, N>`.
  */
 export template <IsMatrixScalar F, std::size_t N>
 using Covector = LinearMap<F, 1, N>;
 
 /**
  * @class DifferentiableMap
- * @brief A finite-dimensional map paired with an exact Jacobian witness.
+ * @brief A finite-dimensional map paired with a user-supplied Jacobian
+ * witness.
  *
  * This is the first differentiation contract in Dedekind's finite-dimensional
  * geometry layer. It packages:
  * - a primal map F^DomainDim -> F^CodomainDim
- * - an exact Jacobian oracle returning LinearMap<F, CodomainDim, DomainDim>
+ * - a user-supplied callable returning LinearMap<F, CodomainDim, DomainDim>
  *
- * The Jacobian is therefore a concrete Fr\'echet derivative witness in the
- * existing LinearMap carrier.
+ * Compile time checks only that `value(x)` and `jacobian(x)` have the
+ * prescribed result types in the existing `LinearMap` carrier. It does not
+ * verify that the returned linear map is the actual Fr\'echet derivative of
+ * `value` at `x`; that correctness remains a caller-side contract.
  */
 export template <IsMatrixScalar F, std::size_t DomainDim,
                  std::size_t CodomainDim, typename ValueFn, typename JacobianFn>
@@ -407,15 +415,29 @@ class DifferentiableMap {
 
 /**
  * @concept HasJacobianAt
- * @brief Map-like object exposing an exact finite-dimensional Jacobian.
+ * @brief Map-like object exposing a finite-dimensional LinearMap Jacobian.
  */
 export template <typename Map>
 concept HasJacobianAt =
-    requires(const Map& map, const typename Map::Domain& x) {
+  requires {
       typename Map::scalar_type;
       typename Map::Domain;
       typename Map::Codomain;
       typename Map::Jacobian;
+    { Map::domain_dimension } -> std::convertible_to<std::size_t>;
+    { Map::codomain_dimension } -> std::convertible_to<std::size_t>;
+    requires IsMatrixScalar<typename Map::scalar_type>;
+    requires std::same_as<
+      typename Map::Domain,
+      Vector<typename Map::scalar_type, Map::domain_dimension>>;
+    requires std::same_as<
+      typename Map::Codomain,
+      Vector<typename Map::scalar_type, Map::codomain_dimension>>;
+    requires std::same_as<
+      typename Map::Jacobian,
+      LinearMap<typename Map::scalar_type, Map::codomain_dimension,
+          Map::domain_dimension>>;
+  } && requires(const Map& map, const typename Map::Domain& x) {
       { map(x) } -> std::same_as<typename Map::Codomain>;
       { map.jacobian_at(x) } -> std::same_as<typename Map::Jacobian>;
     };
@@ -456,7 +478,10 @@ constexpr auto frechet_derivative_at(const Map& map,
  * @brief Return the scalar-valued differential as a covector.
  */
 export template <HasJacobianAt Map>
-  requires(Map::codomain_dimension == 1)
+  requires(Map::codomain_dimension == 1) &&
+          std::same_as<typename Map::Jacobian,
+                       Covector<typename Map::scalar_type,
+                                Map::domain_dimension>>
 constexpr Covector<typename Map::scalar_type, Map::domain_dimension>
 differential_at(const Map& map, const typename Map::Domain& x) {
   return jacobian_at(map, x);
@@ -519,6 +544,13 @@ constexpr LinearMap<F, M, N> outer(const Vector<F, M>& u,
  * 3. Associativity: (s1 * s2) * m = s1 * (s2 * m)
  * 4. Identity: 1.0 * m = m
  *
+ * This alias is the explicit machine-real lift into the current finite
+ * matrix carrier. It remains intentionally extensional for this PR.
+ *
+ * FIXME(https://github.com/vincentk/dedekind/issues/185): Generalize the
+ * geometry layer from fixed extensional dimensions to first-class dimension
+ * witnesses where the surrounding carrier supports it.
+ *
  * For square matrices (R == C), composition forms a non-commutative ring.
  */
 export template <std::size_t Rows, std::size_t Cols>
@@ -557,6 +589,10 @@ using TangentVector = Vector<F, N>;
  * The cotangent space T*_p(F^N) ≅ (F^N)* is the dual of the tangent space.
  * In the finite-dimensional flat case this is canonically represented as a
  * row vector (Covector), i.e. a LinearMap<F, 1, N>.
+ *
+ * FIXME(https://github.com/vincentk/dedekind/issues/185): Replace the
+ * extensional dimension parameter with a first-class dimension witness once
+ * the flat geometry carrier is widened accordingly.
  */
 export template <IsMatrixScalar F, std::size_t N>
 using CotangentVector = Covector<F, N>;
@@ -568,6 +604,10 @@ using CotangentVector = Covector<F, N>;
  * Packages a base-point with a tangent vector at that point.  For the flat
  * manifold F^N the bundle is trivially the product; in a non-flat setting
  * (future issue) this struct would generalise to an atlas-chart-local section.
+ *
+ * FIXME(https://github.com/vincentk/dedekind/issues/185): Lift the bundle
+ * point carriers from extensional `N` to first-class dimension/cardinality
+ * witnesses when manifold-local geometry is introduced.
  */
 export template <IsMatrixScalar F, std::size_t N>
 struct TangentBundlePoint {

--- a/src/main/modules/dedekind/geometry/linear_map.cppm
+++ b/src/main/modules/dedekind/geometry/linear_map.cppm
@@ -47,10 +47,15 @@
  * Licensed under the Apache License, Version 2.0.
  *
  * @note "أشدُّ ما يحتاج إليه من يُعنى بعلم الحساب أن يعرف ما يحتاج الناس إليه في
- * معاملاتهم من المقادير، إذ بذلك يقاس العدل في القضاء." — محمد بن موسى
- * الخوارزمي، منسوب في ويكي الاقتباس العربي. [Trans: "What one most needs in the
- * science of computation is to know the quantities people need in their
- * dealings, for by that, justice in judgment is measured."]
+ * معاملاتهم من المقادير، إذ بذلك يقاس العدل في القضاء."
+ * — Muḥammad ibn Mūsā al-Khwārizmī (c. 780–850 CE), mathematician of the
+ * Islamic Golden Age, House of Wisdom, Baghdad. Author of *Al-Kitāb
+ * al-mukhtaṣar fī ḥisāb al-jabr wal-muqābala* (Al-Jabr, ~820 CE), the
+ * foundational treatise on algebra. The quote is attributed to al-Khwārizmī
+ * on Arabic Wikiquote; the specific primary source within his corpus has not
+ * been independently verified. [Trans: "What one most needs in the science of
+ * computation is to know the quantities people need in their dealings, for by
+ * that, justice in judgment is measured."]
  */
 
 module;

--- a/src/main/modules/dedekind/geometry/linear_map.cppm
+++ b/src/main/modules/dedekind/geometry/linear_map.cppm
@@ -418,29 +418,27 @@ class DifferentiableMap {
  * @brief Map-like object exposing a finite-dimensional LinearMap Jacobian.
  */
 export template <typename Map>
-concept HasJacobianAt =
-  requires {
-      typename Map::scalar_type;
-      typename Map::Domain;
-      typename Map::Codomain;
-      typename Map::Jacobian;
-    { Map::domain_dimension } -> std::convertible_to<std::size_t>;
-    { Map::codomain_dimension } -> std::convertible_to<std::size_t>;
-    requires IsMatrixScalar<typename Map::scalar_type>;
-    requires std::same_as<
-      typename Map::Domain,
-      Vector<typename Map::scalar_type, Map::domain_dimension>>;
-    requires std::same_as<
+concept HasJacobianAt = requires {
+  typename Map::scalar_type;
+  typename Map::Domain;
+  typename Map::Codomain;
+  typename Map::Jacobian;
+  { Map::domain_dimension } -> std::convertible_to<std::size_t>;
+  { Map::codomain_dimension } -> std::convertible_to<std::size_t>;
+  requires IsMatrixScalar<typename Map::scalar_type>;
+  requires std::same_as<typename Map::Domain, Vector<typename Map::scalar_type,
+                                                     Map::domain_dimension>>;
+  requires std::same_as<
       typename Map::Codomain,
       Vector<typename Map::scalar_type, Map::codomain_dimension>>;
-    requires std::same_as<
+  requires std::same_as<
       typename Map::Jacobian,
       LinearMap<typename Map::scalar_type, Map::codomain_dimension,
-          Map::domain_dimension>>;
-  } && requires(const Map& map, const typename Map::Domain& x) {
-      { map(x) } -> std::same_as<typename Map::Codomain>;
-      { map.jacobian_at(x) } -> std::same_as<typename Map::Jacobian>;
-    };
+                Map::domain_dimension>>;
+} && requires(const Map& map, const typename Map::Domain& x) {
+  { map(x) } -> std::same_as<typename Map::Codomain>;
+  { map.jacobian_at(x) } -> std::same_as<typename Map::Jacobian>;
+};
 
 /**
  * @brief Construct a finite-dimensional differentiable map from primal and
@@ -479,9 +477,9 @@ constexpr auto frechet_derivative_at(const Map& map,
  */
 export template <HasJacobianAt Map>
   requires(Map::codomain_dimension == 1) &&
-          std::same_as<typename Map::Jacobian,
-                       Covector<typename Map::scalar_type,
-                                Map::domain_dimension>>
+          std::same_as<
+              typename Map::Jacobian,
+              Covector<typename Map::scalar_type, Map::domain_dimension>>
 constexpr Covector<typename Map::scalar_type, Map::domain_dimension>
 differential_at(const Map& map, const typename Map::Domain& x) {
   return jacobian_at(map, x);

--- a/src/test/cpp/modules/dedekind/analysis/forms_test.cpp
+++ b/src/test/cpp/modules/dedekind/analysis/forms_test.cpp
@@ -29,4 +29,32 @@ TEST_CASE("Analysis: OneForm and Covector", "[analysis][forms][covector]") {
     REQUIRE(cov.coefficient(0, 0) == w.components[0]);
     REQUIRE(cov.coefficient(0, 1) == w.components[1]);
   }
+
+  SECTION("from_covector is the inverse view of to_covector") {
+    auto cov = to_covector(w);
+    auto round_trip = from_covector(cov);
+
+    REQUIRE(round_trip.components == w.components);
+    REQUIRE(round_trip(v) == w(v));
+  }
+
+  SECTION("Scalar-valued differentials admit a OneForm interpretation") {
+    const auto quadratic = make_differentiable_map<R, 2, 1>(
+        [](const Vec2& x) { return Vector<R, 1>{x[0] * x[0] + 3.0 * x[1]}; },
+        [](const Vec2& x) {
+          Covector<R, 2> cov;
+          cov.set_coefficient(0, 0, 2.0 * x[0]);
+          cov.set_coefficient(0, 1, 3.0);
+          return cov;
+        });
+
+    const Vec2 point{2.0, -1.0};
+    const Vec2 direction{0.5, 2.0};
+    const auto cov = differential_at(quadratic, point);
+    const auto one_form = from_covector(cov);
+
+    REQUIRE(one_form.components[0] == 4.0);
+    REQUIRE(one_form.components[1] == 3.0);
+    REQUIRE(one_form(direction) == cov(direction)[0]);
+  }
 }

--- a/src/test/cpp/modules/dedekind/geometry/linear_map_test.cpp
+++ b/src/test/cpp/modules/dedekind/geometry/linear_map_test.cpp
@@ -416,6 +416,52 @@ TEST_CASE("Geometry: Finite-Dimensional Jacobian Contract",
     REQUIRE(cov.coefficient(0, 1) == 3.0);
     REQUIRE(cov(direction)[0] == 8.0);
   }
+
+  SECTION("Piecewise constant Heaviside map is differentiable away from 0") {
+    const auto heaviside = make_differentiable_map<R, 1, 1>(
+        [](const Vector<R, 1>& x) { return Vec1{x[0] < 0.0 ? 0.0 : 1.0}; },
+        [](const Vector<R, 1>& x) {
+          Covector<R, 1> cov;
+          // Classical derivative is 0 for x != 0; x = 0 is a non-smooth point.
+          cov.set_coefficient(0, 0, x[0] == 0.0 ? 0.0 : 0.0);
+          return cov;
+        });
+
+    const Vector<R, 1> left_point{-2.0};
+    const Vector<R, 1> right_point{3.0};
+
+    REQUIRE(heaviside(left_point)[0] == 0.0);
+    REQUIRE(heaviside(right_point)[0] == 1.0);
+    REQUIRE(differential_at(heaviside, left_point).coefficient(0, 0) == 0.0);
+    REQUIRE(differential_at(heaviside, right_point).coefficient(0, 0) == 0.0);
+  }
+
+  SECTION("Option payoff (max(S-K,0)) is piecewise linear") {
+    const R strike = 100.0;
+    const auto call_payoff = make_differentiable_map<R, 1, 1>(
+        [strike](const Vector<R, 1>& x) {
+          const R intrinsic = x[0] - strike;
+          return Vec1{intrinsic > 0.0 ? intrinsic : 0.0};
+        },
+        [strike](const Vector<R, 1>& x) {
+          Covector<R, 1> cov;
+          // Classical derivative: 0 below strike, 1 above strike.
+          // At-the-money (x = strike) is non-differentiable and left for
+          // future generalized-derivative abstractions.
+          cov.set_coefficient(0, 0, x[0] > strike ? 1.0 : 0.0);
+          return cov;
+        });
+
+    const Vector<R, 1> out_of_money{80.0};
+    const Vector<R, 1> in_the_money{130.0};
+
+    REQUIRE(call_payoff(out_of_money)[0] == 0.0);
+    REQUIRE(call_payoff(in_the_money)[0] == 30.0);
+    REQUIRE(differential_at(call_payoff, out_of_money).coefficient(0, 0) ==
+            0.0);
+    REQUIRE(differential_at(call_payoff, in_the_money).coefficient(0, 0) ==
+            1.0);
+  }
 }
 
 TEST_CASE("Geometry: Flat-Space Tangent/Cotangent Bundle Structures",

--- a/src/test/cpp/modules/dedekind/geometry/linear_map_test.cpp
+++ b/src/test/cpp/modules/dedekind/geometry/linear_map_test.cpp
@@ -423,7 +423,8 @@ TEST_CASE("Geometry: Finite-Dimensional Jacobian Contract",
         [](const Vector<R, 1>& x) {
           Covector<R, 1> cov;
           // Classical derivative is 0 for x != 0; x = 0 is a non-smooth point.
-          cov.set_coefficient(0, 0, x[0] == 0.0 ? 0.0 : 0.0);
+          (void)x;
+          cov.set_coefficient(0, 0, 0.0);
           return cov;
         });
 

--- a/src/test/cpp/modules/dedekind/geometry/linear_map_test.cpp
+++ b/src/test/cpp/modules/dedekind/geometry/linear_map_test.cpp
@@ -369,3 +369,99 @@ TEST_CASE("Geometry: Covectors and Outer Products",
     }
   }
 }
+
+TEST_CASE("Geometry: Finite-Dimensional Jacobian Contract",
+          "[geometry][jacobian][derivative]") {
+  using R = double;
+  using Vec2 = Vector<R, 2>;
+  using Vec1 = Vector<R, 1>;
+  using Map22 = LinearMap<R, 2, 2>;
+
+  SECTION("Affine maps carry a constant Jacobian witness") {
+    const Map22 linear_part{{{2.0, 1.0}, {0.0, 3.0}}};
+    const Vec2 translation{1.0, -2.0};
+
+    const auto affine = make_differentiable_map<R, 2, 2>(
+        [linear_part, translation](const Vec2& x) {
+          return linear_part(x) + translation;
+        },
+        [linear_part](const Vec2&) { return linear_part; });
+
+    static_assert(HasJacobianAt<decltype(affine)>);
+
+    const Vec2 point_a{1.0, 2.0};
+    const Vec2 point_b{-3.0, 0.5};
+
+    REQUIRE(affine(point_a) == (linear_part(point_a) + translation));
+    REQUIRE(jacobian_at(affine, point_a) == linear_part);
+    REQUIRE(frechet_derivative_at(affine, point_b) == linear_part);
+  }
+
+  SECTION("Scalar-valued maps expose their differential as a covector") {
+    const auto quadratic = make_differentiable_map<R, 2, 1>(
+        [](const Vec2& x) { return Vec1{x[0] * x[0] + 3.0 * x[1]}; },
+        [](const Vec2& x) {
+          Covector<R, 2> cov;
+          cov.set_coefficient(0, 0, 2.0 * x[0]);
+          cov.set_coefficient(0, 1, 3.0);
+          return cov;
+        });
+
+    const Vec2 point{2.0, -1.0};
+    const Vec2 direction{0.5, 2.0};
+    const auto cov = differential_at(quadratic, point);
+
+    REQUIRE(quadratic(point)[0] == 1.0);
+    REQUIRE(cov.coefficient(0, 0) == 4.0);
+    REQUIRE(cov.coefficient(0, 1) == 3.0);
+    REQUIRE(cov(direction)[0] == 8.0);
+  }
+}
+
+TEST_CASE("Geometry: Flat-Space Tangent/Cotangent Bundle Structures",
+          "[geometry][tangent][cotangent][bundle]") {
+  using R = double;
+  using Vec3 = Vector<R, 3>;
+
+  // Static alias checks — TangentVector and CotangentVector are the expected
+  // types for the flat manifold ℝ^3.
+  static_assert(std::same_as<TangentVector<R, 3>, Vector<R, 3>>);
+  static_assert(std::same_as<CotangentVector<R, 3>, Covector<R, 3>>);
+
+  SECTION("TangentBundlePoint stores base and fiber independently") {
+    const Vec3 base{1.0, 2.0, 3.0};
+    const TangentVector<R, 3> fiber{0.1, 0.2, 0.3};
+    const TangentBundlePoint<R, 3> pt{base, fiber};
+
+    REQUIRE(pt.base == base);
+    REQUIRE(pt.fiber == fiber);
+  }
+
+  SECTION("CotangentBundlePoint stores base and covector fiber") {
+    const Vec3 base{-1.0, 0.0, 1.0};
+    CotangentVector<R, 3> fiber;
+    fiber.set_coefficient(0, 0, 1.0);
+    fiber.set_coefficient(0, 1, 2.0);
+    fiber.set_coefficient(0, 2, 3.0);
+    const CotangentBundlePoint<R, 3> pt{base, fiber};
+
+    REQUIRE(pt.base == base);
+    REQUIRE(pt.fiber == fiber);
+  }
+
+  SECTION(
+      "Jacobian of differentiable map maps TangentVector to TangentVector") {
+    // The Jacobian J at p maps tangent vectors at p to tangent vectors at f(p).
+    // For the identity map, J = Id.
+    const auto identity = make_differentiable_map<R, 3, 3>(
+        [](const Vec3& x) { return x; },
+        [](const Vec3&) { return identity_linear_map<R, 3>(); });
+
+    const TangentBundlePoint<R, 3> source{Vec3{1.0, 2.0, 3.0},
+                                          TangentVector<R, 3>{1.0, 0.0, 0.0}};
+    const auto jac = jacobian_at(identity, source.base);
+    const TangentVector<R, 3> pushed = jac(source.fiber);
+
+    REQUIRE(pushed == source.fiber);  // identity pushforward
+  }
+}


### PR DESCRIPTION
## Summary

Implements the finite-dimensional Jacobian contract over `LinearMap` (issue #181),
flat tangent/cotangent bundle aliases, a `from_covector` bridge in `forms.cppm`,
and updates the build tooling so that `make` targets are the canonical interface for
both local development and CI.

## Changes

### `dedekind.geometry:linear_map`
- Added `DifferentiableMap<F, DomainDim, CodomainDim, ValueFn, JacobianFn>` — packages
  a primal callable and a Jacobian callable; exposes `operator()` and `jacobian_at(x)`.
- Added `HasJacobianAt` concept — requires `scalar_type`, `Domain`, `Codomain`, `Jacobian`
  nested types plus matching call and Jacobian signatures.
- Added free functions `jacobian_at`, `frechet_derivative_at`, `differential_at`.
- Added `TangentVector<F,N>` and `CotangentVector<F,N>` flat-space aliases.
- Added `TangentBundlePoint<F,N>` and `CotangentBundlePoint<F,N>` flat-space bundle structs.

### `dedekind.analysis:forms`
- Added `from_covector` — inverse of the existing `to_covector`; bridges `Covector` ↔ `OneForm`.
- Widened `OneForm` and `to_covector` scalar constraint from `std::floating_point` to `IsMatrixScalar`
  for consistency with `LinearMap`.

### Tests
- New `TEST_CASE("Geometry: Finite-Dimensional Jacobian Contract")` covering affine and
  scalar-valued maps, Jacobian evaluation, `frechet_derivative_at`, and `differential_at`.
- New `TEST_CASE("Geometry: Flat-Space Tangent/Cotangent Bundle Structures")` covering
  alias static-asserts and bundle point construction/access.
- Extended forms test with `from_covector` round-trip and `differential_at` ↔ `OneForm` consistency.

### Build & docs
- Added `-DDEDEKIND_ENABLE_DOUBLE_REAL_PROXY=ON` to the `Makefile` cmake configure step,
  aligning local builds with CI (was the root cause of local `IsMatrixScalar` failures on `double`).
- Updated `README` Quickstart and `CONTRIBUTING.md` to use `make` targets as the preferred
  build interface, with a reference table of all available targets.

## Follow-up

Full manifold abstraction (charts, atlas, non-flat tangent bundles) is tracked in #185.

## References
- Closes #181
- Follow-up: #185
- Related roadmap: #176
