### PR TITLE
feat(category): reify Initial F-Algebra + Terminal F-Coalgebra concepts (slice of #449)

### DIFF
--- a/src/main/modules/dedekind/category/category.cppm
+++ b/src/main/modules/dedekind/category/category.cppm
@@ -67,6 +67,9 @@ export import :action;
 
 // Level 2: The Bridge (Functorial Spine)
 export import :functor;
+export import :f_algebra;  // Initial F-algebra / terminal F-coalgebra
+                           // universal- property reification (Pierce §5; closes
+                           // #449)
 export import :natural;
 export import :adjunction;  // Free / Forgetful pair, IsAdjunction (Pierce-style
                             // separate section)

--- a/src/main/modules/dedekind/category/category.cppm
+++ b/src/main/modules/dedekind/category/category.cppm
@@ -68,7 +68,7 @@ export import :action;
 // Level 2: The Bridge (Functorial Spine)
 export import :functor;
 export import :f_algebra;  // Initial F-algebra / terminal F-coalgebra
-                           // universal- property reification (Pierce §5; closes
+                           // universal-property reification (Pierce §5; closes
                            // #449)
 export import :natural;
 export import :adjunction;  // Free / Forgetful pair, IsAdjunction (Pierce-style

--- a/src/main/modules/dedekind/category/f_algebra.cppm
+++ b/src/main/modules/dedekind/category/f_algebra.cppm
@@ -48,6 +48,19 @@
  * @c N via coproduct copairing on the standard injections @c inl @c
  * : @c 1 @c → @c 1 @c + @c N and @c inr @c : @c N @c → @c 1 @c + @c N.
  *
+ * The @c 1 in @c 1 @c + @c N is the @b terminal object of the
+ * ambient category — concretely, the @c category::One @c = @c
+ * std::monostate reified in the @c :limit partition (which carries
+ * @c IsTerminalObject<One> as a static_assert).  The categorical
+ * pattern @c IsInitialFAlgebra is itself one level up from the
+ * @c IsInitialObject reification in @c :limit (which pins
+ * @c category::Zero @c = @c std::nullptr_t as the initial in Set):
+ * the F-Alg category has its own initial object @c (μF, in), and
+ * @c IsInitialFAlgebra is the engineer's honesty obligation that
+ * a particular @c (A, α) is that initial object.  See
+ * @c f_algebra_test.cpp for the static_assert witnesses linking the
+ * two layers.
+ *
  * @section Honesty_Obligation
  *
  * As with @c :nno, C++ concepts cannot quantify over the universal
@@ -99,6 +112,7 @@ module;
 export module dedekind.category:f_algebra;
 
 export import :functor;
+import :limit;
 
 namespace dedekind::category {
 
@@ -162,5 +176,39 @@ concept IsInitialFAlgebra =
 export template <typename F, typename A, typename α>
 concept IsTerminalFCoalgebra =
     IsFCoalgebra<A, α, F> && is_terminal_f_coalgebra_v<F, A, α>;
+
+// Cross-partition invariants connecting @c :f_algebra to @c :limit.
+// These compose primitives from @c :limit ( @c One, @c Zero,
+// @c TerminalCategory, @c InitialCategory, @c unit<>, @c zero<>)
+// with the structural-shape concept @c IsFAlgebra from @c :functor.
+// The combinations are non-trivial — they fail to type-check if
+// either partition's invariants drift independently — and the
+// @c static_asserts here make the compiler the witness rather than
+// deferring the check to the test suite.
+
+// (1) The unique terminal-typed morphism @c unit<One>() :
+//     @c One @c → @c One is structurally the structure map of an
+//     F-algebra over @c identity_functor<TerminalCategory> with
+//     carrier @c One.  Composes @c :limit's terminal-object data
+//     ( @c One, @c TerminalCategory, @c unit<>) with @c :functor's
+//     @c identity_functor and @c IsFAlgebra.  Categorical
+//     content: the identity endomorphism on the terminal object is
+//     the canonical F-algebra structure map at carrier @c One.
+static_assert(
+    IsFAlgebra<One, decltype(unit<One>()), identity_functor<TerminalCategory>>,
+    "Bridge :f_algebra ↔ :limit: unit<One>() : One → One is structurally "
+    "the F-algebra structure map for identity_functor on TerminalCategory "
+    "with carrier One.  Fails fast if :limit's One / TerminalCategory or "
+    ":functor's IsFAlgebra / identity_functor invariants drift apart.");
+
+// (2) Dually, @c zero<Zero>() : @c Zero @c → @c Zero is structurally
+//     the structure map of an F-coalgebra over @c
+//     identity_functor<InitialCategory> with carrier @c Zero.  Same
+//     cross-partition invariant on the initial side.
+static_assert(IsFCoalgebra<Zero, decltype(zero<Zero>()),
+                           identity_functor<InitialCategory>>,
+              "Bridge :f_algebra ↔ :limit: zero<Zero>() : Zero → Zero is "
+              "structurally the F-coalgebra structure map for "
+              "identity_functor on InitialCategory with carrier Zero.");
 
 }  // namespace dedekind::category

--- a/src/main/modules/dedekind/category/f_algebra.cppm
+++ b/src/main/modules/dedekind/category/f_algebra.cppm
@@ -1,0 +1,168 @@
+/**
+ * @file dedekind/category/f_algebra.cppm
+ * @partition :f_algebra
+ * @module dedekind.category:f_algebra
+ * @brief Level 2 (Bridge): Universal-property reification of @b F-algebras
+ *        and @b F-coalgebras — the @b initial F-algebra (the carrier of
+ *        catamorphisms) and the @b terminal F-coalgebra (the carrier of
+ *        anamorphisms).  Closes the universal-property layer for #449.
+ *
+ * @copyright 2026 The Dedekind Authors
+ * Licensed under the Apache License, Version 2.0.
+ *
+ * @section FAlg_Universal_Property
+ *
+ * Pierce §5 introduces F-algebras and F-coalgebras immediately after
+ * functors and before natural transformations because they are the
+ * load-bearing concept that grounds recursive types and the universal
+ * property of recursion.  This project's @c :functor partition already
+ * carries the @b structural-shape concepts:
+ *
+ *   @c IsFAlgebra<Carrier, Structure, Functor>  — structure map
+ *   @c F<A> @c → @c A.
+ *
+ *   @c IsFCoalgebra<Carrier, Structure, Functor> — structure map
+ *   @c A @c → @c F<A>.
+ *
+ * What was missing — and what this partition adds — is the
+ * @b universal-property layer:
+ *
+ *   @b Initial @b F-algebra: an F-algebra @c (A, α) is initial if for
+ *   every other F-algebra @c (B, β) there exists a @b unique morphism
+ *   @c h @c : @c A @c → @c B with @c h @c ∘ @c α @c = @c β @c ∘ @c F(h).
+ *   That unique morphism is the @b catamorphism (fold).
+ *
+ *   @b Terminal @b F-coalgebra: dually; the unique morphism is the
+ *   @b anamorphism (unfold).
+ *
+ * @section Bridge_to_NNO
+ *
+ * The @c :nno partition reifies Lawvere's NNO universal property as
+ * the @c (z, s) shape — pedagogically the more recognisable form for
+ * a working mathematician.  The @b textbook reading of NNO is that it
+ * is the @b initial @b F-algebra for @c F(X) @c = @c 1 @c + @c X (the
+ * "Maybe" endofunctor; Pierce §5.4, Mac Lane III–VI).  This partition
+ * exposes that reading as a separate concept; the two universal
+ * properties are operationally equivalent — the @c (z, s) pair is
+ * exactly the structure map @c 1 @c + @c N @c → @c N.
+ *
+ * @section Honesty_Obligation
+ *
+ * As with @c :nno and @c algebra:initial_ring, C++ concepts cannot
+ * quantify over the universal property's @b uniqueness clause.  The
+ * structural shape ( @c IsFAlgebra / @c IsFCoalgebra in @c :functor)
+ * is what the type system can pin; the universal-property concepts
+ * here are @b opt-in @b traits that carriers must explicitly register
+ * via @c is_initial_f_algebra_v / @c is_terminal_f_coalgebra_v.  The
+ * trait is the engineer's honesty obligation: declaring it asserts
+ * that the carrier truly satisfies the universal property, and the
+ * paper's @b ethical @b register applies (Wadler 2015, NSPE Code of
+ * Ethics).
+ *
+ * @section Categorical_Duality
+ *
+ * The dual pair carries the recursion ↔ corecursion split
+ * structurally — no catamorphism without an anamorphism.  Both halves
+ * land in this partition (concepts only); the operational discharge
+ * ( @c cata / @c ana / @c hylo combinators) is deferred to a sibling
+ * partition under the same issue ladder.
+ *
+ * | side                         | universal property                | unique
+ * morphism      |
+ * |------------------------------|------------------------------------|----------------------|
+ * | initial F-algebra @c (μF, in) | initial in F-Alg                  | @c cata
+ * (fold)       | | terminal F-coalgebra @c (νF, out) | terminal in F-Coalg | @c
+ * ana  (unfold)     |
+ *
+ * @note "An algebra over an endofunctor F is just a structure map
+ *        @c F(A) @c → @c A; what makes some particular algebra
+ *        @b interesting is that other algebras factor through it
+ *        uniquely."
+ *       — paraphrase of Pierce 1991, §5.
+ *
+ * @see Pierce, B.C. (1991) "Basic Category Theory for Computer
+ *       Scientists" §5.
+ * @see Mac Lane, S. (1971) "Categories for the Working Mathematician"
+ *       III–VI.
+ * @see Meijer, E., Fokkinga, M., Paterson, R. (1991) "Functional
+ *       Programming with Bananas, Lenses, Envelopes and Barbed Wire"
+ *       (FPCA).
+ */
+module;
+
+#include <concepts>
+#include <type_traits>
+
+export module dedekind.category:f_algebra;
+
+import :functor;
+
+namespace dedekind::category {
+
+// Re-export the structural-shape concepts and witnesses from @c
+// :functor so the universal-property layer + structural-shape layer
+// share a single namespace surface.  The structural shapes
+// @c IsFAlgebra / @c IsFCoalgebra and the @c f_algebra / @c f_coalgebra
+// witness types remain authored in @c :functor (they were there
+// first); this partition is their universal-property dual.
+//
+// (The aliases below are stylistic only — they keep the partition's
+// header surface coherent.  Direct use of @c IsFAlgebra etc. via
+// @c dedekind.category continues to work since both partitions are
+// re-exported by the umbrella.)
+
+/**
+ * @brief Opt-in trait: does carrier @c A witness the @b initial
+ *        F-algebra universal property for endofunctor @c F with
+ *        structure map @c Alpha?
+ *
+ * @details Defaults to @c false.  Carriers register by partial-
+ * specialising this template to @c true at the point where they
+ * have the operational evidence (typically near the structural
+ * @c IsFAlgebra witness).  The trait is the engineer's honesty
+ * obligation: declaring it asserts that the carrier truly satisfies
+ * the universal property's existence + uniqueness clause.
+ */
+export template <typename F, typename A, typename Alpha>
+inline constexpr bool is_initial_f_algebra_v = false;
+
+/**
+ * @brief Opt-in trait: does carrier @c A witness the @b terminal
+ *        F-coalgebra universal property for endofunctor @c F with
+ *        structure map @c Alpha?
+ */
+export template <typename F, typename A, typename Alpha>
+inline constexpr bool is_terminal_f_coalgebra_v = false;
+
+/**
+ * @concept IsInitialFAlgebra
+ * @brief Carrier @c A is the initial F-algebra for endofunctor @c F
+ *        with structure map @c Alpha.
+ *
+ * @details Combines the structural-shape clause @c IsFAlgebra (from
+ * @c :functor) with the universal-property opt-in trait above.  The
+ * structural part is mechanically checked; the universal-property
+ * part is the engineer's honesty obligation.
+ *
+ * The catamorphism @c cata(β) @c : @c A @c → @c B for any F-algebra
+ * @c (B, β) is the unique morphism guaranteed by initiality; its
+ * operational discharge is filed as a sibling concern.
+ */
+export template <typename F, typename A, typename Alpha>
+concept IsInitialFAlgebra =
+    IsFAlgebra<A, Alpha, F> && is_initial_f_algebra_v<F, A, Alpha>;
+
+/**
+ * @concept IsTerminalFCoalgebra
+ * @brief Carrier @c A is the terminal F-coalgebra for endofunctor
+ *        @c F with structure map @c Alpha.
+ *
+ * @details Dual to @c IsInitialFAlgebra.  The anamorphism
+ * @c ana(β) @c : @c B @c → @c A for any F-coalgebra @c (B, β) is the
+ * unique morphism guaranteed by terminality.
+ */
+export template <typename F, typename A, typename Alpha>
+concept IsTerminalFCoalgebra =
+    IsFCoalgebra<A, Alpha, F> && is_terminal_f_coalgebra_v<F, A, Alpha>;
+
+}  // namespace dedekind::category

--- a/src/main/modules/dedekind/category/f_algebra.cppm
+++ b/src/main/modules/dedekind/category/f_algebra.cppm
@@ -43,21 +43,24 @@
  * is the @b initial @b F-algebra for @c F(X) @c = @c 1 @c + @c X (the
  * "Maybe" endofunctor; Pierce §5.4, Mac Lane III–VI).  This partition
  * exposes that reading as a separate concept; the two universal
- * properties are operationally equivalent — the @c (z, s) pair is
- * exactly the structure map @c 1 @c + @c N @c → @c N.
+ * properties are operationally equivalent — the @c (z, s) pair
+ * @b induces the structure map @c [z, @c s] @c : @c 1 @c + @c N @c →
+ * @c N via coproduct copairing on the standard injections @c inl @c
+ * : @c 1 @c → @c 1 @c + @c N and @c inr @c : @c N @c → @c 1 @c + @c N.
  *
  * @section Honesty_Obligation
  *
- * As with @c :nno and @c algebra:initial_ring, C++ concepts cannot
- * quantify over the universal property's @b uniqueness clause.  The
- * structural shape ( @c IsFAlgebra / @c IsFCoalgebra in @c :functor)
- * is what the type system can pin; the universal-property concepts
- * here are @b opt-in @b traits that carriers must explicitly register
- * via @c is_initial_f_algebra_v / @c is_terminal_f_coalgebra_v.  The
+ * As with @c :nno, C++ concepts cannot quantify over the universal
+ * property's @b uniqueness clause.  The structural shape ( @c
+ * IsFAlgebra / @c IsFCoalgebra in @c :functor) is what the type
+ * system can pin; the universal-property concepts here are @b opt-in
+ * @b traits that carriers must explicitly register via
+ * @c is_initial_f_algebra_v / @c is_terminal_f_coalgebra_v.  The
  * trait is the engineer's honesty obligation: declaring it asserts
  * that the carrier truly satisfies the universal property, and the
  * paper's @b ethical @b register applies (Wadler 2015, NSPE Code of
- * Ethics).
+ * Ethics).  An identical opt-in pattern is used by @c
+ * algebra:initial_ring (PR #451) for @c ℤ as the initial ring.
  *
  * @section Categorical_Duality
  *
@@ -67,12 +70,12 @@
  * ( @c cata / @c ana / @c hylo combinators) is deferred to a sibling
  * partition under the same issue ladder.
  *
- * | side                         | universal property                | unique
- * morphism      |
- * |------------------------------|------------------------------------|----------------------|
- * | initial F-algebra @c (μF, in) | initial in F-Alg                  | @c cata
- * (fold)       | | terminal F-coalgebra @c (νF, out) | terminal in F-Coalg | @c
- * ana  (unfold)     |
+ * @code
+ * | side               | UP                  | unique morphism |
+ * |--------------------|---------------------|-----------------|
+ * | initial (μF, in)   | initial in F-Alg    | cata (fold)     |
+ * | terminal (νF, out) | terminal in F-Coalg | ana  (unfold)   |
+ * @endcode
  *
  * @note "An algebra over an endofunctor F is just a structure map
  *        @c F(A) @c → @c A; what makes some particular algebra
@@ -95,26 +98,21 @@ module;
 
 export module dedekind.category:f_algebra;
 
-import :functor;
+export import :functor;
 
 namespace dedekind::category {
 
-// Re-export the structural-shape concepts and witnesses from @c
-// :functor so the universal-property layer + structural-shape layer
-// share a single namespace surface.  The structural shapes
-// @c IsFAlgebra / @c IsFCoalgebra and the @c f_algebra / @c f_coalgebra
-// witness types remain authored in @c :functor (they were there
-// first); this partition is their universal-property dual.
-//
-// (The aliases below are stylistic only — they keep the partition's
-// header surface coherent.  Direct use of @c IsFAlgebra etc. via
-// @c dedekind.category continues to work since both partitions are
-// re-exported by the umbrella.)
+// The structural-shape concepts @c IsFAlgebra / @c IsFCoalgebra and
+// the @c f_algebra / @c f_coalgebra witness types are authored in
+// @c :functor (they were there first).  This partition imports them
+// transitively via @c export @c import @c :functor above so the
+// universal-property layer + structural-shape layer share a single
+// namespace surface for downstream callers.
 
 /**
  * @brief Opt-in trait: does carrier @c A witness the @b initial
  *        F-algebra universal property for endofunctor @c F with
- *        structure map @c Alpha?
+ *        structure map @c α?
  *
  * @details Defaults to @c false.  Carriers register by partial-
  * specialising this template to @c true at the point where they
@@ -123,21 +121,21 @@ namespace dedekind::category {
  * obligation: declaring it asserts that the carrier truly satisfies
  * the universal property's existence + uniqueness clause.
  */
-export template <typename F, typename A, typename Alpha>
+export template <typename F, typename A, typename α>
 inline constexpr bool is_initial_f_algebra_v = false;
 
 /**
  * @brief Opt-in trait: does carrier @c A witness the @b terminal
  *        F-coalgebra universal property for endofunctor @c F with
- *        structure map @c Alpha?
+ *        structure map @c α?
  */
-export template <typename F, typename A, typename Alpha>
+export template <typename F, typename A, typename α>
 inline constexpr bool is_terminal_f_coalgebra_v = false;
 
 /**
  * @concept IsInitialFAlgebra
  * @brief Carrier @c A is the initial F-algebra for endofunctor @c F
- *        with structure map @c Alpha.
+ *        with structure map @c α.
  *
  * @details Combines the structural-shape clause @c IsFAlgebra (from
  * @c :functor) with the universal-property opt-in trait above.  The
@@ -148,21 +146,21 @@ inline constexpr bool is_terminal_f_coalgebra_v = false;
  * @c (B, β) is the unique morphism guaranteed by initiality; its
  * operational discharge is filed as a sibling concern.
  */
-export template <typename F, typename A, typename Alpha>
+export template <typename F, typename A, typename α>
 concept IsInitialFAlgebra =
-    IsFAlgebra<A, Alpha, F> && is_initial_f_algebra_v<F, A, Alpha>;
+    IsFAlgebra<A, α, F> && is_initial_f_algebra_v<F, A, α>;
 
 /**
  * @concept IsTerminalFCoalgebra
  * @brief Carrier @c A is the terminal F-coalgebra for endofunctor
- *        @c F with structure map @c Alpha.
+ *        @c F with structure map @c α.
  *
  * @details Dual to @c IsInitialFAlgebra.  The anamorphism
  * @c ana(β) @c : @c B @c → @c A for any F-coalgebra @c (B, β) is the
  * unique morphism guaranteed by terminality.
  */
-export template <typename F, typename A, typename Alpha>
+export template <typename F, typename A, typename α>
 concept IsTerminalFCoalgebra =
-    IsFCoalgebra<A, Alpha, F> && is_terminal_f_coalgebra_v<F, A, Alpha>;
+    IsFCoalgebra<A, α, F> && is_terminal_f_coalgebra_v<F, A, α>;
 
 }  // namespace dedekind::category

--- a/src/main/modules/dedekind/category/nno.cppm
+++ b/src/main/modules/dedekind/category/nno.cppm
@@ -105,11 +105,13 @@ namespace dedekind::category {
  * F-algebras of @c F(X) @c = @c 1 @c + @c X) is reified in the
  * sibling partition @c :f_algebra (closes the universal-property
  * layer for #449; Pierce §5.4, Mac Lane III–VI).  The two readings
- * are operationally equivalent — the @c (z, s) pair pinned here is
- * exactly the structure map @c 1 @c + @c N @c → @c N when @c 1 @c +
- * is encoded as the coproduct.  This partition focuses on the
- * @c (z, s) shape since it is the more directly recognisable one
- * to a working mathematician.
+ * are operationally equivalent — the @c (z, s) pair pinned here
+ * @b induces the structure map @c [z, @c s] @c : @c 1 @c + @c N @c →
+ * @c N via coproduct copairing on the standard injections
+ * @c inl @c : @c 1 @c → @c 1 @c + @c N and
+ * @c inr @c : @c N @c → @c 1 @c + @c N.  This partition focuses on
+ * the @c (z, s) shape since it is the more directly recognisable
+ * one to a working mathematician.
  *
  * @tparam N The carrier object.
  * @tparam Z A nullary callable @c Z : 1 → N (the zero element).

--- a/src/main/modules/dedekind/category/nno.cppm
+++ b/src/main/modules/dedekind/category/nno.cppm
@@ -102,10 +102,14 @@ namespace dedekind::category {
  * presentation: @c Z(), @c S(Z()), @c S(S(Z())), ...
  *
  * The dual shape concept on the @b Functor side (NNOs as initial
- * algebras of @c F(X) @c = @c 1 @c + @c X) is a natural sibling and
- * is filed for follow-up; this partition focuses on the universal-
- * property shape since it is the more directly recognisable one to
- * a working mathematician.
+ * F-algebras of @c F(X) @c = @c 1 @c + @c X) is reified in the
+ * sibling partition @c :f_algebra (closes the universal-property
+ * layer for #449; Pierce §5.4, Mac Lane III–VI).  The two readings
+ * are operationally equivalent — the @c (z, s) pair pinned here is
+ * exactly the structure map @c 1 @c + @c N @c → @c N when @c 1 @c +
+ * is encoded as the coproduct.  This partition focuses on the
+ * @c (z, s) shape since it is the more directly recognisable one
+ * to a working mathematician.
  *
  * @tparam N The carrier object.
  * @tparam Z A nullary callable @c Z : 1 → N (the zero element).

--- a/src/test/cpp/modules/dedekind/category/f_algebra_test.cpp
+++ b/src/test/cpp/modules/dedekind/category/f_algebra_test.cpp
@@ -33,13 +33,17 @@ using namespace dedekind::category;
 // ===========================================================================
 
 namespace {
-// Reuse the existing IdF setup from functor_test.cpp so this suite
-// stands on its own without leaking helpers.
-using IntCat = DiscreteCategory<int>;
-using IdF = identity_functor<IntCat>;
+// Use @c unsigned to keep the toy successor / halve shape aligned
+// with the textbook @c F(X) @c = @c 1 @c + @c X reading on naturals
+// (@c unsigned wraps under overflow, which is well-defined; @c int
+// would have signed-overflow UB).  The successor map @c x @c ↦ @c
+// x @c + @c 1 is the structural Peano-style step the universal-
+// property concept ranges over.
+using NatCat = DiscreteCategory<unsigned>;
+using IdF = identity_functor<NatCat>;
 
-constexpr auto successor_arrow = arrow([](int x) { return x + 1; });
-constexpr auto halve_arrow = arrow([](int x) { return x / 2; });
+constexpr auto successor_arrow = arrow([](unsigned x) { return x + 1u; });
+constexpr auto halve_arrow = arrow([](unsigned x) { return x / 2u; });
 using SuccArrow = std::decay_t<decltype(successor_arrow)>;
 using HalveArrow = std::decay_t<decltype(halve_arrow)>;
 }  // namespace
@@ -52,16 +56,16 @@ TEST_CASE(
   // universal-property concept @c IsInitialFAlgebra does not, since
   // initiality is the engineer's honesty obligation and must be
   // explicitly registered.
-  STATIC_CHECK(IsFAlgebra<int, SuccArrow, IdF>);
-  STATIC_CHECK(!is_initial_f_algebra_v<IdF, int, SuccArrow>);
-  STATIC_CHECK(!IsInitialFAlgebra<IdF, int, SuccArrow>);
+  STATIC_CHECK(IsFAlgebra<unsigned, SuccArrow, IdF>);
+  STATIC_CHECK(!is_initial_f_algebra_v<IdF, unsigned, SuccArrow>);
+  STATIC_CHECK(!IsInitialFAlgebra<IdF, unsigned, SuccArrow>);
 }
 
 TEST_CASE("f_algebra: IsTerminalFCoalgebra opt-in trait defaults to false",
           "[category][f_algebra][terminal][negative]") {
-  STATIC_CHECK(IsFCoalgebra<int, HalveArrow, IdF>);
-  STATIC_CHECK(!is_terminal_f_coalgebra_v<IdF, int, HalveArrow>);
-  STATIC_CHECK(!IsTerminalFCoalgebra<IdF, int, HalveArrow>);
+  STATIC_CHECK(IsFCoalgebra<unsigned, HalveArrow, IdF>);
+  STATIC_CHECK(!is_terminal_f_coalgebra_v<IdF, unsigned, HalveArrow>);
+  STATIC_CHECK(!IsTerminalFCoalgebra<IdF, unsigned, HalveArrow>);
 }
 
 // ===========================================================================

--- a/src/test/cpp/modules/dedekind/category/f_algebra_test.cpp
+++ b/src/test/cpp/modules/dedekind/category/f_algebra_test.cpp
@@ -1,0 +1,112 @@
+/**
+ * @file f_algebra_test.cpp
+ * @brief Test suite for the @c category:f_algebra partition (closes
+ *        the universal-property layer for #449).
+ *
+ * @section Scope
+ * Exercises the universal-property reification of F-algebras:
+ *
+ *   1. @c IsInitialFAlgebra<F, A, Alpha> — opt-in trait defaults to
+ *      false; carriers must explicitly register the universal-
+ *      property witness.  The structural-shape clause @c IsFAlgebra
+ *      (in @c :functor) is mechanically checked; the universal-
+ *      property uniqueness clause is the engineer's honesty
+ *      obligation.
+ *
+ *   2. @c IsTerminalFCoalgebra<F, A, Alpha> — dual.
+ *
+ * The Cardinality witness ( @c Cardinality is the initial F-algebra
+ * for @c F(X) @c = @c 1 @c + @c X) requires the @c 1 @c + @c X
+ * endofunctor encoding and is filed as a sibling concern.  This
+ * suite pins the concept-layer behaviour: opt-in, defaults to false,
+ * fires on explicit registration.
+ */
+#include <catch2/catch_test_macros.hpp>
+
+import dedekind.category;
+
+using namespace dedekind::category;
+
+// ===========================================================================
+// (1) Default: opt-in trait is false; concepts do not fire without
+//     explicit registration.
+// ===========================================================================
+
+namespace {
+// Reuse the existing IdF setup from functor_test.cpp so this suite
+// stands on its own without leaking helpers.
+using IntCat = DiscreteCategory<int>;
+using IdF = identity_functor<IntCat>;
+
+constexpr auto successor_arrow = arrow([](int x) { return x + 1; });
+constexpr auto halve_arrow = arrow([](int x) { return x / 2; });
+using SuccArrow = std::decay_t<decltype(successor_arrow)>;
+using HalveArrow = std::decay_t<decltype(halve_arrow)>;
+}  // namespace
+
+TEST_CASE(
+    "f_algebra: IsInitialFAlgebra opt-in trait defaults to false (no "
+    "universal-property witness without explicit registration)",
+    "[category][f_algebra][initial][negative]") {
+  // Structural shape fires ( @c IsFAlgebra in @c :functor) — but the
+  // universal-property concept @c IsInitialFAlgebra does not, since
+  // initiality is the engineer's honesty obligation and must be
+  // explicitly registered.
+  STATIC_CHECK(IsFAlgebra<int, SuccArrow, IdF>);
+  STATIC_CHECK(!is_initial_f_algebra_v<IdF, int, SuccArrow>);
+  STATIC_CHECK(!IsInitialFAlgebra<IdF, int, SuccArrow>);
+}
+
+TEST_CASE("f_algebra: IsTerminalFCoalgebra opt-in trait defaults to false",
+          "[category][f_algebra][terminal][negative]") {
+  STATIC_CHECK(IsFCoalgebra<int, HalveArrow, IdF>);
+  STATIC_CHECK(!is_terminal_f_coalgebra_v<IdF, int, HalveArrow>);
+  STATIC_CHECK(!IsTerminalFCoalgebra<IdF, int, HalveArrow>);
+}
+
+// ===========================================================================
+// (2) Explicit registration fires the concept.
+// ===========================================================================
+//
+// A test-local toy carrier that opts in to both universal properties
+// for a fixed structure map.  The opt-in is what asserts the honesty
+// clause; the test simply pins that the concept fires once the
+// trait is registered.
+
+namespace test_local {
+struct ToyCarrier {
+  int value{};
+  constexpr bool operator==(ToyCarrier const&) const = default;
+};
+using ToyCat = DiscreteCategory<ToyCarrier>;
+using ToyIdF = identity_functor<ToyCat>;
+constexpr auto toy_alpha =
+    arrow([](ToyCarrier const& x) { return ToyCarrier{x.value + 1}; });
+using ToyAlpha = std::decay_t<decltype(toy_alpha)>;
+}  // namespace test_local
+
+namespace dedekind::category {
+template <>
+inline constexpr bool is_initial_f_algebra_v<
+    test_local::ToyIdF, test_local::ToyCarrier, test_local::ToyAlpha> = true;
+template <>
+inline constexpr bool is_terminal_f_coalgebra_v<
+    test_local::ToyIdF, test_local::ToyCarrier, test_local::ToyAlpha> = true;
+}  // namespace dedekind::category
+
+TEST_CASE("f_algebra: IsInitialFAlgebra fires on explicit opt-in registration",
+          "[category][f_algebra][initial][witness]") {
+  using namespace test_local;
+  STATIC_CHECK(IsFAlgebra<ToyCarrier, ToyAlpha, ToyIdF>);
+  STATIC_CHECK(is_initial_f_algebra_v<ToyIdF, ToyCarrier, ToyAlpha>);
+  STATIC_CHECK(IsInitialFAlgebra<ToyIdF, ToyCarrier, ToyAlpha>);
+}
+
+TEST_CASE(
+    "f_algebra: IsTerminalFCoalgebra fires on explicit opt-in registration",
+    "[category][f_algebra][terminal][witness]") {
+  using namespace test_local;
+  STATIC_CHECK(IsFCoalgebra<ToyCarrier, ToyAlpha, ToyIdF>);
+  STATIC_CHECK(is_terminal_f_coalgebra_v<ToyIdF, ToyCarrier, ToyAlpha>);
+  STATIC_CHECK(IsTerminalFCoalgebra<ToyIdF, ToyCarrier, ToyAlpha>);
+}


### PR DESCRIPTION
Closes the **concepts slice** of #449. The Cardinality witness (NNO ↔ initial F-algebra of `F(X) = 1 + X`) needs an endofunctor encoding for the Maybe-style shape and is filed as a sibling concern — see \"Out of scope\" below.

## What lands

- New `dedekind.category:f_algebra` partition wedged between `:functor` and `:natural` (Pierce §5 placement).
- `IsInitialFAlgebra<F, A, Alpha>` — carrier of catamorphisms; combines the structural-shape clause `IsFAlgebra` (already in \`:functor\`) with an opt-in `is_initial_f_algebra_v` honesty trait, matching the project's recurring engineering-honesty doctrine (cf. `IsNNO`, `IsInitialRing`).
- `IsTerminalFCoalgebra<F, A, Alpha>` — dual; carrier of anamorphisms.
- `:nno` header doc cross-references the F-algebra reading explicitly (Pierce §5.4, Mac Lane III–VI), naming the dual universal property without yet wiring up the witness.
- Test suite (4 cases / 12 assertions): default-false opt-in behaviour + concept firing on a toy carrier with explicit registration.

## What this PR explicitly **does not** ship

- **The Cardinality witness** (`Cardinality is the initial F-algebra of F(X) = 1 + X`). Requires the $F(X) = 1 + X$ endofunctor as a true `IsEndofunctor` (`Σ_cat == Τ_cat`). The existing `maybe_functor` does not satisfy that strict encoding (it's flagged as such at `functor.cppm:67-68`). Sibling issue to follow.
- **`cata` / `ana` / `hylo` operational combinators**. Filed under #449 as paired delivery once the witness lands.

## Local checklist

- [x] `make build` clean.
- [x] `ctest` 15/15 green; `f_algebra_test` 4/4 cases / 12/12 assertions pass.
- [ ] CI (will run on push).

## References

- #449 — parent issue (Initial F-Algebra + anamorphism circle of life).
- #447 — NNO reification (the natural predecessor).
- #451 — Initial Ring / Grothendieck reification (the structurally-equivalent move at the algebra level).
- Pierce 1991 §5; Mac Lane 1971 III–VI; Meijer/Fokkinga/Paterson 1991 (\"Bananas, Lenses, Envelopes and Barbed Wire\").

🤖 Generated with [Claude Code](https://claude.com/claude-code)