### PR TITLE
docs(numbers): close acceptance gaps in :uint / :sint classification (closes #417, #418)

### DIFF
--- a/src/main/modules/dedekind/numbers/sint.cppm
+++ b/src/main/modules/dedekind/numbers/sint.cppm
@@ -291,14 +291,14 @@ static_assert(dedekind::order::HasLatticeOperators<long long>,
 // Pinned explicitly so the std::signed_integral reader sees the
 // dichotomy in one place: the operator surface fires, the axiomatic
 // ring witness does not.
-static_assert(!dedekind::category::IsRing<int, std::plus<int>,
-                                          std::multiplies<int>>,
-              "int is NOT an axiomatic ring under std::plus / "
-              "std::multiplies: signed-overflow UB defeats closure "
-              "before the ring axioms are reachable.");
-static_assert(!dedekind::category::IsRing<long, std::plus<long>,
-                                          std::multiplies<long>>,
-              "long is NOT an axiomatic ring: same reason as int.");
+static_assert(
+    !dedekind::category::IsRing<int, std::plus<int>, std::multiplies<int>>,
+    "int is NOT an axiomatic ring under std::plus / "
+    "std::multiplies: signed-overflow UB defeats closure "
+    "before the ring axioms are reachable.");
+static_assert(
+    !dedekind::category::IsRing<long, std::plus<long>, std::multiplies<long>>,
+    "long is NOT an axiomatic ring: same reason as int.");
 static_assert(!dedekind::category::IsRing<long long, std::plus<long long>,
                                           std::multiplies<long long>>,
               "long long is NOT an axiomatic ring: same reason as int.");

--- a/src/main/modules/dedekind/numbers/sint.cppm
+++ b/src/main/modules/dedekind/numbers/sint.cppm
@@ -275,6 +275,34 @@ static_assert(dedekind::order::IsTotallyOrdered<int>,
 static_assert(dedekind::order::IsDirectedSet<int>,
               "int is a directed set (net domain).");
 
+// Bitwise / lattice operator surface — std::signed_integral carries
+// the four bitwise operators (mirrors the unsigned-side claim in
+// :uint). No axiomatic lattice claim is made here.
+static_assert(dedekind::order::HasLatticeOperators<int>,
+              "int carries the bitwise / lattice operator surface "
+              "(&, |, ^, ~).");
+static_assert(dedekind::order::HasLatticeOperators<long>,
+              "long carries the bitwise / lattice operator surface.");
+static_assert(dedekind::order::HasLatticeOperators<long long>,
+              "long long carries the bitwise / lattice operator surface.");
+
+// Axiomatic-ring rejection — the strictly weaker downstream consequence
+// of the @c !Group_ℤ / @c !IsArithmeticAdditiveGroup pins above.
+// Pinned explicitly so the std::signed_integral reader sees the
+// dichotomy in one place: the operator surface fires, the axiomatic
+// ring witness does not.
+static_assert(!dedekind::category::IsRing<int, std::plus<int>,
+                                          std::multiplies<int>>,
+              "int is NOT an axiomatic ring under std::plus / "
+              "std::multiplies: signed-overflow UB defeats closure "
+              "before the ring axioms are reachable.");
+static_assert(!dedekind::category::IsRing<long, std::plus<long>,
+                                          std::multiplies<long>>,
+              "long is NOT an axiomatic ring: same reason as int.");
+static_assert(!dedekind::category::IsRing<long long, std::plus<long long>,
+                                          std::multiplies<long long>>,
+              "long long is NOT an axiomatic ring: same reason as int.");
+
 // Sequence witness: machine signed int is a valid sequence codomain.
 static_assert(
     dedekind::sequences::IsFiniteSequence<dedekind::sequences::FinitePath<int>>,

--- a/src/main/modules/dedekind/numbers/uint.cppm
+++ b/src/main/modules/dedekind/numbers/uint.cppm
@@ -260,6 +260,18 @@ static_assert(dedekind::order::IsTotallyOrdered<unsigned int>,
 static_assert(dedekind::order::IsDirectedSet<unsigned int>,
               "unsigned int is a directed set (net domain).");
 
+// Bitwise / lattice operator surface — std::unsigned_integral carries
+// the four bitwise operators, satisfying the syntactic-shape concept
+// from :order:lattice. The bundled IsOrderLattice axiomatic claim is
+// not made here (it lives at the Boolean-ring reading on :boolean).
+static_assert(dedekind::order::HasLatticeOperators<unsigned int>,
+              "unsigned int carries the bitwise / lattice operator surface "
+              "(&, |, ^, ~).");
+static_assert(dedekind::order::HasLatticeOperators<unsigned long>,
+              "unsigned long carries the bitwise / lattice operator surface.");
+static_assert(dedekind::order::HasLatticeOperators<std::size_t>,
+              "std::size_t carries the bitwise / lattice operator surface.");
+
 // Sequence witness: machine unsigned is a valid sequence codomain.
 static_assert(dedekind::sequences::IsFiniteSequence<
                   dedekind::sequences::FinitePath<unsigned int>>,


### PR DESCRIPTION
## Summary

Verification pass against the acceptance criteria of #417 and #418 (both substantively shipped via PRs #441 / #444 but with two small gaps each).

**`:uint`** (closes #417):
- `HasLatticeOperators<unsigned int / unsigned long / std::size_t>` — the bitwise / lattice operator surface (`&, |, ^, ~`) is the only explicit acceptance bullet not previously pinned.

**`:sint`** (closes #418):
- `HasLatticeOperators<int / long / long long>` — same bitwise surface as the unsigned-side claim.
- `!category::IsRing<T, std::plus, std::multiplies>` for `int / long / long long` — the strictly weaker downstream consequence of the existing `!Group_ℤ` / `!IsArithmeticAdditiveGroup` pins. Filed at the umbrella level so the `std::signed_integral` reader sees the operator-shape ✓ vs axiomatic-ring ✗ dichotomy in one place.

Everything else in the two issues was already in place across the partitions.

## Test plan

- [x] \`make compile\` — green.
- [x] No code changes; \`static_assert\`-only doc completeness sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)