### PR TITLE
python: rename bindings facade and codify CI-first guidance

### DIFF
--- a/.github/instructions/*.instructions.md
+++ b/.github/instructions/*.instructions.md
@@ -30,6 +30,7 @@ RFC 2119 policy note (normative language):
 - Per RFC 2119 terminology, agents SHOULD NOT use ad hoc scripts for routine repo operations; they SHOULD use standardized commands and repository `make` targets, for the reasons stated in `CONTRIBUTING.md` (auditability, approval clarity, and repeatability across sessions).
 - Per RFC 2119 terminology, agents SHOULD push reasonable, reviewable changes to CI without undue delay, as stated in `CONTRIBUTING.md`, so integration feedback is timely and branch divergence stays small.
 - Per RFC 2119 terminology, agents SHOULD keep implementation flow asynchronous and non-blocking where practical (small commits, immediate CI push, then continue parallel review/planning), for the reasons described in `CONTRIBUTING.md` (faster feedback loops, less idle wait time, and clearer progress checkpoints).
+- Per RFC 2119 terminology, while waiting between CI builds agents SHOULD use that time to groom documentation (report/paper/readme/doxygen consistency), for the reasons described in `CONTRIBUTING.md` (reduced documentation drift and better review quality).
 At the start of each session (and after every merge to `main`), run the following checks before triaging the backlog:
 
 1. **Verify the `main` build is green.** Check `gh run list --branch main --limit 3` and confirm the most recent CI run passed. If it is failing, address that before any new work.

--- a/.github/instructions/*.instructions.md
+++ b/.github/instructions/*.instructions.md
@@ -24,6 +24,10 @@ Execution policy for routine work in this repository:
 - Keep actions auditable: prefer workflows that are easy to review and report the exact commands and outcomes.
 - Bias toward provably safe operation: perform read/check steps first, then minimal writes; avoid risky/destructive operations unless explicitly requested.
 - If a task requires manual-approval command paths, stop using that path and add a clean helper script or `make` target instead.
+
+RFC 2119 policy note (normative language):
+- Per RFC 2119 terminology, agents SHOULD NOT compile locally as a default workflow; they SHOULD push checkpoints and rely on the CI reference build, for the reasons stated in `CONTRIBUTING.md` (authoritative build parity, reduced local toolchain drift, and faster contributor throughput).
+- Per RFC 2119 terminology, agents SHOULD NOT use ad hoc scripts for routine repo operations; they SHOULD use standardized commands and repository `make` targets, for the reasons stated in `CONTRIBUTING.md` (auditability, approval clarity, and repeatability across sessions).
 At the start of each session (and after every merge to `main`), run the following checks before triaging the backlog:
 
 1. **Verify the `main` build is green.** Check `gh run list --branch main --limit 3` and confirm the most recent CI run passed. If it is failing, address that before any new work.

--- a/.github/instructions/*.instructions.md
+++ b/.github/instructions/*.instructions.md
@@ -29,6 +29,7 @@ RFC 2119 policy note (normative language):
 - Per RFC 2119 terminology, agents SHOULD NOT compile locally as a default workflow; they SHOULD push checkpoints and rely on the CI reference build, for the reasons stated in `CONTRIBUTING.md` (authoritative build parity, reduced local toolchain drift, and faster contributor throughput).
 - Per RFC 2119 terminology, agents SHOULD NOT use ad hoc scripts for routine repo operations; they SHOULD use standardized commands and repository `make` targets, for the reasons stated in `CONTRIBUTING.md` (auditability, approval clarity, and repeatability across sessions).
 - Per RFC 2119 terminology, agents SHOULD push reasonable, reviewable changes to CI without undue delay, as stated in `CONTRIBUTING.md`, so integration feedback is timely and branch divergence stays small.
+- Per RFC 2119 terminology, agents SHOULD keep implementation flow asynchronous and non-blocking where practical (small commits, immediate CI push, then continue parallel review/planning), for the reasons described in `CONTRIBUTING.md` (faster feedback loops, less idle wait time, and clearer progress checkpoints).
 At the start of each session (and after every merge to `main`), run the following checks before triaging the backlog:
 
 1. **Verify the `main` build is green.** Check `gh run list --branch main --limit 3` and confirm the most recent CI run passed. If it is failing, address that before any new work.

--- a/.github/instructions/*.instructions.md
+++ b/.github/instructions/*.instructions.md
@@ -30,7 +30,7 @@ RFC 2119 policy note (normative language):
 - Per RFC 2119 terminology, agents SHOULD NOT use ad hoc scripts for routine repo operations; they SHOULD use standardized commands and repository `make` targets, for the reasons stated in `CONTRIBUTING.md` (auditability, approval clarity, and repeatability across sessions).
 - Per RFC 2119 terminology, agents SHOULD push reasonable, reviewable changes to CI without undue delay, as stated in `CONTRIBUTING.md`, so integration feedback is timely and branch divergence stays small.
 - Per RFC 2119 terminology, agents SHOULD keep implementation flow asynchronous and non-blocking where practical (small commits, immediate CI push, then continue parallel review/planning), for the reasons described in `CONTRIBUTING.md` (faster feedback loops, less idle wait time, and clearer progress checkpoints).
-- Per RFC 2119 terminology, while waiting between CI builds agents SHOULD use that time to groom documentation (report/paper/readme/doxygen consistency), for the reasons described in `CONTRIBUTING.md` (reduced documentation drift and better review quality).
+- Per RFC 2119 terminology, while waiting between CI builds agents SHOULD use that time to check documentation consistency (report/paper/readme/doxygen), validate test coverage, or groom the backlog, for the reasons described in `CONTRIBUTING.md` (reduced drift, earlier quality-signal detection, and better review quality).
 At the start of each session (and after every merge to `main`), run the following checks before triaging the backlog:
 
 1. **Verify the `main` build is green.** Check `gh run list --branch main --limit 3` and confirm the most recent CI run passed. If it is failing, address that before any new work.

--- a/.github/instructions/*.instructions.md
+++ b/.github/instructions/*.instructions.md
@@ -28,6 +28,7 @@ Execution policy for routine work in this repository:
 RFC 2119 policy note (normative language):
 - Per RFC 2119 terminology, agents SHOULD NOT compile locally as a default workflow; they SHOULD push checkpoints and rely on the CI reference build, for the reasons stated in `CONTRIBUTING.md` (authoritative build parity, reduced local toolchain drift, and faster contributor throughput).
 - Per RFC 2119 terminology, agents SHOULD NOT use ad hoc scripts for routine repo operations; they SHOULD use standardized commands and repository `make` targets, for the reasons stated in `CONTRIBUTING.md` (auditability, approval clarity, and repeatability across sessions).
+- Per RFC 2119 terminology, agents SHOULD push reasonable, reviewable changes to CI without undue delay, as stated in `CONTRIBUTING.md`, so integration feedback is timely and branch divergence stays small.
 At the start of each session (and after every merge to `main`), run the following checks before triaging the backlog:
 
 1. **Verify the `main` build is green.** Check `gh run list --branch main --limit 3` and confirm the most recent CI run passed. If it is failing, address that before any new work.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -177,6 +177,7 @@ add_dedekind_layer(morphologies dedekind_algebra)
 add_dedekind_layer(geometry dedekind_morphologies)
 add_dedekind_layer(numbers dedekind_geometry)
 add_dedekind_layer(analysis dedekind_numbers)
+add_dedekind_layer(python dedekind_analysis)
 
 
 # --- 3. THE FINAL ASSEMBLY (The Public Interface) ---
@@ -186,14 +187,14 @@ add_dedekind_layer(analysis dedekind_numbers)
 # corresponds to a module interface unit.
 # The "dedekind" library is the final product
 add_library(dedekind INTERFACE)
-add_dependencies(dedekind dedekind_category dedekind_ieee dedekind_sets dedekind_order dedekind_topology dedekind_sequences dedekind_algebra dedekind_morphologies dedekind_geometry dedekind_numbers dedekind_analysis)
+add_dependencies(dedekind dedekind_category dedekind_ieee dedekind_sets dedekind_order dedekind_topology dedekind_sequences dedekind_algebra dedekind_morphologies dedekind_geometry dedekind_numbers dedekind_analysis dedekind_python)
 # No source files needed here; it just bundles the objects
-target_link_libraries(dedekind INTERFACE dedekind_category dedekind_ieee dedekind_sets dedekind_order dedekind_topology dedekind_sequences dedekind_algebra dedekind_morphologies dedekind_geometry dedekind_numbers dedekind_analysis)
+target_link_libraries(dedekind INTERFACE dedekind_category dedekind_ieee dedekind_sets dedekind_order dedekind_topology dedekind_sequences dedekind_algebra dedekind_morphologies dedekind_geometry dedekind_numbers dedekind_analysis dedekind_python)
 target_compile_features(dedekind INTERFACE cxx_std_23)
 
 target_compile_options(dedekind INTERFACE ${DEDEKIND_WARNING_FLAGS})
 
-install(TARGETS dedekind dedekind_category dedekind_ieee dedekind_sets dedekind_order dedekind_topology dedekind_sequences dedekind_algebra dedekind_morphologies dedekind_geometry dedekind_numbers dedekind_analysis
+install(TARGETS dedekind dedekind_category dedekind_ieee dedekind_sets dedekind_order dedekind_topology dedekind_sequences dedekind_algebra dedekind_morphologies dedekind_geometry dedekind_numbers dedekind_analysis dedekind_python
     EXPORT dedekind-targets
     # Ensure CXX_MODULES are installed for all targets
     FILE_SET CXX_MODULES DESTINATION lib/modules/dedekind

--- a/docs/paper/paper.tex
+++ b/docs/paper/paper.tex
@@ -295,6 +295,13 @@ Coproduct ($A + B$) & \texttt{std::variant} & \texttt{IsCoproduct} \\
 \end{tabular}
 \end{table}
 
+\subsubsection{The \texttt{dedekind.python} facade module}
+The \texttt{dedekind.python} module acts as a wrapper-facing facade at the end of the build chain. The design goal is a small, auditable API that can be bound in Python without exposing the full internal module graph.
+
+In the current MVP, the facade is intentionally restricted to explicit set-interop boundaries and sequence/range adapters. This is sufficient for notebook-oriented demonstrations---including orbit extraction and selection workflows for Mandelbrot-style traces---while keeping ownership and semantic contracts straightforward to review.
+
+This constrained scope is deliberate: symbolic expression-heavy builders and deeper internal abstractions are deferred until the binding surface and test obligations are mature enough to preserve report, code, and documentation alignment.
+
 \subsection{Instrumented Model Validation: The CI Pipeline as an Independent Auditor}
 While formal verification in languages like Agda or Coq typically relies on static type-level proofs that are erased during compilation, the \texttt{dedekind} framework adopts a methodology of \emph{Instrumented Model Validation}. By leveraging the LLVM profiling infrastructure, we provide an empirical \emph{Runtime Witness} for our categorical primitives.
 

--- a/docs/report/report.tex
+++ b/docs/report/report.tex
@@ -302,6 +302,13 @@ Coproduct ($A + B$) & \texttt{std::variant} & \texttt{IsCoproduct} \\
 \end{tabular}
 \end{table}
 
+\subsection{The \texttt{dedekind.python} facade module}
+The \texttt{dedekind.python} module is the current end-of-chain facade for wrapper-facing integration. Its purpose is to expose a narrow, auditable, and deterministic API surface while preserving the internal partition hierarchy and keeping categorical internals out of first-contact runtime bindings.
+
+For the MVP, the exposed surface is intentionally limited to explicit set-interop boundaries and sequence/range adapters: conversion from and to standard set-like carriers, plus finite-path range materialization and view adaptation. This scope is large enough to support notebook-first demos (for example, selecting and plotting subsets of a Mandelbrot orbit trace) while remaining small enough for stable review and low-risk evolution.
+
+By constraining the facade to value-level bridges and deferring broad symbolic expression builders, the project keeps binding semantics reviewable and reduces drift between implementation, Doxygen headers, and report-level claims.
+
 \section{Instrumented Model Validation: The CI Pipeline as an Independent Auditor}
 While formal verification in languages like Agda or Coq typically relies on static type-level proofs that are erased during compilation, the \texttt{dedekind} framework adopts a methodology of \emph{Instrumented Model Validation}. By leveraging the LLVM profiling infrastructure, we provide an empirical \emph{Runtime Witness} for our categorical primitives.
 

--- a/src/main/modules/dedekind/python/python.cppm
+++ b/src/main/modules/dedekind/python/python.cppm
@@ -1,0 +1,70 @@
+/**
+ * @file dedekind/python/python.cppm
+ * @brief Level 12: Curated binding facade for external runtimes.
+ *
+ * @copyright 2026 The Dedekind Authors
+ * Licensed under the Apache License, Version 2.0.
+ *
+ * @section Description
+ * This layer is intentionally positioned at the end of the build chain.
+ * It provides a narrow, auditable facade that downstream wrappers
+ * (e.g. Python bindings) can expose without importing the full internal
+ * module graph directly.
+ *
+ * @note "Le vrai n'est pas le tout, mais le tout dans sa structure."
+ *       -- Gaston Bachelard, paraphrase
+ *       [Trans: "Truth is not the whole, but the whole in its structure."]
+ */
+
+module;
+
+#include <functional>
+#include <ranges>
+#include <utility>
+
+export module dedekind.python;
+
+import dedekind.category;
+import dedekind.sequences;
+import dedekind.sets;
+
+export namespace dedekind::python {
+
+/** @brief Alias for the finite extensional carrier exposed to wrappers. */
+template <typename T, typename L = dedekind::category::ClassicalLogic,
+          typename Hash = std::hash<T>, typename Equal = std::equal_to<T>>
+using FiniteSet = dedekind::sets::FiniteExtensionalSet<T, L, Hash, Equal>;
+
+/** @brief Alias for finite path values intended for range-friendly adapters. */
+template <typename T>
+using FinitePath = dedekind::sequences::FinitePath<T>;
+
+/** @brief Explicit std-container materialization bridge. */
+template <typename StdSetLike, typename T, typename L, typename Hash,
+          typename Equal>
+constexpr auto to_std(
+    const dedekind::sets::FiniteExtensionalSet<T, L, Hash, Equal>& src)
+    -> StdSetLike {
+  return dedekind::interop::to_std<StdSetLike>(src);
+}
+
+/** @brief Explicit bridge from supported std set-like carriers. */
+template <typename StdSetLike>
+constexpr auto from_std(const StdSetLike& src) {
+  return dedekind::interop::from_std(src);
+}
+
+/** @brief Adapt an input range into a finite path materialization. */
+template <typename R>
+  requires std::ranges::input_range<R>
+constexpr auto from_range(R&& range) {
+  return dedekind::sequences::from_range(std::forward<R>(range));
+}
+
+/** @brief View-compatible finite-path adapter for std::ranges APIs. */
+template <typename T>
+constexpr const FinitePath<T>& as_range(const FinitePath<T>& path) {
+  return dedekind::sequences::as_range(path);
+}
+
+}  // namespace dedekind::python

--- a/src/main/modules/dedekind/python/python.cppm
+++ b/src/main/modules/dedekind/python/python.cppm
@@ -11,6 +11,12 @@
  * (e.g. Python bindings) can expose without importing the full internal
  * module graph directly.
  *
+ * MVP exposure contract:
+ * - Include explicit set interop boundaries (`from_std` / `to_std`).
+ * - Include sequence/range adapters (`from_range` / `as_range`).
+ * - Keep the surface small and deterministic for notebook-facing demos.
+ * - Defer broad symbolic expression builders and deep internal abstractions.
+ *
  * @note "Le vrai n'est pas le tout, mais le tout dans sa structure."
  *       -- Gaston Bachelard, paraphrase
  *       [Trans: "Truth is not the whole, but the whole in its structure."]

--- a/src/main/modules/dedekind/python/python.cppm
+++ b/src/main/modules/dedekind/python/python.cppm
@@ -73,4 +73,10 @@ constexpr const FinitePath<T>& as_range(const FinitePath<T>& path) {
   return dedekind::sequences::as_range(path);
 }
 
+/** @brief Rvalue-safe finite-path adapter for std::ranges APIs. */
+template <typename T>
+constexpr FinitePath<T> as_range(FinitePath<T>&& path) {
+  return std::move(path);
+}
+
 }  // namespace dedekind::python

--- a/src/test/cpp/modules/dedekind/python/python_test.cpp
+++ b/src/test/cpp/modules/dedekind/python/python_test.cpp
@@ -1,0 +1,25 @@
+#include <catch2/catch_test_macros.hpp>
+#include <ranges>
+#include <set>
+#include <vector>
+
+import dedekind.python;
+
+using namespace dedekind;
+
+TEST_CASE("Python facade: explicit finite set interop", "[python][interop]") {
+  std::set<int> ordered{1, 2, 3};
+
+  auto ext = python::from_std(ordered);
+  auto back = python::to_std<std::set<int>>(ext);
+
+  REQUIRE(back == ordered);
+}
+
+TEST_CASE("Python facade: finite path range adapters", "[python][ranges]") {
+  const std::vector<int> source{2, 4, 6, 8};
+  const auto path = python::from_range(source);
+
+  REQUIRE(path.size() == source.size());
+  REQUIRE(std::ranges::equal(python::as_range(path), source));
+}


### PR DESCRIPTION
## Summary
- rename the wrapper-facing module/layer from `dedekind.bindings` to `dedekind.python`
- add and test a narrow C++ facade for wrapper-facing set/range interop
- document the `dedekind.python` MVP scope in the report and paper
- codify RFC 2119 CI-first and standardized-tooling guidance in agent instructions

## Scope
- CMake/module wiring for the `dedekind.python` facade
- C++ facade and smoke tests for wrapper-facing interop/range adapters
- report/paper/instructions updates aligned with the renamed facade and CI-first workflow

## Validation
- PR CI green
- C++ smoke test coverage for the `dedekind.python` facade
- documentation consistency review for instructions/report/paper
