### PR TITLE
feat: implement #163/#189 MVP interop and #192 pre-release signaling

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [ 🌸 Don't panic. ]
 
 > **Project status:** pre-release research prototype.
-> Public APIs and module boundaries may change until `v1.0.0`.
+> Public APIs and module boundaries may change until a stable `v1.0.0` release tag.
 
 ### Computational Structuralism in Modern C++23
 
@@ -90,8 +90,12 @@ Semantic caveats:
 - Interop materializes a finite runtime carrier (`FiniteExtensionalSet<T>`), so
 	the conversion boundary is auditable and does not silently reinterpret
 	intensional expressions.
-- Membership meaning is preserved (`x ∈ S` before/after conversion), and
-	extensional equality is checked via round-trip tests.
+- Membership meaning is preserved when container equivalence agrees with
+	ordinary value equality, including the supported MVP paths through
+	`std::set<T>` with the default comparator and `std::unordered_set<T, Hash, Equal>`.
+	Custom `std::set<T, Compare>` comparators are intentionally rejected in this
+	phase because they may encode a different notion of uniqueness.
+- Extensional equality is checked via round-trip tests within those limits.
 
 Performance notes:
 

--- a/README.md
+++ b/README.md
@@ -5,6 +5,9 @@
 
 [ 🌸 Don't panic. ]
 
+> **Project status:** pre-release research prototype.
+> Public APIs and module boundaries may change until `v1.0.0`.
+
 ### Computational Structuralism in Modern C++23
 
 The `dedekind` library intends to be a faithful translation of mathematical concepts into modern `C++`. 
@@ -62,6 +65,39 @@ In this approach;
 3. **Bi-directional Fidelity**: Once a concept compiles, its fidelity is verified by checking that `C++` invariants map correctly back to their mathematical counterparts within the test suite.
 
 _AI assistance is used during the development of this project._
+
+### Interoperability Notes (MVP)
+
+`dedekind::interop` provides explicit type-boundary adapters between
+Dedekind extensional sets and standard set containers:
+
+- `from_std(std::set<T>)` / `from_std(std::unordered_set<T>)`
+- `to_std<std::set<T>>(ext)` / `to_std<std::unordered_set<T>>(ext)`
+
+Example:
+
+```cpp
+import dedekind.sets;
+
+std::set<int> ordered{1, 2, 3};
+auto ext = dedekind::interop::from_std(ordered);
+auto back = dedekind::interop::to_std<std::set<int>>(ext);
+```
+
+Semantic caveats:
+
+- Conversions are explicit on purpose; there are no implicit container bridges.
+- Interop materializes a finite runtime carrier (`FiniteExtensionalSet<T>`), so
+	the conversion boundary is auditable and does not silently reinterpret
+	intensional expressions.
+- Membership meaning is preserved (`x ∈ S` before/after conversion), and
+	extensional equality is checked via round-trip tests.
+
+Performance notes:
+
+- `from_std` and `to_std` are linear in the number of elements (`O(n)`).
+- `std::unordered_set` targets generally provide expected `O(1)` lookup,
+	while `std::set` targets provide `O(log n)` lookup.
 
 ### Further reading:
 

--- a/docs/report/report.tex
+++ b/docs/report/report.tex
@@ -55,7 +55,7 @@
 \usetikzlibrary{shapes.geometric, arrows.meta, positioning, calc, backgrounds}
 
 \usepackage{draftwatermark}
-\SetWatermarkScale{5}
+\SetWatermarkScale{2}
 
 \usepackage[style=numeric, sorting=none]{biblatex}
 \addbibresource{references.bib}     % Points to your .bib file (include the extension)
@@ -112,7 +112,7 @@
 \newcommand{\bind}{\mathbin{>\!\!>\mkern-6.7mu=}}
 
 % --- Document Metadata ---
-\title{Axiomatic Systems Programming: Structural Type Theory and Exact Arithmetic in C++23}
+\title{Axiomatic Systems Programming in C++23: Structural Type Theory, Verified Set Interfaces, and Accuracy-Latency Tradeoffs}
 \author{The \texttt{dedekind} Authors}
 \date{\today} % Automatically inserts current date
 
@@ -121,9 +121,11 @@
 \maketitle
 
 \begin{abstract}
-This paper introduces \texttt{dedekind}, a \texttt{C++23} library designed to embed formal mathematical structures directly within the language's type system as first-class, verified specifications. We address the performance-productivity gap in computational science---often characterized as the ``two-language problem''---by leveraging modern \texttt{C++} features, including modules, concepts, and non-type template parameters (NTTP), to implement a structural type theory. Unlike traditional object-oriented frameworks that rely on nominal inheritance, \texttt{dedekind} reifies mathematical entities as positions within a categorical system of relations. 
+This report presents \texttt{dedekind}, a \texttt{C++23} research library for embedding mathematical structure directly into compile-time interfaces through modules, concepts, and constrained species traits. Rather than treating algebraic intent as runtime convention, \texttt{dedekind} reifies categorical and mereological invariants as type-level contracts that can be audited by the compiler and validated by tests.
 
-We demonstrate the utility of this approach through a formal construction of the continuum $\mathbb{R}$ via Dedekind cuts, enabling the exact resolution of transcendental numbers without floating-point overhead. Furthermore, we show how hoisting mereological and algebraic invariants into type signatures allows the \texttt{LLVM} backend to perform aggressive structural pruning, such as collapsing contradictory set-builder predicates into zero-instruction machine code. By addressing language-level constraints through the introduction of the ``Highway Notation'' for Kleisli composition, this work illustrates that integrating formal mathematical rigor into systems programming can yield zero-overhead abstractions suitable for high-performance symbolic computing. We propose this methodology as a nascent paradigm for \textit{Axiomatic Systems Programming}, where the compiler serves as a formal verification engine for mathematical truth.
+The project demonstrates three complementary goals. First, it supports symbolic and exact constructions (including Dedekind-cut style reasoning) where compile-time pruning can collapse contradictory structures to near-zero runtime cost. Second, it acknowledges the accuracy-latency paradox in numeric systems programming: exactness and hardware throughput are not globally maximizable at once. To make this tradeoff explicit, \texttt{dedekind} exposes policy-guided IEEE workflows ranging from pass-through machine arithmetic to monitored and actively managed execution paths. Third, it lowers adoption cost through explicit interoperability boundaries, including finite sequence integration with standard ranges and controlled set-container bridges for standard library set types.
+
+The resulting methodology is practical rather than absolutist: enforce what can be guaranteed in the current type/concept layer, document limitations where theory or machinery is still maturing, and preserve mechanical sympathy with modern compiler backends. We position this as Axiomatic Systems Programming: a workflow in which formal structure, performance constraints, and developer-facing interoperability are co-designed instead of treated as separate phases.
 
 \end{abstract}
 
@@ -598,6 +600,23 @@ The core objective is to anchor the C++ type system as a substrate for modeling 
 \textasteriskcentered \textit{Fails bit-perfect associativity due to rounding/NaN.}
 \end{flushleft}
 \end{table}
+
+
+\subsection{The Accuracy-Latency Paradox: Transcendental Reality vs. Silicon Speed}
+
+A central tension in Axiomatic Systems Programming is what we term the "Accuracy-Latency Paradox." As demonstrated in our formal construction of the continuum $\mathbb{R}$ via Dedekind cuts, achieving a definitive accuracy gain over the IEEE 754 standard necessitates a departure from the hardware-accelerated floating-point units (FPUs) baked into modern silicon. While \texttt{dedekind} can resolve the predicate $e < \pi$ as a zero-instruction compile-time proof, any runtime evaluation of transcendental logic that seeks to surpass standard bit-widths inevitably incurs a performance penalty. Software-defined exact arithmetic simply cannot compete with the gigahertz-scale throughput of dedicated hardware circuits designed for the IEEE standard.
+
+To reconcile the requirements of mathematical rigor with the necessity of systems-level performance, the library does not enforce a singular, global mode of computation. Instead, we acknowledge that the definition of "optimal" varies by domain. Consequently, \texttt{dedekind} introduces three distinct \textbf{Approximation Policies} within the \texttt{dedekind.ieee} and \texttt{dedekind.numbers} modules, allowing the developer to calibrate the position of their species on the accuracy-latency spectrum:
+
+\begin{enumerate}
+  \item \textbf{Classic IEEE (Pass-Through):} This policy treats machine types like \texttt{double} as primal atoms. The library performs no active monitoring, allowing the LLVM backend to emit standard FPU instructions. In this mode, the categorical layer serves primarily as a documentation and signature-matching tool, accepting the inherent risks of numerical non-associativity and $NaN$ singularities in exchange for maximum hardware throughput.
+
+  \item \textbf{IEEE with Monitoring (The Auditor):} This policy utilizes the \texttt{SubobjectClassifier} to perform passive auditing. By leveraging compiler built-ins (e.g., \texttt{\_\_builtin\_add\_overflow}), the library identifies when a calculation breaches the Lipschitz boundary or enters a $NaN$ "truth-hole." While the computation proceeds at near-native speed, the result is "tagged" within the \texttt{Partial<T>} rescue pod, enabling downstream verification of the structural integrity of the execution path.
+
+  \item \textbf{IEEE with Active Management (The Rescue):} This is the most rigorous policy, where the library actively intervenes in the algebraic flow. It explicitly disables hazardous compiler optimizations---such as \texttt{-ffast-math} reassociations---that violate the species' axioms. If a singularity is detected, the $\Omega$-Monad propagates the \texttt{Unknown} state through the Kleisli chain, ensuring that hardware-level "noise" never contaminates the symbolic logic of the broader model.
+\end{enumerate}
+
+By providing these levels of engagement, \texttt{dedekind} shifts the paradigm from an unattainable "universal speed-accuracy win" toward \textbf{Informed Trade-offs}. This ensures that the developer can maintain mechanical sympathy for the hardware while remaining semantically honest about the mathematical validity of their results.
 
 
 

--- a/src/main/modules/dedekind/analysis/hamilton.cppm
+++ b/src/main/modules/dedekind/analysis/hamilton.cppm
@@ -160,14 +160,13 @@ constexpr auto harmonic_oscillator_leapfrog_finite_path(R q0, R p0, R dt,
 static_assert(IsCurve<decltype(harmonic_oscillator_curve<double>(1.0, 0.0))>,
               "Closed-form harmonic trajectory must be a curve.");
 
-static_assert(
-    IsSequence<decltype(harmonic_oscillator_leapfrog_path<double>(1.0, 0.0,
-                                                                  0.01))>,
-    "Leapfrog trajectory must be a discrete sequence path.");
+static_assert(IsSequence<decltype(harmonic_oscillator_leapfrog_path<double>(
+                  1.0, 0.0, 0.01))>,
+              "Leapfrog trajectory must be a discrete sequence path.");
 
-static_assert(IsFiniteSequence<decltype(
-          harmonic_oscillator_leapfrog_finite_path<double>(
-            1.0, 0.0, 0.01, 32))>,
-        "Dedicated finite-horizon leapfrog trajectory must be finite.");
+static_assert(
+    IsFiniteSequence<decltype(harmonic_oscillator_leapfrog_finite_path<double>(
+        1.0, 0.0, 0.01, 32))>,
+    "Dedicated finite-horizon leapfrog trajectory must be finite.");
 
 }  // namespace dedekind::analysis

--- a/src/main/modules/dedekind/analysis/hamilton.cppm
+++ b/src/main/modules/dedekind/analysis/hamilton.cppm
@@ -26,6 +26,7 @@
  */
 module;
 
+#include <cmath>
 #include <concepts>
 #include <cstddef>
 
@@ -34,10 +35,12 @@ export module dedekind.analysis:hamilton;
 import dedekind.category;
 import dedekind.algebra;
 import dedekind.geometry;
+import dedekind.sequences;
 
 namespace dedekind::analysis {
 using namespace dedekind::algebra;
 using namespace dedekind::geometry;
+using namespace dedekind::sequences;
 
 /**
  * @concept IsHamiltonian
@@ -87,5 +90,84 @@ export template <typename A>
 concept IsPoissonAlgebra = IsRing<A> && requires(A f, A g) {
   { bracket(f, g) } -> std::same_as<A>;
 };
+
+/** @brief Canonical 1D phase-space state (q, p). */
+export template <std::floating_point R>
+using PhasePoint = Vector<R, 2>;
+
+/**
+ * @brief Closed-form harmonic-oscillator flow at time t.
+ * @details
+ * For H(q,p) = 1/2 (p^2 + ω^2 q^2) with unit mass:
+ *   q(t) = q0 cos(ωt) + (p0/ω) sin(ωt)
+ *   p(t) = p0 cos(ωt) - ω q0 sin(ωt)
+ */
+export template <std::floating_point R>
+constexpr PhasePoint<R> harmonic_oscillator_closed_form(R q0, R p0, R t,
+                                                        R omega = R{1}) {
+  const R wt = omega * t;
+  const R c = std::cos(wt);
+  const R s = std::sin(wt);
+  return PhasePoint<R>{q0 * c + (p0 / omega) * s, p0 * c - (omega * q0) * s};
+}
+
+/**
+ * @brief Continuum-indexed Hamiltonian trajectory as a Curve.
+ */
+export template <std::floating_point R>
+constexpr auto harmonic_oscillator_curve(R q0, R p0, R omega = R{1}) {
+  auto flow = [q0, p0, omega](R t) {
+    return harmonic_oscillator_closed_form<R>(q0, p0, t, omega);
+  };
+  return Curve<R, PhasePoint<R>>{flow};
+}
+
+/**
+ * @brief Discrete Hamiltonian trajectory via leapfrog/Verlet (infinite path).
+ * @details
+ * The update is the symplectic kick-drift-kick form used in N-body style
+ * benchmark loops: preserve qualitative energy behavior over long horizons.
+ */
+export template <std::floating_point R>
+constexpr auto harmonic_oscillator_leapfrog_path(R q0, R p0, R dt,
+                                                 R omega = R{1}) {
+  auto trajectory = [q0, p0, dt, omega](std::size_t n) {
+    R q = q0;
+    R p = p0;
+    const R half = R{0.5};
+    const R k = omega * omega;
+
+    for (std::size_t i = 0; i < n; ++i) {
+      const R p_half = p - half * dt * (k * q);
+      q += dt * p_half;
+      p = p_half - half * dt * (k * q);
+    }
+    return PhasePoint<R>{q, p};
+  };
+
+  return Path<PhasePoint<R>>{trajectory};
+}
+
+export template <std::floating_point R>
+constexpr auto harmonic_oscillator_leapfrog_finite_path(R q0, R p0, R dt,
+                                                        std::size_t steps,
+                                                        R omega = R{1}) {
+  auto infinite = harmonic_oscillator_leapfrog_path<R>(q0, p0, dt, omega);
+  return prefix(infinite, steps);
+}
+
+/** @section Formal_Verification */
+static_assert(IsCurve<decltype(harmonic_oscillator_curve<double>(1.0, 0.0))>,
+              "Closed-form harmonic trajectory must be a curve.");
+
+static_assert(
+    IsSequence<decltype(harmonic_oscillator_leapfrog_path<double>(1.0, 0.0,
+                                                                  0.01))>,
+    "Leapfrog trajectory must be a discrete sequence path.");
+
+static_assert(IsFiniteSequence<decltype(
+          harmonic_oscillator_leapfrog_finite_path<double>(
+            1.0, 0.0, 0.01, 32))>,
+        "Dedicated finite-horizon leapfrog trajectory must be finite.");
 
 }  // namespace dedekind::analysis

--- a/src/main/modules/dedekind/sequences/curve.cppm
+++ b/src/main/modules/dedekind/sequences/curve.cppm
@@ -1,0 +1,81 @@
+/**
+ * @file dedekind/sequences/curve.cppm
+ * @partition :curve
+ * @brief Level 2.5c: The Curve (Continuum-Indexed Morphism Family).
+ *
+ * @section Curve_Morphism
+ * A curve is modeled as a morphism family γ: I -> T where I is a real-valued
+ * index species. This complements Path (countable/discrete indexing) with a
+ * continuum-indexed sibling.
+ *
+ * @copyright 2026 The Dedekind Authors
+ * Licensed under the Apache License, Version 2.0.
+ *
+ * @note "God made the integers; all else is the work of man."
+ *       -- Leopold Kronecker
+ */
+module;
+
+#include <concepts>
+#include <cstddef>
+#include <functional>
+
+export module dedekind.sequences:curve;
+
+import dedekind.category;
+import dedekind.sets;
+import :net;
+
+namespace dedekind::sequences {
+
+using namespace dedekind::category;
+using namespace dedekind::sets;
+
+/**
+ * @class Curve
+ * @brief A continuum-indexed family γ: I -> T.
+ *
+ * @tparam Parameter Real-valued index species (typically float/double).
+ * @tparam T Codomain species sampled along the parameter.
+ * @tparam Cardinality Magnitude metadata for the index family.
+ */
+export template <std::floating_point Parameter, typename T,
+                 typename Cardinality = ℶ_1>
+struct Curve {
+  using Domain = Parameter;
+  using Codomain = T;
+  using cardinality_type = Cardinality;
+
+  std::function<T(Parameter)> generator;
+
+  constexpr Codomain operator()(Domain t) const { return generator(t); }
+  constexpr T at(Parameter t) const { return generator(t); }
+
+  static consteval cardinality_type cardinality() { return {}; }
+};
+
+/**
+ * @concept IsCurve
+ * @brief A real-parameter indexed morphism family.
+ */
+export template <typename C>
+concept IsCurve = IsIndexedMorphismFamily<C> &&
+                  std::floating_point<typename std::remove_cvref_t<C>::Domain>;
+
+/** @section Formal_Verification */
+static_assert(IsArrow<Curve<double, int>>,
+              "Curve must satisfy the categorical arrow concept.");
+
+static_assert(IsIndexedMorphismFamily<Curve<double, int>>,
+              "Curve must satisfy indexed morphism family semantics.");
+
+static_assert(IsCurve<Curve<double, int>>,
+              "Curve must satisfy the IsCurve concept.");
+
+static_assert(!IsCountablyIndexedFamily<Curve<double, int>>,
+              "Curve is continuum-indexed by default, not countably indexed.");
+
+static_assert(!IsSequence<Curve<double, int>>,
+              "Continuum-indexed curves must remain distinct from sequences.");
+
+}  // namespace dedekind::sequences

--- a/src/main/modules/dedekind/sequences/net.cppm
+++ b/src/main/modules/dedekind/sequences/net.cppm
@@ -42,6 +42,33 @@ using namespace dedekind::category;
 using namespace dedekind::sets;
 using namespace dedekind::order;
 
+/**
+ * @concept IsIndexedMorphismFamily
+ * @brief A category arrow equipped with explicit index cardinality metadata.
+ *
+ * @details
+ * This concept captures families F: I -> X as first-class morphisms whose
+ * index species I and codomain species X are represented by Domain/Codomain,
+ * while cardinality metadata remains inspectable at compile time.
+ */
+export template <typename F>
+concept IsIndexedMorphismFamily = IsArrow<F> && requires(const F f) {
+  typename F::Domain;
+  typename F::Codomain;
+  typename F::cardinality_type;
+  requires IsCardinality<typename F::cardinality_type>;
+  { f.cardinality() } -> std::same_as<typename F::cardinality_type>;
+};
+
+/**
+ * @concept IsCountablyIndexedFamily
+ * @brief An indexed family whose index magnitude is finite or countably
+ * infinite.
+ */
+export template <typename F>
+concept IsCountablyIndexedFamily =
+    IsIndexedMorphismFamily<F> && IsCountable<typename F::cardinality_type>;
+
 /** @concept IsNet: A Morphism from a Directed Set. */
 export template <typename N>
 concept IsNet = IsArrow<N> && IsDirectedSet<typename N::Domain>;
@@ -51,13 +78,12 @@ concept IsNet = IsArrow<N> && IsDirectedSet<typename N::Domain>;
  * @brief The fundamental mapping from a Domain Set to a Value Type.
  */
 export template <typename Seq>
-concept IsSequence = IsNet<Seq> && requires {
+concept IsSequence = IsNet<Seq> && IsCountablyIndexedFamily<Seq> && requires {
   // Refactored: value_type -> Codomain
   typename Seq::Codomain;
   typename Seq::Domain;
-} && requires(Seq s) {
+} && requires(const Seq s) {
   requires IsSpecies<typename Seq::Domain>;
-  { s.cardinality() } -> IsCardinality;
 };
 
 /**
@@ -88,5 +114,24 @@ export template <typename S>
 concept IsTerminalSet = IsCountableSet<S> && requires(S s) {
   { s.size() } -> std::integral;
 };
+
+namespace detail {
+template <typename T>
+struct toy_countable_family {
+  using Domain = std::size_t;
+  using Codomain = T;
+  using cardinality_type = ℵ_0;
+
+  constexpr T operator()(Domain) const { return T{}; }
+  static consteval cardinality_type cardinality() { return {}; }
+};
+}  // namespace detail
+
+/** @section Formal_Verification */
+static_assert(IsIndexedMorphismFamily<detail::toy_countable_family<int>>,
+              "Countable toy family must satisfy indexed family concept.");
+
+static_assert(IsCountablyIndexedFamily<detail::toy_countable_family<int>>,
+              "Countable toy family must satisfy countable-index concept.");
 
 }  // namespace dedekind::sequences

--- a/src/main/modules/dedekind/sequences/net.cppm
+++ b/src/main/modules/dedekind/sequences/net.cppm
@@ -82,9 +82,7 @@ concept IsSequence = IsNet<Seq> && IsCountablyIndexedFamily<Seq> && requires {
   // Refactored: value_type -> Codomain
   typename Seq::Codomain;
   typename Seq::Domain;
-} && requires(const Seq s) {
-  requires IsSpecies<typename Seq::Domain>;
-};
+} && requires(const Seq s) { requires IsSpecies<typename Seq::Domain>; };
 
 /**
  * @concept IsFiniteSequence

--- a/src/main/modules/dedekind/sequences/path.cppm
+++ b/src/main/modules/dedekind/sequences/path.cppm
@@ -408,12 +408,43 @@ constexpr auto forall(const Path<T, Cardinality>& path, Pred&& pred) {
 
 }  // namespace dedekind::sequences
 
+namespace dedekind::category {
+
+// Path participates in the Kleisli witness framework as an infinite constant
+// path for η and head sampling for ε.
+export template <typename T>
+struct unit_witness<dedekind::sequences::Path, T> final {
+  constexpr auto operator()(T x) const {
+    return dedekind::sequences::Path<T>{[x](std::size_t) { return x; }};
+  }
+};
+
+export template <typename T>
+struct counit_witness<dedekind::sequences::Path, T> final {
+  constexpr T operator()(const dedekind::sequences::Path<T>& p) const {
+    return p.at(0);
+  }
+};
+
+}  // namespace dedekind::category
+
 namespace dedekind::sequences {
 using namespace dedekind::category;
 
-/** @section Formal_Verification
- * Deferred while path-level categorical bridges are being retargeted to the
- * current dedekind.category hub/spoke interfaces.
- */
+/** @section Formal_Verification */
+static_assert(IsSequence<Path<int>>,
+              "Path must satisfy the sequence concept.");
+
+static_assert(IsFiniteSequence<FinitePath<int>>,
+              "FinitePath must satisfy the finite sequence concept.");
+
+static_assert(IsKleisliExtension<Path, int, long>,
+              "Path must satisfy the Kleisli extension witness.");
+
+static_assert(IsCoKleisliExtension<Path, int, long>,
+              "Path must satisfy the co-Kleisli extension witness.");
+
+static_assert(IsFrobenius<Path, int, long>,
+              "Path must satisfy the Frobenius witness (Kleisli + co-Kleisli).");
 
 }  // namespace dedekind::sequences

--- a/src/main/modules/dedekind/sequences/path.cppm
+++ b/src/main/modules/dedekind/sequences/path.cppm
@@ -266,6 +266,10 @@ constexpr auto from_range(R&& range) {
   using U = std::ranges::range_value_t<R>;
 
   auto values = std::make_shared<std::vector<U>>();
+  if constexpr (std::ranges::sized_range<R>) {
+    values->reserve(
+        static_cast<typename std::vector<U>::size_type>(std::ranges::size(range)));
+  }
   for (auto&& value : range) values->push_back(static_cast<U>(value));
 
   return FinitePath<U>{

--- a/src/main/modules/dedekind/sequences/path.cppm
+++ b/src/main/modules/dedekind/sequences/path.cppm
@@ -267,8 +267,8 @@ constexpr auto from_range(R&& range) {
 
   auto values = std::make_shared<std::vector<U>>();
   if constexpr (std::ranges::sized_range<R>) {
-    values->reserve(
-        static_cast<typename std::vector<U>::size_type>(std::ranges::size(range)));
+    values->reserve(static_cast<typename std::vector<U>::size_type>(
+        std::ranges::size(range)));
   }
   for (auto&& value : range) values->push_back(static_cast<U>(value));
 

--- a/src/main/modules/dedekind/sequences/path.cppm
+++ b/src/main/modules/dedekind/sequences/path.cppm
@@ -31,11 +31,14 @@ module;
 
 #include <algorithm>
 #include <cassert>
+#include <compare>
 #include <concepts>
 #include <cstddef>
 #include <functional>
+#include <iterator>
 #include <limits>
 #include <memory>
+#include <ranges>
 #include <type_traits>
 #include <utility>
 #include <vector>
@@ -62,6 +65,112 @@ struct Path {
   using Domain = std::size_t;
   using Codomain = T;
   using cardinality_type = Cardinality;
+
+  struct const_iterator {
+    using iterator_concept = std::random_access_iterator_tag;
+    using iterator_category = std::random_access_iterator_tag;
+    using value_type = T;
+    using difference_type = std::ptrdiff_t;
+    using reference = T;
+
+    const Path* owner = nullptr;
+    std::size_t index = 0;
+
+    constexpr reference operator*() const {
+      assert(owner != nullptr && "path iterator requires owner");
+      return owner->at(index);
+    }
+
+    constexpr reference operator[](difference_type n) const {
+      assert(owner != nullptr && "path iterator requires owner");
+      return owner->at(
+          static_cast<std::size_t>(static_cast<difference_type>(index) + n));
+    }
+
+    constexpr const_iterator& operator++() {
+      ++index;
+      return *this;
+    }
+
+    constexpr const_iterator operator++(int) {
+      auto tmp = *this;
+      ++(*this);
+      return tmp;
+    }
+
+    constexpr const_iterator& operator--() {
+      --index;
+      return *this;
+    }
+
+    constexpr const_iterator operator--(int) {
+      auto tmp = *this;
+      --(*this);
+      return tmp;
+    }
+
+    constexpr const_iterator& operator+=(difference_type n) {
+      index = static_cast<std::size_t>(static_cast<difference_type>(index) + n);
+      return *this;
+    }
+
+    constexpr const_iterator& operator-=(difference_type n) {
+      return (*this += -n);
+    }
+
+    friend constexpr const_iterator operator+(const const_iterator& it,
+                                              difference_type n) {
+      auto copy = it;
+      copy += n;
+      return copy;
+    }
+
+    friend constexpr const_iterator operator+(difference_type n,
+                                              const const_iterator& it) {
+      return it + n;
+    }
+
+    friend constexpr const_iterator operator-(const const_iterator& it,
+                                              difference_type n) {
+      auto copy = it;
+      copy -= n;
+      return copy;
+    }
+
+    friend constexpr difference_type operator-(const const_iterator& lhs,
+                                               const const_iterator& rhs) {
+      assert(lhs.owner == rhs.owner && "cannot diff iterators from two paths");
+      return static_cast<difference_type>(lhs.index) -
+             static_cast<difference_type>(rhs.index);
+    }
+
+    friend constexpr bool operator==(const const_iterator& lhs,
+                                     const const_iterator& rhs) {
+      return lhs.owner == rhs.owner && lhs.index == rhs.index;
+    }
+
+    friend constexpr bool operator<(const const_iterator& lhs,
+                                    const const_iterator& rhs) {
+      assert(lhs.owner == rhs.owner &&
+             "cannot compare iterators from two paths");
+      return lhs.index < rhs.index;
+    }
+
+    friend constexpr bool operator>(const const_iterator& lhs,
+                                    const const_iterator& rhs) {
+      return rhs < lhs;
+    }
+
+    friend constexpr bool operator<=(const const_iterator& lhs,
+                                     const const_iterator& rhs) {
+      return !(rhs < lhs);
+    }
+
+    friend constexpr bool operator>=(const const_iterator& lhs,
+                                     const const_iterator& rhs) {
+      return !(lhs < rhs);
+    }
+  };
 
   /** @brief The underlying mapping f(n). */
   std::function<T(std::size_t)> generator;
@@ -127,12 +236,45 @@ struct Path {
     return extent;
   }
 
+  constexpr auto begin() const noexcept
+    requires IsFiniteMagnitude<Cardinality>
+  {
+    return const_iterator{.owner = this, .index = 0};
+  }
+
+  constexpr auto end() const noexcept
+    requires IsFiniteMagnitude<Cardinality>
+  {
+    return const_iterator{.owner = this, .index = size()};
+  }
+
   /** @brief The Path is generally viewed as a mapping from N. */
   constexpr auto cardinality() const noexcept { return Cardinality{}; }
 };
 
 export template <typename T>
 using FinitePath = Path<T, Finite>;
+
+export template <typename T>
+constexpr const FinitePath<T>& as_range(const FinitePath<T>& path) {
+  return path;
+}
+
+export template <typename R>
+  requires std::ranges::input_range<R>
+constexpr auto from_range(R&& range) {
+  using U = std::ranges::range_value_t<R>;
+
+  auto values = std::make_shared<std::vector<U>>();
+  for (auto&& value : range) values->push_back(static_cast<U>(value));
+
+  return FinitePath<U>{
+      [values](std::size_t i) {
+        assert(i < values->size() && "from_range: index out of range");
+        return (*values)[i];
+      },
+      values->size()};
+}
 
 export template <typename T, typename Cardinality>
 constexpr auto prefix(const Path<T, Cardinality>& path, std::size_t length) {

--- a/src/main/modules/dedekind/sequences/path.cppm
+++ b/src/main/modules/dedekind/sequences/path.cppm
@@ -432,8 +432,7 @@ namespace dedekind::sequences {
 using namespace dedekind::category;
 
 /** @section Formal_Verification */
-static_assert(IsSequence<Path<int>>,
-              "Path must satisfy the sequence concept.");
+static_assert(IsSequence<Path<int>>, "Path must satisfy the sequence concept.");
 
 static_assert(IsFiniteSequence<FinitePath<int>>,
               "FinitePath must satisfy the finite sequence concept.");
@@ -444,7 +443,8 @@ static_assert(IsKleisliExtension<Path, int, long>,
 static_assert(IsCoKleisliExtension<Path, int, long>,
               "Path must satisfy the co-Kleisli extension witness.");
 
-static_assert(IsFrobenius<Path, int, long>,
-              "Path must satisfy the Frobenius witness (Kleisli + co-Kleisli).");
+static_assert(
+    IsFrobenius<Path, int, long>,
+    "Path must satisfy the Frobenius witness (Kleisli + co-Kleisli).");
 
 }  // namespace dedekind::sequences

--- a/src/main/modules/dedekind/sequences/sequences.cppm
+++ b/src/main/modules/dedekind/sequences/sequences.cppm
@@ -15,4 +15,5 @@ export module dedekind.sequences;
 export import :net;
 export import :limits;
 export import :path;
+export import :curve;
 export import :ranges;

--- a/src/main/modules/dedekind/sets/interop.cppm
+++ b/src/main/modules/dedekind/sets/interop.cppm
@@ -1,0 +1,143 @@
+/**
+ * @file dedekind/sets/interop.cppm
+ * @partition :interop
+ * @brief Explicit bridges between Dedekind extensional sets and std set-like
+ * containers.
+ *
+ * Copyright 2026 The Dedekind Authors
+ * Licensed under the Apache License, Version 2.0.
+ */
+module;
+
+#include <concepts>
+#include <cstddef>
+#include <functional>
+#include <iterator>
+#include <set>
+#include <type_traits>
+#include <unordered_set>
+
+export module dedekind.sets:interop;
+
+import dedekind.category;
+import :mereology;
+
+namespace dedekind::sets {
+
+export template <typename T, typename L = dedekind::category::ClassicalLogic,
+                 typename Hash = std::hash<T>,
+                 typename Equal = std::equal_to<T>>
+struct FiniteExtensionalSet {
+  using Domain = T;
+  using Codomain = typename L::Ω;
+  using logic_species = L;
+  using cardinality_type = Finite;
+  using is_extensional_tag = void;
+
+  std::unordered_set<T, Hash, Equal> elements;
+
+  constexpr Codomain operator()(const T& value) const {
+    return elements.contains(value) ? L::True : L::False;
+  }
+
+  constexpr bool contains(const T& value) const {
+    return elements.contains(value);
+  }
+
+  constexpr std::size_t size() const noexcept { return elements.size(); }
+  constexpr std::size_t upper_bound() const noexcept { return elements.size(); }
+  constexpr cardinality_type cardinality() const noexcept {
+    return cardinality_type{};
+  }
+
+  constexpr auto begin() const noexcept { return elements.begin(); }
+  constexpr auto end() const noexcept { return elements.end(); }
+
+  constexpr bool operator==(const FiniteExtensionalSet& other) const {
+    return elements == other.elements;
+  }
+};
+
+}  // namespace dedekind::sets
+
+namespace dedekind::interop {
+
+namespace detail {
+
+template <typename...>
+inline constexpr bool always_false_v = false;
+
+template <typename C>
+concept StdSetLike = requires(C c, const typename C::value_type& value) {
+  typename C::value_type;
+  { c.begin() } -> std::input_iterator;
+  { c.end() } -> std::sentinel_for<decltype(c.begin())>;
+  { c.insert(value) };
+  { c.find(value) };
+};
+
+template <typename C, typename T>
+concept StdSetLikeOf = StdSetLike<C> && std::same_as<typename C::value_type, T>;
+
+}  // namespace detail
+
+export template <typename C>
+concept StdSetLike = detail::StdSetLike<C>;
+
+export template <typename StdSetLike, typename T, typename L, typename Hash,
+                 typename Equal>
+  requires detail::StdSetLikeOf<StdSetLike, T>
+constexpr auto to_std(
+    const dedekind::sets::FiniteExtensionalSet<T, L, Hash, Equal>& source)
+    -> StdSetLike {
+  StdSetLike out;
+  out.insert(source.begin(), source.end());
+  return out;
+}
+
+export template <typename StdSetLike, typename ExtSet>
+constexpr auto to_std(const ExtSet&) -> StdSetLike {
+  static_assert(detail::always_false_v<StdSetLike, ExtSet>,
+                "dedekind::interop::to_std requires a "
+                "dedekind::sets::FiniteExtensionalSet "
+                "source and a std set-like target with matching value_type.");
+}
+
+export template <typename T, typename Compare, typename Alloc>
+constexpr auto from_std(const std::set<T, Compare, Alloc>& source)
+    -> dedekind::sets::FiniteExtensionalSet<T> {
+  dedekind::sets::FiniteExtensionalSet<T> out;
+  out.elements.insert(source.begin(), source.end());
+  return out;
+}
+
+export template <typename T, typename Hash, typename Equal, typename Alloc>
+constexpr auto from_std(const std::unordered_set<T, Hash, Equal, Alloc>& source)
+    -> dedekind::sets::FiniteExtensionalSet<
+        T, dedekind::category::ClassicalLogic, Hash, Equal> {
+  dedekind::sets::FiniteExtensionalSet<T, dedekind::category::ClassicalLogic,
+                                       Hash, Equal>
+      out;
+  out.elements.insert(source.begin(), source.end());
+  return out;
+}
+
+export template <typename StdSetLike>
+  requires detail::StdSetLike<StdSetLike>
+constexpr auto from_std(const StdSetLike& source)
+    -> dedekind::sets::FiniteExtensionalSet<typename StdSetLike::value_type> {
+  using T = typename StdSetLike::value_type;
+  dedekind::sets::FiniteExtensionalSet<T> out;
+  out.elements.insert(source.begin(), source.end());
+  return out;
+}
+
+export template <typename ExtSet, typename StdSetLike>
+constexpr auto from_std(const StdSetLike&) -> ExtSet {
+  static_assert(detail::always_false_v<ExtSet, StdSetLike>,
+                "dedekind::interop::from_std currently materializes as "
+                "dedekind::sets::FiniteExtensionalSet<T>. Use auto ext = "
+                "from_std(container).");
+}
+
+}  // namespace dedekind::interop

--- a/src/main/modules/dedekind/sets/interop.cppm
+++ b/src/main/modules/dedekind/sets/interop.cppm
@@ -67,6 +67,12 @@ namespace detail {
 template <typename...>
 inline constexpr bool always_false_v = false;
 
+template <typename T>
+concept DefaultHashable = requires(const T& value) {
+  { std::hash<T>{}(value) } -> std::convertible_to<std::size_t>;
+  { std::equal_to<T>{}(value, value) } -> std::convertible_to<bool>;
+};
+
 template <typename C>
 concept StdSetLike = requires(C c, const typename C::value_type& value) {
   typename C::value_type;
@@ -91,7 +97,7 @@ constexpr auto to_std(
     const dedekind::sets::FiniteExtensionalSet<T, L, Hash, Equal>& source)
     -> StdSetLike {
   StdSetLike out;
-  out.insert(source.begin(), source.end());
+  for (const auto& value : source) out.insert(value);
   return out;
 }
 
@@ -103,12 +109,35 @@ constexpr auto to_std(const ExtSet&) -> StdSetLike {
                 "source and a std set-like target with matching value_type.");
 }
 
-export template <typename T, typename Compare, typename Alloc>
-constexpr auto from_std(const std::set<T, Compare, Alloc>& source)
+export template <typename T, typename Alloc>
+  requires detail::DefaultHashable<T>
+constexpr auto from_std(const std::set<T, std::less<T>, Alloc>& source)
     -> dedekind::sets::FiniteExtensionalSet<T> {
   dedekind::sets::FiniteExtensionalSet<T> out;
-  out.elements.insert(source.begin(), source.end());
+  for (const auto& value : source) out.elements.insert(value);
   return out;
+}
+
+export template <typename T, typename Alloc>
+  requires(!detail::DefaultHashable<T>)
+constexpr auto from_std(const std::set<T, std::less<T>, Alloc>&)
+    -> dedekind::sets::FiniteExtensionalSet<T> {
+  static_assert(detail::always_false_v<T, Alloc>,
+                "dedekind::interop::from_std(std::set<T>) requires T to be "
+                "hashable by std::hash<T> and comparable by std::equal_to<T> "
+                "because the MVP finite extensional carrier is hash-based.");
+}
+
+export template <typename T, typename Compare, typename Alloc>
+  requires(!std::same_as<Compare, std::less<T>>)
+constexpr auto from_std(const std::set<T, Compare, Alloc>&)
+    -> dedekind::sets::FiniteExtensionalSet<T> {
+  static_assert(detail::always_false_v<T, Compare, Alloc>,
+                "dedekind::interop::from_std currently supports only "
+                "std::set<T> with the default std::less<T> comparator. "
+                "Custom comparators may encode a different notion of "
+                "membership/uniqueness than the MVP hash-based extensional "
+                "carrier preserves.");
 }
 
 export template <typename T, typename Hash, typename Equal, typename Alloc>
@@ -118,18 +147,19 @@ constexpr auto from_std(const std::unordered_set<T, Hash, Equal, Alloc>& source)
   dedekind::sets::FiniteExtensionalSet<T, dedekind::category::ClassicalLogic,
                                        Hash, Equal>
       out;
-  out.elements.insert(source.begin(), source.end());
+  for (const auto& value : source) out.elements.insert(value);
   return out;
 }
 
 export template <typename StdSetLike>
   requires detail::StdSetLike<StdSetLike>
-constexpr auto from_std(const StdSetLike& source)
+constexpr auto from_std(const StdSetLike&)
     -> dedekind::sets::FiniteExtensionalSet<typename StdSetLike::value_type> {
-  using T = typename StdSetLike::value_type;
-  dedekind::sets::FiniteExtensionalSet<T> out;
-  out.elements.insert(source.begin(), source.end());
-  return out;
+  static_assert(detail::always_false_v<StdSetLike>,
+                "dedekind::interop::from_std currently supports only "
+                "std::set<T> with the default comparator and "
+                "std::unordered_set<T, Hash, Equal>. Other set-like types are "
+                "reserved for a follow-up interop phase.");
 }
 
 export template <typename ExtSet, typename StdSetLike>

--- a/src/main/modules/dedekind/sets/sets.cppm
+++ b/src/main/modules/dedekind/sets/sets.cppm
@@ -38,6 +38,7 @@ export module dedekind.sets;
 
 export import :boundaries;
 export import :expressions;
+export import :interop;
 export import :mereology;
 export import :singleton;
 export import :relational;

--- a/src/test/cpp/modules/dedekind/analysis/hamilton_test.cpp
+++ b/src/test/cpp/modules/dedekind/analysis/hamilton_test.cpp
@@ -1,5 +1,6 @@
 #include <catch2/catch_test_macros.hpp>
 #include <cmath>
+#include <numbers>
 import dedekind.analysis;
 import dedekind.geometry;
 
@@ -79,5 +80,41 @@ TEST_CASE("Analysis: Hamiltonian Observables", "[analysis][hamilton]") {
 
     // For H = 0.5(p²+q²), dq/dt = p = 2.0
     REQUIRE(std::abs(dq_dt - 2.0) < 1e-3);
+  }
+
+  SECTION("Closed-form curve: quarter period rotation") {
+    const auto gamma = harmonic_oscillator_curve<ℝ>(1.0, 0.0);
+    const auto at_quarter_turn = gamma.at(std::numbers::pi_v<ℝ> / 2.0);
+
+    REQUIRE(std::abs(at_quarter_turn[0]) < 1e-12);
+    REQUIRE(std::abs(at_quarter_turn[1] + 1.0) < 1e-12);
+  }
+
+  SECTION("Leapfrog path: matches closed-form over short horizon") {
+    constexpr ℝ dt = 0.001;
+    const auto path = harmonic_oscillator_leapfrog_path<ℝ>(1.0, 0.0, dt);
+
+    const auto numeric = path.at(1000);  // t = 1.0
+    const auto exact = harmonic_oscillator_closed_form<ℝ>(1.0, 0.0, 1.0);
+
+    REQUIRE(std::abs(numeric[0] - exact[0]) < 1e-3);
+    REQUIRE(std::abs(numeric[1] - exact[1]) < 1e-3);
+  }
+
+  SECTION("Finite leapfrog path: approximate energy conservation") {
+    constexpr ℝ dt = 0.01;
+    const auto states =
+        harmonic_oscillator_leapfrog_finite_path<ℝ>(1.0, 0.0, dt, 500);
+
+    const auto energy = [](const Vec2& s) {
+      const ℝ q = s[0];
+      const ℝ p = s[1];
+      return 0.5 * (p * p + q * q);
+    };
+
+    const ℝ e0 = energy(states.at(0));
+    const ℝ eN = energy(states.at(states.size() - 1));
+
+    REQUIRE(std::abs(eN - e0) < 2e-2);
   }
 }

--- a/src/test/cpp/modules/dedekind/sequences/path_test.cpp
+++ b/src/test/cpp/modules/dedekind/sequences/path_test.cpp
@@ -1,4 +1,7 @@
+#include <algorithm>
 #include <catch2/catch_test_macros.hpp>
+#include <ranges>
+#include <vector>
 
 import dedekind.sequences;
 import dedekind.topology;
@@ -92,5 +95,27 @@ TEST_CASE("Sequences: The Path to Continuity",
     REQUIRE(orbit.at(5) == 6);
     REQUIRE(count_if(orbit, [](int x) { return x >= 4; }) == 3u);
     REQUIRE(step_calls == 5u);
+  }
+
+  SECTION("Finite paths interoperate with std::ranges algorithms") {
+    const auto orbit = iterate(2, [](int x) { return x + 2; }, 5);
+
+    static_assert(std::ranges::random_access_range<decltype(orbit)>);
+
+    std::vector<int> visited;
+    for (const int value : orbit) visited.push_back(value);
+
+    REQUIRE(visited == std::vector<int>{2, 4, 6, 8, 10});
+    REQUIRE(std::ranges::count_if(orbit, [](int x) { return x >= 6; }) == 3);
+  }
+
+  SECTION("from_range and as_range adapt finite paths") {
+    const std::vector<int> source{1, 2, 3, 4};
+    const auto doubled =
+        from_range(source | std::views::transform([](int x) { return x * 2; }));
+
+    REQUIRE(doubled.size() == source.size());
+    REQUIRE(
+        std::ranges::equal(as_range(doubled), std::vector<int>{2, 4, 6, 8}));
   }
 }

--- a/src/test/cpp/modules/dedekind/sets/interop_test.cpp
+++ b/src/test/cpp/modules/dedekind/sets/interop_test.cpp
@@ -1,0 +1,50 @@
+#include <catch2/catch_test_macros.hpp>
+#include <set>
+#include <unordered_set>
+#include <vector>
+
+import dedekind.sets;
+
+using namespace dedekind::sets;
+using namespace dedekind::interop;
+
+TEST_CASE("Sets: std container interop bridges explicit extensional sets",
+          "[sets][interop]") {
+  SECTION("Set-like concept recognizes supported std containers") {
+    static_assert(StdSetLike<std::set<int>>);
+    static_assert(StdSetLike<std::unordered_set<int>>);
+    static_assert(!StdSetLike<std::vector<int>>);
+  }
+
+  SECTION("Round trip through std::set preserves extensional equality") {
+    const std::set<int> ordered{1, 3, 7};
+
+    const auto ext = from_std(ordered);
+    REQUIRE(ext.size() == 3u);
+    REQUIRE(ext.contains(1));
+    REQUIRE(ext.contains(3));
+    REQUIRE(ext.contains(7));
+
+    const auto back = to_std<std::set<int>>(ext);
+    REQUIRE(back == ordered);
+
+    const auto ext_round_trip = from_std(back);
+    REQUIRE(ext_round_trip == ext);
+  }
+
+  SECTION("Round trip through std::unordered_set preserves membership") {
+    const std::unordered_set<int> values{11, 13, 17};
+
+    const auto ext = from_std(values);
+    REQUIRE(ext.size() == 3u);
+    REQUIRE(ext.contains(11));
+    REQUIRE(ext.contains(13));
+    REQUIRE(ext.contains(17));
+
+    const auto back = to_std<std::unordered_set<int>>(ext);
+    REQUIRE(back == values);
+
+    const auto ext_round_trip = from_std(back);
+    REQUIRE(ext_round_trip == ext);
+  }
+}


### PR DESCRIPTION
## Summary
- Implement finite `Path` `std::ranges` interop and adapters.
- Add MVP `std::set`/`std::unordered_set` bridge via `dedekind::interop`, including concept checks and round-trip tests.
- Update README with pre-release signaling plus interop caveats and performance notes.

## Closing references
Closes #163
Closes #189
Closes #192