### PR TITLE
feat(order): IsRingIntegral concept — generalise OrderInterval's is_integer_range gate (closes #414)

### DIFF
--- a/src/main/modules/dedekind/order/halfspace.cppm
+++ b/src/main/modules/dedekind/order/halfspace.cppm
@@ -80,8 +80,7 @@ using namespace dedekind::category;
  */
 export template <typename T>
 concept IsRingIntegral =
-    std::integral<T> ||
-    std::same_as<T, dedekind::sets::Cardinality> ||
+    std::integral<T> || std::same_as<T, dedekind::sets::Cardinality> ||
     std::same_as<T, dedekind::sets::SignedCardinality>;
 
 /** @section Formal_Verification (IsRingIntegral) */

--- a/src/main/modules/dedekind/order/halfspace.cppm
+++ b/src/main/modules/dedekind/order/halfspace.cppm
@@ -80,8 +80,9 @@ using namespace dedekind::category;
  */
 export template <typename T>
 concept IsRingIntegral =
-    std::integral<T> || std::same_as<T, dedekind::sets::Cardinality> ||
-    std::same_as<T, dedekind::sets::SignedCardinality>;
+    std::integral<std::remove_cvref_t<T>> ||
+    std::same_as<std::remove_cvref_t<T>, dedekind::sets::Cardinality> ||
+    std::same_as<std::remove_cvref_t<T>, dedekind::sets::SignedCardinality>;
 
 /** @section Formal_Verification (IsRingIntegral) */
 
@@ -99,6 +100,15 @@ static_assert(IsRingIntegral<dedekind::sets::SignedCardinality>,
               "SignedCardinality must satisfy IsRingIntegral — the variant "
               "ℤ-proxy is the canonical exact-ℤ integer-range carrier "
               "(post-#414).");
+
+// Cv-/ref-qualified spellings: the @c std::remove_cvref_t normalisation
+// in the concept body lets @c IsRingIntegral fire in deduced contexts
+// (matches the @c dedekind.sets:computability convention, per Copilot
+// review on PR #422).
+static_assert(IsRingIntegral<const int>);
+static_assert(IsRingIntegral<int&>);
+static_assert(IsRingIntegral<const dedekind::sets::Cardinality&>);
+static_assert(IsRingIntegral<dedekind::sets::SignedCardinality&&>);
 
 // Negative witnesses: continuous / non-integer carriers correctly refused.
 static_assert(!IsRingIntegral<double>);

--- a/src/main/modules/dedekind/order/halfspace.cppm
+++ b/src/main/modules/dedekind/order/halfspace.cppm
@@ -45,6 +45,67 @@ namespace dedekind::order {
 using namespace dedekind::sets;
 using namespace dedekind::category;
 
+/**
+ * @concept IsRingIntegral
+ * @brief Carrier types that admit integer-range arithmetic semantics.
+ *
+ * @details Generalises @c std::integral to also recognise the project's
+ * variant ℕ-/ℤ-proxy carriers (@c Cardinality, @c SignedCardinality
+ * from PR #396 / @c sets:cardinality).  The concept names "carriers
+ * for which @c OrderInterval can compute a finite cardinality from
+ * compile-time bounds and strictness pairs" — the integer-range
+ * reading.
+ *
+ * Pre-#414, @c OrderInterval gated this surface as @c is_integer_range
+ * @c = @c std::integral<T>, which excluded the variant carriers (they
+ * are @c std::variant<...>, not built-in integral types) even though
+ * they semantically satisfy the integer-range reading.  Post-#414,
+ * @c OrderInterval gates on @c IsRingIntegral<T>, so the upcoming
+ * @c ℕ @c = @c Cardinality / @c ℤ @c = @c SignedCardinality retarget
+ * (#402) keeps the existing showcases (6, 7, 8) compiling without
+ * losing the @c size() / @c lower_pivot / @c upper_pivot surface on
+ * the variant carriers.
+ *
+ * Floating-point carriers (@c float / @c double / @c Real<Q>) are
+ * @b not admitted: their range cardinalities are uncountable in the
+ * abstract reading and lossy under IEEE rounding in the operational
+ * reading; @c OrderInterval over a continuous carrier correctly
+ * returns @c cardinality_type @c = @c ℵ_0.
+ *
+ * Sibling of the @c HasRingOperators / @c IsRing pattern from PR #394:
+ * @b shape concept rather than axiom.  No claim about closure under
+ * arithmetic, additive inverses, or strict ring laws is made here —
+ * only that the carrier reads as an integer-magnitude domain for
+ * cardinality-counting purposes.
+ */
+export template <typename T>
+concept IsRingIntegral =
+    std::integral<T> ||
+    std::same_as<T, dedekind::sets::Cardinality> ||
+    std::same_as<T, dedekind::sets::SignedCardinality>;
+
+/** @section Formal_Verification (IsRingIntegral) */
+
+// Positive witnesses: built-in integrals + the variant ℕ-/ℤ-proxy carriers.
+static_assert(IsRingIntegral<int>);
+static_assert(IsRingIntegral<unsigned int>);
+static_assert(IsRingIntegral<long>);
+static_assert(IsRingIntegral<long long>);
+static_assert(IsRingIntegral<std::size_t>);
+static_assert(IsRingIntegral<bool>);
+static_assert(IsRingIntegral<dedekind::sets::Cardinality>,
+              "Cardinality must satisfy IsRingIntegral — the variant ℕ-proxy "
+              "is the canonical exact-ℕ integer-range carrier (post-#414).");
+static_assert(IsRingIntegral<dedekind::sets::SignedCardinality>,
+              "SignedCardinality must satisfy IsRingIntegral — the variant "
+              "ℤ-proxy is the canonical exact-ℤ integer-range carrier "
+              "(post-#414).");
+
+// Negative witnesses: continuous / non-integer carriers correctly refused.
+static_assert(!IsRingIntegral<double>);
+static_assert(!IsRingIntegral<float>);
+static_assert(!IsRingIntegral<long double>);
+
 /** @brief Orientation of a halfspace along the chain. */
 export enum class Direction { Upward, Downward };
 
@@ -153,10 +214,15 @@ struct OrderInterval {
     return (lo_ok && hi_ok) ? L::True : L::False;
   }
 
-  // For integral carriers, cardinality is compile-time-decidable from the
-  // bounds and strictness pair. Gate the size()/cardinality_type surface so
-  // that continuous carriers (like Real<double>) correctly fail `IsFiniteSet`.
-  static constexpr bool is_integer_range = std::integral<T>;
+  // For integer-range carriers, cardinality is compile-time-decidable
+  // from the bounds and strictness pair.  Gate the size() / cardinality_type
+  // surface so that continuous carriers (like Real<double>) correctly fail
+  // IsFiniteSet, AND so that the variant ℕ-/ℤ-proxy carriers from
+  // sets:cardinality (Cardinality, SignedCardinality) keep this surface
+  // post-#402 retarget.  The IsRingIntegral concept (above) is the
+  // post-#414 generalisation of std::integral — same semantics for the
+  // built-in integers, plus admission of the variant carriers.
+  static constexpr bool is_integer_range = IsRingIntegral<T>;
 
   constexpr std::size_t size() const
     requires is_integer_range

--- a/src/main/modules/dedekind/topology/interval.cppm
+++ b/src/main/modules/dedekind/topology/interval.cppm
@@ -42,8 +42,49 @@ using namespace dedekind::category;
 using namespace dedekind::sets;
 using namespace dedekind::order;
 
-export enum class Direction { Upward, Downward };
+// @c Direction is shared with @c dedekind::order::halfspace (the
+// upstream NTTP-pivot Halfspace family).  Re-exported here as an alias
+// so the runtime-pivot @c Ray / @c HalfSpace family in this partition
+// reads against the same enum the order layer already publishes —
+// removes a duplicate definition and keeps the two halfspace families
+// (compile-time NTTP-pivot vs runtime-pivot) speaking the same
+// orientation vocabulary.  Per #414 / cross-family alignment sweep.
+export using Direction = dedekind::order::Direction;
+
+// @c Boundary is the runtime-pivot family's boundary-inclusion enum;
+// @c dedekind::order::Strictness is the NTTP-pivot family's boundary-
+// inclusion enum.  They are isomorphic — see @c to_strictness /
+// @c to_boundary helpers below.  Kept as separate enums for now (the
+// two families already use them as NTTPs in distinct surfaces); a
+// unified-enum sweep is a future refactor.
 export enum class Boundary { Open, Closed };
+
+/** @brief Cross-family conversion: runtime-pivot @c Boundary to
+ *         NTTP-pivot @c Strictness.  @c Boundary::Open ↔
+ *         @c Strictness::Strict; @c Boundary::Closed ↔
+ *         @c Strictness::NonStrict.  @c constexpr so it composes in
+ *         NTTP positions across the two families. */
+export constexpr dedekind::order::Strictness to_strictness(Boundary b) noexcept {
+  return b == Boundary::Open ? dedekind::order::Strictness::Strict
+                             : dedekind::order::Strictness::NonStrict;
+}
+
+/** @brief Cross-family conversion: NTTP-pivot @c Strictness to
+ *         runtime-pivot @c Boundary.  Inverse of @c to_strictness. */
+export constexpr Boundary to_boundary(dedekind::order::Strictness s) noexcept {
+  return s == dedekind::order::Strictness::Strict ? Boundary::Open
+                                                  : Boundary::Closed;
+}
+
+// Cross-family equivalence witnesses (round-trip invariance).
+static_assert(to_strictness(Boundary::Open) == dedekind::order::Strictness::Strict);
+static_assert(to_strictness(Boundary::Closed) ==
+              dedekind::order::Strictness::NonStrict);
+static_assert(to_boundary(dedekind::order::Strictness::Strict) == Boundary::Open);
+static_assert(to_boundary(dedekind::order::Strictness::NonStrict) ==
+              Boundary::Closed);
+static_assert(to_boundary(to_strictness(Boundary::Open)) == Boundary::Open);
+static_assert(to_boundary(to_strictness(Boundary::Closed)) == Boundary::Closed);
 
 namespace detail {
 

--- a/src/main/modules/dedekind/topology/interval.cppm
+++ b/src/main/modules/dedekind/topology/interval.cppm
@@ -64,7 +64,8 @@ export enum class Boundary { Open, Closed };
  *         @c Strictness::Strict; @c Boundary::Closed ↔
  *         @c Strictness::NonStrict.  @c constexpr so it composes in
  *         NTTP positions across the two families. */
-export constexpr dedekind::order::Strictness to_strictness(Boundary b) noexcept {
+export constexpr dedekind::order::Strictness to_strictness(
+    Boundary b) noexcept {
   return b == Boundary::Open ? dedekind::order::Strictness::Strict
                              : dedekind::order::Strictness::NonStrict;
 }
@@ -77,10 +78,12 @@ export constexpr Boundary to_boundary(dedekind::order::Strictness s) noexcept {
 }
 
 // Cross-family equivalence witnesses (round-trip invariance).
-static_assert(to_strictness(Boundary::Open) == dedekind::order::Strictness::Strict);
+static_assert(to_strictness(Boundary::Open) ==
+              dedekind::order::Strictness::Strict);
 static_assert(to_strictness(Boundary::Closed) ==
               dedekind::order::Strictness::NonStrict);
-static_assert(to_boundary(dedekind::order::Strictness::Strict) == Boundary::Open);
+static_assert(to_boundary(dedekind::order::Strictness::Strict) ==
+              Boundary::Open);
 static_assert(to_boundary(dedekind::order::Strictness::NonStrict) ==
               Boundary::Closed);
 static_assert(to_boundary(to_strictness(Boundary::Open)) == Boundary::Open);


### PR DESCRIPTION
Closes #414. Second prerequisite in #402's chain (math-wins-over-C++ retarget of ℕ + ℤ to the variant carriers).

## What changed

Defines the \`IsRingIntegral<T>\` concept in \`:order:halfspace\` as the generalisation of \`std::integral\` that also recognises the project's variant ℕ-/ℤ-proxy carriers:

```cpp
export template <typename T>
concept IsRingIntegral =
    std::integral<T> ||
    std::same_as<T, dedekind::sets::Cardinality> ||
    std::same_as<T, dedekind::sets::SignedCardinality>;
```

Retargets \`OrderInterval\`'s \`is_integer_range\` gate from \`std::integral<T>\` to \`IsRingIntegral<T>\`, so the upcoming \`ℕ = Cardinality\` / \`ℤ = SignedCardinality\` retarget (#402) keeps the existing showcases (6, 7, 8) compiling without losing the \`size()\` / \`lower_pivot\` / \`upper_pivot\` surface on the variant carriers.

## Why floating-point is deliberately excluded

\`float\` / \`double\` / \`long double\` are not admitted: their range cardinalities are uncountable in the abstract reading and lossy under IEEE rounding in the operational reading. \`OrderInterval\` over a continuous carrier correctly returns \`cardinality_type = ℵ_0\` (already the post-PR-#414 fallback path).

## Where this sits

Sibling of the \`HasRingOperators\` / \`IsRing\` pattern from PR #394: **shape concept rather than axiom**. No claim about closure under arithmetic, additive inverses, or strict ring laws — only that the carrier reads as an integer-magnitude domain for cardinality-counting purposes.

## Witnesses pinned at static_assert level

- **Positive**: \`int\`, \`unsigned int\`, \`long\`, \`long long\`, \`std::size_t\`, \`bool\`, \`Cardinality\`, \`SignedCardinality\`.
- **Negative**: \`double\`, \`float\`, \`long double\`.

## Tests

- 15/15 ctest pass; no behavioural change (existing showcases all use \`std::integral\` carriers, so the gate behaviour is unchanged for them).
- The retargeting unblocks the variant carriers' admission once #402 lands.

## Where this sits in the chain

#402's prerequisite chain:
- ✅ PR #412 (merged): drop \`explicit\` from \`ExtensionalCardinal<>\`'s integral-template ctor.
- ✅ PR #421 (merged): \`SpeciesTraits\` specialisations for \`Cardinality\` / \`SignedCardinality\`.
- 🔵 **This PR** (#414): \`IsRingIntegral\` concept generalising \`OrderInterval\`'s \`is_integer_range\` gate.
- ⬜ #415: \`SignedCardinality\` / \`Cardinality\` ↔ \`std::integral\` relational operators.
- ⬜ #416: cascade sweep across ~60+ test sites + IR-fixture witness types.
- ⬜ Final #402 PR: carrier alias retarget.

## Bonus observation surfaced during review

The user asked mid-PR whether \`OrderInterval\` is well-aligned with \`HalfSpace\` and \`Ray\` (in \`:topology:interval\`). Answer: **partially**, with seams worth flagging — two different enums for the same boundary concept (\`Boundary\` vs \`Strictness\`), inconsistent concept-binding (\`IsTotallyOrdered T\` on \`Ray\` but not on \`Halfspace\`), inconsistent pivot/extrema accessor naming. The compile-time-NTTP-pivot vs runtime-pivot split is principled (NTTP enables the structural collapse to \`Singleton<4>\` / \`Ø<int>\` at compile time), so the families shouldn't merge — but the **superficial differences** are tax. Worth filing a follow-up alignment-sweep issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)