### PR TITLE
feat(order,sets): variant↔integral comparison ops + :order:total split (#410, #415)

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ In this approach:
 1. **Verbatim Lifting**: Mathematical concepts are translated into `C++` `concept`s with minimal adjustments. The flow from axioms to theorems is enforced by the `module` build order, the `import` graph and `C++` declaration order rules.
 2. **Language Conformity**: Modifications required to satisfy the host language (`C++`) are kept as non-intrusive as possible. Textbook naming conventions using `UTF-8` are preferred, i.e. `ℝ` instead of `IsRealNumberSet`.
 3. **Bi-directional Fidelity**: Once a concept compiles, its fidelity is verified by checking that `C++` invariants map correctly back to their mathematical counterparts within the test suite.
-3. **Co-Domain Anchoring**: Where the C++ standard library provides native support for algebraic concepts, this anchoring is made explicit (e.g. `bool`, `std:pair`, `std::variant`, ...) and documented via translation tables.
+4. **Co-Domain Anchoring**: Where the C++ standard library provides native support for algebraic concepts, this anchoring is made explicit (e.g. `bool`, `std::pair`, `std::variant`, ...) and documented via translation tables.
 
 _AI assistance is used during the development of this project._
 

--- a/README.md
+++ b/README.md
@@ -42,10 +42,11 @@ The project rests on two pillars: **C++23** and **Category Theory**.
  - **Why C++?** It is a mainstream language with many features which is suitable for performance-optimized code. Its flexible type system allows for the simulation of functional concepts—such as higher-kinded and dependent types—via template metaprogramming, concepts, and traits.
  - **Why Category Theory?** It bridges the gap from the mathematical end: typed λ-calculus can be expressed directly in the terminology of established mathematical textbooks.
 
-In this approach;
+In this approach:
 1. **Verbatim Lifting**: Mathematical concepts are translated into `C++` `concept`s with minimal adjustments. The flow from axioms to theorems is enforced by the `module` build order, the `import` graph and `C++` declaration order rules.
 2. **Language Conformity**: Modifications required to satisfy the host language (`C++`) are kept as non-intrusive as possible. Textbook naming conventions using `UTF-8` are preferred, i.e. `ℝ` instead of `IsRealNumberSet`.
 3. **Bi-directional Fidelity**: Once a concept compiles, its fidelity is verified by checking that `C++` invariants map correctly back to their mathematical counterparts within the test suite.
+3. **Co-Domain Anchoring**: Where the C++ standard library provides native support for algebraic concepts, this anchoring is made explicit (e.g. `bool`, `std:pair`, `std::variant`, ...) and documented via translation tables.
 
 _AI assistance is used during the development of this project._
 

--- a/src/main/modules/dedekind/numbers/cardinality.cppm
+++ b/src/main/modules/dedekind/numbers/cardinality.cppm
@@ -71,4 +71,40 @@ static_assert(dedekind::order::IsDirectedSet<Z1>,
 // IsInteger<C1> is verified in rational.cppm (which imports both
 // :cardinality and :integer) to avoid a circular import chain.
 
+// Heterogeneous partial-order shape: the variant ℕ-/ℤ-proxy carriers
+// admit cross-type relational comparison with built-in @c std::integral
+// values via the operators defined in @c sets/cardinality.cppm
+// (closes #415).  Pinning the shape concept here --- not in @c sets ---
+// because the @c HasPartialOrderOperatorsWith concept itself lives in
+// @c dedekind.order:poset, which is downstream of @c sets.
+//
+// The load-bearing pair is @c (SignedCardinality, int) --- the halfspace
+// machinery's @c (x @c > @c Pivot) substitution where @c x is the
+// variant ℤ-proxy and @c Pivot is the @c int NTTP from @c bound<-21>.
+// The other pairs witness the symmetric (rhs-first) direction and the
+// unsigned ℕ-proxy slot for completeness.
+
+using SC = dedekind::sets::SignedCardinality;
+using Card = dedekind::sets::Cardinality;
+
+static_assert(dedekind::order::HasPartialOrderOperatorsWith<SC, int>,
+              "SignedCardinality must accept partial-order comparison "
+              "with int (the halfspace bound<-21> NTTP path).");
+static_assert(dedekind::order::HasPartialOrderOperatorsWith<int, SC>,
+              "int must accept partial-order comparison with "
+              "SignedCardinality (rhs-first direction).");
+static_assert(dedekind::order::HasPartialOrderOperatorsWith<SC, long>,
+              "SignedCardinality must accept partial-order comparison "
+              "with long (cross-width signed integral).");
+
+static_assert(dedekind::order::HasPartialOrderOperatorsWith<Card, unsigned int>,
+              "Cardinality must accept partial-order comparison with "
+              "unsigned int (the ℕ-proxy slot).");
+static_assert(dedekind::order::HasPartialOrderOperatorsWith<unsigned int, Card>,
+              "unsigned int must accept partial-order comparison with "
+              "Cardinality (rhs-first direction).");
+static_assert(dedekind::order::HasPartialOrderOperatorsWith<Card, int>,
+              "Cardinality vs signed int: negative signed values land "
+              "strictly below the ℕ proxy (no element is negative).");
+
 }  // namespace dedekind::numbers

--- a/src/main/modules/dedekind/numbers/cardinality.cppm
+++ b/src/main/modules/dedekind/numbers/cardinality.cppm
@@ -81,8 +81,9 @@ static_assert(dedekind::order::IsDirectedSet<Z1>,
 // The load-bearing pair is @c (SignedCardinality, int) --- the halfspace
 // machinery's @c (x @c > @c Pivot) substitution where @c x is the
 // variant ℤ-proxy and @c Pivot is the @c int NTTP from @c bound<-21>.
-// The other pairs witness the symmetric (rhs-first) direction and the
-// unsigned ℕ-proxy slot for completeness.
+// @c HasPartialOrderOperatorsWith is symmetric in @c T and @c U
+// (mirrors @c std::three_way_comparable_with), so a single witness per
+// pair pins both directions of the relational surface.
 
 using SC = dedekind::sets::SignedCardinality;
 using Card = dedekind::sets::Cardinality;
@@ -90,9 +91,6 @@ using Card = dedekind::sets::Cardinality;
 static_assert(dedekind::order::HasPartialOrderOperatorsWith<SC, int>,
               "SignedCardinality must accept partial-order comparison "
               "with int (the halfspace bound<-21> NTTP path).");
-static_assert(dedekind::order::HasPartialOrderOperatorsWith<int, SC>,
-              "int must accept partial-order comparison with "
-              "SignedCardinality (rhs-first direction).");
 static_assert(dedekind::order::HasPartialOrderOperatorsWith<SC, long>,
               "SignedCardinality must accept partial-order comparison "
               "with long (cross-width signed integral).");
@@ -100,11 +98,12 @@ static_assert(dedekind::order::HasPartialOrderOperatorsWith<SC, long>,
 static_assert(dedekind::order::HasPartialOrderOperatorsWith<Card, unsigned int>,
               "Cardinality must accept partial-order comparison with "
               "unsigned int (the ℕ-proxy slot).");
-static_assert(dedekind::order::HasPartialOrderOperatorsWith<unsigned int, Card>,
-              "unsigned int must accept partial-order comparison with "
-              "Cardinality (rhs-first direction).");
 static_assert(dedekind::order::HasPartialOrderOperatorsWith<Card, int>,
               "Cardinality vs signed int: negative signed values land "
               "strictly below the ℕ proxy (no element is negative).");
+static_assert(dedekind::order::HasPartialOrderOperatorsWith<Card, bool>,
+              "Cardinality vs bool: bool is std::integral so the "
+              "ctor / comparison path must handle it (regression for "
+              "the make_unsigned_t<bool>-undefined trap).");
 
 }  // namespace dedekind::numbers

--- a/src/main/modules/dedekind/order/completeness.cppm
+++ b/src/main/modules/dedekind/order/completeness.cppm
@@ -32,6 +32,7 @@ export module dedekind.order:completeness;
 
 import dedekind.category;
 import :poset;
+import :total;  // IsTotallyOrdered relocated here per #410
 
 namespace dedekind::order {
 using namespace dedekind::category;

--- a/src/main/modules/dedekind/order/order.cppm
+++ b/src/main/modules/dedekind/order/order.cppm
@@ -8,7 +8,14 @@
  * Licensed under the Apache License, Version 2.0.
  *
  * @section Partitions
- *   - `:poset`        — preorders, partial orders, directed sets, chains.
+ *   - `:poset`        — preorders, partial orders, directed sets;
+ *                       `HasPartialOrderOperators` (shape) +
+ *                       `HasPartialOrderOperatorsWith<T, U>` (heterogeneous shape).
+ *   - `:total`        — total orders, linear orders, strict weak orders,
+ *                       chains; `HasTotalOrderOperators` (spaceship shape) +
+ *                       `HasTotalOrderOperatorsWith<T, U>` (heterogeneous shape).
+ *                       Strictly stronger than `:poset`; mirrors `:category:total`'s
+ *                       order/algebra split (per #410).
  *   - `:lattice`      — meet / join / lattice / distributive lattice.
  *   - `:completeness` — successor, Archimedean, dense / discrete,
  *                       Dedekind-complete.
@@ -26,6 +33,7 @@
 export module dedekind.order;
 
 export import :poset;
+export import :total;
 export import :lattice;
 export import :completeness;
 export import :halfspace;

--- a/src/main/modules/dedekind/order/order.cppm
+++ b/src/main/modules/dedekind/order/order.cppm
@@ -8,13 +8,15 @@
  * Licensed under the Apache License, Version 2.0.
  *
  * @section Partitions
- *   - `:poset`        — preorders, partial orders, directed sets;
- *                       `HasPartialOrderOperators` (shape) +
- *                       `HasPartialOrderOperatorsWith<T, U>` (heterogeneous shape).
+ *   - `:poset`        — preorders, partial orders, directed sets; the
+ *                       homogeneous `HasPartialOrderOperators` shape and
+ *                       its heterogeneous sibling
+ *                       `HasPartialOrderOperatorsWith<T, U>`.
  *   - `:total`        — total orders, linear orders, strict weak orders,
- *                       chains; `HasTotalOrderOperators` (spaceship shape) +
- *                       `HasTotalOrderOperatorsWith<T, U>` (heterogeneous shape).
- *                       Strictly stronger than `:poset`; mirrors `:category:total`'s
+ *                       chains; the homogeneous `HasTotalOrderOperators`
+ *                       (spaceship) shape and its heterogeneous sibling
+ *                       `HasTotalOrderOperatorsWith<T, U>`.  Strictly
+ *                       stronger than `:poset`; mirrors `:category:total`'s
  *                       order/algebra split (per #410).
  *   - `:lattice`      — meet / join / lattice / distributive lattice.
  *   - `:completeness` — successor, Archimedean, dense / discrete,

--- a/src/main/modules/dedekind/order/poset.cppm
+++ b/src/main/modules/dedekind/order/poset.cppm
@@ -105,17 +105,23 @@ concept IsDirectedPoset = IsPartiallyOrdered<T, L> && IsDirectedSet<T, L>;
 /**
  * @concept HasPartialOrderOperators
  * @brief @b Pure @b syntactic @b shape: T supports the partial-order
- *        operators @c <, @c <=, @c >, @c >= with bool-convertible
- *        results.
+ *        operators @c <, @c <=, @c >, @c >= with results in the
+ *        truth-value carrier @c L::Ω of a chosen logical species.
  *
  * @details
  * Use this concept where a callsite needs the four relational operators
- * to compile and yield a value coercible to @c bool, but does @b not
- * want to bind to a particular axiomatic order (preorder, partial,
- * total).  No claim about reflexivity, antisymmetry, transitivity, or
- * comparability is made here; for those, use @c IsPreOrdered /
- * @c IsPartiallyOrdered / @c IsTotallyOrdered (the last in
- * @c :order:total).
+ * to compile and yield a value in the truth-value carrier of a chosen
+ * @c IsLogicalSpecies, but does @b not want to bind to a particular
+ * axiomatic order (preorder, partial, total).  No claim about
+ * reflexivity, antisymmetry, transitivity, or comparability is made
+ * here; for those, use @c IsPreOrdered / @c IsPartiallyOrdered /
+ * @c IsTotallyOrdered (the last in @c :order:total).
+ *
+ * The @c L parameter defaults to @c ClassicalLogic (so @c L::Ω is
+ * @c bool); supply a different @c IsLogicalSpecies to constrain the
+ * return type to a non-Boolean truth-value carrier (e.g.\ Kleene
+ * @c TernaryLogic).  Mirrors the @c L-parametric pattern already used
+ * by @c IsPreOrdered / @c IsPartiallyOrdered.
  *
  * Sibling of @c dedekind::algebra::HasRingOperators (in @c
  * algebra:ring), @c dedekind::algebra::HasFieldOperators (in @c
@@ -123,39 +129,47 @@ concept IsDirectedPoset = IsPartiallyOrdered<T, L> && IsDirectedSet<T, L>;
  * in the shape-concept family.  The split between @b shape and @b
  * axiom mirrors the literal-vs-strict tier introduced under PR #394.
  */
-export template <typename T>
+export template <typename T, typename L = ClassicalLogic>
 concept HasPartialOrderOperators = requires(const T a, const T b) {
-  { a < b } -> std::convertible_to<bool>;
-  { a <= b } -> std::convertible_to<bool>;
-  { a > b } -> std::convertible_to<bool>;
-  { a >= b } -> std::convertible_to<bool>;
+  { a < b } -> std::same_as<typename L::Ω>;
+  { a <= b } -> std::same_as<typename L::Ω>;
+  { a > b } -> std::same_as<typename L::Ω>;
+  { a >= b } -> std::same_as<typename L::Ω>;
 };
 
 /**
  * @concept HasPartialOrderOperatorsWith
  * @brief @b Heterogeneous shape: T and U can be compared via the
- *        four partial-order operators in @b both directions.
+ *        four partial-order operators in @b both directions, yielding
+ *        results in the truth-value carrier @c L::Ω.
  *
  * @details
  * The cross-type relational-operator shape: requires @c <, @c <=,
- * @c >, @c >= to compile and yield bool-convertible results between
- * @c T and @c U values.  Names the surface needed for cross-carrier
- * comparisons — e.g.\ @c SignedCardinality @c < @c int (the
- * load-bearing path for the halfspace machinery's @c (x @c > @c
- * Pivot) substitution where @c x is the variant ℤ-proxy carrier and
- * @c Pivot is the @c int NTTP from @c bound<-21>).
+ * @c >, @c >= to compile in both directions and yield results in
+ * @c L::Ω.  Names the surface needed for cross-carrier comparisons —
+ * e.g.\ @c SignedCardinality @c < @c int (the load-bearing path for
+ * the halfspace machinery's @c (x @c > @c Pivot) substitution where
+ * @c x is the variant ℤ-proxy carrier and @c Pivot is the @c int NTTP
+ * from @c bound<-21>).
+ *
+ * @c L defaults to @c ClassicalLogic, mirroring the homogeneous
+ * sibling above and @c IsPreOrdered / @c IsPartiallyOrdered.
  *
  * Sibling of the homogeneous @c HasPartialOrderOperators above; the
  * spaceship-aware total-order variant
  * @c HasTotalOrderOperatorsWith<T, U> lives in @c :order:total.  Per
  * #415 / cross-issue note on PR #422.
  */
-export template <typename T, typename U>
+export template <typename T, typename U, typename L = ClassicalLogic>
 concept HasPartialOrderOperatorsWith = requires(const T t, const U u) {
-  { t < u } -> std::convertible_to<bool>;
-  { t <= u } -> std::convertible_to<bool>;
-  { t > u } -> std::convertible_to<bool>;
-  { t >= u } -> std::convertible_to<bool>;
+  { t < u } -> std::same_as<typename L::Ω>;
+  { t <= u } -> std::same_as<typename L::Ω>;
+  { t > u } -> std::same_as<typename L::Ω>;
+  { t >= u } -> std::same_as<typename L::Ω>;
+  { u < t } -> std::same_as<typename L::Ω>;
+  { u <= t } -> std::same_as<typename L::Ω>;
+  { u > t } -> std::same_as<typename L::Ω>;
+  { u >= t } -> std::same_as<typename L::Ω>;
 };
 
 /** @section Formal_Verification */

--- a/src/main/modules/dedekind/order/poset.cppm
+++ b/src/main/modules/dedekind/order/poset.cppm
@@ -95,24 +95,12 @@ concept IsPartiallyOrdered =
 export template <typename T, typename L = ClassicalLogic>
 concept IsDirectedPoset = IsPartiallyOrdered<T, L> && IsDirectedSet<T, L>;
 
-/**
- * @concept IsStrictWeakOrder
- * @brief The standard C++ 'Compare' requirement (e.g., for std::sort).
- * @details A relation < where incomparability is transitive.
- */
-export template <typename T>
-concept IsStrictWeakOrder = std::strict_weak_order<std::less<T>, T, T>;
-
-/**
- * @concept IsTotallyOrdered
- * @brief A refinement where every pair is comparable (The Chain).
- */
-export template <typename T>
-concept IsTotallyOrdered = IsPartiallyOrdered<T> && std::totally_ordered<T>;
-
-/** @brief Synonym for Total Order. */
-export template <typename T>
-concept IsLinearOrder = IsTotallyOrdered<T>;
+// IsStrictWeakOrder, IsTotallyOrdered, IsLinearOrder, HasTotalOrderOperators
+// have been relocated to @c :order:total per #410 — the strictly-stronger
+// total-order layer is now its own partition (mirrors @c :category:total
+// which already houses the strict total-axiomatic content for algebra).
+// They remain accessible via the @c dedekind.order umbrella; partition-
+// scoped imports may need to add @c import @c :total directly.
 
 /**
  * @concept HasPartialOrderOperators
@@ -126,7 +114,8 @@ concept IsLinearOrder = IsTotallyOrdered<T>;
  * want to bind to a particular axiomatic order (preorder, partial,
  * total).  No claim about reflexivity, antisymmetry, transitivity, or
  * comparability is made here; for those, use @c IsPreOrdered /
- * @c IsPartiallyOrdered / @c IsTotallyOrdered.
+ * @c IsPartiallyOrdered / @c IsTotallyOrdered (the last in
+ * @c :order:total).
  *
  * Sibling of @c dedekind::algebra::HasRingOperators (in @c
  * algebra:ring), @c dedekind::algebra::HasFieldOperators (in @c
@@ -143,48 +132,45 @@ concept HasPartialOrderOperators = requires(const T a, const T b) {
 };
 
 /**
- * @concept HasTotalOrderOperators
- * @brief @b Pure @b syntactic @b shape: T supports the spaceship
- *        operator @c <=> alongside the four partial-order operators.
+ * @concept HasPartialOrderOperatorsWith
+ * @brief @b Heterogeneous shape: T and U can be compared via the
+ *        four partial-order operators in @b both directions.
  *
  * @details
- * The C++20 three-way comparison shape: a @c <=> that returns one of
- * @c std::strong_ordering / @c std::weak_ordering / @c
- * std::partial_ordering, witnessing that @c T can act as a totally /
- * weakly ordered carrier at the @b operator level.  Composes @c
- * HasPartialOrderOperators with the spaceship so callsites can check
- * the full relational surface in one constraint.
+ * The cross-type relational-operator shape: requires @c <, @c <=,
+ * @c >, @c >= to compile and yield bool-convertible results between
+ * @c T and @c U values.  Names the surface needed for cross-carrier
+ * comparisons — e.g.\ @c SignedCardinality @c < @c int (the
+ * load-bearing path for the halfspace machinery's @c (x @c > @c
+ * Pivot) substitution where @c x is the variant ℤ-proxy carrier and
+ * @c Pivot is the @c int NTTP from @c bound<-21>).
  *
- * Note: a partial-ordering @c <=> still satisfies this shape (the
- * spaceship's three-way result type carries the order strength); for
- * an @b axiomatic total-order witness use @c IsTotallyOrdered, which
- * additionally requires @c std::totally_ordered (excluded middle on
- * comparability).  The shape vs.\ axiom split follows the @c
- * HasRingOperators / @c IsRing pattern from PR #394.
+ * Sibling of the homogeneous @c HasPartialOrderOperators above; the
+ * spaceship-aware total-order variant
+ * @c HasTotalOrderOperatorsWith<T, U> lives in @c :order:total.  Per
+ * #415 / cross-issue note on PR #422.
  */
-export template <typename T>
-concept HasTotalOrderOperators =
-    HasPartialOrderOperators<T> && std::three_way_comparable<T>;
+export template <typename T, typename U>
+concept HasPartialOrderOperatorsWith = requires(const T t, const U u) {
+  { t < u } -> std::convertible_to<bool>;
+  { t <= u } -> std::convertible_to<bool>;
+  { t > u } -> std::convertible_to<bool>;
+  { t >= u } -> std::convertible_to<bool>;
+};
 
 /** @section Formal_Verification */
 
-// int / unsigned int / bool are the canonical totally-ordered carriers,
-// with spaceship and the four partial-order operators.  Pin them as the
-// canonical witnesses for the new shape concepts.
+// int / unsigned int / bool are the canonical carriers; the homogeneous
+// partial-order shape fires on each.  Total-order witnesses live in
+// @c :order:total.
 static_assert(HasPartialOrderOperators<int>);
-static_assert(HasTotalOrderOperators<int>);
 static_assert(HasPartialOrderOperators<unsigned int>);
-static_assert(HasTotalOrderOperators<unsigned int>);
 static_assert(HasPartialOrderOperators<bool>);
-static_assert(HasTotalOrderOperators<bool>);
 
-// int is the canonical totally ordered chain.
-static_assert(IsTotallyOrdered<int>, "int must satisfy IsTotallyOrdered.");
-
-// IsTotallyOrdered<double> is architecturally withheld: dedekind's
-// is_reflexive_v<double, std::less_equal<>> is false by design because IEEE 754
-// NaN violates reflexivity (NaN <= NaN is false). See species.cppm note.
-// Use IsOrderedField<double> (archimedean.cppm) or std::totally_ordered<double>
-// for the operational ordering witness.
+// Heterogeneous partial-order shape on canonical std::integral pairs.
+static_assert(HasPartialOrderOperatorsWith<int, int>);
+static_assert(HasPartialOrderOperatorsWith<int, long>);
+static_assert(HasPartialOrderOperatorsWith<long, int>);
+static_assert(HasPartialOrderOperatorsWith<unsigned int, int>);
 
 }  // namespace dedekind::order

--- a/src/main/modules/dedekind/order/total.cppm
+++ b/src/main/modules/dedekind/order/total.cppm
@@ -70,36 +70,39 @@ concept IsLinearOrder = IsTotallyOrdered<T>;
 /**
  * @concept HasTotalOrderOperators
  * @brief @b Pure @b syntactic @b shape: T supports the spaceship
- *        operator @c <=> alongside the four partial-order operators.
+ *        operator @c <=> alongside the four partial-order operators
+ *        (the latter return @c L::Ω).
  *
  * @details
  * The C++20 three-way comparison shape: a @c <=> that returns one of
  * @c std::strong_ordering / @c std::weak_ordering / @c
  * std::partial_ordering, witnessing that @c T can act as a totally /
  * weakly ordered carrier at the @b operator level.  Composes @c
- * HasPartialOrderOperators with the spaceship so callsites can check
- * the full relational surface in one constraint.
+ * HasPartialOrderOperators<T, L> with the spaceship so callsites can
+ * check the full relational surface in one constraint.
  *
  * Note: a partial-ordering @c <=> still satisfies this shape (the
  * spaceship's three-way result type carries the order strength); for
  * an @b axiomatic total-order witness use @c IsTotallyOrdered, which
  * additionally requires @c std::totally_ordered (excluded middle on
  * comparability).  The shape vs.\ axiom split follows the @c
- * HasRingOperators / @c IsRing pattern from PR #394.
+ * HasRingOperators / @c IsRing pattern from PR #394.  @c L defaults to
+ * @c ClassicalLogic, mirroring @c HasPartialOrderOperators / @c
+ * IsPreOrdered.
  */
-export template <typename T>
+export template <typename T, typename L = ClassicalLogic>
 concept HasTotalOrderOperators =
-    HasPartialOrderOperators<T> && std::three_way_comparable<T>;
+    HasPartialOrderOperators<T, L> && std::three_way_comparable<T>;
 
 /**
  * @concept HasTotalOrderOperatorsWith
  * @brief @b Heterogeneous shape: T and U can be compared via @c <=> in
  *        @b both directions, alongside the four partial-order
- *        operators.
+ *        operators (the latter return @c L::Ω).
  *
  * @details
  * The cross-type spaceship-comparison shape: composes
- * @c HasPartialOrderOperatorsWith<T, U> with @c
+ * @c HasPartialOrderOperatorsWith<T, U, L> with @c
  * std::three_way_comparable_with<T, U>.  Names the surface needed for
  * cross-carrier comparisons — e.g.\ @c SignedCardinality @c <=> @c int
  * (the load-bearing path for the halfspace machinery's
@@ -107,12 +110,13 @@ concept HasTotalOrderOperators =
  * and @c Pivot is the @c int NTTP from @c bound<-21>).
  *
  * Sibling of the homogeneous @c HasTotalOrderOperators above and
- * @c HasPartialOrderOperatorsWith in @c :poset.  Per #415 /
- * cross-issue note on PR #422.
+ * @c HasPartialOrderOperatorsWith in @c :poset.  @c L defaults to
+ * @c ClassicalLogic.  Per #415 / cross-issue note on PR #422.
  */
-export template <typename T, typename U>
+export template <typename T, typename U, typename L = ClassicalLogic>
 concept HasTotalOrderOperatorsWith =
-    HasPartialOrderOperatorsWith<T, U> && std::three_way_comparable_with<T, U>;
+    HasPartialOrderOperatorsWith<T, U, L> &&
+    std::three_way_comparable_with<T, U>;
 
 /** @section Formal_Verification */
 

--- a/src/main/modules/dedekind/order/total.cppm
+++ b/src/main/modules/dedekind/order/total.cppm
@@ -1,0 +1,147 @@
+/**
+ * @file dedekind/order/total.cppm
+ * @partition :total
+ * @brief Level 1.5b: Total-order layer — strictly stronger than the
+ *        partial-order content in @c :poset.
+ *
+ * @copyright 2026 The Dedekind Authors
+ * Licensed under the Apache License, Version 2.0.
+ *
+ * @section Scope
+ * Concepts that genuinely require comparability of every pair (the chain
+ * axiom): @c IsTotallyOrdered, @c IsLinearOrder, @c IsStrictWeakOrder,
+ * the spaceship-aware shape concept @c HasTotalOrderOperators, and the
+ * heterogeneous variant @c HasTotalOrderOperatorsWith<T, U>.  All of
+ * these compose @c IsPartiallyOrdered / @c HasPartialOrderOperators
+ * from @c :poset; the split lets generic code that needs only the
+ * partial-order content not pull in the strictly-stronger total-order
+ * machinery (cf.\ @c :category:total which already houses the strict
+ * total-axiomatic content for algebra; this partition is its order
+ * sibling).  Per #410.
+ *
+ * @section Heterogeneous_Comparison_Surface
+ * @c HasTotalOrderOperatorsWith<T, U> — and its partial-order sibling
+ * in @c :poset — fill the seam between the homogeneous @c <=>-shape
+ * (which only describes @c T @c <=> @c T) and the real-world need to
+ * compare a variant carrier (e.g.\ @c SignedCardinality) with an
+ * integer NTTP literal (e.g.\ from @c bound<-21>).  Names the
+ * cross-type shape that the halfspace machinery silently relies on.
+ * Per #415 / cross-issue note on PR #422.
+ *
+ * Wikipedia: Total order, Strict weak ordering, Three-way comparison
+ *
+ * @note "אִם אֵין אֲנִי לִי, מִי לִי?  וּכְשֶׁאֲנִי לְעַצְמִי, מָה אֲנִי?
+ *        וְאִם לֹא עַכְשָׁו, אֵימָתָי?"
+ *       — Hillel the Elder, Pirkei Avot 1:14.
+ *       [Trans: "If I am not for myself, who will be for me?  And being
+ *        only for myself, what am I?  And if not now, when?"]
+ */
+module;
+#include <compare>  // std::three_way_comparable for HasTotalOrderOperators
+#include <concepts>
+#include <functional>
+
+export module dedekind.order:total;
+
+import dedekind.category;
+import :poset;
+
+namespace dedekind::order {
+
+/**
+ * @concept IsStrictWeakOrder
+ * @brief The standard C++ 'Compare' requirement (e.g., for std::sort).
+ * @details A relation < where incomparability is transitive.
+ */
+export template <typename T>
+concept IsStrictWeakOrder = std::strict_weak_order<std::less<T>, T, T>;
+
+/**
+ * @concept IsTotallyOrdered
+ * @brief A refinement where every pair is comparable (The Chain).
+ */
+export template <typename T>
+concept IsTotallyOrdered = IsPartiallyOrdered<T> && std::totally_ordered<T>;
+
+/** @brief Synonym for Total Order. */
+export template <typename T>
+concept IsLinearOrder = IsTotallyOrdered<T>;
+
+/**
+ * @concept HasTotalOrderOperators
+ * @brief @b Pure @b syntactic @b shape: T supports the spaceship
+ *        operator @c <=> alongside the four partial-order operators.
+ *
+ * @details
+ * The C++20 three-way comparison shape: a @c <=> that returns one of
+ * @c std::strong_ordering / @c std::weak_ordering / @c
+ * std::partial_ordering, witnessing that @c T can act as a totally /
+ * weakly ordered carrier at the @b operator level.  Composes @c
+ * HasPartialOrderOperators with the spaceship so callsites can check
+ * the full relational surface in one constraint.
+ *
+ * Note: a partial-ordering @c <=> still satisfies this shape (the
+ * spaceship's three-way result type carries the order strength); for
+ * an @b axiomatic total-order witness use @c IsTotallyOrdered, which
+ * additionally requires @c std::totally_ordered (excluded middle on
+ * comparability).  The shape vs.\ axiom split follows the @c
+ * HasRingOperators / @c IsRing pattern from PR #394.
+ */
+export template <typename T>
+concept HasTotalOrderOperators =
+    HasPartialOrderOperators<T> && std::three_way_comparable<T>;
+
+/**
+ * @concept HasTotalOrderOperatorsWith
+ * @brief @b Heterogeneous shape: T and U can be compared via @c <=> in
+ *        @b both directions, alongside the four partial-order
+ *        operators.
+ *
+ * @details
+ * The cross-type spaceship-comparison shape: composes
+ * @c HasPartialOrderOperatorsWith<T, U> with @c
+ * std::three_way_comparable_with<T, U>.  Names the surface needed for
+ * cross-carrier comparisons — e.g.\ @c SignedCardinality @c <=> @c int
+ * (the load-bearing path for the halfspace machinery's
+ * @c (x @c > @c Pivot) substitution where @c x is a variant ℤ-proxy
+ * and @c Pivot is the @c int NTTP from @c bound<-21>).
+ *
+ * Sibling of the homogeneous @c HasTotalOrderOperators above and
+ * @c HasPartialOrderOperatorsWith in @c :poset.  Per #415 /
+ * cross-issue note on PR #422.
+ */
+export template <typename T, typename U>
+concept HasTotalOrderOperatorsWith =
+    HasPartialOrderOperatorsWith<T, U> &&
+    std::three_way_comparable_with<T, U>;
+
+/** @section Formal_Verification */
+
+// int / unsigned int / bool: canonical totally-ordered chains, spaceship
+// + the four partial-order operators all fire.
+static_assert(HasTotalOrderOperators<int>);
+static_assert(HasTotalOrderOperators<unsigned int>);
+static_assert(HasTotalOrderOperators<bool>);
+
+// int is the canonical totally ordered chain (axiomatic).
+static_assert(IsTotallyOrdered<int>, "int must satisfy IsTotallyOrdered.");
+
+// IsTotallyOrdered<double> is architecturally withheld: dedekind's
+// is_reflexive_v<double, std::less_equal<>> is false by design because IEEE 754
+// NaN violates reflexivity (NaN <= NaN is false). See species.cppm note.
+// Use IsOrderedField<double> (archimedean.cppm) or std::totally_ordered<double>
+// for the operational ordering witness.
+
+// Heterogeneous total-order shape on canonical std::integral pairs.
+// Same-signedness pairs witness cleanly; cross-signedness is excluded
+// here because @c std::three_way_comparable_with<unsigned, signed> is
+// false (the library treats the implicit narrowing in @c unsigned @c
+// <=> @c signed as ill-formed), even though the four partial-order
+// operators @c <, @c <=, @c >, @c >= still compile (with their
+// surprising signed→unsigned conversion semantics).  See the
+// homogeneous partial-order witness section in @c :poset.
+static_assert(HasTotalOrderOperatorsWith<int, int>);
+static_assert(HasTotalOrderOperatorsWith<int, long>);
+static_assert(HasTotalOrderOperatorsWith<long, int>);
+
+}  // namespace dedekind::order

--- a/src/main/modules/dedekind/order/total.cppm
+++ b/src/main/modules/dedekind/order/total.cppm
@@ -114,9 +114,8 @@ concept HasTotalOrderOperators =
  * @c ClassicalLogic.  Per #415 / cross-issue note on PR #422.
  */
 export template <typename T, typename U, typename L = ClassicalLogic>
-concept HasTotalOrderOperatorsWith =
-    HasPartialOrderOperatorsWith<T, U, L> &&
-    std::three_way_comparable_with<T, U>;
+concept HasTotalOrderOperatorsWith = HasPartialOrderOperatorsWith<T, U, L> &&
+                                     std::three_way_comparable_with<T, U>;
 
 /** @section Formal_Verification */
 

--- a/src/main/modules/dedekind/order/total.cppm
+++ b/src/main/modules/dedekind/order/total.cppm
@@ -112,8 +112,7 @@ concept HasTotalOrderOperators =
  */
 export template <typename T, typename U>
 concept HasTotalOrderOperatorsWith =
-    HasPartialOrderOperatorsWith<T, U> &&
-    std::three_way_comparable_with<T, U>;
+    HasPartialOrderOperatorsWith<T, U> && std::three_way_comparable_with<T, U>;
 
 /** @section Formal_Verification */
 

--- a/src/main/modules/dedekind/sets/cardinality.cppm
+++ b/src/main/modules/dedekind/sets/cardinality.cppm
@@ -921,6 +921,77 @@ export constexpr bool operator<(const SignedCardinality& lhs,
   return compare_signed(lhs, rhs) == std::partial_ordering::less;
 }
 
+// ---------------------------------------------------------------------------
+// Heterogeneous comparison: variant ↔ std::integral (closes #415)
+// ---------------------------------------------------------------------------
+//
+// Cross-type relational operators between the variant ℕ-/ℤ-proxy carriers
+// (@c Cardinality, @c SignedCardinality) and built-in @c std::integral
+// values.  The load-bearing path is the halfspace machinery's
+// @c (x @c > @c Pivot) substitution where @c x is a variant ℤ-proxy and
+// @c Pivot is the @c int NTTP from @c bound<-21>: previously this
+// required an explicit lift of the literal to the variant alternative.
+//
+// Defining @c operator<=> together with @c operator== lets the C++20
+// rewrite rules synthesise the four partial-order operators (@c <,
+// @c <=, @c >, @c >=) and the symmetric (rhs-first) direction
+// uniformly --- the witness section in @c numbers/cardinality.cppm
+// pins both directions via @c HasPartialOrderOperatorsWith.
+
+/** @brief @c Cardinality @c <=> @c std::integral.  ℵ_0 is greater than
+ *         any finite integer; negative signed values are below the
+ *         entire ℕ proxy (no element of @c Cardinality is negative),
+ *         which is encoded as @c lhs @c > @c rhs.  Otherwise the
+ *         comparison reduces to the @c ExtensionalCardinal<> spaceship.
+ */
+export template <std::integral T>
+constexpr std::strong_ordering operator<=>(const Cardinality& lhs,
+                                           T rhs) noexcept {
+  if (std::holds_alternative<ℵ_0>(lhs)) return std::strong_ordering::greater;
+  if constexpr (std::signed_integral<T>) {
+    if (rhs < 0) return std::strong_ordering::greater;
+  }
+  using U = std::make_unsigned_t<T>;
+  return std::get<ExtensionalCardinal<>>(lhs) <=>
+         ExtensionalCardinal<>{static_cast<U>(rhs)};
+}
+
+/** @brief @c Cardinality @c == @c std::integral.  Negative signed values
+ *         and ℵ_0 never equal a finite integer; the finite alternative
+ *         delegates to @c ExtensionalCardinal<>'s defaulted @c ==. */
+export template <std::integral T>
+constexpr bool operator==(const Cardinality& lhs, T rhs) noexcept {
+  if (std::holds_alternative<ℵ_0>(lhs)) return false;
+  if constexpr (std::signed_integral<T>) {
+    if (rhs < 0) return false;
+  }
+  using U = std::make_unsigned_t<T>;
+  return std::get<ExtensionalCardinal<>>(lhs) ==
+         ExtensionalCardinal<>{static_cast<U>(rhs)};
+}
+
+/** @brief @c SignedCardinality @c <=> @c std::integral.  Lifts @c rhs
+ *         to a finite @c SignedCardinality and routes through
+ *         @c compare_signed; @c NaZ on @c lhs propagates as
+ *         @c std::partial_ordering::unordered, mirroring IEEE-NaN's
+ *         unordered semantics. */
+export template <std::integral T>
+constexpr std::partial_ordering operator<=>(const SignedCardinality& lhs,
+                                            T rhs) noexcept {
+  return compare_signed(lhs, finite_signed_cardinality(rhs));
+}
+
+/** @brief @c SignedCardinality @c == @c std::integral.  @c NaZ and
+ *         @c ±ℵ_0 never equal a finite integer; the finite
+ *         alternative delegates to @c SignedExtensionalCardinal<>'s
+ *         canonical-zero-aware equality. */
+export template <std::integral T>
+constexpr bool operator==(const SignedCardinality& lhs, T rhs) noexcept {
+  if (!detail::sc_is_finite(lhs)) return false;
+  return std::get<SignedExtensionalCardinal<>>(lhs) ==
+         SignedExtensionalCardinal<>{rhs};
+}
+
 }  // namespace dedekind::sets
 
 // ---------------------------------------------------------------------------

--- a/src/main/modules/dedekind/sets/cardinality.cppm
+++ b/src/main/modules/dedekind/sets/cardinality.cppm
@@ -943,6 +943,10 @@ export constexpr bool operator<(const SignedCardinality& lhs,
  *         entire ℕ proxy (no element of @c Cardinality is negative),
  *         which is encoded as @c lhs @c > @c rhs.  Otherwise the
  *         comparison reduces to the @c ExtensionalCardinal<> spaceship.
+ *         Delegates the integral lift through @c ExtensionalCardinal<>'s
+ *         existing @c std::integral ctor, which subsumes @c bool /
+ *         @c size_t / signed-non-negative paths uniformly --- avoiding
+ *         @c std::make_unsigned_t (undefined for @c bool).
  */
 export template <std::integral T>
 constexpr std::strong_ordering operator<=>(const Cardinality& lhs,
@@ -951,9 +955,7 @@ constexpr std::strong_ordering operator<=>(const Cardinality& lhs,
   if constexpr (std::signed_integral<T>) {
     if (rhs < 0) return std::strong_ordering::greater;
   }
-  using U = std::make_unsigned_t<T>;
-  return std::get<ExtensionalCardinal<>>(lhs) <=>
-         ExtensionalCardinal<>{static_cast<U>(rhs)};
+  return std::get<ExtensionalCardinal<>>(lhs) <=> ExtensionalCardinal<>{rhs};
 }
 
 /** @brief @c Cardinality @c == @c std::integral.  Negative signed values
@@ -965,9 +967,7 @@ constexpr bool operator==(const Cardinality& lhs, T rhs) noexcept {
   if constexpr (std::signed_integral<T>) {
     if (rhs < 0) return false;
   }
-  using U = std::make_unsigned_t<T>;
-  return std::get<ExtensionalCardinal<>>(lhs) ==
-         ExtensionalCardinal<>{static_cast<U>(rhs)};
+  return std::get<ExtensionalCardinal<>>(lhs) == ExtensionalCardinal<>{rhs};
 }
 
 /** @brief @c SignedCardinality @c <=> @c std::integral.  Lifts @c rhs

--- a/src/test/cpp/modules/dedekind/numbers/cardinality_test.cpp
+++ b/src/test/cpp/modules/dedekind/numbers/cardinality_test.cpp
@@ -172,3 +172,51 @@ TEST_CASE("Numbers: ExtensionalCardinal additive inverse",
     CHECK(inverse(zero, std::plus<C1>{}) == C1{0});
   }
 }
+
+TEST_CASE("Numbers: Cardinality heterogeneous comparison vs std::integral (#415)",
+          "[numbers][cardinality][order][heterogeneous]") {
+  const Cardinality five = finite_cardinality(5);
+  const Cardinality inf = ℵ_0{};
+
+  SECTION("Finite vs unsigned and signed (non-negative) — three-way") {
+    CHECK((five <=> 5u) == std::strong_ordering::equal);
+    CHECK((five <=> 4u) == std::strong_ordering::greater);
+    CHECK((five <=> 6u) == std::strong_ordering::less);
+    CHECK((five <=> 5) == std::strong_ordering::equal);  // signed int, rhs >= 0
+    CHECK(five == 5u);
+    CHECK(five == 5);
+    CHECK(five > 4u);
+    CHECK(five < 6);
+  }
+  SECTION("Negative signed values land strictly below the ℕ proxy") {
+    // No element of Cardinality is negative; finite > any negative int.
+    CHECK((five <=> -1) == std::strong_ordering::greater);
+    CHECK(five > -1);
+    CHECK_FALSE(five == -1);
+    // Even the empty cardinal (zero) is greater than a negative int.
+    const Cardinality zero = finite_cardinality(0);
+    CHECK(zero > -1);
+    CHECK_FALSE(zero == -7);
+  }
+  SECTION("ℵ_0 dominates every finite int") {
+    CHECK((inf <=> 0u) == std::strong_ordering::greater);
+    CHECK(inf > std::numeric_limits<unsigned>::max());
+    CHECK(inf > -1);
+    CHECK_FALSE(inf == 0u);
+  }
+  SECTION("bool is std::integral (regression for make_unsigned_t<bool>)") {
+    // std::make_unsigned_t<bool> is undefined; the comparison path must
+    // delegate through ExtensionalCardinal<>'s integral ctor instead.
+    const Cardinality one = finite_cardinality(1);
+    const Cardinality zero = finite_cardinality(0);
+    CHECK(one == true);
+    CHECK(zero == false);
+    CHECK(one > false);
+    CHECK(zero < true);
+  }
+  SECTION("Rhs-first direction synthesised by C++20 rewrite rules") {
+    CHECK(5u == five);
+    CHECK(4 < five);
+    CHECK(0u < inf);
+  }
+}

--- a/src/test/cpp/modules/dedekind/numbers/cardinality_test.cpp
+++ b/src/test/cpp/modules/dedekind/numbers/cardinality_test.cpp
@@ -173,8 +173,9 @@ TEST_CASE("Numbers: ExtensionalCardinal additive inverse",
   }
 }
 
-TEST_CASE("Numbers: Cardinality heterogeneous comparison vs std::integral (#415)",
-          "[numbers][cardinality][order][heterogeneous]") {
+TEST_CASE(
+    "Numbers: Cardinality heterogeneous comparison vs std::integral (#415)",
+    "[numbers][cardinality][order][heterogeneous]") {
   const Cardinality five = finite_cardinality(5);
   const Cardinality inf = ℵ_0{};
 

--- a/src/test/cpp/modules/dedekind/sets/signed_cardinality_test.cpp
+++ b/src/test/cpp/modules/dedekind/sets/signed_cardinality_test.cpp
@@ -331,3 +331,59 @@ TEST_CASE(
   CHECK(five < seven);
   CHECK_FALSE(seven < five);
 }
+
+TEST_CASE(
+    "SignedCardinality — heterogeneous comparison vs std::integral (#415)",
+    "[sets][cardinality][signed][order][heterogeneous]") {
+  const auto pos_inf = SignedCardinality{PositiveInfinity{}};
+  const auto neg_inf = SignedCardinality{NegativeInfinity{}};
+  const auto naz = SignedCardinality{NaZ{}};
+  const auto five = finite_signed_cardinality(5);
+  const auto neg_three = finite_signed_cardinality(-3);
+
+  SECTION("Finite vs int — three-way and four partial-order ops") {
+    CHECK((five <=> 5) == std::partial_ordering::equivalent);
+    CHECK((five <=> 4) == std::partial_ordering::greater);
+    CHECK((five <=> 6) == std::partial_ordering::less);
+    CHECK(five == 5);
+    CHECK(five != 4);
+    CHECK(five > 4);
+    CHECK(five >= 5);
+    CHECK(five < 6);
+    CHECK(five <= 5);
+  }
+  SECTION("Negative finite vs negative int") {
+    CHECK((neg_three <=> -3) == std::partial_ordering::equivalent);
+    CHECK(neg_three == -3);
+    CHECK(neg_three < 0);
+    CHECK(neg_three < -2);
+    CHECK(neg_three > -4);
+  }
+  SECTION("+ℵ_0 dominates every finite int") {
+    CHECK((pos_inf <=> 0) == std::partial_ordering::greater);
+    CHECK(pos_inf > 0);
+    CHECK(pos_inf > INT_MAX);
+    CHECK_FALSE(pos_inf == 0);
+  }
+  SECTION("-ℵ_0 sits below every finite int") {
+    CHECK((neg_inf <=> 0) == std::partial_ordering::less);
+    CHECK(neg_inf < 0);
+    CHECK(neg_inf < INT_MIN);
+    CHECK_FALSE(neg_inf == 0);
+  }
+  SECTION("NaZ is unordered with every int (IEEE-NaN style)") {
+    CHECK((naz <=> 5) == std::partial_ordering::unordered);
+    CHECK_FALSE(naz < 5);
+    CHECK_FALSE(naz > 5);
+    CHECK_FALSE(naz == 5);
+    CHECK(naz != 5);
+  }
+  SECTION("Rhs-first direction synthesised by C++20 rewrite rules") {
+    // 5 == five compiles via the synthesised reversed operator==.
+    CHECK(5 == five);
+    CHECK(4 < five);
+    CHECK(6 > five);
+    CHECK(0 < pos_inf);
+    CHECK(0 > neg_inf);
+  }
+}


### PR DESCRIPTION
## Summary

Combined PR for two adjacent order-layer changes plus their heterogeneous-shape sibling concepts.

### #415 — variant ℕ-/ℤ-proxy ↔ `std::integral` comparison

Cross-type relational operators between the variant carriers (`Cardinality`, `SignedCardinality`) and built-in `std::integral` values:

- `Cardinality <=> T` (T : `std::integral`) → `std::strong_ordering`; negative signed values land strictly below the ℕ proxy.
- `SignedCardinality <=> T` → `std::partial_ordering`; `NaZ` propagates as unordered (IEEE-NaN-style).
- Heterogeneous `==` for both, mirroring the spaceship.

C++20's rewrite rules synthesise the four partial-order operators and the rhs-first direction uniformly. The load-bearing path is the halfspace machinery's `(x > Pivot)` substitution where `x` is a variant ℤ-proxy and `Pivot` is the `int` NTTP from `bound<-21>`.

### #410 — extract `:order:total` partition

Relocate the strictly-stronger total-order content out of `:poset` into a new `:total` partition: `IsTotallyOrdered`, `IsLinearOrder`, `IsStrictWeakOrder`, `HasTotalOrderOperators`. Mirrors `:category:total` which already houses the strict total-axiomatic content for algebra. Generic code that needs only the partial-order surface no longer pulls in the spaceship-shape concept transitively.

### Heterogeneous shape concepts (sibling scope)

`HasPartialOrderOperatorsWith<T, U>` in `:poset` and `HasTotalOrderOperatorsWith<T, U>` in `:order:total` — fill the seam between the homogeneous spaceship-shape (which only describes `T <=> T`) and the real-world need to compare a variant carrier with an integer NTTP literal. Witnesses pin `SignedCardinality↔int`, `Cardinality↔unsigned int`, and the rhs-first direction in `numbers/cardinality.cppm`.

Cross-signedness `<=>` is excluded (libc++'s `three_way_comparable_with<unsigned, signed>` is false on narrowing grounds) — the four partial-order operators still compile under their surprising signed→unsigned conversion semantics, which the witness section in `:poset` names explicitly.

### README

Adds the **Co-Domain Anchoring** tenet: where the C++ standard library provides native support for algebraic concepts, the anchoring is made explicit (`bool`, `std::pair`, `std::variant`, …).

## Test plan

- [x] `make test-compile` passes (partition-split cascade resolved: `:completeness` adds `import :total;`).
- [x] `make test` — all 15 suites green.
- [x] Witness `static_assert`s pin the new concepts on the variant↔integral pairs in `numbers/cardinality.cppm`.
- [ ] CI green on the pushed branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)