### PR TITLE
feat(numbers): retarget embed_K3_ℤ to land on SignedCardinality (closes #430)

### DIFF
--- a/src/main/modules/dedekind/numbers/integer.cppm
+++ b/src/main/modules/dedekind/numbers/integer.cppm
@@ -418,21 +418,29 @@ export inline constexpr auto embed_ℕ_ℤ = arrow<unsigned, int>(
     [](const unsigned& x) noexcept { return static_cast<int>(x); });
 
 /**
- * @brief Canonical embedding K3 ↪ ℤ: Ternary → int.
- * @details Maps False -> -1, Unknown -> 0, True -> 1.
+ * @brief Canonical embedding K3 ↪ ℤ: Ternary → SignedCardinality.
+ * @details Maps False → -1, Unknown → 0, True → 1.  Lands on the
+ *          variant ℤ-proxy carrier @c SignedCardinality (closes #430,
+ *          a #402 prerequisite); the previous @c int codomain made
+ *          the K3 → variant-ℤ chain require an explicit machine-side
+ *          extraction step.  The unreachable default returns @c NaZ
+ *          for IEEE-NaN-style propagation if a non-canonical
+ *          @c Ternary value were ever constructed (cannot happen in
+ *          practice — @c Ternary is a closed enum).
  */
 export inline constexpr auto embed_K3_ℤ =
-    arrow<Ternary, int>([](const Ternary& t) noexcept {
-      switch (t) {
-        case Ternary::False:
-          return -1;
-        case Ternary::Unknown:
-          return 0;
-        case Ternary::True:
-          return 1;
-      }
-      return 0;
-    });
+    arrow<Ternary, dedekind::sets::SignedCardinality>(
+        [](const Ternary& t) noexcept -> dedekind::sets::SignedCardinality {
+          switch (t) {
+            case Ternary::False:
+              return dedekind::sets::finite_signed_cardinality(-1);
+            case Ternary::Unknown:
+              return dedekind::sets::finite_signed_cardinality(0);
+            case Ternary::True:
+              return dedekind::sets::finite_signed_cardinality(1);
+          }
+          return dedekind::sets::SignedCardinality{dedekind::sets::NaZ{}};
+        });
 
 /**
  * @brief Canonical embedding of any std::unsigned_integral into formal ℕ.

--- a/src/main/modules/dedekind/numbers/integer.cppm
+++ b/src/main/modules/dedekind/numbers/integer.cppm
@@ -378,7 +378,13 @@ struct IntegersOf {
     return operator()(static_cast<int>(n));
   }
 
-  // Embedded Ternary (via embed_K3_ℤ)
+  // Embedded Ternary: False ↦ -1, Unknown ↦ 0, True ↦ 1.  Delegates
+  // to the int overload directly rather than routing through @c
+  // embed_K3_ℤ — post-#430 that arrow lands on @c SignedCardinality
+  // (the variant ℤ-proxy), whereas this @c IntegersOf<> predicate-set
+  // is parameterised on the int machine carrier.  The {-1, 0, 1}
+  // mapping is the same; the implementations are deliberately
+  // separate to keep this overload at the machine-int layer.
   constexpr typename L::Ω operator()(Ternary t) const {
     switch (t) {
       case Ternary::False:

--- a/src/test/cpp/modules/dedekind/numbers/tower_test.cpp
+++ b/src/test/cpp/modules/dedekind/numbers/tower_test.cpp
@@ -47,8 +47,8 @@ static_assert(
     std::same_as<Cod<std::decay_t<decltype(embed_ℕ_ℤ)>>, machine_integer>);
 
 static_assert(std::same_as<Dom<std::decay_t<decltype(embed_K3_ℤ)>>, Ternary>);
-static_assert(
-    std::same_as<Cod<std::decay_t<decltype(embed_K3_ℤ)>>, machine_integer>);
+static_assert(std::same_as<Cod<std::decay_t<decltype(embed_K3_ℤ)>>,
+                           dedekind::sets::SignedCardinality>);
 
 static_assert(
     std::same_as<Dom<std::decay_t<decltype(embed_ℤ_ℚ<>)>>, machine_integer>);
@@ -145,7 +145,13 @@ TEST_CASE("Tower: ℕ ↪ ℤ via embed_ℕ_ℤ", "[numbers][tower][embedding]")
 // ---------------------------------------------------------------------------
 
 TEST_CASE("Tower: K3 ↪ ℤ via embed_K3_ℤ", "[numbers][tower][embedding]") {
-  const auto integers = ambient_set<int>([](const int&) { return true; });
+  // Post-#430: embed_K3_ℤ lands on the variant ℤ-proxy SignedCardinality
+  // rather than the int machine carrier.  The runtime equality checks
+  // below use the heterogeneous SignedCardinality × std::integral
+  // comparison contract pinned by #415 / PR #438; the ambient set is
+  // built directly on SignedCardinality.
+  const auto integers = ambient_set<dedekind::sets::SignedCardinality>(
+      [](const dedekind::sets::SignedCardinality&) { return true; });
 
   CHECK(embed_K3_ℤ(Ternary::False) == -1);
   CHECK(embed_K3_ℤ(Ternary::Unknown) == 0);
@@ -212,10 +218,22 @@ TEST_CASE("Tower: composed chain unsigned -> ℤ -> ℚ -> ℝ -> ℂ",
 
 TEST_CASE("Stress: Im(K3->ℤ) intersect positive-real ℂ",
           "[numbers][tower][embedding][intersection]") {
-  // Image of K3 in ℤ under canonical embedding: {-1, 0, 1}.
-  const int z_false = embed_K3_ℤ(Ternary::False);
-  const int z_unknown = embed_K3_ℤ(Ternary::Unknown);
-  const int z_true = embed_K3_ℤ(Ternary::True);
+  // Image of K3 in ℤ under canonical embedding: {-1, 0, 1}.  Post-#430
+  // @c embed_K3_ℤ lands on @c SignedCardinality; the heterogeneous
+  // @c == contract pinned by #415 / PR #438 lets us verify the image
+  // values directly.
+  CHECK(embed_K3_ℤ(Ternary::False) == -1);
+  CHECK(embed_K3_ℤ(Ternary::Unknown) == 0);
+  CHECK(embed_K3_ℤ(Ternary::True) == 1);
+
+  // FIXME(#429): bridging from @c SignedCardinality to the @c int-typed
+  // @c embed_ℤ_ℚ<> needs the @c realize_signed_to_machine extraction
+  // arrow (filed under #429 as a #402 prerequisite).  Until that lands,
+  // we feed the downstream tower the canonical int values directly —
+  // the variant-side embedding is verified by the @c CHECKs above.
+  const int z_false = -1;
+  const int z_unknown = 0;
+  const int z_true = 1;
 
   const auto embed_ℤ_ℂ = embed_ℤ_ℚ<> >> embed_ℚ_ℝ<> >> embed_ℝ_ℂ<>;
 


### PR DESCRIPTION
## Summary

Closes #430. A #402 prerequisite: retargets the canonical embedding K3 ↪ ℤ from `arrow<Ternary, int>` to `arrow<Ternary, SignedCardinality>` so the K3 → variant-ℤ chain composes without forcing every consumer through an explicit machine-side extraction step.

## What lands

### [integer.cppm](src/main/modules/dedekind/numbers/integer.cppm)

```cpp
export inline constexpr auto embed_K3_ℤ =
    arrow<Ternary, dedekind::sets::SignedCardinality>(
        [](const Ternary& t) noexcept {
          switch (t) {
            case Ternary::False:   return finite_signed_cardinality(-1);
            case Ternary::Unknown: return finite_signed_cardinality(0);
            case Ternary::True:    return finite_signed_cardinality(1);
          }
          return SignedCardinality{NaZ{}};  // unreachable; closed enum
        });
```

The unreachable default returns `NaZ` for IEEE-NaN-style propagation if a non-canonical `Ternary` value were ever constructed (cannot happen — `Ternary` is a closed enum, but the defined fallback satisfies `-Wreturn-type` cleanly). Monicity registration in `dedekind::category::is_monic_arrow_v` unchanged.

### [tower_test.cpp](src/test/cpp/modules/dedekind/numbers/tower_test.cpp)

- `Cod` static_assert flipped from `machine_integer` to `SignedCardinality`.
- `"K3 ↪ ℤ via embed_K3_ℤ"` runtime test: `ambient_set` switches to `SignedCardinality`; equality checks (`== -1`, `0`, `1`) work via the heterogeneous `SignedCardinality × std::integral` comparison contract pinned by #415 / PR #438.
- `"Stress: Im(K3->ℤ) intersect positive-real ℂ"` test composes K3 → ℂ via `embed_ℤ_ℚ<> >> embed_ℚ_ℝ<> >> embed_ℝ_ℂ<>` where `embed_ℤ_ℚ<>` still takes `int`. Bridging the variant-ℤ output to the int-typed downstream needs `realize_signed_to_machine`, filed under #429 as a #402 prerequisite. **`FIXME(#429)` breadcrumb added**; the variant-side embedding is verified by the `CHECK`s above, then canonical int values are fed downstream until #429 lands.

## Test results

Full `make compile` clean; 600 assertions across 85 `TEST_CASE`s pass in `test_numbers`.

## Blocks / unblocks

- **Closes** #430.
- **Blocked on** #429 (`realize_signed_to_machine` extraction arrow) for the K3 → ℂ stress-test composition to land structurally — currently bridged via canonical literals + `FIXME(#429)` breadcrumb.
- **Unblocks** part of #416 (cascade sweep) — embeddings shipped on the variant ℤ-proxy.

## References

- Issue #430 — the K3 retarget spec.
- PR #438 — heterogeneous `SignedCardinality × std::integral` comparison contract used by the test.
- Issue #402 — umbrella for the variant-carrier retarget.

🤖 Generated with [Claude Code](https://claude.com/claude-code)