### PR TITLE
feat(category): equivalence-relation / directed-graph / undirected-graph axes (closes part of #464)

### DIFF
--- a/src/main/modules/dedekind/category/cartesian.cppm
+++ b/src/main/modules/dedekind/category/cartesian.cppm
@@ -776,4 +776,123 @@ constexpr To lift(From const&) {
                        // constructible (which @c return @c To{} would).
 }
 
+// ---------------------------------------------------------------------------
+// Order / equivalence / graph axes for binary relations (closes #464).
+//
+// Extends the relation-classification taxonomy started by #460 / PR #463
+// with the symmetric-side / order-side opt-in traits, all R-keyed for
+// parity with @c is_left_total_v / @c is_right_unique_v.  Sibling to
+// the @c (T, Op)-keyed @c is_reflexive_v / @c is_transitive_v / @c
+// is_antisymmetric_v in @c :mereology — those classify @b binary @b
+// operations @c T @c × @c T @c → @c T (closure), while these classify
+// @b binary @b relations @c R(A, B) @c → @c bool (membership of pair).
+//
+// Compositions yield textbook special cases:
+//
+//   | composition (homogeneous V × V)        | reading              |
+//   |----------------------------------------|----------------------|
+//   | IsBinaryRelation                       | directed graph       |
+//   | + symmetric                            | undirected graph     |
+//   | + reflexive + symmetric + transitive   | equivalence relation |
+//   | + reflexive + antisymmetric+transitive | partial order        |
+// ---------------------------------------------------------------------------
+
+/**
+ * @brief User-declared reflexivity witness for a binary relation.
+ * @details Reflexivity: @c R(a, @c a) holds for every @c a.  Cannot be
+ *          checked at compile time in general; opt-in.  Sibling to
+ *          @c :mereology's @c is_reflexive_v<T, Op> (which is keyed on
+ *          a binary @b operation, not a binary @b relation).
+ */
+export template <typename R>
+inline constexpr bool is_reflexive_relation_v = false;
+
+/**
+ * @brief User-declared symmetry witness for a binary relation.
+ * @details Symmetry: @c R(a, @c b) implies @c R(b, @c a).  Combined
+ *          with reflexivity and transitivity, characterises an
+ *          @b equivalence @b relation; combined with @c IsBinaryRelation
+ *          on a homogeneous @c V @c × @c V, characterises an
+ *          @b undirected @b graph.
+ */
+export template <typename R>
+inline constexpr bool is_symmetric_relation_v = false;
+
+/**
+ * @brief User-declared antisymmetry witness for a binary relation.
+ * @details Antisymmetry: @c R(a, @c b) and @c R(b, @c a) imply @c a
+ *          @c == @c b.  Combined with reflexivity and transitivity,
+ *          characterises a @b partial @b order.  Sibling to
+ *          @c :mereology's @c is_antisymmetric_v<T, Op>.
+ */
+export template <typename R>
+inline constexpr bool is_antisymmetric_relation_v = false;
+
+/**
+ * @brief User-declared transitivity witness for a binary relation.
+ * @details Transitivity: @c R(a, @c b) and @c R(b, @c c) imply
+ *          @c R(a, @c c).  Sibling to @c :mereology's
+ *          @c is_transitive_v<T, Op>.
+ */
+export template <typename R>
+inline constexpr bool is_transitive_relation_v = false;
+
+/**
+ * @concept IsEquivalenceRelation
+ * @brief A homogeneous binary relation @c R @c ⊆ @c V @c × @c V is an
+ *        @b equivalence @b relation when reflexive, symmetric, and
+ *        transitive.
+ * @details Combines @c IsBinaryRelation<R, V, V> with the three opt-in
+ *          honesty traits.  Canonical witness: @c std::equal_to<V>
+ *          (registered below for @c V @c = @c int as the existential
+ *          proof).
+ */
+export template <typename R, typename V>
+concept IsEquivalenceRelation =
+    IsBinaryRelation<R, V, V> && is_reflexive_relation_v<R> &&
+    is_symmetric_relation_v<R> && is_transitive_relation_v<R>;
+
+/**
+ * @concept IsDirectedGraph
+ * @brief A homogeneous binary relation @c R @c ⊆ @c V @c × @c V on a
+ *        vertex set @c V is a @b directed @b graph: each ordered pair
+ *        @c (u, @c v) with @c R(u, @c v) @c == @c true is an edge.
+ * @details Just @c IsBinaryRelation on a homogeneous carrier — the
+ *          structural shape is the relation; no extra trait registration
+ *          is required to call something a "directed graph" (the
+ *          generality is the point).
+ */
+export template <typename R, typename V>
+concept IsDirectedGraph = IsBinaryRelation<R, V, V>;
+
+/**
+ * @concept IsUndirectedGraph
+ * @brief A directed graph @c R is @b undirected when its relation is
+ *        symmetric: @c R(u, @c v) iff @c R(v, @c u).
+ */
+export template <typename R, typename V>
+concept IsUndirectedGraph = IsDirectedGraph<R, V> && is_symmetric_relation_v<R>;
+
+// ---------------------------------------------------------------------------
+// Canonical existential-proof witness: std::equal_to<int> is THE
+// equivalence relation on int.
+// ---------------------------------------------------------------------------
+template <typename V>
+inline constexpr bool is_reflexive_relation_v<std::equal_to<V>> = true;
+template <typename V>
+inline constexpr bool is_symmetric_relation_v<std::equal_to<V>> = true;
+template <typename V>
+inline constexpr bool is_transitive_relation_v<std::equal_to<V>> = true;
+
+static_assert(IsBinaryRelation<std::equal_to<int>, int, int>,
+              "std::equal_to<int> is a binary relation on int × int.");
+static_assert(IsEquivalenceRelation<std::equal_to<int>, int>,
+              "std::equal_to<int> is the canonical equivalence relation: "
+              "reflexive, symmetric, transitive.");
+static_assert(IsDirectedGraph<std::equal_to<int>, int>,
+              "Every binary relation on V × V is a directed graph "
+              "structurally; std::equal_to<int> is the trivial loop graph.");
+static_assert(IsUndirectedGraph<std::equal_to<int>, int>,
+              "std::equal_to<int> is symmetric, hence an undirected graph.");
+
 }  // namespace dedekind::category

--- a/src/main/modules/dedekind/category/cartesian.cppm
+++ b/src/main/modules/dedekind/category/cartesian.cppm
@@ -874,14 +874,23 @@ export template <typename R, typename V>
 concept IsUndirectedGraph = IsDirectedGraph<R, V> && is_symmetric_relation_v<R>;
 
 // ---------------------------------------------------------------------------
-// Canonical existential-proof witness: std::equal_to<int> is THE
-// equivalence relation on int.
+// Canonical existential-proof witness: std::equal_to<V> is the equivalence
+// relation on V — but ONLY for integral V.  Floating-point @c V breaks
+// reflexivity (NaN @c == @c NaN is false under IEEE 754); user-defined
+// types may have an @c operator== that violates equivalence laws (the
+// project trusts only what it verifies, and it has not verified
+// arbitrary user-defined equality).  The constraint is therefore
+// @c std::integral<V>; equality on integral types is a true equivalence
+// (no NaN, no overflow-induced asymmetry).  Floating-point and user-
+// defined V are NOT registered here; downstream callers that want
+// structural-equivalence treatment for those carriers register their
+// own opt-in traits site-locally.
 // ---------------------------------------------------------------------------
-template <typename V>
+template <std::integral V>
 inline constexpr bool is_reflexive_relation_v<std::equal_to<V>> = true;
-template <typename V>
+template <std::integral V>
 inline constexpr bool is_symmetric_relation_v<std::equal_to<V>> = true;
-template <typename V>
+template <std::integral V>
 inline constexpr bool is_transitive_relation_v<std::equal_to<V>> = true;
 
 static_assert(IsBinaryRelation<std::equal_to<int>, int, int>,
@@ -894,5 +903,19 @@ static_assert(IsDirectedGraph<std::equal_to<int>, int>,
               "structurally; std::equal_to<int> is the trivial loop graph.");
 static_assert(IsUndirectedGraph<std::equal_to<int>, int>,
               "std::equal_to<int> is symmetric, hence an undirected graph.");
+
+// Negative witness: std::equal_to<double> is NOT registered as
+// reflexive (NaN == NaN is false under IEEE 754), so it does not
+// fire IsEquivalenceRelation.  Pinned mechanically so the policy
+// is type-checked, not just commentary.
+static_assert(!is_reflexive_relation_v<std::equal_to<double>>,
+              "std::equal_to<double> is NOT reflexive (NaN == NaN is false "
+              "under IEEE 754); the integral-only constraint above prevents "
+              "the floating-point specialisation from firing.");
+static_assert(!IsEquivalenceRelation<std::equal_to<double>, double>,
+              "std::equal_to<double> is therefore NOT registered as an "
+              "equivalence relation; downstream callers needing structural "
+              "equivalence on double must opt-in site-locally with a NaN-"
+              "exclusion clause.");
 
 }  // namespace dedekind::category

--- a/src/test/cpp/modules/dedekind/category/cartesian_test.cpp
+++ b/src/test/cpp/modules/dedekind/category/cartesian_test.cpp
@@ -1,6 +1,7 @@
 /** @file src/test/cpp/modules/dedekind/category/cartesian_test.cpp */
 #include <catch2/catch_test_macros.hpp>
 #include <concepts>
+#include <functional>
 #include <utility>
 #include <variant>
 
@@ -140,5 +141,61 @@ TEST_CASE("Cartesian: Product Projection Semantics",
                               -> const std::pair<int, bool>& {
                    return arrow_drill_down(envelope);
                  })>);
+  }
+}
+
+TEST_CASE(
+    "Cartesian: Relation classification — equivalence / directed / "
+    "undirected graph axes (#464)",
+    "[category][cartesian][relation][equivalence][graph]") {
+  SECTION(
+      "std::equal_to<int> is the canonical equivalence relation: "
+      "reflexive, symmetric, transitive (registered upstream in :cartesian)") {
+    STATIC_CHECK(IsBinaryRelation<std::equal_to<int>, int, int>);
+    STATIC_CHECK(is_reflexive_relation_v<std::equal_to<int>>);
+    STATIC_CHECK(is_symmetric_relation_v<std::equal_to<int>>);
+    STATIC_CHECK(is_transitive_relation_v<std::equal_to<int>>);
+    STATIC_CHECK(IsEquivalenceRelation<std::equal_to<int>, int>);
+    // Equivalence on V × V is structurally an undirected graph (the
+    // identity loops + a-loops only when a == b).
+    STATIC_CHECK(IsUndirectedGraph<std::equal_to<int>, int>);
+
+    // Operational witness: equality reflects, symmetrises, transits.
+    constexpr std::equal_to<int> eq{};
+    CHECK(eq(7, 7));
+    CHECK(eq(3, 3));
+    CHECK(eq(3, 4) == eq(4, 3));  // symmetry
+    CHECK_FALSE(eq(3, 4));
+  }
+
+  SECTION(
+      "Negative case: std::less<int> is a binary relation but NOT an "
+      "equivalence — it is reflexive-failure (a < a is false), symmetry-"
+      "failure (a < b ≠ b < a), and antisymmetric instead.  Default "
+      "trait registration leaves it unclassified; this test pins the "
+      "negative facts as type-checked documentation") {
+    STATIC_CHECK(IsBinaryRelation<std::less<int>, int, int>);
+    STATIC_CHECK(IsDirectedGraph<std::less<int>, int>);
+    // No traits opt-in by default — std::less is not an equivalence.
+    STATIC_CHECK(!is_reflexive_relation_v<std::less<int>>);
+    STATIC_CHECK(!is_symmetric_relation_v<std::less<int>>);
+    STATIC_CHECK(!IsEquivalenceRelation<std::less<int>, int>);
+    STATIC_CHECK(!IsUndirectedGraph<std::less<int>, int>);
+  }
+
+  SECTION(
+      "Negative case: a multi-valued relation { (1,1), (1,2), (2,2) } "
+      "is a binary relation and a (degenerate) directed graph but NOT "
+      "an equivalence (no symmetry without (2,1)) and NOT a function "
+      "(fails right-uniqueness)") {
+    struct R {
+      constexpr bool operator()(int x, int y) const {
+        return (x == 1 && (y == 1 || y == 2)) || (x == 2 && y == 2);
+      }
+    };
+    STATIC_CHECK(IsBinaryRelation<R, int, int>);
+    STATIC_CHECK(IsDirectedGraph<R, int>);
+    STATIC_CHECK(!IsEquivalenceRelation<R, int>);
+    STATIC_CHECK(!IsBinaryFunction<R, int, int>);
   }
 }


### PR DESCRIPTION
Closes part of #464.  Extends the relation-classification taxonomy started by [PR #463](https://github.com/vincentk/dedekind/pull/463) (#460) with the symmetric-side axes that make graphs and equivalence relations first-class structural classifications.

## What lands

**Four new R-keyed opt-in traits in `:cartesian`** (parallel to `is_left_total_v` / `is_right_unique_v` from #463):

- `is_reflexive_relation_v<R>`
- `is_symmetric_relation_v<R>`
- `is_antisymmetric_relation_v<R>`
- `is_transitive_relation_v<R>`

Sibling to the **(T, Op)-keyed** `is_reflexive_v` / `is_transitive_v` / `is_antisymmetric_v` already in `:mereology` — those classify binary OPERATIONS (closure: `T × T → T`); these classify binary RELATIONS (membership of pair: `R(A, B) → bool`). Naming distinction (`is_reflexive_v` vs `is_reflexive_relation_v`) captures the keying difference explicitly.

**Three new homogeneous-relation concepts**:

- `IsDirectedGraph<R, V> = IsBinaryRelation<R, V, V>` — every binary relation on `V × V` is structurally a directed graph; no extra trait registration needed.
- `IsUndirectedGraph<R, V> = IsDirectedGraph + symmetric`.
- `IsEquivalenceRelation<R, V> = IsBinaryRelation<R, V, V> + reflexive + symmetric + transitive`.

**Existential-proof witness**: `std::equal_to<V>` is registered as reflexive + symmetric + transitive. Static_asserts in the partition's main pin `IsBinaryRelation`, `IsEquivalenceRelation`, `IsDirectedGraph`, `IsUndirectedGraph` for `std::equal_to<int>` as type-checked documentation.

## Test cases

- **Positive**: `std::equal_to<int>` fires every classification clause (reflexive / symmetric / transitive / equivalence / directed-graph / undirected-graph).
- **Negative**: `std::less<int>` is a binary relation / directed graph but **not** an equivalence (no reflexive / symmetric trait registration).
- **Negative**: an ad-hoc multi-valued relation `{ (1,1), (1,2), (2,2) }` is a directed graph but neither an equivalence nor a function — confirms the orthogonality of the function vs equivalence axes.

## Out of scope (filed for follow-up)

- Concrete `DirectedGraph<V, R>` / `UndirectedGraph<V, R>` reified types (set-of-pairs reading, sibling to `sets::Relation`).
- Concrete graph showcases (grid graphs, Cayley graphs, dependency graphs).
- Extending `:mereology` traits to the relation shape — the naming distinction is the explicit decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)