### PR TITLE
feat(category): fish-operator concept tier — HasArrowComposeOperators / HasKleisliBindOperators / HasComonadicExtendOperators (closes #450)

### DIFF
--- a/src/main/modules/dedekind/category/kleisli.cppm
+++ b/src/main/modules/dedekind/category/kleisli.cppm
@@ -293,32 +293,44 @@ constexpr auto operator<<(WA const& wa, F&& f) {
 
 /**
  * @concept HasKleisliBindOperators
- * @brief A monadic carrier @c MA supports Kleisli bind via @c >>=
- *        (and the fish alias @c >> ) with a Kleisli arrow @c F.
+ * @brief A monadic carrier @c MA supports Kleisli bind via BOTH
+ *        @c >>= AND its fish alias @c >> with a Kleisli arrow @c F.
  * @details Captures the operator-shape availability of monadic bind:
  *          given @c ma @c : @c M<A> and @c f @c : @c A @c → @c M<B>,
- *          the expression @c ma @c >>= @c f must compile.  The laws
- *          (left/right unit, associativity) are not enforced here;
- *          they are pinned by @c IsMonad in @c :monad.
+ *          @b both @c ma @c >>= @c f and @c ma @c >> @c f must
+ *          compile.  Requiring both makes the concept faithful to the
+ *          docstring's claim of fish-pair support; downstream code
+ *          constrained by this concept may freely use either spelling.
+ *          The laws (left/right unit, associativity) are not enforced
+ *          here; they are pinned by @c IsMonad in @c :monad.
  */
 export template <typename MA, typename F>
 concept HasKleisliBindOperators = requires(MA const& ma, F&& f) {
   { ma >>= std::forward<F>(f) };
+  { ma >> std::forward<F>(f) };
 };
 
 /**
  * @concept HasComonadicExtendOperators
  * @brief A comonadic carrier @c WA supports comonadic extend via
- *        @c <<= (and the fish alias @c << ) with a co-Kleisli arrow @c F.
+ *        BOTH @c <<= AND its fish alias @c << with a co-Kleisli
+ *        arrow @c F.
  * @details Captures the operator-shape availability of comonadic
  *          extend: given @c wa @c : @c W<A> and @c f @c : @c W<A> @c
- *          → @c B, the expression @c wa @c <<= @c f must compile.
- *          The laws (counit, coassociativity) are pinned by @c
- *          IsComonad in @c :monad.
+ *          → @c B, @b both @c wa @c <<= @c f and @c wa @c << @c f
+ *          must compile.  Mirrors the existing @c operator<< guard
+ *          on @c :kleisli that excludes @c std::ios_base-derived
+ *          types so the concept doesn't accidentally fire on stream
+ *          carriers; downstream code constrained by this concept may
+ *          freely use either spelling.  The laws (counit,
+ *          coassociativity) are pinned by @c IsComonad in @c :monad.
  */
 export template <typename WA, typename F>
-concept HasComonadicExtendOperators = requires(WA const& wa, F&& f) {
-  { wa <<= std::forward<F>(f) };
-};
+concept HasComonadicExtendOperators =
+    (!std::derived_from<std::remove_cvref_t<WA>, std::ios_base>) &&
+    requires(WA const& wa, F&& f) {
+      { wa <<= std::forward<F>(f) };
+      { wa << std::forward<F>(f) };
+    };
 
 }  // namespace dedekind::category

--- a/src/main/modules/dedekind/category/kleisli.cppm
+++ b/src/main/modules/dedekind/category/kleisli.cppm
@@ -274,4 +274,51 @@ constexpr auto operator<<(WA const& wa, F&& f) {
   return σ(wa, std::forward<F>(f));
 }
 
+// ---------------------------------------------------------------------------
+// Kleisli-bind / comonadic-extend operator-shape concepts (closes part of
+// #450).  Sibling to @c HasArrowComposeOperators (in @c :morphism).
+//
+// Categorical reading:
+//   * @c HasKleisliBindOperators<MA, F> classifies @c MA as supporting
+//     composition in the Kleisli category 𝒞_M of a monad @c M (via @c
+//     >>= ; @c >> is the fish alias).
+//   * @c HasComonadicExtendOperators<WA, F> is the dual on the comonadic
+//     side (via @c <<= ; @c << is the fish alias).
+//
+// The concepts pin only the @b syntactic surface; the monadic / comonadic
+// laws (left/right unit, associativity for monads; counit, coassociativity
+// for comonads) are the engineer's honesty obligation, structurally
+// witnessed by the @c IsMonad / @c IsComonad concepts in @c :monad.
+// ---------------------------------------------------------------------------
+
+/**
+ * @concept HasKleisliBindOperators
+ * @brief A monadic carrier @c MA supports Kleisli bind via @c >>=
+ *        (and the fish alias @c >> ) with a Kleisli arrow @c F.
+ * @details Captures the operator-shape availability of monadic bind:
+ *          given @c ma @c : @c M<A> and @c f @c : @c A @c → @c M<B>,
+ *          the expression @c ma @c >>= @c f must compile.  The laws
+ *          (left/right unit, associativity) are not enforced here;
+ *          they are pinned by @c IsMonad in @c :monad.
+ */
+export template <typename MA, typename F>
+concept HasKleisliBindOperators = requires(MA const& ma, F&& f) {
+  { ma >>= std::forward<F>(f) };
+};
+
+/**
+ * @concept HasComonadicExtendOperators
+ * @brief A comonadic carrier @c WA supports comonadic extend via
+ *        @c <<= (and the fish alias @c << ) with a co-Kleisli arrow @c F.
+ * @details Captures the operator-shape availability of comonadic
+ *          extend: given @c wa @c : @c W<A> and @c f @c : @c W<A> @c
+ *          → @c B, the expression @c wa @c <<= @c f must compile.
+ *          The laws (counit, coassociativity) are pinned by @c
+ *          IsComonad in @c :monad.
+ */
+export template <typename WA, typename F>
+concept HasComonadicExtendOperators = requires(WA const& wa, F&& f) {
+  { wa <<= std::forward<F>(f) };
+};
+
 }  // namespace dedekind::category

--- a/src/main/modules/dedekind/category/morphism.cppm
+++ b/src/main/modules/dedekind/category/morphism.cppm
@@ -755,4 +755,49 @@ static_assert(IsBijective<Identity<int>>,
               "IsBijective synonym must agree with IsBijectiveArrow on "
               "Identity.");
 
+// ---------------------------------------------------------------------------
+// Fish-operator concept tier (closes part of #450).
+//
+// The project's operator surface for arrow composition / monadic bind /
+// comonadic extend is informally called the "fish family":
+//   * @c >>   — arrow composition (here in @c :morphism); fish alias for
+//               monadic bind (in @c :kleisli) on monadic carriers.
+//   * @c <<   — fish alias for comonadic extend (in @c :kleisli).
+//   * @c >>=  — monadic bind (in @c :kleisli).
+//   * @c <<=  — comonadic extend (in @c :kleisli).
+//
+// This concept tier reifies the @b operator-shape availability — does
+// the type support the named operator? — at the type level.  Categorical
+// reading: @c >> on arrows is composition in the base category C; @c
+// >>= on a monadic carrier is composition in the Kleisli category 𝒞_M.
+// The concepts here pin only the @b syntactic surface; the equational
+// laws (associativity, unit) are the engineer's honesty obligation for
+// each registration site.
+// ---------------------------------------------------------------------------
+
+/**
+ * @concept HasArrowComposeOperators
+ * @brief Two arrow-shaped types @c F, @c G compose via @c >> (and
+ *        @c << for the reverse direction).
+ * @details Captures the operator-shape availability of categorical
+ *          arrow composition: given @c f @c : @c A @c → @c B and
+ *          @c g @c : @c B @c → @c C, the expression @c f @c >> @c g
+ *          must compile and yield an arrow @c A @c → @c C.  This
+ *          partition's @c operator>> on @c IsSpokeArrow witnesses the
+ *          concept; the laws (associativity, identity) are the
+ *          engineer's honesty obligation, mechanically discharged
+ *          by the existing @c "id ∘ id @c = @c id" static_asserts.
+ */
+export template <typename F, typename G>
+concept HasArrowComposeOperators =
+    IsArrow<F> && IsArrow<G> && requires(F const& f, G const& g) {
+      { f >> g };
+    };
+
+// Witness: Identity arrows compose (id_int >> id_int = id_int) — the
+// canonical syntactic check of @c >> availability on the simplest pair.
+static_assert(HasArrowComposeOperators<Identity<int>, Identity<int>>,
+              "Identity<int> must support @c >> arrow composition with "
+              "itself; this is the canonical fish-operator witness.");
+
 }  // namespace dedekind::category

--- a/src/main/modules/dedekind/category/morphism.cppm
+++ b/src/main/modules/dedekind/category/morphism.cppm
@@ -763,6 +763,8 @@ static_assert(IsBijective<Identity<int>>,
 //   * @c >>   — arrow composition (here in @c :morphism); fish alias for
 //               monadic bind (in @c :kleisli) on monadic carriers.
 //   * @c <<   — fish alias for comonadic extend (in @c :kleisli).
+//               @b No spoke-level overload exists at the @c :morphism
+//               layer; this is comonadic-extend specific.
 //   * @c >>=  — monadic bind (in @c :kleisli).
 //   * @c <<=  — comonadic extend (in @c :kleisli).
 //
@@ -777,21 +779,33 @@ static_assert(IsBijective<Identity<int>>,
 
 /**
  * @concept HasArrowComposeOperators
- * @brief Two arrow-shaped types @c F, @c G compose via @c >> (and
- *        @c << for the reverse direction).
+ * @brief Two spoke-arrow types @c F, @c G compose via @c >> .
  * @details Captures the operator-shape availability of categorical
- *          arrow composition: given @c f @c : @c A @c → @c B and
- *          @c g @c : @c B @c → @c C, the expression @c f @c >> @c g
- *          must compile and yield an arrow @c A @c → @c C.  This
- *          partition's @c operator>> on @c IsSpokeArrow witnesses the
- *          concept; the laws (associativity, identity) are the
- *          engineer's honesty obligation, mechanically discharged
- *          by the existing @c "id ∘ id @c = @c id" static_asserts.
+ *          arrow composition aligned with this partition's
+ *          @c operator>> policy: spoke-only ( @c IsSpokeArrow ) and
+ *          codomain/domain-matched ( @c F::Codomain @c = @c G::Domain ).
+ *          Given @c f @c : @c A @c → @c B and @c g @c : @c B @c → @c C,
+ *          the expression @c f @c >> @c g must compile and yield a
+ *          result modelling @c IsArrow.
+ *
+ *          @b Note: this concept covers @c >> only.  There is no
+ *          spoke-level @c << overload at the @c :morphism layer
+ *          ( @c << in the project is comonadic extend in @c :kleisli);
+ *          the reverse-composition direction, if reified later, is a
+ *          separate concept.  Hub arrows (e.g. functors) compose in
+ *          their own partitions.
+ *
+ *          The laws (associativity, identity) are the engineer's
+ *          honesty obligation, mechanically discharged by the
+ *          existing @c "id @c ∘ @c id @c = @c id" static_asserts.
  */
 export template <typename F, typename G>
 concept HasArrowComposeOperators =
-    IsArrow<F> && IsArrow<G> && requires(F const& f, G const& g) {
-      { f >> g };
+    IsSpokeArrow<F> && IsSpokeArrow<G> &&
+    std::same_as<typename std::remove_cvref_t<F>::Codomain,
+                 typename std::remove_cvref_t<G>::Domain> &&
+    requires(F const& f, G const& g) {
+      { f >> g } -> IsArrow;
     };
 
 // Witness: Identity arrows compose (id_int >> id_int = id_int) — the

--- a/src/test/cpp/modules/dedekind/category/kleisli_test.cpp
+++ b/src/test/cpp/modules/dedekind/category/kleisli_test.cpp
@@ -201,3 +201,29 @@ TEST_CASE("Category: Named Kleisli aliases", "[category][kleisli][aliases]") {
     CHECK(extended == Box<int>{18});
   }
 }
+
+TEST_CASE(
+    "Category: Fish-operator concept tier (#450) — operator-shape "
+    "concepts for arrow compose / Kleisli bind / comonadic extend",
+    "[category][fish-operators][concept-shape]") {
+  // The fish-operator concept tier classifies types by which fish-family
+  // operator surfaces they support.  These are operator-shape concepts:
+  // they pin syntactic availability, not the equational laws (which are
+  // pinned by IsArrow / IsMonad / IsComonad in their own partitions).
+  using BoxBind = decltype([](int x) { return Box<int>{x + 1}; });
+
+  SECTION("HasKleisliBindOperators: Box<int> + Kleisli arrow fires") {
+    STATIC_CHECK(HasKleisliBindOperators<Box<int>, BoxBind>);
+  }
+
+  SECTION("HasComonadicExtendOperators: Box<int> + co-Kleisli arrow fires") {
+    using BoxCoBind = decltype([](Box<int> b) { return b.value * 2; });
+    STATIC_CHECK(HasComonadicExtendOperators<Box<int>, BoxCoBind>);
+  }
+
+  SECTION(
+      "HasKleisliBindOperators negative: bare int + bind-arrow does NOT "
+      "fire (no Kleisli operator surface on a non-monadic carrier)") {
+    STATIC_CHECK(!HasKleisliBindOperators<int, BoxBind>);
+  }
+}

--- a/src/test/cpp/modules/dedekind/category/morphism_test.cpp
+++ b/src/test/cpp/modules/dedekind/category/morphism_test.cpp
@@ -141,4 +141,13 @@ TEST_CASE("Category: Algebraic Proofs (Runtime Witnesses)",
     STATIC_CHECK(!IsSurjective<std::decay_t<decltype(constant)>>);
     STATIC_CHECK(!IsBijective<std::decay_t<decltype(constant)>>);
   }
+
+  SECTION("Fish-operator concept tier (#450) — HasArrowComposeOperators") {
+    // Categorical arrow composition: f : A → B and g : B → C compose
+    // via f >> g : A → C.  The concept pins syntactic availability;
+    // identity-on-int is the canonical witness.
+    STATIC_CHECK(HasArrowComposeOperators<Identity<int>, Identity<int>>);
+    // Negative: a non-arrow type does NOT support categorical composition.
+    STATIC_CHECK(!HasArrowComposeOperators<int, int>);
+  }
 }


### PR DESCRIPTION
Closes #450.

## What lands

Three operator-shape concepts classifying types by which fish-family operators they support:

- **`HasArrowComposeOperators<F, G>`** in `:morphism` — `F` and `G` compose via `>>` for categorical arrow composition. Witness: `Identity<int> >> Identity<int>`.
- **`HasKleisliBindOperators<MA, F>`** in `:kleisli` — monadic `MA` supports Kleisli bind via `>>=` (and the `>>` fish alias) with a Kleisli arrow `F`. Witness: `Box<int> >>= λ`.
- **`HasComonadicExtendOperators<WA, F>`** in `:kleisli` — comonadic `WA` supports comonadic extend via `<<=` (and the `<<` fish alias) with a co-Kleisli arrow `F`. Witness: `Box<int> <<= λ`.

## Categorical reading

- `>>` on arrows is composition in the base category C.
- `>>=` on a monadic carrier is composition in the **Kleisli category 𝒞_M** of a monad M.
- `<<=` on a comonadic carrier is composition in the **co-Kleisli category** of a comonad W.

## Operator-shape vs axiom-shape

The concepts pin only syntactic surface; equational laws (associativity + identity for arrows; left/right unit + associativity for monads; counit + coassociativity for comonads) are pinned by `IsArrow` / `IsMonad` / `IsComonad` respectively. This is the standard split the project uses elsewhere (e.g. `HasRingOperators` vs `IsRing`).

## Test cases

- `morphism_test`: `HasArrowComposeOperators<Identity<int>, Identity<int>>` (positive); `HasArrowComposeOperators<int, int>` (negative — bare type lacks arrow shape).
- `kleisli_test`: `HasKleisliBindOperators<Box<int>, Kleisli arrow>` (positive); `HasComonadicExtendOperators<Box<int>, co-Kleisli arrow>` (positive); `HasKleisliBindOperators<int, Kleisli arrow>` (negative — bare `int` is not monadic).

🤖 Generated with [Claude Code](https://claude.com/claude-code)