### PR TITLE
feat(category): SpeciesTraits<Cardinality> + SpeciesTraits<SignedCardinality> specialisations (closes #413)

### DIFF
--- a/src/main/modules/dedekind/sets/cardinality.cppm
+++ b/src/main/modules/dedekind/sets/cardinality.cppm
@@ -1209,4 +1209,44 @@ static_assert(IsRing<SC, std::plus<SC>, std::multiplies<SC>>,
 static_assert(IsCommutativeRing<SC, std::plus<SC>, std::multiplies<SC>>,
               "SignedCardinality must certify as a commutative ring.");
 
+// ---------------------------------------------------------------------------
+// SpeciesTraits specialisations: lift the variant ℕ-/ℤ-proxy carriers
+// to first-class @c IsSpecies status (per #413; prerequisite for #402).
+//
+// Without these, @c std::variant<...> doesn't satisfy
+// @c IsSpecies (the primary @c SpeciesTraits<T> registration covers
+// @c std::integral / @c std::floating_point / @c bool only), so
+// @c ambient_set<Cardinality>(...) and @c ambient_set<SignedCardinality>(...)
+// can't anchor IsSet witnesses on the variant carriers — which blocks
+// the @c ℕ @c = @c Cardinality / @c ℤ @c = @c SignedCardinality
+// retarget under #402.
+//
+// Pattern follows @c SpeciesTraits<Rational<Z>> in @c numbers/rational.cppm:
+// @c Domain @c = the carrier itself (variants are their own elements),
+// @c machine_type @c = the carrier (no separate machine sibling — the
+// variants ARE the project's canonical exact ℕ-/ℤ-proxy carriers).
+// ---------------------------------------------------------------------------
+
+template <>
+struct SpeciesTraits<dedekind::sets::Cardinality> {
+  using Domain = dedekind::sets::Cardinality;
+  using machine_type = dedekind::sets::Cardinality;
+};
+
+template <>
+struct SpeciesTraits<dedekind::sets::SignedCardinality> {
+  using Domain = dedekind::sets::SignedCardinality;
+  using machine_type = dedekind::sets::SignedCardinality;
+};
+
+// IsSpecies witnesses: the variant carriers are now first-class
+// species and can flow into @c ambient_set<...> / ETCS object
+// construction in downstream partitions (cf.\ @c sets:boundaries,
+// where @c Ω<Cardinality> / @c Ω<SignedCardinality> instantiations
+// will land as part of the #402 retarget PR).
+static_assert(IsSpecies<dedekind::sets::Cardinality>,
+              "Cardinality must be a recognised Species (post-#413).");
+static_assert(IsSpecies<dedekind::sets::SignedCardinality>,
+              "SignedCardinality must be a recognised Species (post-#413).");
+
 }  // namespace dedekind::category


### PR DESCRIPTION
Closes #413. First prerequisite in the #402 chain (math-wins-over-C++ retarget of ℕ + ℤ to the variant carriers).

## What changed

Lifts the variant ℕ-/ℤ-proxy carriers (\`Cardinality\`, \`SignedCardinality\` — both from PR #396) to first-class \`IsSpecies\` status. Without this, \`std::variant<...>\` doesn't satisfy \`IsSpecies\` (the primary registration covers \`std::integral / std::floating_point / bool\` only), so \`ambient_set<Cardinality>\` / \`ambient_set<SignedCardinality>\` callsites can't anchor IsSet witnesses on the variant carriers — which is the path #402's final retarget PR needs.

## Pattern

Follows \`SpeciesTraits<Rational<Z>>\` in \`numbers/rational.cppm\`: \`Domain = the carrier itself\` (variants are their own elements); \`machine_type = the carrier\` (no separate machine sibling — the variants ARE the project's canonical exact ℕ-/ℤ-proxy carriers).

```cpp
template <>
struct SpeciesTraits<dedekind::sets::Cardinality> {
  using Domain = dedekind::sets::Cardinality;
  using machine_type = dedekind::sets::Cardinality;
};

template <>
struct SpeciesTraits<dedekind::sets::SignedCardinality> {
  using Domain = dedekind::sets::SignedCardinality;
  using machine_type = dedekind::sets::SignedCardinality;
};
```

Witnesses pinned at static_assert level:
- \`IsSpecies<Cardinality>\` ✓
- \`IsSpecies<SignedCardinality>\` ✓

## What's deferred

Downstream-consumer witnesses (\`ambient_set<Cardinality>\` / \`ambient_set<SignedCardinality>\` instantiations) will land as part of #402's retarget PR — they need \`Ω<T>\` from \`sets:boundaries\` which is downstream of \`sets:cardinality\`, so the witness can't compose in the same partition. The \`IsSpecies\` witness is sufficient AC for #413; #414 / #415 / #416 unblock the rest of the chain.

## Tests

15/15 ctest pass. No behavioural change — pure additive type-traits registration.

## Where this sits

#402's prerequisite chain:
- ✅ PR #412 (merged): drop \`explicit\` from \`ExtensionalCardinal<>\`'s integral-template ctor.
- 🔵 **This PR** (#413): \`SpeciesTraits\` specialisations.
- ⬜ #414: \`IsRingIntegral\` concept generalising \`OrderInterval\`'s \`is_integer_range\` gate.
- ⬜ #415: \`SignedCardinality\` / \`Cardinality\` ↔ \`std::integral\` relational operators.
- ⬜ #416: cascade sweep across ~60+ test sites + IR-fixture witness types.
- ⬜ Final #402 PR: carrier alias retarget (\`using ℕ = Cardinality;\` + \`using ℤ = SignedCardinality;\`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)