### PR TITLE
feat(category,sets): complete the elementwise carrier-aware vocabulary — abs (#436) + adjunction natural-transformation tightening (#434) + Galois-connection framing (#435)

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ The project rests on two pillars: **C++23** and **Category Theory**.
 In this approach:
 1. **Verbatim Lifting**: Mathematical concepts are translated into `C++` `concept`s with minimal adjustments. The flow from axioms to theorems is enforced by the `module` build order, the `import` graph and `C++` declaration order rules.
 2. **Language Conformity**: Modifications required to satisfy the host language (`C++`) are kept as non-intrusive as possible. Textbook naming conventions using `UTF-8` are preferred, i.e. `ℝ` instead of `IsRealNumberSet`.
-3. **Bi-directional Fidelity**: Once a concept compiles, its fidelity is verified by checking that `C++` invariants map correctly back to their mathematical counterparts within the test suite.
+3. **Bi-directional Fidelity**: Once a `concept` compiles, its fidelity is verified by checking that `C++` invariants map correctly back to their mathematical counterparts within the test suite.
 4. **Co-Domain Anchoring**: Where the C++ standard library provides native support for algebraic concepts, this anchoring is made explicit (e.g. `bool`, `std::pair`, `std::variant`, ...) and documented via translation tables.
 
 _AI assistance is used during the development of this project._

--- a/src/main/modules/dedekind/category/adjunction.cppm
+++ b/src/main/modules/dedekind/category/adjunction.cppm
@@ -281,9 +281,10 @@ constexpr auto make_adjunction(Left&& left, Right&& right, Unit&& unit,
  * @concept IsGaloisConnection
  * @brief @b Structural @b shape: @c F and @c G form a Galois
  *        connection @c F ⊣ @c G in a posetal setting — the simplest
- *        adjunction.  Both are monotone functions @c P → @c Q and
- *        @c Q → @c P (poset categories with @c ≤ as the morphism
- *        relation), and the universal-property test
+ *        adjunction.  Both are monotone arrows; @c F : @c P → @c Q
+ *        and @c G : @c Q → @c P with the source/target carriers
+ *        crossed (so @c F's @c Codomain matches @c G's @c Domain
+ *        and vice versa).  The universal-property test
  *
  *          f(x) ≤ y  ⟺  x ≤ g(y)
  *
@@ -300,17 +301,20 @@ constexpr auto make_adjunction(Left&& left, Right&& right, Unit&& unit,
  *  naturality content trivialises.  Useful as a lightweight
  *  vocabulary anchor for arithmetic-flavoured adjunctions
  *  (floor/ceiling, addition/subtraction, etc.).
+ *
+ *  @c P and @c Q are not free template parameters — they are
+ *  recovered from @c F's @c Domain / @c Codomain.  @c G's
+ *  carriers are required to be the cross-pair: @c G : @c Q → @c P.
  */
-export template <typename F, typename G, typename P, typename Q>
-concept IsGaloisConnection = requires(F f, G g, P x, Q y) {
-  { f(x) } -> std::convertible_to<Q>;
-  { g(y) } -> std::convertible_to<P>;
-};
+export template <typename F, typename G>
+concept IsGaloisConnection =
+    IsArrow<F> && IsArrow<G> && std::same_as<Dom<G>, Cod<F>> &&
+    std::same_as<Cod<G>, Dom<F>>;
 
 /**
  * @concept IsClosureOperator
  * @brief @b Structural @b shape: @c C is a closure operator on a
- *        poset @c P — a function @c C : @c P → @c P that is
+ *        poset @c P — an arrow @c C : @c P → @c P that is
  *        idempotent (@c C(C(x)) @c = @c C(x)), monotone (@c x @c ≤
  *        @c y @c ⇒ @c C(x) @c ≤ @c C(y)), and extensive (@c x @c ≤
  *        @c C(x)) for all @c x.
@@ -325,11 +329,10 @@ concept IsGaloisConnection = requires(F f, G g, P x, Q y) {
  *  C++ concepts cannot quantify universally over @c P, so the
  *  three properties (idempotent / monotone / extensive) are the
  *  engineer's honesty obligation; the structural shape names the
- *  @b signature only (@c P → @c P).
+ *  @b signature only (an @c IsArrow whose @c Domain equals its
+ *  @c Codomain).
  */
-export template <typename C, typename P>
-concept IsClosureOperator = requires(C c, P x) {
-  { c(x) } -> std::convertible_to<P>;
-};
+export template <typename C>
+concept IsClosureOperator = IsArrow<C> && std::same_as<Dom<C>, Cod<C>>;
 
 }  // namespace dedekind::category

--- a/src/main/modules/dedekind/category/adjunction.cppm
+++ b/src/main/modules/dedekind/category/adjunction.cppm
@@ -240,4 +240,97 @@ constexpr auto make_adjunction(Left&& left, Right&& right, Unit&& unit,
       std::forward<Unit>(unit), std::forward<Counit>(counit)};
 }
 
+// ===========================================================================
+// Galois connections — adjunctions in posets (closes #435)
+// ===========================================================================
+//
+// When the source and target categories of an adjunction are @b
+// posets (categories where there's at most one morphism between any
+// two objects, namely the @c ≤ relation), the adjunction degenerates
+// to its simplest form: a Galois connection.  The Hom-set bijection
+// @c Hom_𝒞(F(d), c) ≅ Hom_𝒟(d, U(c)) collapses to the order-theoretic
+// equivalence
+//
+//   f(x) ≤ y  ⟺  x ≤ g(y)
+//
+// (Pierce, @c Basic @c Category @c Theory @c §2.6.)  In posets the
+// triangle identities trivialise — there's at most one arrow between
+// any two objects, so all naturality squares commute automatically;
+// the universal-property content reduces to the inequality above.
+//
+// Concrete examples in arithmetic (per the user-shared Gemini
+// conversation during PR #433):
+//   * Inclusion @c ι : ℤ ↪ ℝ; floor @c ⌊·⌋ is its right adjoint:
+//     @c ι(n) ≤ x ⟺ n ≤ ⌊x⌋.
+//   * Ceiling @c ⌈·⌉ is the left adjoint of @c ι:
+//     @c ⌈x⌉ ≤ n ⟺ x ≤ ι(n).
+//   * Addition @c +k ⊣ subtraction @c -k:
+//     @c x + k ≤ y ⟺ x ≤ y - k.
+//   * In ℕ, the right adjoint of @c +k is @b truncated @b subtraction
+//     @c y −̇ k = max(y - k, 0); see @c
+//     docs/design/carrier-lattice.md, "A road not taken: truncated
+//     subtraction" — the order-theoretic dual of the closure-forcing
+//     @c ℕ - ℕ → ℤ this codebase chose.
+//
+// Composing both directions of a Galois connection produces a @b
+// closure @b operator: @c g ∘ f is idempotent (@c g(f(g(f(x)))) =
+// @c g(f(x))), monotone, and extensive (@c x ≤ g(f(x))).  The
+// closure-operator concept below names this structural rotation.
+
+/**
+ * @concept IsGaloisConnection
+ * @brief @b Structural @b shape: @c F and @c G form a Galois
+ *        connection @c F ⊣ @c G in a posetal setting — the simplest
+ *        adjunction.  Both are monotone functions @c P → @c Q and
+ *        @c Q → @c P (poset categories with @c ≤ as the morphism
+ *        relation), and the universal-property test
+ *
+ *          f(x) ≤ y  ⟺  x ≤ g(y)
+ *
+ *        holds.  C++ concepts cannot quantify universally over @c x
+ *        and @c y, so the equivalence is the engineer's honesty
+ *        obligation; the structural shape names the @b signatures.
+ *
+ *  @b Relationship @b to @b @c HasAdjunctionShape: a Galois
+ *  connection @b is an adjunction in the simplest possible
+ *  category-theoretic setting (posets).  @c IsGaloisConnection is
+ *  the order-theoretic specialisation — it doesn't @b require the
+ *  full functor / natural-transformation machinery because in a
+ *  poset there's at most one arrow between any two objects, so the
+ *  naturality content trivialises.  Useful as a lightweight
+ *  vocabulary anchor for arithmetic-flavoured adjunctions
+ *  (floor/ceiling, addition/subtraction, etc.).
+ */
+export template <typename F, typename G, typename P, typename Q>
+concept IsGaloisConnection =
+    requires(F f, G g, P x, Q y) {
+      { f(x) } -> std::convertible_to<Q>;
+      { g(y) } -> std::convertible_to<P>;
+    };
+
+/**
+ * @concept IsClosureOperator
+ * @brief @b Structural @b shape: @c C is a closure operator on a
+ *        poset @c P — a function @c C : @c P → @c P that is
+ *        idempotent (@c C(C(x)) @c = @c C(x)), monotone (@c x @c ≤
+ *        @c y @c ⇒ @c C(x) @c ≤ @c C(y)), and extensive (@c x @c ≤
+ *        @c C(x)) for all @c x.
+ *
+ *  Every Galois connection induces a closure operator via @c g ∘
+ *  @c f (the round-trip on the source side).  Examples in arithmetic:
+ *  @c ⌊·⌋ ∘ ι : @c ℝ → @c ℝ is the round-down-to-nearest-integer
+ *  closure (idempotent and monotone but not extensive on @c ℝ;
+ *  extensive holds on @c ℤ).  In the carrier lattice, @c
+ *  embed_ℕ_ℤ ∘ abs : @c ℤ → @c ℤ is the absolute-value closure.
+ *
+ *  C++ concepts cannot quantify universally over @c P, so the
+ *  three properties (idempotent / monotone / extensive) are the
+ *  engineer's honesty obligation; the structural shape names the
+ *  @b signature only (@c P → @c P).
+ */
+export template <typename C, typename P>
+concept IsClosureOperator = requires(C c, P x) {
+  { c(x) } -> std::convertible_to<P>;
+};
+
 }  // namespace dedekind::category

--- a/src/main/modules/dedekind/category/adjunction.cppm
+++ b/src/main/modules/dedekind/category/adjunction.cppm
@@ -78,7 +78,8 @@ export module dedekind.category:adjunction;
 
 import :functor;
 import :morphism;
-import :natural;  // For IsNaturalTransformation, used in unit/counit witnesses (#434)
+import :natural;  // For IsNaturalTransformation, used in unit/counit witnesses
+                  // (#434)
 import :small;
 
 namespace dedekind::category {
@@ -204,8 +205,7 @@ concept IsCounitOfAdjunction =
  */
 export template <typename Left, typename Right, typename Unit, typename Counit>
 concept IsAdjunction =
-    HasAdjunctionShape<Left, Right> &&
-    IsUnitOfAdjunction<Unit, Left, Right> &&
+    HasAdjunctionShape<Left, Right> && IsUnitOfAdjunction<Unit, Left, Right> &&
     IsCounitOfAdjunction<Counit, Left, Right>;
 
 /**
@@ -302,11 +302,10 @@ constexpr auto make_adjunction(Left&& left, Right&& right, Unit&& unit,
  *  (floor/ceiling, addition/subtraction, etc.).
  */
 export template <typename F, typename G, typename P, typename Q>
-concept IsGaloisConnection =
-    requires(F f, G g, P x, Q y) {
-      { f(x) } -> std::convertible_to<Q>;
-      { g(y) } -> std::convertible_to<P>;
-    };
+concept IsGaloisConnection = requires(F f, G g, P x, Q y) {
+  { f(x) } -> std::convertible_to<Q>;
+  { g(y) } -> std::convertible_to<P>;
+};
 
 /**
  * @concept IsClosureOperator

--- a/src/main/modules/dedekind/category/adjunction.cppm
+++ b/src/main/modules/dedekind/category/adjunction.cppm
@@ -320,11 +320,17 @@ concept IsGaloisConnection =
  *        @c C(x)) for all @c x.
  *
  *  Every Galois connection induces a closure operator via @c g ∘
- *  @c f (the round-trip on the source side).  Examples in arithmetic:
- *  @c ⌊·⌋ ∘ ι : @c ℝ → @c ℝ is the round-down-to-nearest-integer
- *  closure (idempotent and monotone but not extensive on @c ℝ;
- *  extensive holds on @c ℤ).  In the carrier lattice, @c
- *  embed_ℕ_ℤ ∘ abs : @c ℤ → @c ℤ is the absolute-value closure.
+ *  @c f (the round-trip on the source side).  Example in arithmetic:
+ *  for the ceiling/inclusion adjunction @c ⌈·⌉ ⊣ @c ι, the
+ *  source-side round-trip @c ι ∘ @c ⌈·⌉ : @c ℝ → @c ℝ is the
+ *  round-up-to-nearest-integer closure (extensive, monotone, and
+ *  idempotent on @c (ℝ, ≤)).  Dually, for the floor/inclusion
+ *  adjunction @c ι ⊣ @c ⌊·⌋, the source-side round-trip @c ⌊·⌋ ∘ @c ι :
+ *  @c ℤ → @c ℤ is a closure operator as well — indeed, the identity
+ *  on @c ℤ.  Note: @c embed_ℕ_ℤ ∘ @c abs is @b not a closure operator
+ *  because it isn't monotone on @c (ℤ, ≤) (sign-folding inverts
+ *  order on the negative fragment); the @c (embed_ℕ_ℤ, @c abs) pair
+ *  is a split mono / split epi rather than a Galois connection.
  *
  *  C++ concepts cannot quantify universally over @c P, so the
  *  three properties (idempotent / monotone / extensive) are the

--- a/src/main/modules/dedekind/category/adjunction.cppm
+++ b/src/main/modules/dedekind/category/adjunction.cppm
@@ -78,6 +78,7 @@ export module dedekind.category:adjunction;
 
 import :functor;
 import :morphism;
+import :natural;  // For IsNaturalTransformation, used in unit/counit witnesses (#434)
 import :small;
 
 namespace dedekind::category {
@@ -153,22 +154,59 @@ export template <typename U, typename F>
 concept IsForgetfulFunctor = HasAdjunctionShape<F, U>;
 
 /**
+ * @concept IsUnitOfAdjunction
+ * @brief @b Structural @b shape: @c η is the unit of an adjunction
+ *        @c F ⊣ @c U — a natural transformation @c id_𝒟 ⇒ @c U ∘ @c F.
+ *
+ *  Composes the existing @c IsNaturalTransformation (in @c :natural)
+ *  with @c HasAdjunctionShape.  The triangle identities — the actual
+ *  content of the adjunction — remain universal-property territory
+ *  (engineer's honesty obligation; not deducible by the type-checker).
+ *
+ *  In carrier-lattice terms, @c η_d : @c d → @c U(F(d)) is the
+ *  canonical embedding of @c d into the underlying object of its
+ *  free construction — for example, @c η_ℕ : @c ℕ ↪ @c ℤ is the
+ *  variant-level analog of @c embed_ℕ_ℤ.  Closes #434.
+ */
+export template <typename Eta, typename F, typename U>
+concept IsUnitOfAdjunction =
+    HasAdjunctionShape<F, U> &&
+    IsNaturalTransformation<Eta, identity_functor<typename F::Σ_cat>,
+                            composite_functor<F, U>>;
+
+/**
+ * @concept IsCounitOfAdjunction
+ * @brief @b Structural @b shape: @c ε is the counit of an adjunction
+ *        @c F ⊣ @c U — a natural transformation @c F ∘ @c U ⇒
+ *        @c id_𝒞.  Dual of @c IsUnitOfAdjunction.
+ */
+export template <typename Epsilon, typename F, typename U>
+concept IsCounitOfAdjunction =
+    HasAdjunctionShape<F, U> &&
+    IsNaturalTransformation<Epsilon, composite_functor<U, F>,
+                            identity_functor<typename F::Τ_cat>>;
+
+/**
  * @concept IsAdjunction
  * @brief A typed unit/counit witness relating a left and right functor.
+ *
+ *  Tightened (#434) to require the unit and counit to be @b natural
+ *  @b transformations, not raw arrows.  Per Mac Lane (Ch. IV) /
+ *  Milewski (*Category Theory for Programmers*, Ch. on Adjunctions):
+ *  an adjunction is @b defined by natural transformations; the
+ *  earlier arrow-based form (pre-#434) was structurally under-strict.
+ *  The arrow-shape constraints on @c Unit / @c Counit are retained
+ *  via @c IsNaturalTransformation's own requirements.
+ *
+ *  The triangle identities — @c (εF) ∘ (Fη) = @c 1_F and @c (Gε) ∘
+ *  (ηG) = @c 1_G — remain universal-property territory; they're the
+ *  engineer's honesty obligation at the witness site.
  */
 export template <typename Left, typename Right, typename Unit, typename Counit>
 concept IsAdjunction =
-    IsFunctor<Left> && IsFunctor<Right> && IsArrow<Unit> && IsArrow<Counit> &&
-    std::same_as<typename Left::Σ_cat, typename Right::Τ_cat> &&
-    std::same_as<typename Left::Τ_cat, typename Right::Σ_cat> &&
-    std::same_as<typename Unit::Domain, typename Left::Σ_cat::Species> &&
-    std::same_as<typename Unit::Codomain,
-                 typename Right::template Shape<typename Left::template Shape<
-                     typename Left::Σ_cat::Species>>> &&
-    std::same_as<typename Counit::Domain,
-                 typename Left::template Shape<typename Right::template Shape<
-                     typename Right::Σ_cat::Species>>> &&
-    std::same_as<typename Counit::Codomain, typename Right::Σ_cat::Species>;
+    HasAdjunctionShape<Left, Right> &&
+    IsUnitOfAdjunction<Unit, Left, Right> &&
+    IsCounitOfAdjunction<Counit, Left, Right>;
 
 /**
  * @brief Typed unit/counit data for an adjunction witness.

--- a/src/main/modules/dedekind/sets/cardinality.cppm
+++ b/src/main/modules/dedekind/sets/cardinality.cppm
@@ -1445,6 +1445,42 @@ export constexpr SignedCardinality operator-(const Cardinality& v) noexcept {
   return -detail::lift_cardinality_to_signed(v);
 }
 
+/** @brief Retraction direction: @c abs : @c ℤ @c → @c ℕ.  The math-
+ *         honest signature for absolute value: every element of
+ *         @c SignedCardinality has a non-negative magnitude, so the
+ *         result type @b is @c Cardinality (not @c
+ *         SignedCardinality), announcing the non-negativity guarantee
+ *         at the type level.
+ *
+ *  Categorically, @c abs is a @b retraction (left inverse) of the
+ *  canonical embedding @c embed_ℕ_ℤ on the non-negative fragment of
+ *  ℤ — i.e., @c abs ∘ embed_ℕ_ℤ @c = @c id_ℕ — extended by sign-
+ *  folding on the negative fragment.  This is the @b downward
+ *  complement of the closure-forcing @c -Cardinality direction
+ *  above: where unary @c - @b widens @c ℕ @c → @c ℤ along the
+ *  Grothendieck embedding, @c abs @b narrows @c ℤ @c → @c ℕ along
+ *  the same embedding's retraction.  Closes #436.
+ *
+ *  Sentinel handling:
+ *    * @c finite_signed_cardinality(n) (any sign) → finite
+ *      Cardinality with magnitude @c |n|.
+ *    * @c PositiveInfinity → @c ℵ_0 (the bound on the magnitude
+ *      escalates to ℵ_0).
+ *    * @c NegativeInfinity → @c ℵ_0 (sign is folded; magnitude
+ *      escalates).
+ *    * @c NaZ → @c ℵ_0 by analogy with the IEEE-NaN-style propagation
+ *      that #396 chose for the saturating semantics; NaZ has no
+ *      well-defined magnitude, but the saturated answer is the
+ *      conservative bound.
+ */
+export constexpr Cardinality abs(const SignedCardinality& z) noexcept {
+  if (detail::sc_is_naz(z)) return Cardinality{ℵ_0{}};
+  if (detail::sc_is_pos_inf(z) || detail::sc_is_neg_inf(z))
+    return Cardinality{ℵ_0{}};
+  // Finite: extract the magnitude (an ExtensionalCardinal<>) directly.
+  return Cardinality{std::get<SignedExtensionalCardinal<>>(z).magnitude};
+}
+
 /** @brief Closure-forcing binary minus on @c Cardinality: well-defined
  *         as a function @c ℕ × ℕ → ℤ; ℕ isn't closed under it.  The
  *         operator's existence with the wider return type @b is the

--- a/src/test/cpp/modules/dedekind/category/functor_test.cpp
+++ b/src/test/cpp/modules/dedekind/category/functor_test.cpp
@@ -126,20 +126,29 @@ TEST_CASE("Category: Endofunctor algebras and fixed points",
 
   auto successor = arrow([](int x) { return x + 1; });
   auto halve = arrow([](int x) { return x / 2; });
-  auto identity = arrow([](int x) { return x; });
 
   STATIC_CHECK(IsFAlgebra<int, decltype(successor), IdF>);
   STATIC_CHECK(IsFCoalgebra<int, decltype(halve), IdF>);
-  STATIC_CHECK(IsAdjunction<IdF, IdF, decltype(identity), decltype(identity)>);
+
+  // IsAdjunction tightened (#434) to require IsNaturalTransformation
+  // unit/counit per Mac Lane / Milewski; the trivial @c IdF ⊣ @c IdF
+  // self-adjunction's unit and counit are both the @c
+  // identity_transformation on @c IdF.
+  using IdT = identity_transformation<IdF>;
+  STATIC_CHECK(IsAdjunction<IdF, IdF, IdT, IdT>);
 
   auto algebra = make_f_algebra(IdF{}, successor);
   auto coalgebra = make_f_coalgebra(IdF{}, halve);
-  auto adjunction = make_adjunction(IdF{}, IdF{}, identity, identity);
+  auto adjunction = make_adjunction(IdF{}, IdF{}, IdT{}, IdT{});
 
   CHECK(algebra(41) == 42);
   CHECK(coalgebra(42) == 21);
-  CHECK(adjunction.unit(7) == 7);
-  CHECK(adjunction.counit(9) == 9);
+  // Unit / counit of @c IdF ⊣ @c IdF as natural transformations on
+  // @c IntCat: at object @c c they return @c id_c, the identity
+  // arrow on @c c.  Witnessed structurally — calling the components
+  // is enough; the typing derivation discharges the rest.
+  STATIC_CHECK(IsArrow<decltype(adjunction.unit(7))>);
+  STATIC_CHECK(IsArrow<decltype(adjunction.counit(9))>);
 
   CHECK(least_fixpoint(0, [](int x) { return x < 5 ? x + 1 : x; }) == 5);
 

--- a/src/test/cpp/modules/dedekind/numbers/cardinality_test.cpp
+++ b/src/test/cpp/modules/dedekind/numbers/cardinality_test.cpp
@@ -624,3 +624,46 @@ TEST_CASE(
     CHECK(diff == finite_signed_cardinality(-3));
   }
 }
+
+TEST_CASE(
+    "Elementwise carrier-promotion: abs as the retraction ℤ → ℕ "
+    "(closes #436)",
+    "[numbers][cardinality][carrier-lattice][elementwise]") {
+  // abs is the downward complement of the closure-forcing direction:
+  // where unary − widens ℕ → ℤ along the Grothendieck embedding,
+  // abs narrows ℤ → ℕ along the same embedding's retraction.  The
+  // result type announces the non-negativity guarantee at the type
+  // level.  See docs/design/carrier-lattice.md.
+  SECTION("Type-level: abs(SignedCardinality) returns Cardinality") {
+    const auto z = finite_signed_cardinality(-5);
+    STATIC_CHECK(std::same_as<decltype(abs(z)), Cardinality>);
+  }
+  SECTION("Positive finite: abs preserves magnitude") {
+    CHECK(abs(finite_signed_cardinality(5)) == finite_cardinality(5));
+  }
+  SECTION("Negative finite: abs folds the sign") {
+    CHECK(abs(finite_signed_cardinality(-5)) == finite_cardinality(5));
+  }
+  SECTION("Canonical zero: abs(0) == 0") {
+    CHECK(abs(finite_signed_cardinality(0)) == finite_cardinality(0));
+  }
+  SECTION("Retraction identity: abs(positive_signed_with_magnitude_n) == n") {
+    // The retraction-on-the-non-negative-fragment claim:
+    //   abs ∘ embed_ℕ_ℤ = id_ℕ
+    // witnessed without reaching into the detail::lift helper — we
+    // build a non-negative SignedCardinality directly with magnitude
+    // 7 (the embedding's image of finite_cardinality(7)) and verify
+    // abs returns to the original.
+    const auto z = finite_signed_cardinality(7);  // ≡ embed_ℕ_ℤ(7)
+    CHECK(abs(z) == finite_cardinality(7));
+  }
+  SECTION("PositiveInfinity → ℵ_0") {
+    CHECK(abs(SignedCardinality{PositiveInfinity{}}) == Cardinality{ℵ_0{}});
+  }
+  SECTION("NegativeInfinity → ℵ_0 (sign folded; magnitude escalates)") {
+    CHECK(abs(SignedCardinality{NegativeInfinity{}}) == Cardinality{ℵ_0{}});
+  }
+  SECTION("NaZ → ℵ_0 (saturating fallback for indeterminate forms)") {
+    CHECK(abs(SignedCardinality{NaZ{}}) == Cardinality{ℵ_0{}});
+  }
+}

--- a/src/test/cpp/modules/dedekind/numbers/integer_test.cpp
+++ b/src/test/cpp/modules/dedekind/numbers/integer_test.cpp
@@ -1,5 +1,9 @@
 #include <catch2/catch_test_macros.hpp>
-#include <variant>
+#include <variant>  // For std::variant's operator== reached via ADL on
+                    // SignedCardinality / Cardinality (aliases of
+                    // std::variant<...>).  Without this include the
+                    // CHECK assertions below fail to find the comparison
+                    // operator — see PR #437 review thread.
 
 import dedekind.category;
 import dedekind.numbers;

--- a/src/test/cpp/modules/dedekind/numbers/integer_test.cpp
+++ b/src/test/cpp/modules/dedekind/numbers/integer_test.cpp
@@ -1,0 +1,67 @@
+#include <catch2/catch_test_macros.hpp>
+#include <variant>
+
+import dedekind.category;
+import dedekind.numbers;
+
+using namespace dedekind::category;
+using namespace dedekind::numbers;
+using namespace dedekind::sets;
+
+// ===========================================================================
+// Carrier-lattice round-trip: ℕ → ℤ → ℕ
+// ===========================================================================
+//
+// Two structurally-distinct arrows take ℕ into ℤ at the variant level:
+//   * unary @c -Cardinality → SignedCardinality (closure-forcing
+//     negation; PR #433)
+//   * binary @c Cardinality - Cardinality → SignedCardinality
+//     (closure-forcing subtraction; PR #433)
+// and one arrow brings ℤ back to ℕ:
+//   * @c abs(SignedCardinality) → Cardinality (retraction; PR #437,
+//     #436)
+// The round-trip property @c abs ∘ embed = id_ℕ on the non-negative
+// fragment — which is the @b retraction defining clause — is what's
+// exercised below.  ℤ → ℕ → ℤ is @b not bijective: @c abs folds
+// sign, so re-embedding loses the sign bit.  The asymmetry is what
+// makes the pair @c (embed_ℕ_ℤ, @c abs) a @b split @b mono / @b split
+// @b epi rather than an isomorphism (see @c
+// docs/design/carrier-lattice.md).
+
+TEST_CASE("Integer: ℕ → ℤ → ℕ via unary − then abs (closes #436 round-trip)",
+          "[numbers][integer][carrier-lattice][round-trip]") {
+  const auto n = finite_cardinality(7);
+  const auto neg = -n;         // ℕ → ℤ (closure-forcing negation)
+  const auto back = abs(neg);  // ℤ → ℕ (retraction)
+  CHECK(back == n);
+}
+
+TEST_CASE("Integer: ℕ → ℤ → ℕ via binary − then abs",
+          "[numbers][integer][carrier-lattice][round-trip]") {
+  const auto n = finite_cardinality(7);
+  const auto z = finite_cardinality(0) - n;  // → -7 in ℤ
+  const auto back = abs(z);                  // → 7 in ℕ
+  CHECK(back == n);
+}
+
+TEST_CASE("Integer: ℤ → ℕ → ℤ folds sign — abs is not a bijection",
+          "[numbers][integer][carrier-lattice][round-trip]") {
+  const auto z_neg = finite_signed_cardinality(-5);
+  const auto folded = abs(z_neg);                           // → 5 in ℕ
+  const auto re_embedded = folded - finite_cardinality(0);  // → +5 in ℤ
+  CHECK(re_embedded == finite_signed_cardinality(5));
+  CHECK_FALSE(re_embedded == z_neg);  // sign was lost on the round-trip
+}
+
+TEST_CASE("Integer: ℕ → ℤ → ℕ on canonical zero — 0 ↦ 0 ↦ 0",
+          "[numbers][integer][carrier-lattice][round-trip]") {
+  const auto zero = finite_cardinality(0);
+  CHECK(abs(-zero) == zero);
+  CHECK(abs(zero - zero) == zero);
+}
+
+TEST_CASE("Integer: ℕ → ℤ → ℕ on ℵ_0 — saturating round-trip",
+          "[numbers][integer][carrier-lattice][round-trip]") {
+  const auto inf = Cardinality{ℵ_0{}};
+  CHECK(abs(-inf) == inf);
+}


### PR DESCRIPTION
## Summary

Combined PR completing the elementwise carrier-aware vocabulary established in PR #433. Three sibling concerns, all conceptually one thread:

### 1. `abs : ℤ → ℕ` (closes #436)

The **retraction direction** complementing the closure-forcing direction shipped in PR #433. Where unary `-Cardinality` widens ℕ → ℤ along the Grothendieck embedding, `abs(SignedCardinality)` narrows ℤ → ℕ along the same embedding's retraction. The result type announces the non-negativity guarantee at the type level.

Categorically `abs` is a left inverse of `embed_ℕ_ℤ` on the non-negative fragment (so `abs ∘ embed_ℕ_ℤ = id_ℕ`); not a Galois adjoint. The pair `(embed_ℕ_ℤ, abs)` is a *split mono / split epi*, a different categorical structure than closure-forcing.

### 2. `IsUnitOfAdjunction` / `IsCounitOfAdjunction` + tighten existing `IsAdjunction` (closes #434)

Two new concepts in `:adjunction`, plus a meaningful tightening of the existing 4-param `IsAdjunction`. Per Mac Lane / Milewski: an adjunction is **defined** by natural transformations, not by raw arrows; the previous arrow-based form was structurally under-strict.

```cpp
// Tightened:
template <typename Left, typename Right, typename Unit, typename Counit>
concept IsAdjunction =
    HasAdjunctionShape<Left, Right> &&
    IsUnitOfAdjunction<Unit, Left, Right> &&
    IsCounitOfAdjunction<Counit, Left, Right>;
```

The triangle identities — `(εF) ∘ (Fη) = 1_F` and `(Gε) ∘ (ηG) = 1_G` — remain universal-property territory (engineer's honesty obligation).

The only consumer of the old form (`functor_test.cpp:138`) was updated to use `identity_transformation<IdF>` for the IdF ⊣ IdF self-adjunction witness.

### 3. Galois-connection / order-theoretic framing (closes #435)

Concept-only additions in `:adjunction` (co-located rather than split into a separate `:galois` partition — same theorem, just collapsed):
- `IsGaloisConnection<F, G, P, Q>` — the simplest adjunction in a poset, with the `f(x) ≤ y ⟺ x ≤ g(y)` signature reified.
- `IsClosureOperator<C, P>` — for the `g ∘ f` composition any Galois connection induces (idempotent + monotone + extensive).

Names truncated subtraction as the dual-of-our-choice (already documented in `docs/design/carrier-lattice.md` post-PR #433).

### 4. Carrier-lattice round-trip tests (`numbers/integer_test.cpp`)

New test file exercising `ℕ → ℤ → ℕ` paths through the variant-level operators introduced across PRs #433 / #437:
- Unary `-Cardinality` then `abs`: round-trip identity.
- Binary `Cardinality - Cardinality` then `abs`: same round-trip via the binary direction.
- `ℤ → ℕ → ℤ` folds sign — explicit witness that `abs` is **not** a bijection (the asymmetry making `(embed, abs)` a split mono / split epi rather than an isomorphism).
- Canonical zero round-trip (both directions).
- `ℵ_0` saturating round-trip.

## Commits

- `51d6449` — `feat(sets)`: abs as the retraction ℤ → ℕ (#436).
- `5c52b22` — `feat(category)`: IsUnitOfAdjunction / IsCounitOfAdjunction + tighten IsAdjunction (#434).
- `20f3d65` — `feat(category)`: IsGaloisConnection / IsClosureOperator — adjunctions in posets (#435).
- `20d2bcd` — `style(category)`: clang-format adjunction.cppm post-#435.
- `309f2b6` — `test(numbers)`: integer_test.cpp — ℕ → ℤ → ℕ carrier-lattice round-trips.

## Out of scope

- The full `carrier_arithmetic_promote_t<Op, T1, T2>` generic framework (post-existential-proof successor; remains a #432 / #362 follow-up).
- The constructive `monad_from_adjunction<F, U, Eta, Epsilon>` adapter realising the classical theorem that every adjunction induces a monad. The #434 tightening was the prerequisite; the bridge can land standalone.
- Quantifiers as adjoints (`∃ ⊣ Δ ⊣ ∀`) — Mac Lane / Lawvere reading; potentially a future ticket if it becomes load-bearing for `:logic`.
- Concrete `IsCanonicalEmbedding<Phi, S, T>` opt-in trait — that's #380's deliverable.

## References

- Issues #434, #435, #436 — full bodies for each ticket.
- PR #433 — Set-level + elementwise upward direction (closure-forcing); textbook-CT vocabulary anchoring.
- `docs/design/carrier-lattice.md` — design discussion of the carrier lattice; truncated-subtraction road-not-taken; honesty obligation framing.
- Mac Lane, *Categories for the Working Mathematician*, Ch. IV.
- Pierce, *Basic Category Theory for Computer Scientists*, §2.6.
- Bartosz Milewski, *Category Theory for Programmers*, Ch. on Adjunctions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)