### PR TITLE
refactor(category, sets): document Domain-picking policy + audit :small (closes part of #411)

### DIFF
--- a/src/main/modules/dedekind/category/morphism.cppm
+++ b/src/main/modules/dedekind/category/morphism.cppm
@@ -91,31 +91,35 @@ concept IsArrow = requires {
 // type of a species / arrow.  They are not strict duplicates — each
 // serves a distinct audience.  Pick the right one for your call site:
 //
-//   | Helper                                    | Home                | Use
-//   when                                                  |
-//   |-------------------------------------------|---------------------|-----------------------------------------------------------|
-//   | @c Dom<F> / @c Cod<F>                     | @c :morphism (here) | The
-//   site is @c IsArrow-strict (functors, naturality, hub-arrows; the callable +
-//   Domain/Codomain shape is required). | | @c element_of_t<S> | @c
-//   :sets:boundaries | The site needs to work on @b primitive carriers as well
-//   as predicate-set carriers (post-carrier-migration code paths; "species or
-//   carrier" generality). | | @c
-//   MorphicBridge<signature_extractor<F>::type>::Domain | @c :morphism (below)|
-//   The site is a typed-lambda context where @c F doesn't expose @c ::Domain
-//   directly. |
+//   * @c Dom<F> / @c Cod<F> — home: @c :morphism (here).
+//     Use when the site is @c IsArrow-strict: functors, naturality,
+//     hub-arrows; i.e. when the callable-with-Domain/Codomain shape
+//     is required by the surrounding code.
+//
+//   * @c element_of_t<S> — home: @c :sets:boundaries.
+//     Use when the site needs to accept @b primitive carriers
+//     (@c bool, @c unsigned, …) as well as predicate-set carriers
+//     (post-carrier-migration code paths; the "species or carrier"
+//     generality).  This is the only helper with a primitive
+//     fallback.
+//
+//   * @c MorphicBridge<signature_extractor<F>::type>::Domain —
+//     home: @c :morphism (below).
+//     Use in typed-lambda contexts where @c F doesn't expose
+//     @c ::Domain directly.
 //
 // @b Bare @c typename @c T::Domain is acceptable @b only when:
-//   * The site has its own @c requires @c { @c typename @c T::Domain;
-//     @c } constraint that excludes primitives, OR
-//   * The type is locally constructed (e.g. struct member ordering inside
-//     a producer site like @c using @c Domain @c = @c T;).
+//   * The site has its own @c requires @c { @c typename @c T::Domain; @c }
+//     constraint that excludes primitives, OR
+//   * The type is locally constructed (e.g. inside a producer site
+//     like @c using @c Domain @c = @c T;).
 //
 // In post-carrier-migration code paths (post-#400 / #401 / #402 etc.)
-// where a "species" parameter may be a primitive carrier (@c bool,
-// @c unsigned, …), prefer @c element_of_t<S>; bare @c S::Domain there
-// fails to compile on primitives and forces a cascade fix at every
-// consumer site.  See PR #409 / @c :order:halfspace for the precedent
-// where the cascade was caught.
+// where a "species" parameter may be a primitive carrier, prefer
+// @c element_of_t<S>; bare @c S::Domain there fails to compile on
+// primitives and forces a cascade fix at every consumer site.  See
+// PR #409 / @c :order:halfspace for the precedent where the cascade
+// was caught.
 // ---------------------------------------------------------------------------
 
 /**

--- a/src/main/modules/dedekind/category/morphism.cppm
+++ b/src/main/modules/dedekind/category/morphism.cppm
@@ -84,14 +84,54 @@ concept IsArrow = requires {
   { f(x) } -> std::convertible_to<typename std::remove_cvref_t<F>::Codomain>;
 };
 
+// ---------------------------------------------------------------------------
+// Picking policy for Domain-resolving helpers (closes #411).
+//
+// The codebase has @b three helpers for retrieving the underlying-element
+// type of a species / arrow.  They are not strict duplicates — each
+// serves a distinct audience.  Pick the right one for your call site:
+//
+//   | Helper                                    | Home                | Use
+//   when                                                  |
+//   |-------------------------------------------|---------------------|-----------------------------------------------------------|
+//   | @c Dom<F> / @c Cod<F>                     | @c :morphism (here) | The
+//   site is @c IsArrow-strict (functors, naturality, hub-arrows; the callable +
+//   Domain/Codomain shape is required). | | @c element_of_t<S> | @c
+//   :sets:boundaries | The site needs to work on @b primitive carriers as well
+//   as predicate-set carriers (post-carrier-migration code paths; "species or
+//   carrier" generality). | | @c
+//   MorphicBridge<signature_extractor<F>::type>::Domain | @c :morphism (below)|
+//   The site is a typed-lambda context where @c F doesn't expose @c ::Domain
+//   directly. |
+//
+// @b Bare @c typename @c T::Domain is acceptable @b only when:
+//   * The site has its own @c requires @c { @c typename @c T::Domain;
+//     @c } constraint that excludes primitives, OR
+//   * The type is locally constructed (e.g. struct member ordering inside
+//     a producer site like @c using @c Domain @c = @c T;).
+//
+// In post-carrier-migration code paths (post-#400 / #401 / #402 etc.)
+// where a "species" parameter may be a primitive carrier (@c bool,
+// @c unsigned, …), prefer @c element_of_t<S>; bare @c S::Domain there
+// fails to compile on primitives and forces a cascade fix at every
+// consumer site.  See PR #409 / @c :order:halfspace for the precedent
+// where the cascade was caught.
+// ---------------------------------------------------------------------------
+
 /**
  * @brief Shorthand to look up the Domain of an Arrow type F.
+ *
+ * @details Picking-policy slot 1 of 3 — see the policy comment above.
+ *          Use this in @c IsArrow-strict contexts; for primitive-aware
+ *          generality use @c element_of_t<S> from @c :sets:boundaries.
  */
 export template <IsArrow F>
 using Dom = typename std::remove_cvref_t<F>::Domain;
 
 /**
  * @brief Shorthand to look up the Codomain of an Arrow type F.
+ *
+ * @details Codomain analogue of @c Dom; same picking-policy slot.
  */
 export template <IsArrow F>
 using Cod = typename std::remove_cvref_t<F>::Codomain;
@@ -206,7 +246,17 @@ struct SpeciesTraits<std::less_equal<T>>
 template <typename T>
 struct SpeciesTraits<std::less<T>> : infer_morphism<std::less<T>, T, T> {};
 
-/** @section Lambda_Introspection */
+/** @section Lambda_Introspection
+ *
+ * @c MorphicBridge synthesises @c Domain / @c Codomain for callable
+ * types that don't expose those nested aliases directly (lambdas,
+ * function pointers, @c std::function instances).  This is picking-
+ * policy slot 3 of 3 — see the policy comment near @c Dom / @c Cod
+ * above.  Use @c MorphicBridge<signature_extractor<F>::type>::Domain
+ * for typed-lambda contexts; for @c IsArrow-strict contexts use
+ * @c Dom<F>; for primitive-aware sites use @c element_of_t<S> from
+ * @c :sets:boundaries.
+ */
 template <typename T>
 struct MorphicBridge;
 

--- a/src/main/modules/dedekind/category/small.cppm
+++ b/src/main/modules/dedekind/category/small.cppm
@@ -135,7 +135,10 @@ concept IsCategory = requires {
 
   // The 'label' type for objects in this category
   typename Cat::Species;
-  requires std::same_as<typename Cat::Species, typename Cat::Arrow::Domain>;
+  // Per the picking policy in :morphism (#411): use Dom<...> in
+  // IsArrow-strict contexts (Cat::Arrow is constrained as IsArrow
+  // below).  Self-documents that the Domain comes via the arrow shape.
+  requires std::same_as<typename Cat::Species, Dom<typename Cat::Arrow>>;
 
   // 1. The Type: Capitalized to avoid shadowing the function
   typename Cat::Id;
@@ -154,10 +157,10 @@ concept IsCategory = requires {
    */
   requires requires(typename Cat::Arrow f, typename Cat::Arrow g) {
     { f >> g } -> IsArrow;
-    requires std::same_as<typename decltype(f >> g)::Domain,
-                          typename Cat::Arrow::Domain>;
-    requires std::same_as<typename decltype(f >> g)::Codomain,
-                          typename Cat::Arrow::Codomain>;
+    // Per the picking policy in :morphism (#411): use Dom / Cod for
+    // arrow-shaped composite results.
+    requires std::same_as<Dom<decltype(f >> g)>, Dom<typename Cat::Arrow>>;
+    requires std::same_as<Cod<decltype(f >> g)>, Cod<typename Cat::Arrow>>;
   };
 
   /**

--- a/src/main/modules/dedekind/sets/boundaries.cppm
+++ b/src/main/modules/dedekind/sets/boundaries.cppm
@@ -73,6 +73,27 @@ struct Boundaries {};
  * @c :family to @c :boundaries so the upstream @c Variable / @c var
  * machinery in @c :expressions can use the same trait without
  * duplicating the resolution logic.
+ *
+ * @section Picking_Policy_Cross_Reference
+ *
+ * @c element_of_t is one of @b three Domain-resolving helpers in the
+ * project — see @c :morphism's "Picking policy" comment block (post-
+ * #411) for the canonical decision rule.  In short:
+ *
+ *   * @c Dom<F> / @c Cod<F> ( @c :morphism) — for @c IsArrow-strict
+ *     contexts.
+ *   * @c element_of_t<S> ( @b here) — for sites that must accept @b
+ *     primitive carriers as well as predicate-set carriers.  This is
+ *     the only helper with a primitive fallback; per-symbol carrier
+ *     migrations (post-#401 / #402 etc.) prefer this on consumer sites
+ *     to avoid the "primitive doesn't satisfy @c Species::Domain"
+ *     cascade.
+ *   * @c MorphicBridge<signature_extractor<F>::type>::Domain ( @c
+ *     :morphism) — for typed-lambda contexts without nested @c ::Domain.
+ *
+ * Bare @c typename @c T::Domain is acceptable only at @b producer sites
+ * (where @c using @c Domain @c = @c T; is the @b defining clause), or
+ * inside a @c requires that already excludes primitives.
  */
 export template <typename T>
 struct resolve_species {


### PR DESCRIPTION
Closes part of #411 — first instalment.

## What lands

**Canonical picking-policy doc-block in \`:morphism\`** spelling out which of the three Domain-resolving helpers to pick:

| Helper                             | Use when                                                                  |
|------------------------------------|---------------------------------------------------------------------------|
| `Dom<F>` / `Cod<F>`            | The site is `IsArrow`-strict (functors, naturality, hub-arrows).        |
| `element_of_t<S>`                | Site must accept **primitive carriers** as well as predicate-set carriers. |
| `MorphicBridge<...>::Domain`     | Typed-lambda site without nested `::Domain`.                            |

**Cross-references** added at the other two helpers' docstrings:

- `:sets:boundaries` (where `element_of_t` lives) — new `@section Picking_Policy_Cross_Reference` pointing back to the canonical block in `:morphism\` and noting that `element_of_t` is the only helper with a primitive fallback (consumer sites in carrier-migration code paths should prefer it).
- `:morphism` Lambda_Introspection section (where `MorphicBridge` lives) — short note linking back to the canonical block.

**Audit-and-retarget sweep — first instalment** (`:category:small`):

- 3 sites where `Cat::Arrow::Domain` / `Cat::Arrow::Codomain` was used directly are retargeted to `Dom<typename Cat::Arrow>` / `Cod<typename Cat::Arrow>`. These are `IsArrow`-strict consumer sites where the arrow shape is implied; the helper form self-documents the picking choice.

## Out of scope (filed for follow-up)

The sweep across the remaining consumer sites lands in instalments to keep PRs reviewable:

- \`:category:natural\` — \`Σ_cat::Arrow::Domain\` chains.
- \`:category:logic\` — line ~340.
- Other categorical-witness partitions identified by the audit.

Producer-side \`using Domain = T;\` clauses in species definitions are explicitly **not** touched (those are the defining clauses, not consumer references).

## No code-behaviour change

The audit is name-equivalent (\`Dom<F>\` is defined as \`typename remove_cvref_t<F>::Domain\`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)