### PR TITLE
feat(sets): bare-Variable<bool> truthy form recognised by collapse machinery (closes #408)

### DIFF
--- a/src/main/modules/dedekind/sets/expressions.cppm
+++ b/src/main/modules/dedekind/sets/expressions.cppm
@@ -129,7 +129,8 @@ struct MembershipBinding {
    *  @c !b) routing into it.
    */
   template <typename OtherSpecies>
-    requires std::same_as<element_of_t<OtherSpecies>, bool>
+    requires std::same_as<element_of_t<Species>, bool> &&
+             std::same_as<element_of_t<OtherSpecies>, bool>
   constexpr auto operator|(const Variable<OtherSpecies>&) const {
     return Comprehension<Species, BooleanEqPredicate>{base,
                                                       BooleanEqPredicate{true}};

--- a/src/main/modules/dedekind/sets/expressions.cppm
+++ b/src/main/modules/dedekind/sets/expressions.cppm
@@ -78,13 +78,27 @@ struct Comprehension {
   static constexpr bool is_idempotent_v = true;
 };
 
-// Forward declarations: resolved below where Variable / BooleanEqPredicate
-// are fully defined.  Both are @c export-declared here so the later
-// definitions match in module linkage.
+// Forward declaration of @c Variable: the @c MembershipBinding pipe
+// below has a Variable<bool>-truthy specialisation that needs the
+// type name; the full definition lives just below.
 export template <typename Species>
 struct Variable;
 
-export struct BooleanEqPredicate;
+/** @brief Boolean equality predicate for compile-time pruning over 𝔹.
+ *
+ *  Defined here (rather than further down where the @c FiniteBooleanSet
+ *  collapse machinery lives) because the @c MembershipBinding pipe's
+ *  Variable<bool>-truthy specialisation rewrites the bare-@c b form to
+ *  @c BooleanEqPredicate{true}, and that overload needs the type to
+ *  be complete (#408).  The collapse-machinery uses further down still
+ *  see the same definition — it's the single source of truth for the
+ *  bool-domain predicate.
+ */
+export struct BooleanEqPredicate {
+  bool expected;
+
+  constexpr bool operator()(bool v) const { return v == expected; }
+};
 
 /** @brief The Membership Binding: Bridges a Variable to its Domain. */
 template <typename Species>
@@ -211,13 +225,6 @@ inline constexpr bool IsComplementPair_v =
 
 export template <typename T, typename L, typename Predicate>
 class Set;
-
-/** @brief Boolean equality predicate for compile-time pruning over 𝔹. */
-export struct BooleanEqPredicate {
-  bool expected;
-
-  constexpr bool operator()(bool v) const { return v == expected; }
-};
 
 /** @brief Extensional finite bool-domain result for collapsed 𝔹 operations. */
 export template <typename L>

--- a/src/main/modules/dedekind/sets/expressions.cppm
+++ b/src/main/modules/dedekind/sets/expressions.cppm
@@ -78,9 +78,13 @@ struct Comprehension {
   static constexpr bool is_idempotent_v = true;
 };
 
-// Forward declaration: resolved below where Variable lives.
+// Forward declarations: resolved below where Variable / BooleanEqPredicate
+// are fully defined.  Both are @c export-declared here so the later
+// definitions match in module linkage.
 export template <typename Species>
 struct Variable;
+
+export struct BooleanEqPredicate;
 
 /** @brief The Membership Binding: Bridges a Variable to its Domain. */
 template <typename Species>

--- a/src/main/modules/dedekind/sets/expressions.cppm
+++ b/src/main/modules/dedekind/sets/expressions.cppm
@@ -78,6 +78,10 @@ struct Comprehension {
   static constexpr bool is_idempotent_v = true;
 };
 
+// Forward declaration: resolved below where Variable lives.
+export template <typename Species>
+struct Variable;
+
 /** @brief The Membership Binding: Bridges a Variable to its Domain. */
 template <typename Species>
 struct MembershipBinding {
@@ -87,6 +91,30 @@ struct MembershipBinding {
   template <typename P>
   constexpr auto operator|(P&& p) const {
     return Comprehension<Species, std::decay_t<P>>{base, std::forward<P>(p)};
+  }
+
+  /** @brief Bare-Variable<bool> truthy-predicate specialisation (#408).
+   *
+   *  The textbook set-builder form @c Set{b @c % @c B @c | @c b}
+   *  reads "the elements of @c B for which @c b holds".  When @c b's
+   *  underlying element type is @c bool, the bare-@c b form is the
+   *  truthy predicate — semantically equivalent to @c b @c == @c true,
+   *  which produces a @c BooleanEqPredicate{true}.  This overload
+   *  rewrites the bare form to that canonical predicate so the
+   *  existing collapse machinery ( @c structured_and / @c
+   *  FiniteBooleanSet operators / @c Set::operator& / @c
+   *  Set::operator|) recognises it as the truthy half of a
+   *  complementary pair.  Mirrors the existing @c operator==(b, bool)
+   *  and @c operator!(b) overloads in this partition: the bool-domain
+   *  encoding lives in exactly one place ( @c BooleanEqPredicate),
+   *  with all three syntactic surfaces ( @c b, @c b @c == @c true,
+   *  @c !b) routing into it.
+   */
+  template <typename OtherSpecies>
+    requires std::same_as<element_of_t<OtherSpecies>, bool>
+  constexpr auto operator|(const Variable<OtherSpecies>&) const {
+    return Comprehension<Species, BooleanEqPredicate>{base,
+                                                      BooleanEqPredicate{true}};
   }
 };
 

--- a/src/test/cpp/modules/dedekind/sets/expressions_test.cpp
+++ b/src/test/cpp/modules/dedekind/sets/expressions_test.cpp
@@ -79,6 +79,36 @@ TEST_CASE("Dedekind Identities: Boolean literals collapse over 𝔹",
   CHECK((b_false | b_true)(true) == true);
 }
 
+TEST_CASE(
+    "Dedekind Identities: bare-Variable<bool> truthy form collapses (#408)",
+    "[sets][identities][boolean][variable-truthy]") {
+  // The textbook DSL form `Set{b % B | b}` reads "elements of B for
+  // which b holds" — the bare-b form is the truthy predicate, and
+  // should be recognised as semantically equivalent to b == true by
+  // the structured-and / FiniteBooleanSet collapse machinery.
+  using BoolAmbient = Ω<bool, ClassicalLogic, Finite>;
+  constexpr BoolAmbient B_bool{};
+
+  constexpr auto b = var<BoolAmbient>;
+
+  // Bare-b form (the issue's target ergonomics).
+  constexpr auto b_true_bare = Set{b % B_bool | b};
+  // Equivalent comparison form.
+  constexpr auto b_true_eq = Set{b % B_bool | (b == true)};
+  // Negated bare-b form.
+  constexpr auto b_false = Set{b % B_bool | !b};
+
+  // The collapse machinery treats both bare-b and (b == true) as the
+  // same predicate (BooleanEqPredicate{true}) so the static_asserts
+  // pinning the Boolean partition laws fire on the bare-b form.
+  STATIC_CHECK(Ø<bool, ClassicalLogic>{} == (b_false & b_true_bare));
+  STATIC_CHECK(B_bool == (b_false | b_true_bare));
+
+  // Operational witness: bare-b agrees with (b == true) at every input.
+  CHECK(b_true_bare(false) == b_true_eq(false));
+  CHECK(b_true_bare(true) == b_true_eq(true));
+}
+
 TEST_CASE("Dedekind Sets: Cartesian product and relation witnesses",
           "[sets][relations][cartesian]") {
   auto x = var<Ω<int>>;


### PR DESCRIPTION
Closes #408.

## What lands

Extends `sets:expressions`'s Comprehension pipe to recognise the textbook DSL form

```cpp
Set{b % B_bool | b}
```

as semantically equivalent to

```cpp
Set{b % B_bool | (b == true)}
```

The bare-`b` form is the right ergonomic target — it matches blackboard notation `{b ∈ 𝔹 | b}` — but previously the collapse machinery specialised on `BooleanEqPredicate` (the type produced by `b == true`), which meant bare-`b` didn't trigger the `structured_and` / `FiniteBooleanSet` laws.

## Implementation

A specialised `MembershipBinding<Species>::operator|` that takes a `Variable<OtherSpecies>` with bool element type and rewrites it to `Comprehension<Species, BooleanEqPredicate>{base, BooleanEqPredicate{true}}` — same canonical predicate the `b == true` form produces.

Mirrors the existing `operator==(b, bool)` and `operator!(b)` overloads in this partition: the bool-domain encoding lives in exactly **one place** (`BooleanEqPredicate`), with all three syntactic surfaces (`b`, `b == true`, `!b`) routing into it.

## Test case

`[sets][identities][boolean][variable-truthy]` — pins the Boolean-partition laws on the bare-`b` form:

```cpp
STATIC_CHECK(Ø<bool, ClassicalLogic>{} == (b_false & b_true_bare));
STATIC_CHECK(B_bool == (b_false | b_true_bare));
```

Plus operational equivalence with the `(b == true)` form on every input.

## No regression

The new overload is strictly additive (`requires std::same_as<element_of_t<OtherSpecies>, bool>` constraint); existing `(b == true)` / `!b` paths are unchanged.