### PR TITLE
feat(category, sets, numbers, geometry): pedagogical-accessibility synonyms IsInjective / IsSurjective / IsBijective + abs_ as the project's first surjective arrow

### DIFF
--- a/src/main/modules/dedekind/category/morphism.cppm
+++ b/src/main/modules/dedekind/category/morphism.cppm
@@ -683,4 +683,76 @@ concept IsBijectiveArrow = IsMonicArrow<E> && IsEpicArrow<E>;
 static_assert(IsBijectiveArrow<Identity<int>>,
               "Identity must be recognised as a bijective arrow.");
 
+// ---------------------------------------------------------------------------
+// Pedagogical-accessibility synonyms (closes #459).
+//
+// The categorical names @c IsMonicArrow / @c IsEpicArrow /
+// @c IsBijectiveArrow are the canonical primitives.  The set-theoretic
+// names @c IsInjective / @c IsSurjective / @c IsBijective are exposed
+// here as @c = aliases so readers coming from the standard high-school /
+// undergraduate set-theory baseline can find the concepts under the
+// vocabulary they already know.  No new structural content; the
+// underlying opt-in traits ( @c is_monic_arrow_v / @c is_epic_arrow_v)
+// retain their categorical names — register monicity / epicity once,
+// either spelling fires.
+//
+// Hierarchy (strict ⇒ relaxed):
+//   @c IsIsomorphism<F>  (above) — has @c inverse(f) ADL arrow available.
+//          ⇓ structurally implies (in Set: iso ⇒ mono + epi)
+//   @c IsBijective<E>  ≡  @c IsBijectiveArrow<E>
+//          ⇓
+//   @c IsInjective<E>  (≡ @c IsMonicArrow), @c IsSurjective<E> (≡ @c
+//   IsEpicArrow)
+//
+// @c IsIsomorphism is the @b strictest: it additionally demands that the
+// inverse morphism be present as an ADL-discoverable @c inverse() arrow.
+// A @c IsBijective arrow is the set-theoretic statement of the same fact
+// (injective + surjective) without requiring the inverse arrow to be
+// reified.  The reverse implication ( @c IsBijective @c ⇒ @c
+// IsIsomorphism) does @b not hold: a bijection can be declared via the
+// opt-in traits without its inverse being available as a callable arrow.
+// ---------------------------------------------------------------------------
+
+/**
+ * @concept IsInjective
+ * @brief Set-theoretic synonym for @c IsMonicArrow — an arrow is
+ *        @b injective iff distinct inputs yield distinct outputs
+ *        (@c f(x) @c == @c f(y) @c → @c x @c == @c y).
+ * @details Categorically the same concept: a monomorphism in the
+ *          category of sets.  Opt-in via @c is_monic_arrow_v<E>.
+ */
+export template <typename E>
+concept IsInjective = IsMonicArrow<E>;
+
+/**
+ * @concept IsSurjective
+ * @brief Set-theoretic synonym for @c IsEpicArrow — an arrow is
+ *        @b surjective iff every codomain element has a preimage
+ *        (∀ @c b ∈ @c B ∃ @c a ∈ @c A. @c f(a) @c == @c b).
+ * @details Categorically the same concept: an epimorphism in the
+ *          category of sets.  Opt-in via @c is_epic_arrow_v<E>.
+ */
+export template <typename E>
+concept IsSurjective = IsEpicArrow<E>;
+
+/**
+ * @concept IsBijective
+ * @brief Set-theoretic synonym for @c IsBijectiveArrow — an arrow is
+ *        @b bijective iff it is both injective and surjective, i.e. a
+ *        set-theoretic isomorphism @c A @c ≅ @c B.
+ */
+export template <typename E>
+concept IsBijective = IsBijectiveArrow<E>;
+
+// Mechanical witnesses that the synonyms agree with the categorical
+// originals on the canonical Identity arrow (and would diverge if any
+// future drift broke the alias).
+static_assert(IsInjective<Identity<int>>,
+              "IsInjective synonym must agree with IsMonicArrow on Identity.");
+static_assert(IsSurjective<Identity<int>>,
+              "IsSurjective synonym must agree with IsEpicArrow on Identity.");
+static_assert(IsBijective<Identity<int>>,
+              "IsBijective synonym must agree with IsBijectiveArrow on "
+              "Identity.");
+
 }  // namespace dedekind::category

--- a/src/main/modules/dedekind/geometry/lattice.cppm
+++ b/src/main/modules/dedekind/geometry/lattice.cppm
@@ -241,6 +241,9 @@ inline constexpr bool
 static_assert(
     IsMonicArrow<std::decay_t<decltype(dedekind::geometry::embed_z2_r2)>>,
     "embed_z2_r2 must be recognised as a monic arrow.");
+static_assert(
+    IsInjective<std::decay_t<decltype(dedekind::geometry::embed_z2_r2)>>,
+    "embed_z2_r2 (ℤ² ↪ ℝ²) is registered injective.");
 
 }  // namespace dedekind::category
 

--- a/src/main/modules/dedekind/numbers/boolean.cppm
+++ b/src/main/modules/dedekind/numbers/boolean.cppm
@@ -259,4 +259,7 @@ template <>
 inline constexpr bool
     is_monic_arrow_v<std::decay_t<decltype(dedekind::numbers::embed_𝔹_𝕂3)>> =
         true;
+static_assert(
+    IsInjective<std::decay_t<decltype(dedekind::numbers::embed_𝔹_𝕂3)>>,
+    "embed_𝔹_𝕂3 (𝔹 ↪ 𝕂3) is registered injective.");
 }  // namespace dedekind::category

--- a/src/main/modules/dedekind/numbers/complex.cppm
+++ b/src/main/modules/dedekind/numbers/complex.cppm
@@ -307,6 +307,9 @@ template <>
 inline constexpr bool
     is_monic_arrow_v<std::decay_t<decltype(dedekind::numbers::embed_ℝ_ℂ<>)>> =
         true;
+static_assert(
+    IsInjective<std::decay_t<decltype(dedekind::numbers::embed_ℝ_ℂ<>)>>,
+    "embed_ℝ_ℂ (ℝ ↪ ℂ) is registered injective.");
 }  // namespace dedekind::category
 
 namespace dedekind::numbers {
@@ -431,6 +434,9 @@ inline constexpr bool
 static_assert(
     IsMonicArrow<std::decay_t<decltype(dedekind::numbers::embed_z2_c)>>,
     "embed_z2_c must be recognised as a monic arrow.");
+static_assert(
+    IsInjective<std::decay_t<decltype(dedekind::numbers::embed_z2_c)>>,
+    "embed_z2_c (ℤ² ↪ ℂ) is registered injective.");
 
 // Structural product proof: ℂ ≅ ℝ × ℝ (or more generally S × S for any
 // carrier).

--- a/src/main/modules/dedekind/numbers/integer.cppm
+++ b/src/main/modules/dedekind/numbers/integer.cppm
@@ -530,21 +530,33 @@ template <>
 inline constexpr bool
     is_monic_arrow_v<std::decay_t<decltype(dedekind::numbers::embed_ℕ_ℤ)>> =
         true;
+static_assert(IsInjective<std::decay_t<decltype(dedekind::numbers::embed_ℕ_ℤ)>>,
+              "embed_ℕ_ℤ (machine-layer ℕ → ℤ) is registered injective.");
 
 template <>
 inline constexpr bool
     is_monic_arrow_v<std::decay_t<decltype(dedekind::numbers::embed_K3_ℤ)>> =
         true;
+static_assert(
+    IsInjective<std::decay_t<decltype(dedekind::numbers::embed_K3_ℤ)>>,
+    "embed_K3_ℤ (𝕂3 → ℤ) is registered injective.");
 
 template <>
 inline constexpr bool is_monic_arrow_v<
     std::decay_t<decltype(dedekind::numbers::embed_unsigned_ℕ)>> = true;
+static_assert(
+    IsInjective<std::decay_t<decltype(dedekind::numbers::embed_unsigned_ℕ)>>,
+    "embed_unsigned_ℕ (unsigned → ExtensionalCardinal) is registered "
+    "injective.");
 // Monicity of @c embed_unsigned_Cardinality_ is registered in @c :uint.
 
 template <>
 inline constexpr bool
     is_monic_arrow_v<std::decay_t<decltype(dedekind::numbers::lift_ℕ_ℤ_)>> =
         true;
+static_assert(IsInjective<std::decay_t<decltype(dedekind::numbers::lift_ℕ_ℤ_)>>,
+              "lift_ℕ_ℤ_ (variant-layer ℕ ↪ ℤ; Grothendieck-construction unit) "
+              "is registered injective.");
 }  // namespace dedekind::category
 
 // ===========================================================================

--- a/src/main/modules/dedekind/numbers/natural.cppm
+++ b/src/main/modules/dedekind/numbers/natural.cppm
@@ -379,4 +379,6 @@ template <>
 inline constexpr bool
     is_monic_arrow_v<std::decay_t<decltype(dedekind::numbers::embed_𝔹_ℕ)>> =
         true;
+static_assert(IsInjective<std::decay_t<decltype(dedekind::numbers::embed_𝔹_ℕ)>>,
+              "embed_𝔹_ℕ (𝔹 ↪ ℕ) is registered injective.");
 }  // namespace dedekind::category

--- a/src/main/modules/dedekind/numbers/rational.cppm
+++ b/src/main/modules/dedekind/numbers/rational.cppm
@@ -407,6 +407,9 @@ template <>
 inline constexpr bool
     is_monic_arrow_v<std::decay_t<decltype(dedekind::numbers::embed_ℤ_ℚ<>)>> =
         true;
+static_assert(
+    IsInjective<std::decay_t<decltype(dedekind::numbers::embed_ℤ_ℚ<>)>>,
+    "embed_ℤ_ℚ (ℤ ↪ ℚ) is registered injective.");
 }  // namespace dedekind::category
 
 namespace dedekind::numbers {

--- a/src/main/modules/dedekind/numbers/real.cppm
+++ b/src/main/modules/dedekind/numbers/real.cppm
@@ -348,6 +348,9 @@ template <>
 inline constexpr bool
     is_monic_arrow_v<std::decay_t<decltype(dedekind::numbers::embed_ℚ_ℝ<>)>> =
         true;
+static_assert(
+    IsInjective<std::decay_t<decltype(dedekind::numbers::embed_ℚ_ℝ<>)>>,
+    "embed_ℚ_ℝ (ℚ ↪ ℝ) is registered injective.");
 }  // namespace dedekind::category
 
 namespace dedekind::numbers {

--- a/src/main/modules/dedekind/numbers/sint.cppm
+++ b/src/main/modules/dedekind/numbers/sint.cppm
@@ -170,17 +170,21 @@ export inline constexpr auto embed_int_SignedCardinality_ =
  * Honest-extension property: @b total at @c INT_MIN where @c
  * std::abs is UB.  The implementation works in @c unsigned modular
  * arithmetic (which is well-defined for all input bit-patterns) and
- * relies on @c -static_cast<unsigned>(INT_MIN) @c = @c 2^31u being
- * the correct magnitude.  This avoids the UB that @c std::abs(INT_MIN)
- * triggers via @c -INT_MIN overflow.
+ * relies on @c 0u @c - @c static_cast<unsigned>(INT_MIN) yielding
+ * @c |INT_MIN| as an @c unsigned (well-defined for any @c int width
+ * and any two's-complement / sign-magnitude / ones'-complement ABI;
+ * the project does not pin a 32-bit assumption).  This avoids the
+ * UB that @c std::abs(INT_MIN) triggers via @c -INT_MIN overflow.
  *
  * Categorical classification: @b neither @b monic @b nor @b epic.
  *   * Not monic: distinct inputs @c +n and @c -n map to the same
  *     @c unsigned magnitude (sign-folding).
- *   * Not epic onto @c unsigned: the image is @c [0, @c 2^31],
- *     missing @c [2^31+1, @c 2^32-1].  Restricted to @c [0, @c 2^31]
- *     as codomain, the function would be epic — but C++ has no clean
- *     "non-negative int" type to express that codomain.
+ *   * Not epic onto @c unsigned: the image is the half-range @c [0,
+ *     @c |INT_MIN|], missing the upper half of @c unsigned.  Restricted
+ *     to @c [0, @c |INT_MIN|] as codomain the function would be epic —
+ *     but C++ has no clean "non-negative int" type to express that
+ *     codomain (cf. @c std::numeric_limits<int>::digits for the
+ *     width-relative phrasing).
  *
  * Variant-layer counterpart: @c abs : @c SignedCardinality @c → @c
  * Cardinality (in @c sets:cardinality), which IS surjective onto

--- a/src/main/modules/dedekind/numbers/sint.cppm
+++ b/src/main/modules/dedekind/numbers/sint.cppm
@@ -234,4 +234,8 @@ template <>
 inline constexpr bool is_monic_arrow_v<
     std::decay_t<decltype(dedekind::numbers::embed_int_SignedCardinality_)>> =
     true;
+static_assert(IsInjective<std::decay_t<
+                  decltype(dedekind::numbers::embed_int_SignedCardinality_)>>,
+              "embed_int_SignedCardinality_ (int → SignedCardinality) is "
+              "registered injective.");
 }  // namespace dedekind::category

--- a/src/main/modules/dedekind/numbers/sint.cppm
+++ b/src/main/modules/dedekind/numbers/sint.cppm
@@ -154,6 +154,56 @@ export inline constexpr auto embed_int_SignedCardinality_ =
           return embed_signed_to_SignedCardinality(i);
         });
 
+/**
+ * @brief Type-honest absolute value at the machine layer:
+ *        @c int @c → @c unsigned.
+ *
+ * @details The natural categorical signature for absolute value on
+ * the signed-integer carrier is @c int @c → @c unsigned (the image
+ * is exactly the non-negative ints, which canonically embed into
+ * @c unsigned).  The C++ standard library's @c std::abs(int) @c → @c
+ * int is type-@b dishonest about this — its result is always non-
+ * negative but the return type doesn't say so, and the caller has to
+ * know.  This function is the type-honest sibling: the @c unsigned
+ * return type announces non-negativity at the type level.
+ *
+ * Honest-extension property: @b total at @c INT_MIN where @c
+ * std::abs is UB.  The implementation works in @c unsigned modular
+ * arithmetic (which is well-defined for all input bit-patterns) and
+ * relies on @c -static_cast<unsigned>(INT_MIN) @c = @c 2^31u being
+ * the correct magnitude.  This avoids the UB that @c std::abs(INT_MIN)
+ * triggers via @c -INT_MIN overflow.
+ *
+ * Categorical classification: @b neither @b monic @b nor @b epic.
+ *   * Not monic: distinct inputs @c +n and @c -n map to the same
+ *     @c unsigned magnitude (sign-folding).
+ *   * Not epic onto @c unsigned: the image is @c [0, @c 2^31],
+ *     missing @c [2^31+1, @c 2^32-1].  Restricted to @c [0, @c 2^31]
+ *     as codomain, the function would be epic — but C++ has no clean
+ *     "non-negative int" type to express that codomain.
+ *
+ * Variant-layer counterpart: @c abs : @c SignedCardinality @c → @c
+ * Cardinality (in @c sets:cardinality), which IS surjective onto
+ * the saturating @c Cardinality (because @c Cardinality has an @c
+ * ℵ_0 sentinel and no upper bound on the finite fragment) — see the
+ * @c Relationship_to_std_abs section in that function's docstring.
+ */
+export constexpr unsigned abs_int_unsigned(int x) noexcept {
+  // The conditional is a clarity move; both branches reduce to
+  // @c -static_cast<unsigned>(x) modulo two's-complement arithmetic.
+  // Authored explicitly to make the type-honest reading obvious to a
+  // reader: "if negative, negate after widening to unsigned".
+  return x < 0 ? -static_cast<unsigned>(x) : static_cast<unsigned>(x);
+}
+
+// Type-signature witness: the function's return type IS @c unsigned,
+// not @c int — that's the load-bearing fact this partition adds vis-
+// à-vis @c std::abs.
+static_assert(std::same_as<decltype(abs_int_unsigned(0)), unsigned>,
+              "abs_int_unsigned has a type-honest unsigned codomain — the "
+              "non-negativity of the result is announced at the type level, "
+              "unlike std::abs(int) → int.");
+
 // ===========================================================================
 // (2) Family classification — std::signed_integral as operator-surface ✓ /
 //     axiomatic-ring ✗

--- a/src/main/modules/dedekind/numbers/uint.cppm
+++ b/src/main/modules/dedekind/numbers/uint.cppm
@@ -352,4 +352,9 @@ template <>
 inline constexpr bool is_monic_arrow_v<
     std::decay_t<decltype(dedekind::numbers::embed_unsigned_Cardinality_)>> =
     true;
+static_assert(
+    IsInjective<
+        std::decay_t<decltype(dedekind::numbers::embed_unsigned_Cardinality_)>>,
+    "embed_unsigned_Cardinality_ (unsigned → Cardinality) is "
+    "registered injective.");
 }  // namespace dedekind::category

--- a/src/main/modules/dedekind/sets/cardinality.cppm
+++ b/src/main/modules/dedekind/sets/cardinality.cppm
@@ -1507,9 +1507,12 @@ export constexpr SignedCardinality operator-(const Cardinality& v) noexcept {
  *  INT_MIN fragment of @c int and is partial at @c INT_MIN — @c
  *  std::abs(INT_MIN) is UB, while @c
  *  abs(embed_int_SignedCardinality_(INT_MIN)) is a finite Cardinality
- *  with magnitude @c 2^31.  This is the same Honest-Rejection /
- *  saturating-extension pattern the project runs for @c int / @c
- *  unsigned vs the variant carriers.
+ *  with magnitude @c |INT_MIN| (computable via the unsigned-modular
+ *  expression @c 0u @c - @c static_cast<unsigned>(INT_MIN) — well-
+ *  defined for any @c int width per @c
+ *  std::numeric_limits<int>::digits, no 32-bit ABI assumption).  This
+ *  is the same Honest-Rejection / saturating-extension pattern the
+ *  project runs for @c int / @c unsigned vs the variant carriers.
  *
  *  @see std::abs (machine-layer counterpart; type-dishonest @c int →
  *       @c int signature; partial under UB at @c INT_MIN).

--- a/src/main/modules/dedekind/sets/cardinality.cppm
+++ b/src/main/modules/dedekind/sets/cardinality.cppm
@@ -1484,6 +1484,17 @@ export constexpr Cardinality abs(const SignedCardinality& z) noexcept {
   return Cardinality{std::get<SignedExtensionalCardinal<>>(z).magnitude};
 }
 
+/** @brief Arrow form of @c abs: an exported @c arrow<SignedCardinality,
+ *         Cardinality> object.  Registered @b epic (surjective) below: every
+ *         @c Cardinality is the image of itself ( @c abs(lift_ℕ_ℤ_(c)) @c =
+ *         @c c) and of its negation; the map is sign-folding, conflating
+ *         @c +n and @c -n.  Companion to the injective @c lift_ℕ_ℤ_ in
+ *         @c numbers:integer — together they exhibit the split-mono pair
+ *         from the carrier-lattice diagram (Figure 1). */
+export inline constexpr auto abs_ =
+    dedekind::category::arrow<SignedCardinality, Cardinality>(
+        [](const SignedCardinality& z) noexcept { return abs(z); });
+
 /** @brief Closure-forcing binary minus on @c Cardinality: well-defined
  *         as a function @c ℕ × ℕ → ℤ; ℕ isn't closed under it.  The
  *         operator's existence with the wider return type @b is the
@@ -2004,5 +2015,26 @@ static_assert(!IsClosedUnder<dedekind::sets::Cardinality, std::minus<>>,
               "Cardinality must @b not satisfy IsClosedUnder under "
               "@c std::minus<> — that's precisely what makes binary @c - "
               "closure-forcing.");
+
+// ---------------------------------------------------------------------------
+// Surjective-arrow witness: @c abs_ is registered @b epic.
+//
+// Every @c Cardinality @c c is the image of itself ( @c abs_(lift_ℕ_ℤ_(c))
+// @c = @c c) under @c abs_, so @c abs_ is surjective.  This is the project's
+// first downstream surjective arrow registration (closes part of #459's
+// downstream-witness goal): the @c IsSurjective synonym now mechanically
+// fires on a real domain arrow, not just on @c Identity.  The arrow is
+// @b not monic: distinct signed cardinalities (e.g. @c +3, @c -3) map to
+// the same @c Cardinality, so sign is folded.
+// ---------------------------------------------------------------------------
+template <>
+inline constexpr bool
+    is_epic_arrow_v<std::decay_t<decltype(dedekind::sets::abs_)>> = true;
+static_assert(IsSurjective<std::decay_t<decltype(dedekind::sets::abs_)>>,
+              "abs_ : SignedCardinality → Cardinality is registered "
+              "surjective; the IsSurjective synonym fires on a real domain "
+              "arrow.");
+static_assert(!IsInjective<std::decay_t<decltype(dedekind::sets::abs_)>>,
+              "abs_ is NOT injective — it folds sign (abs(3) == abs(-3)).");
 
 }  // namespace dedekind::category

--- a/src/main/modules/dedekind/sets/cardinality.cppm
+++ b/src/main/modules/dedekind/sets/cardinality.cppm
@@ -1475,6 +1475,46 @@ export constexpr SignedCardinality operator-(const Cardinality& v) noexcept {
  *      that #396 chose for the saturating semantics; NaZ has no
  *      well-defined magnitude, but the saturated answer is the
  *      conservative bound.
+ *
+ *  @section Relationship_to_std_abs
+ *  Conceptually the same operation as @c std::abs at a different
+ *  carrier layer, with two load-bearing differences:
+ *
+ *  @b 1. @b Type-honest @b codomain.  The natural categorical
+ *  signature for absolute value is @c int @c → @c unsigned (the image
+ *  is exactly the non-negative ints, which canonically embed into
+ *  @c unsigned).  C++'s @c std::abs(int) @c → @c int is type-
+ *  @b dishonest about this: the result is always non-negative but the
+ *  return type doesn't say so, and the caller has to know.  This
+ *  @c abs's variant-layer signature @c SignedCardinality @c → @c
+ *  Cardinality (i.e. @c ℤ @c → @c ℕ) is the @b honest version of the
+ *  same operation: the type announces non-negativity.  In other
+ *  words, the variant @c abs is to the (type-honest) @c int @c → @c
+ *  unsigned absolute value what @c lift_ℕ_ℤ_ is to the unsigned-to-
+ *  signed widening — both honour at the variant layer what the
+ *  machine layer signs implicitly.
+ *
+ *  @b 2. @b Total. @c std::abs(int) has @b undefined @b behaviour at
+ *  @c INT_MIN (since @c -INT_MIN overflows the signed range).  The
+ *  variant carrier @c SignedCardinality has no such pathology — the
+ *  magnitude of the most-negative finite value is representable as a
+ *  non-negative @c Cardinality, and the saturating @c ±ℵ_0 / @c NaZ
+ *  cases extend the operation totally.
+ *
+ *  The commuting square (@c std::abs vs this @c abs across the
+ *  machine ↔ variant lifts, with the post-@c std::abs side coerced to
+ *  @c unsigned to make the codomain match) holds on the non-@c
+ *  INT_MIN fragment of @c int and is partial at @c INT_MIN — @c
+ *  std::abs(INT_MIN) is UB, while @c
+ *  abs(embed_int_SignedCardinality_(INT_MIN)) is a finite Cardinality
+ *  with magnitude @c 2^31.  This is the same Honest-Rejection /
+ *  saturating-extension pattern the project runs for @c int / @c
+ *  unsigned vs the variant carriers.
+ *
+ *  @see std::abs (machine-layer counterpart; type-dishonest @c int →
+ *       @c int signature; partial under UB at @c INT_MIN).
+ *  @see lift_ℕ_ℤ_ in @c numbers:integer (the injective half of the
+ *       split-mono Figure 1 pair).
  */
 export constexpr Cardinality abs(const SignedCardinality& z) noexcept {
   if (detail::sc_is_naz(z)) return Cardinality{ℵ_0{}};

--- a/src/test/cpp/modules/dedekind/category/morphism_test.cpp
+++ b/src/test/cpp/modules/dedekind/category/morphism_test.cpp
@@ -128,12 +128,17 @@ TEST_CASE("Category: Algebraic Proofs (Runtime Witnesses)",
     STATIC_CHECK(IsInjective<Identity<int>>);
     STATIC_CHECK(IsSurjective<Identity<int>>);
     STATIC_CHECK(IsBijective<Identity<int>>);
-    // Cross-check: an arbitrary non-monic arrow is neither injective
-    // nor bijective (default opt-in trait is false).
-    auto const f = arrow([](int x) { return x; });
-    STATIC_CHECK(IsArrow<std::decay_t<decltype(f)>>);
-    STATIC_CHECK(!IsInjective<std::decay_t<decltype(f)>>);
-    STATIC_CHECK(!IsSurjective<std::decay_t<decltype(f)>>);
-    STATIC_CHECK(!IsBijective<std::decay_t<decltype(f)>>);
+    // Cross-check: a clearly non-injective arrow (constant function
+    // returning 0) is structurally NOT injective and NOT bijective —
+    // the default opt-in traits return false, and the synonyms
+    // mechanically agree.  Picked a constant rather than @c
+    // arrow([](int x){return x;}) per Copilot review: the latter is
+    // structurally identity (injective) and would be misleading as a
+    // negative-case witness if property inference is added later.
+    auto const constant = arrow<int, int>([](int) { return 0; });
+    STATIC_CHECK(IsArrow<std::decay_t<decltype(constant)>>);
+    STATIC_CHECK(!IsInjective<std::decay_t<decltype(constant)>>);
+    STATIC_CHECK(!IsSurjective<std::decay_t<decltype(constant)>>);
+    STATIC_CHECK(!IsBijective<std::decay_t<decltype(constant)>>);
   }
 }

--- a/src/test/cpp/modules/dedekind/category/morphism_test.cpp
+++ b/src/test/cpp/modules/dedekind/category/morphism_test.cpp
@@ -121,4 +121,19 @@ TEST_CASE("Category: Algebraic Proofs (Runtime Witnesses)",
     CHECK_FALSE(mv(1, 3));
     CHECK_FALSE(mv(2, 1));
   }
+
+  SECTION("Pedagogical synonyms (#459) agree with categorical originals") {
+    // Set-theoretic spellings are = aliases of the categorical
+    // primitives; either name fires the same opt-in trait.
+    STATIC_CHECK(IsInjective<Identity<int>>);
+    STATIC_CHECK(IsSurjective<Identity<int>>);
+    STATIC_CHECK(IsBijective<Identity<int>>);
+    // Cross-check: an arbitrary non-monic arrow is neither injective
+    // nor bijective (default opt-in trait is false).
+    auto const f = arrow([](int x) { return x; });
+    STATIC_CHECK(IsArrow<std::decay_t<decltype(f)>>);
+    STATIC_CHECK(!IsInjective<std::decay_t<decltype(f)>>);
+    STATIC_CHECK(!IsSurjective<std::decay_t<decltype(f)>>);
+    STATIC_CHECK(!IsBijective<std::decay_t<decltype(f)>>);
+  }
 }

--- a/src/test/cpp/modules/dedekind/numbers/integer_test.cpp
+++ b/src/test/cpp/modules/dedekind/numbers/integer_test.cpp
@@ -1,5 +1,6 @@
 #include <catch2/catch_test_macros.hpp>
 #include <cstdlib>  // For std::abs in the partial-commuting-square test.
+#include <limits>  // For std::numeric_limits in the abs honest-extension tests.
 #include <variant>  // For std::variant's operator== reached via ADL on
                     // SignedCardinality / Cardinality (aliases of
                     // std::variant<...>).  Without this include the
@@ -84,19 +85,25 @@ TEST_CASE(
     "Integer: abs is the honest total extension of std::abs — well-defined "
     "at INT_MIN where std::abs is UB",
     "[numbers][integer][carrier-lattice][abs][honest-extension]") {
-  // The pathological value: INT_MIN = -2^31 on a 32-bit int.  std::abs(INT_MIN)
-  // is undefined behaviour because -INT_MIN overflows the signed-int range.
-  // Our @c abs lifts INT_MIN through the variant embedding and returns a
-  // finite @c Cardinality with magnitude 2^31 — total, no UB, type-level
-  // non-negativity guarantee.
+  // The pathological value: INT_MIN.  std::abs(INT_MIN) is undefined
+  // behaviour because -INT_MIN overflows the signed-int range.  Our
+  // @c abs lifts INT_MIN through the variant embedding and returns a
+  // finite @c Cardinality with the magnitude — total, no UB, type-
+  // level non-negativity guarantee.
+  //
+  // Portability: compute the expected magnitude via unsigned modular
+  // arithmetic so the test does not hard-code 32-bit two's-complement
+  // ABI.  @c 0u @c - @c static_cast<unsigned>(int_min) is well-defined
+  // for any width.
   constexpr int int_min = std::numeric_limits<int>::min();
+  constexpr unsigned int_min_magnitude = 0u - static_cast<unsigned>(int_min);
   const auto z_min = embed_int_SignedCardinality_(int_min);
   const auto magnitude = abs(z_min);
 
   // Magnitude IS representable as a non-negative Cardinality (the
   // saturating ℕ-proxy carrier).  No UB, no truncation; the answer is
-  // the concrete finite value 2^31 = 2147483648.
-  CHECK(magnitude == finite_cardinality(2147483648u));
+  // the concrete finite value @c |INT_MIN|.
+  CHECK(magnitude == finite_cardinality(int_min_magnitude));
   // The answer is NOT ℵ_0 — INT_MIN is well-finite, just not negatable
   // in the int range.
   CHECK_FALSE(magnitude == Cardinality{ℵ_0{}});
@@ -118,8 +125,11 @@ TEST_CASE(
   // non-negativity at the type level; the implementation is total
   // (works for INT_MIN where std::abs is UB).
   constexpr int int_min = std::numeric_limits<int>::min();
-  // abs_int_unsigned(INT_MIN) = 2^31u — total, no UB.
-  CHECK(abs_int_unsigned(int_min) == 2147483648u);
+  // |INT_MIN| computed via unsigned modular arithmetic — well-defined
+  // for any int width / two's-complement ABI.
+  constexpr unsigned int_min_magnitude = 0u - static_cast<unsigned>(int_min);
+  // abs_int_unsigned(INT_MIN) = |INT_MIN| — total, no UB.
+  CHECK(abs_int_unsigned(int_min) == int_min_magnitude);
   // Sign-folding: distinct +n / -n map to the same unsigned magnitude
   // (so the function is NOT injective).
   CHECK(abs_int_unsigned(3) == 3u);
@@ -145,17 +155,17 @@ TEST_CASE(
     CHECK(via_variant == finite_cardinality(via_machine));
   }
   // At INT_MIN: machine-layer abs_int_unsigned and variant-layer abs
-  // both yield magnitude 2^31, even though std::abs(INT_MIN) is UB.
-  // The two honest extensions agree where the UB-bearing original
-  // refuses to commit.
-  CHECK(abs_int_unsigned(int_min) == 2147483648u);
+  // both yield |INT_MIN|, even though std::abs(INT_MIN) is UB.  The
+  // two honest extensions agree where the UB-bearing original refuses
+  // to commit.
+  CHECK(abs_int_unsigned(int_min) == int_min_magnitude);
   CHECK(abs(embed_int_SignedCardinality_(int_min)) ==
-        finite_cardinality(2147483648u));
+        finite_cardinality(int_min_magnitude));
   // The exported arrow form abs_ (from :cardinality) wraps the same
   // operation and exhibits the same totality at INT_MIN.  Covers the
   // arrow's lambda body for codecov.
   CHECK(abs_(embed_int_SignedCardinality_(int_min)) ==
-        finite_cardinality(2147483648u));
+        finite_cardinality(int_min_magnitude));
   CHECK(abs_(embed_int_SignedCardinality_(-3)) == finite_cardinality(3));
   CHECK(abs_(embed_int_SignedCardinality_(0)) == finite_cardinality(0));
 }

--- a/src/test/cpp/modules/dedekind/numbers/integer_test.cpp
+++ b/src/test/cpp/modules/dedekind/numbers/integer_test.cpp
@@ -1,4 +1,5 @@
 #include <catch2/catch_test_macros.hpp>
+#include <cstdlib>  // For std::abs in the partial-commuting-square test.
 #include <variant>  // For std::variant's operator== reached via ADL on
                     // SignedCardinality / Cardinality (aliases of
                     // std::variant<...>).  Without this include the
@@ -68,4 +69,93 @@ TEST_CASE("Integer: ℕ → ℤ → ℕ on ℵ_0 — saturating round-trip",
           "[numbers][integer][carrier-lattice][round-trip]") {
   const auto inf = Cardinality{ℵ_0{}};
   CHECK(abs(-inf) == inf);
+}
+
+// ===========================================================================
+// Honest extension of std::abs: our @c abs is total where @c std::abs(int)
+// is undefined.  At @c INT_MIN, @c std::abs(INT_MIN) is UB (since
+// @c -INT_MIN overflows the signed range), but the variant carrier
+// @c SignedCardinality has no such pathology — the magnitude of @c INT_MIN
+// is representable as a non-negative @c Cardinality.  This test exercises
+// the case @c std::abs cannot.
+// ===========================================================================
+
+TEST_CASE(
+    "Integer: abs is the honest total extension of std::abs — well-defined "
+    "at INT_MIN where std::abs is UB",
+    "[numbers][integer][carrier-lattice][abs][honest-extension]") {
+  // The pathological value: INT_MIN = -2^31 on a 32-bit int.  std::abs(INT_MIN)
+  // is undefined behaviour because -INT_MIN overflows the signed-int range.
+  // Our @c abs lifts INT_MIN through the variant embedding and returns a
+  // finite @c Cardinality with magnitude 2^31 — total, no UB, type-level
+  // non-negativity guarantee.
+  constexpr int int_min = std::numeric_limits<int>::min();
+  const auto z_min = embed_int_SignedCardinality_(int_min);
+  const auto magnitude = abs(z_min);
+
+  // Magnitude IS representable as a non-negative Cardinality (the
+  // saturating ℕ-proxy carrier).  No UB, no truncation; the answer is
+  // the concrete finite value 2^31 = 2147483648.
+  CHECK(magnitude == finite_cardinality(2147483648u));
+  // The answer is NOT ℵ_0 — INT_MIN is well-finite, just not negatable
+  // in the int range.
+  CHECK_FALSE(magnitude == Cardinality{ℵ_0{}});
+
+  // Cross-check: at INT_MAX (where std::abs IS defined), the two
+  // operations agree on the magnitude — the partial commuting square
+  // holds on the non-INT_MIN fragment.
+  constexpr int int_max = std::numeric_limits<int>::max();
+  const auto z_max = embed_int_SignedCardinality_(int_max);
+  CHECK(abs(z_max) == finite_cardinality(static_cast<std::size_t>(int_max)));
+}
+
+TEST_CASE(
+    "Integer: abs_int_unsigned is the type-honest machine-layer absolute "
+    "value — int → unsigned, total at INT_MIN where std::abs is UB",
+    "[numbers][integer][carrier-lattice][abs][honest-extension]") {
+  // abs_int_unsigned : int → unsigned is the type-honest sibling of
+  // std::abs : int → int.  The unsigned codomain announces
+  // non-negativity at the type level; the implementation is total
+  // (works for INT_MIN where std::abs is UB).
+  constexpr int int_min = std::numeric_limits<int>::min();
+  // abs_int_unsigned(INT_MIN) = 2^31u — total, no UB.
+  CHECK(abs_int_unsigned(int_min) == 2147483648u);
+  // Sign-folding: distinct +n / -n map to the same unsigned magnitude
+  // (so the function is NOT injective).
+  CHECK(abs_int_unsigned(3) == 3u);
+  CHECK(abs_int_unsigned(-3) == 3u);
+  CHECK(abs_int_unsigned(0) == 0u);
+
+  // Partial commuting square: on the non-INT_MIN fragment of int, the
+  // type-honest abs_int_unsigned agrees with std::abs coerced to unsigned.
+  // (At INT_MIN the std::abs side would be UB, so the comparison is
+  // omitted there — the previous CHECK already pinned that case.)
+  for (const int v :
+       {1, -1, 42, -42, 1000, -1000, std::numeric_limits<int>::max()}) {
+    CHECK(abs_int_unsigned(v) == static_cast<unsigned>(std::abs(v)));
+  }
+
+  // Three-way bridge: abs_int_unsigned(v) at the machine layer agrees
+  // with the variant-layer abs lifted through embed_int_SignedCardinality_,
+  // when the latter's Cardinality result is realised back to a finite
+  // value.  Holds on the safe fragment of int.
+  for (const int v : {0, 1, -1, 42, -42, 1000, -1000}) {
+    const auto via_machine = abs_int_unsigned(v);
+    const auto via_variant = abs(embed_int_SignedCardinality_(v));
+    CHECK(via_variant == finite_cardinality(via_machine));
+  }
+  // At INT_MIN: machine-layer abs_int_unsigned and variant-layer abs
+  // both yield magnitude 2^31, even though std::abs(INT_MIN) is UB.
+  // The two honest extensions agree where the UB-bearing original
+  // refuses to commit.
+  CHECK(abs_int_unsigned(int_min) == 2147483648u);
+  CHECK(abs(embed_int_SignedCardinality_(int_min)) ==
+        finite_cardinality(2147483648u));
+  // The exported arrow form abs_ (from :cardinality) wraps the same
+  // operation and exhibits the same totality at INT_MIN.  Covers the
+  // arrow's lambda body for codecov.
+  CHECK(abs_(embed_int_SignedCardinality_(int_min)) ==
+        finite_cardinality(2147483648u));
+  CHECK(abs_(embed_int_SignedCardinality_(-3)) == finite_cardinality(3));
+  CHECK(abs_(embed_int_SignedCardinality_(0)) == finite_cardinality(0));
 }


### PR DESCRIPTION
Closes #459.

## What lands

**1. Synonyms in `:morphism`** — `IsInjective` / `IsSurjective` / `IsBijective` exported as `=` aliases of `IsMonicArrow` / `IsEpicArrow` / `IsBijectiveArrow`. No new structural content — opt-in traits keep their categorical names (`is_monic_arrow_v`, `is_epic_arrow_v`); register once, either spelling fires. Hierarchy section in docstring spells out the relationship to `IsIsomorphism` (strictest, requires `inverse(f)` ADL): `IsIsomorphism ⇒ IsBijective ⇒ IsInjective + IsSurjective`; reverse implications do not hold.

**2. Downstream witnesses** — at every monic-trait registration site, the synonym now mechanically fires alongside the categorical spelling. Eleven sites updated:
- `embed_𝔹_ℕ`, `embed_𝔹_𝕂3` (truth-value embeddings)
- `embed_K3_ℤ`, `embed_ℕ_ℤ` machine, `embed_unsigned_ℕ`, `embed_unsigned_Cardinality_`, `embed_int_SignedCardinality_`, `lift_ℕ_ℤ_` (carrier-lattice arrows)
- `embed_ℝ_ℂ`, `embed_ℤ_ℚ`, `embed_ℚ_ℝ` (rational/real/complex chain)
- `embed_z2_r2`, `embed_z2_c` (geometry)

Plus the existing `Identity` witness in `:morphism`.

**3. First surjective arrow** — `abs_` added as exported `arrow<SignedCardinality, Cardinality>` in `:cardinality`, wrapping the existing free function `abs`. Registered `is_epic_arrow_v = true` and explicitly `!IsInjective` (sign-folding: `abs(3) == abs(-3)`). Categorically the surjective half of the carrier-lattice Figure 1 split-mono pair: `lift_ℕ_ℤ_` (injective) / `abs_` (surjective). The `IsSurjective` synonym now fires on a real domain arrow, not just on `Identity`.

## Test cases

`morphism_test` SECTION exercising the three synonyms on `Identity` (positive) and a fresh non-monic arrow (negative). All synonym witnesses are `static_assert`s; no runtime cost.

## Out of scope (filed as follow-ups)

- **Halfspace constructors**: don't fit IsMonicArrow / IsEpicArrow taxonomy — they're predicate-builders (Variable × Bound → Halfspace), not unary arrows. The interesting categorical claim is the meet-collapse story (#454).
- **Set complement**: a bijective involution `Set<T> → Set<T>`; not currently reified as an arrow object (lives at the predicate level via `operator!`). Worth its own follow-up to expose `complement_` arrow + register `IsBijective` (and `IsIsomorphism` since it's self-inverse).
- **Binary set operations** (∪, ∩, \, △): lattice meet/join, not unary arrows. Different taxonomy; needs its own concept tier.
- **`category:partial`** mono/epi classifications.
- **`category:total`** mono/epi classifications.

## Local sanity check

Build clean. Tests pass on the synonym section. Off-loading full verification to GH CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)