### PR TITLE
test(numbers): pin #415 heterogeneous-comparison contract — variant ↔ std::integral witness tests + static_asserts

### DIFF
--- a/src/test/cpp/modules/dedekind/numbers/cardinality_test.cpp
+++ b/src/test/cpp/modules/dedekind/numbers/cardinality_test.cpp
@@ -222,6 +222,120 @@ TEST_CASE(
   }
 }
 
+// Compile-time contract pinning for #415: variant carrier ↔ std::integral
+// relational ops MUST be constexpr-evaluable.  These static_asserts lock
+// the contract that downstream halfspace machinery relies on (e.g.\
+// @c var<ℤ> @c > @c bound<-21> after the @c #402 retarget).
+namespace {
+constexpr auto sa_c5 = finite_cardinality(5);
+constexpr auto sa_c0 = finite_cardinality(0);
+constexpr auto sa_inf = Cardinality{ℵ_0{}};
+constexpr auto sa_z5 = finite_signed_cardinality(5);
+constexpr auto sa_z_neg3 = finite_signed_cardinality(-3);
+constexpr auto sa_z_pos_inf = SignedCardinality{PositiveInfinity{}};
+constexpr auto sa_z_neg_inf = SignedCardinality{NegativeInfinity{}};
+
+// --- Cardinality × std::integral (forward and reversed) ---
+static_assert(sa_c5 > 3u);
+static_assert(sa_c5 > 3);
+static_assert(sa_c5 < 10u);
+static_assert(sa_c5 >= 5);
+static_assert(sa_c5 <= 5u);
+static_assert(sa_c5 == 5u);
+static_assert(sa_c5 > -1);  // any Cardinality > any negative int
+static_assert(sa_c0 > -7);
+static_assert(sa_inf > 0u);
+static_assert(sa_inf > -1);
+// Reversed direction (T on LHS) — C++20 spaceship rewrite synthesis.
+static_assert(3u < sa_c5);
+static_assert(5u == sa_c5);
+static_assert(-1 < sa_inf);
+
+// --- SignedCardinality × std::integral (forward and reversed) ---
+static_assert(sa_z5 > -3);
+static_assert(sa_z5 < 10);
+static_assert(sa_z5 >= 5);
+static_assert(sa_z5 <= 5);
+static_assert(sa_z5 == 5);
+static_assert(sa_z_neg3 < 0);
+static_assert(sa_z_neg3 > -10);
+static_assert(sa_z_neg3 == -3);
+// ±ℵ_0 dominates any finite int unconditionally.
+static_assert(sa_z_pos_inf > 1'000'000);
+static_assert(sa_z_neg_inf < -1'000'000);
+// Reversed direction.
+static_assert(-3 < sa_z5);
+static_assert(0 > sa_z_neg3);
+static_assert(5 == sa_z5);
+}  // namespace
+
+TEST_CASE(
+    "Numbers: SignedCardinality heterogeneous comparison vs std::integral "
+    "(#415)",
+    "[numbers][cardinality][order][heterogeneous][signed]") {
+  const SignedCardinality pos_five = finite_signed_cardinality(5);
+  const SignedCardinality neg_three = finite_signed_cardinality(-3);
+  const SignedCardinality pos_inf{PositiveInfinity{}};
+  const SignedCardinality neg_inf{NegativeInfinity{}};
+  const SignedCardinality naz{NaZ{}};
+
+  SECTION("Positive finite vs signed and unsigned int") {
+    CHECK(pos_five > -3);
+    CHECK(pos_five > 0);
+    CHECK(pos_five > 4);
+    CHECK(pos_five < 6);
+    CHECK(pos_five >= 5);
+    CHECK(pos_five <= 5);
+    CHECK(pos_five == 5);
+    CHECK(pos_five > 4u);
+    CHECK(pos_five == 5u);
+  }
+  SECTION("Negative finite vs signed and unsigned int") {
+    CHECK(neg_three < 0);
+    CHECK(neg_three < -2);
+    CHECK(neg_three > -4);
+    CHECK(neg_three == -3);
+    CHECK_FALSE(neg_three == 3);
+    // Negative SignedCardinality is strictly less than any unsigned.
+    CHECK(neg_three < 0u);
+    CHECK(neg_three < 5u);
+  }
+  SECTION("±ℵ_0 dominates / is dominated unconditionally") {
+    CHECK(pos_inf > std::numeric_limits<int>::max());
+    CHECK(pos_inf > 0);
+    CHECK(pos_inf > -1);
+    CHECK(pos_inf > 0u);
+    CHECK_FALSE(pos_inf == 0);
+    CHECK(neg_inf < std::numeric_limits<int>::min());
+    CHECK(neg_inf < 0);
+    CHECK(neg_inf < -1);
+    CHECK_FALSE(neg_inf == 0);
+  }
+  SECTION("NaZ propagates as unordered: all relational ops false, == false") {
+    CHECK_FALSE(naz < 0);
+    CHECK_FALSE(naz <= 0);
+    CHECK_FALSE(naz > 0);
+    CHECK_FALSE(naz >= 0);
+    CHECK_FALSE(naz == 0);
+    CHECK(naz != 0);  // unordered semantics: NaZ is not equal to anything
+  }
+  SECTION("bool is std::integral on the SignedCardinality side too") {
+    const SignedCardinality one = finite_signed_cardinality(1);
+    const SignedCardinality zero = finite_signed_cardinality(0);
+    CHECK(one == true);
+    CHECK(zero == false);
+    CHECK(one > false);
+    CHECK(zero < true);
+  }
+  SECTION("Rhs-first direction synthesised by C++20 rewrite rules") {
+    CHECK(-3 < pos_five);
+    CHECK(0u < pos_five);
+    CHECK(5 == pos_five);
+    CHECK(0 > neg_three);
+    CHECK(-3 == neg_three);
+  }
+}
+
 TEST_CASE("Numbers: Cardinality homogeneous operator surface (#424)",
           "[numbers][cardinality][operators]") {
   const Cardinality three = finite_cardinality(3);

--- a/src/test/cpp/modules/dedekind/numbers/cardinality_test.cpp
+++ b/src/test/cpp/modules/dedekind/numbers/cardinality_test.cpp
@@ -224,8 +224,8 @@ TEST_CASE(
 
 // Compile-time contract pinning for #415: variant carrier ↔ std::integral
 // relational ops MUST be constexpr-evaluable.  These static_asserts lock
-// the contract that downstream halfspace machinery relies on (e.g.\
-// @c var<ℤ> @c > @c bound<-21> after the @c #402 retarget).
+// the contract that downstream halfspace machinery relies on — for
+// example, @c var<ℤ> @c > @c bound<-21> after the @c #402 retarget.
 namespace {
 constexpr auto sa_c5 = finite_cardinality(5);
 constexpr auto sa_c0 = finite_cardinality(0);
@@ -252,6 +252,7 @@ static_assert(5u == sa_c5);
 static_assert(-1 < sa_inf);
 
 // --- SignedCardinality × std::integral (forward and reversed) ---
+//   * signed-int axis
 static_assert(sa_z5 > -3);
 static_assert(sa_z5 < 10);
 static_assert(sa_z5 >= 5);
@@ -260,13 +261,27 @@ static_assert(sa_z5 == 5);
 static_assert(sa_z_neg3 < 0);
 static_assert(sa_z_neg3 > -10);
 static_assert(sa_z_neg3 == -3);
-// ±ℵ_0 dominates any finite int unconditionally.
+//   * unsigned-int axis (positive finite + negative-finite-vs-unsigned)
+static_assert(sa_z5 > 4u);
+static_assert(sa_z5 == 5u);
+static_assert(sa_z_neg3 < 0u);  // negative SignedCardinality < any unsigned
+static_assert(sa_z_neg3 < 5u);
+//   * bool axis
+static_assert(sa_z5 > false);
+static_assert(sa_z5 > true);
+static_assert(finite_signed_cardinality(1) == true);
+static_assert(finite_signed_cardinality(0) == false);
+//   * ±ℵ_0 dominates any finite int unconditionally
 static_assert(sa_z_pos_inf > 1'000'000);
+static_assert(sa_z_pos_inf > std::numeric_limits<unsigned>::max());
 static_assert(sa_z_neg_inf < -1'000'000);
-// Reversed direction.
+//   * reversed direction (T on LHS)
 static_assert(-3 < sa_z5);
 static_assert(0 > sa_z_neg3);
 static_assert(5 == sa_z5);
+static_assert(4u < sa_z5);
+static_assert(5u == sa_z5);
+static_assert(false < sa_z5);
 }  // namespace
 
 TEST_CASE(


### PR DESCRIPTION
## Summary

Closes #415 (recon + contract pinning, not new operator surface).

The variant ↔ `std::integral` heterogeneous `<=>` overloads needed by #415 were already shipped in PR #431 (and earlier). This PR locks the contract with explicit witness tests so it stays frozen once #402 retargets `ℕ = Cardinality` and `ℤ = SignedCardinality`.

The #415 issue spec asked for explicit `operator<` / `<=` / `>` / `>=` overloads, but **C++20's spaceship-rewrite synthesises all four uniformly from the existing `<=>` overloads** — adding redundant single-purpose overloads would just be noise. The witness tests here document and freeze the working state instead.

## What lands

Two new test surfaces in [cardinality_test.cpp](src/test/cpp/modules/dedekind/numbers/cardinality_test.cpp):

### 1. Compile-time `static_assert` block (anonymous namespace at file scope)

~25 `static_assert`s covering both variant carriers vs signed / unsigned `std::integral`, in both forward and reversed directions:

- `Cardinality` × `unsigned` / `signed`: forward + reversed, including `ℵ_0` dominating.
- `SignedCardinality` × `signed` / `unsigned`: forward + reversed, including `±ℵ_0` dominating / dominated unconditionally.

These guarantee the comparisons remain **constexpr-evaluable** — the precondition for halfspace pivots like `bound<-21>` to keep working post-#402.

### 2. Runtime `TEST_CASE` for `SignedCardinality × std::integral`

The `Cardinality` side already had a #415-tagged `TEST_CASE` from PR #431; this adds the parallel `SignedCardinality` coverage:

- Positive finite vs signed and unsigned int.
- Negative finite vs signed and unsigned int (negative `SignedCardinality` < any `unsigned`).
- `±ℵ_0` dominates / is dominated unconditionally.
- `NaZ` propagates as unordered: all relational ops false, `==` false, `!=` true.
- `bool` integral path (no `make_unsigned_t<bool>` ill-formedness).
- Rhs-first direction synthesised by C++20 rewrite rules.

## Test results

64 assertions across 2 `TEST_CASE`s pass locally. No regressions on the rest of the test suite.

## Out of scope

- Single-purpose `operator<` / `<=` / `>` / `>=` overloads (redundant under spaceship).
- The `embed_K3_ℤ` retarget (#430) and `realize_signed_to_machine` extraction arrow (#429) — separate #402 prerequisites.
- The cascade sweep (#416) — depends on this contract being locked.

## References

- Issue #415 — heterogeneous comparison spec.
- PR #431 — original `<=>` overloads (`Cardinality / SignedCardinality × std::integral` and `× std::floating_point`).
- Issue #402 — umbrella for the variant-carrier retarget; this PR is one of the prerequisites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)