### PR TITLE
refactor(sets): drop `explicit` from ExtensionalCardinal's integral-template ctor (in partial fulfillment of #402)

### DIFF
--- a/src/main/modules/dedekind/sets/cardinality.cppm
+++ b/src/main/modules/dedekind/sets/cardinality.cppm
@@ -101,14 +101,24 @@ struct ExtensionalCardinal {
   constexpr ExtensionalCardinal(limb_type value) noexcept { limbs[0] = value; }
 
   /** @brief Construction from any integral type via two's-complement wrapping.
-   *  The explicit static_cast suppresses -Wsign-conversion at the call site.
-   *  Non-explicit (post-#402) so @c std::variant disambiguation can pick
-   *  this alternative when initialising @c Cardinality from an integral
-   *  literal — the load-bearing path for the @c ℕ-as-Cardinality
-   *  carrier reading. */
+   *  The explicit @c static_cast keeps the sign-conversion at this boundary
+   *  rather than at each call site.
+   *
+   *  Intentionally non-explicit (post-#402) so integral values can convert
+   *  implicitly when initialising or passing a @c Cardinality — the
+   *  load-bearing path for the @c ℕ-as-Cardinality carrier reading.  The
+   *  @c std::variant alternative @c ExtensionalCardinal<> is selected by
+   *  the variant's per-alternative-ctor lookup regardless of @c explicit;
+   *  what the @c explicit drop changes is whether implicit conversions are
+   *  permitted (e.g., copy-initialisation, argument passing, return
+   *  conversion) from @c std::integral source values. */
   template <std::integral S>
     requires(!std::same_as<S, limb_type>)
-  constexpr ExtensionalCardinal(S value) noexcept {  // NOLINT
+  constexpr ExtensionalCardinal(S value) noexcept {
+    // NOLINTNEXTLINE(google-explicit-constructor)
+    // Intentionally implicit so @c std::integral values convert to
+    // @c Cardinality (= @c std::variant<ExtensionalCardinal<>, ℵ_0>)
+    // without the call site spelling @c ExtensionalCardinal<>{...}.
     limbs[0] = static_cast<limb_type>(value);
   }
 

--- a/src/main/modules/dedekind/sets/cardinality.cppm
+++ b/src/main/modules/dedekind/sets/cardinality.cppm
@@ -101,10 +101,14 @@ struct ExtensionalCardinal {
   constexpr ExtensionalCardinal(limb_type value) noexcept { limbs[0] = value; }
 
   /** @brief Construction from any integral type via two's-complement wrapping.
-   *  The explicit static_cast suppresses -Wsign-conversion at the call site. */
+   *  The explicit static_cast suppresses -Wsign-conversion at the call site.
+   *  Non-explicit (post-#402) so @c std::variant disambiguation can pick
+   *  this alternative when initialising @c Cardinality from an integral
+   *  literal — the load-bearing path for the @c ℕ-as-Cardinality
+   *  carrier reading. */
   template <std::integral S>
     requires(!std::same_as<S, limb_type>)
-  constexpr explicit ExtensionalCardinal(S value) noexcept {
+  constexpr ExtensionalCardinal(S value) noexcept {  // NOLINT
     limbs[0] = static_cast<limb_type>(value);
   }
 


### PR DESCRIPTION
**In partial fulfillment** of #402 (ℤ exact-carrier retarget).

This PR delivers the smallest brick of the prerequisite machinery for the math-wins-over-C++ retarget: dropping `explicit` from `ExtensionalCardinal<>`'s integral-template ctor so `Cardinality{7u}` works via std::variant disambiguation. (`SignedExtensionalCardinal<>`'s ctor was already non-explicit.)

## Why this is split out

PR-discussion analysis on #402 surfaced an architectural scope larger than #402's nominal scope: the variant ℤ-proxy retarget requires four discrete pieces of upstream machinery that didn't exist when #402 was filed. Doing them as separate small PRs (one piece per PR) rather than batching the whole cascade.

The full prerequisite chain (filed under epic #374, blocking #402):

- **#413** — `SpeciesTraits<Cardinality>` + `SpeciesTraits<SignedCardinality>` specialisations.
- **#414** — `IsRingIntegral<T>` concept (generalises `OrderInterval`'s `is_integer_range` gate).
- **#415** — `SignedCardinality` / `Cardinality` ↔ `std::integral` relational operators.
- **#416** — cascade sweep across test sites + IR-fixture witness types.
- **This PR** — preparatory `explicit` drop on `ExtensionalCardinal<>`'s ctor (a sub-piece of #413's machinery; useful standalone).

Once all prerequisites land, the actual carrier alias retarget (`using ℤ = SignedCardinality;`) is a small final PR closing #402.

## What landed here

- `src/main/modules/dedekind/sets/cardinality.cppm`: dropped `explicit` from the `template <std::integral S> ExtensionalCardinal(S value)` ctor; updated the doc-comment to explain the variant-disambiguation rationale.

## Tests

- 15/15 ctest pass; 136/136 Python tests pass; no behavioural change beyond the constructor's implicit-conversion availability.

## Out of scope

- Anything else in #402's nominal scope — see prerequisite issues #413–#416 above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)