### PR TITLE
docs: fix doxygen file-list rendering — collapse multi-line @briefs and remove non-standard @module / @concept tags from file headers

### DIFF
--- a/src/main/modules/dedekind/algebra/algebra.cppm
+++ b/src/main/modules/dedekind/algebra/algebra.cppm
@@ -1,6 +1,5 @@
 /**
  * @file algebra.cppm
- * @module dedekind.algebra
  * @brief Level 3: Groups ⊂ Rings ⊂ Modules ⊂ Polynomials.
  *
  * @copyright 2026 The Dedekind Authors

--- a/src/main/modules/dedekind/algebra/boolean.cppm
+++ b/src/main/modules/dedekind/algebra/boolean.cppm
@@ -1,7 +1,6 @@
 /**
  * @file boolean.cppm
  * @partition :boolean
- * @module dedekind.algebra:boolean
  * @brief Boolean Starter Package: canonical Boolean ambient species aliases.
  *
  * @copyright 2026 The Dedekind Authors

--- a/src/main/modules/dedekind/algebra/initial_ring.cppm
+++ b/src/main/modules/dedekind/algebra/initial_ring.cppm
@@ -1,7 +1,6 @@
 /**
  * @file dedekind/algebra/initial_ring.cppm
  * @partition :initial_ring
- * @module dedekind.algebra:initial_ring
  * @brief @c ℤ as a Form — Initial Ring and Grothendieck group of @c ℕ.
  *
  * @copyright 2026 The Dedekind Authors

--- a/src/main/modules/dedekind/analysis/analysis.cppm
+++ b/src/main/modules/dedekind/analysis/analysis.cppm
@@ -1,8 +1,6 @@
 /**
  * @file dedekind/analysis/analysis.cppm
- * @module dedekind.analysis
- * @brief Level 11: Analysis -- kernels, forms, exterior calculus and
- * Hamiltonian structure.
+ * @brief Level 11: kernels, forms, exterior calculus, Hamiltonian flow.
  *
  * @copyright 2026 The Dedekind Authors
  * Licensed under the Apache License, Version 2.0.

--- a/src/main/modules/dedekind/category/adjunction.cppm
+++ b/src/main/modules/dedekind/category/adjunction.cppm
@@ -1,7 +1,6 @@
 /**
  * @file dedekind/category/adjunction.cppm
  * @partition :adjunction
- * @module dedekind.category:adjunction
  * @brief Level 2.3: Adjoint functors (the Free / Forgetful axis).
  *
  * @copyright 2026 The Dedekind Authors

--- a/src/main/modules/dedekind/category/category.cppm
+++ b/src/main/modules/dedekind/category/category.cppm
@@ -1,6 +1,5 @@
 /**
  * @file dedekind/category/category.cppm
- * @module dedekind.category
  * @brief Level 0--4: categorical bedrock + ETCS facade.
  *
  * @copyright 2026 The Dedekind Authors

--- a/src/main/modules/dedekind/category/f_algebra.cppm
+++ b/src/main/modules/dedekind/category/f_algebra.cppm
@@ -1,11 +1,7 @@
 /**
  * @file dedekind/category/f_algebra.cppm
  * @partition :f_algebra
- * @module dedekind.category:f_algebra
- * @brief Level 2 (Bridge): Universal-property reification of @b F-algebras
- *        and @b F-coalgebras — the @b initial F-algebra (the carrier of
- *        catamorphisms) and the @b terminal F-coalgebra (the carrier of
- *        anamorphisms).  Closes the universal-property layer for #449.
+ * @brief Level 2: Initial F-algebras and terminal F-coalgebras.
  *
  * @copyright 2026 The Dedekind Authors
  * Licensed under the Apache License, Version 2.0.

--- a/src/main/modules/dedekind/category/functor.cppm
+++ b/src/main/modules/dedekind/category/functor.cppm
@@ -1,7 +1,6 @@
 /**
  * @file dedekind/category/functor.cppm
  * @partition :functor
- * @module dedekind.category:functor
  * @brief Level 2: The Functorial Spine (Structure Preservation).
  *
  * @copyright 2026 The Dedekind Authors

--- a/src/main/modules/dedekind/category/natural.cppm
+++ b/src/main/modules/dedekind/category/natural.cppm
@@ -1,7 +1,6 @@
 /**
  * @file dedekind/category/natural.cppm
  * @partition :natural
- * @module dedekind.category:natural
  * @brief Level 2.2: Natural Transformations (The Slide between Functors).
  *
  * @copyright 2026 The Dedekind Authors

--- a/src/main/modules/dedekind/category/nno.cppm
+++ b/src/main/modules/dedekind/category/nno.cppm
@@ -1,7 +1,6 @@
 /**
  * @file dedekind/category/nno.cppm
  * @partition :nno
- * @module dedekind.category:nno
  * @brief Level 2: The Natural Numbers Object — Lawvere's ETCS Axiom 9.
  *
  * @copyright 2026 The Dedekind Authors

--- a/src/main/modules/dedekind/category/posetal.cppm
+++ b/src/main/modules/dedekind/category/posetal.cppm
@@ -1,9 +1,7 @@
 /**
  * @file dedekind/category/posetal.cppm
  * @partition :posetal
- * @concept IsPosetal
- * @brief Represents a Posetal Category (A Category derived from a Partially
- * Ordered Set).
+ * @brief Posetal categories — categories derived from partial orders.
  *
  * @section Categorical_Definition
  * A Posetal Category is a category where for any two objects A and B, there is

--- a/src/main/modules/dedekind/category/small.cppm
+++ b/src/main/modules/dedekind/category/small.cppm
@@ -1,7 +1,6 @@
 /**
  * @file dedekind/category/small.cppm
  * @partition :small
- * @module dedekind.category:small
  * @brief Small Categories (Enumerated Morphism Sets).
  *
  * @copyright 2026 The Dedekind Authors

--- a/src/main/modules/dedekind/geometry/affine.cppm
+++ b/src/main/modules/dedekind/geometry/affine.cppm
@@ -1,8 +1,7 @@
 /**
  * @file dedekind/geometry/affine.cppm
  * @partition :affine
- * @brief Level 10: Affine spaces — points, vectors, dimension witnesses
- *        (Finite / Countably-Infinite); base of the geometry hierarchy.
+ * @brief Level 10: Affine spaces — points, vectors, dimension witnesses.
  *
  * @copyright 2026 The Dedekind Authors
  * Licensed under the Apache License, Version 2.0.

--- a/src/main/modules/dedekind/geometry/geometry.cppm
+++ b/src/main/modules/dedekind/geometry/geometry.cppm
@@ -1,8 +1,6 @@
 /**
  * @file geometry.cppm
- * @module dedekind.geometry
- * @brief Level 9: Geometric Species (Affine ⊂ InnerProduct ⊂ Euclidean ⊂
- * Hilbert).
+ * @brief Level 9: Affine ⊂ InnerProduct ⊂ Euclidean ⊂ Hilbert.
  *
  * @copyright 2026 The Dedekind Authors
  * Licensed under the Apache License, Version 2.0.

--- a/src/main/modules/dedekind/geometry/hilbert.cppm
+++ b/src/main/modules/dedekind/geometry/hilbert.cppm
@@ -1,8 +1,7 @@
 /**
  * @file dedekind/geometry/hilbert.cppm
  * @partition :hilbert
- * @brief Level 10.2: The Complete Infinite — Hilbert spaces (Cauchy-
- *        complete inner-product spaces over ℝ or ℂ).
+ * @brief Level 10.2: Hilbert spaces — Cauchy-complete inner-product spaces.
  *
  * @copyright 2026 The Dedekind Authors
  * Licensed under the Apache License, Version 2.0.

--- a/src/main/modules/dedekind/geometry/inner_product.cppm
+++ b/src/main/modules/dedekind/geometry/inner_product.cppm
@@ -1,8 +1,7 @@
 /**
  * @file dedekind/geometry/inner_product.cppm
  * @partition :inner_product
- * @brief Level 10.1: The Metric of Angles — pre-Hilbert spaces (inner-
- *        product spaces over ℝ or ℂ, before Cauchy completion).
+ * @brief Level 10.1: Pre-Hilbert (inner-product) spaces over ℝ or ℂ.
  *
  * @copyright 2026 The Dedekind Authors
  * Licensed under the Apache License, Version 2.0.

--- a/src/main/modules/dedekind/geometry/lattice.cppm
+++ b/src/main/modules/dedekind/geometry/lattice.cppm
@@ -1,8 +1,7 @@
 /**
  * @file dedekind/geometry/lattice.cppm
  * @partition :lattice
- * @brief Level 9.3: Geometric Lattices — discrete subspaces with
- *        periodic structure (e.g. ℤ², ℕ², Gaussian integers in ℂ).
+ * @brief Level 9.3: Geometric lattices (ℤ², ℕ², Gaussian integers in ℂ).
  *
  * @copyright 2026 The Dedekind Authors
  * Licensed under the Apache License, Version 2.0.

--- a/src/main/modules/dedekind/geometry/linear_map.cppm
+++ b/src/main/modules/dedekind/geometry/linear_map.cppm
@@ -1,8 +1,7 @@
 /**
  * @file dedekind/geometry/linear_map.cppm
  * @partition :linear_map
- * @brief Level 10.05: Concrete finite-dimensional linear maps with algebraic
- * verification.
+ * @brief Level 10.05: Finite-dim linear maps with algebraic witnesses.
  *
  * @section Algebraic_Structure
  * LinearMap<F, R, C> represents a finite-dimensional linear map F^C -> F^R

--- a/src/main/modules/dedekind/ieee/approx.cppm
+++ b/src/main/modules/dedekind/ieee/approx.cppm
@@ -1,6 +1,5 @@
 /**
  * @file dedekind/ieee/approx.cppm
- * @module dedekind.ieee.approx
  * @brief Approximation policies for the IEEE effect context.
  *
  * @copyright 2026 The Dedekind Authors

--- a/src/main/modules/dedekind/ieee/ieee.cppm
+++ b/src/main/modules/dedekind/ieee/ieee.cppm
@@ -1,6 +1,5 @@
 /**
  * @file dedekind/ieee/ieee.cppm
- * @module dedekind.ieee
  * @brief Core IEEE fast lane as explicit physical plumbing.
  *
  * @copyright 2026 The Dedekind Authors

--- a/src/main/modules/dedekind/linear_algebra/linear_algebra.cppm
+++ b/src/main/modules/dedekind/linear_algebra/linear_algebra.cppm
@@ -1,6 +1,5 @@
 /**
  * @file linear_algebra.cppm
- * @module dedekind.linear_algebra
  * @brief Level 12.5: Backend-agnostic linear operator contracts.
  *
  * @copyright 2026 The Dedekind Authors

--- a/src/main/modules/dedekind/linear_algebra/matrix.cppm
+++ b/src/main/modules/dedekind/linear_algebra/matrix.cppm
@@ -1,9 +1,7 @@
 /**
  * @file dedekind/linear_algebra/matrix.cppm
  * @partition :matrix
- * @brief Level 12.5a: Matrices as rectangular linear maps between tuple
- *        spaces. Hosts both the NTTP (type-level) and value-level matrix
- *        families, plus the concept witnesses that tie them to `:contracts`.
+ * @brief Level 12.5a: Matrices as rectangular linear maps between tuples.
  *
  * @details
  * Following Stammbach's "Lineare Algebra", matrices are interpreted as

--- a/src/main/modules/dedekind/linear_algebra/tuple.cppm
+++ b/src/main/modules/dedekind/linear_algebra/tuple.cppm
@@ -1,8 +1,7 @@
 /**
  * @file dedekind/linear_algebra/tuple.cppm
  * @partition :tuple
- * @brief Level 12.5a₀: Finite tuples — vectors and covectors as indexed
- *        sequences, oriented as columns or rows.
+ * @brief Level 12.5a₀: Finite tuples — column / row vectors and covectors.
  *
  * @copyright 2026 The Dedekind Authors
  * Licensed under the Apache License, Version 2.0.

--- a/src/main/modules/dedekind/morphologies/archimedean.cppm
+++ b/src/main/modules/dedekind/morphologies/archimedean.cppm
@@ -1,5 +1,5 @@
 /**
- * @file ontology:morphologies.cppm
+ * @file dedekind/morphologies/archimedean.cppm
  * @partition :archimedean
  * @brief Level 3.5b: Archimedean / ordered-field convergence stubs.
  *

--- a/src/main/modules/dedekind/morphologies/archimedean.cppm
+++ b/src/main/modules/dedekind/morphologies/archimedean.cppm
@@ -1,8 +1,7 @@
 /**
  * @file ontology:morphologies.cppm
  * @partition :archimedean
- * @brief Level 3.5b: Convergence morphology stubs for experimental
- * reintegration.
+ * @brief Level 3.5b: Archimedean / ordered-field convergence stubs.
  *
  * @copyright 2026 The Dedekind Authors
  * Licensed under the Apache License, Version 2.0.

--- a/src/main/modules/dedekind/morphologies/morphologies.cppm
+++ b/src/main/modules/dedekind/morphologies/morphologies.cppm
@@ -1,8 +1,6 @@
 /**
  * @file dedekind/morphologies/morphologies.cppm
- * @module dedekind.morphologies
- * @brief Level 4: cyclic and Archimedean morphology carriers and their
- *        operational concept witnesses.
+ * @brief Level 4: Cyclic and Archimedean morphology carriers.
  *
  * @section The_Structural_Seal
  * « La mathématique est l'étude des structures qui sont invariantes par

--- a/src/main/modules/dedekind/numbers/approx.cppm
+++ b/src/main/modules/dedekind/numbers/approx.cppm
@@ -1,6 +1,5 @@
 /**
  * @file dedekind/numbers/approx.cppm
- * @module dedekind.numbers.approx
  * @brief Compatibility bridge for IEEE approximation policies.
  *
  * @copyright 2026 The Dedekind Authors

--- a/src/main/modules/dedekind/numbers/constants.cppm
+++ b/src/main/modules/dedekind/numbers/constants.cppm
@@ -1,9 +1,7 @@
 /**
  * @file dedekind/numbers/constants.cppm
  * @partition :constants
- * @brief Reserved partition for genuine Dedekind-cut realisations of
- *        named real constants ($\sqrt{2}$, $e$, $\pi$, $\gamma$, …).
- *        Currently empty (no exports).
+ * @brief Reserved for Dedekind-cut realisations of named reals (empty).
  *
  * @copyright 2026 The Dedekind Authors
  * Licensed under the Apache License, Version 2.0.

--- a/src/main/modules/dedekind/numbers/dual.cppm
+++ b/src/main/modules/dedekind/numbers/dual.cppm
@@ -1,8 +1,7 @@
 /**
  * @file dedekind/numbers/dual.cppm
  * @partition :dual
- * @brief Level 9.5: The Infinitesimal Extension 𝔻 — dual numbers
- *        a + bε with ε² = 0 (algebraic basis for forward-mode AD).
+ * @brief Level 9.5: Dual numbers 𝔻 = a + bε with ε² = 0 (forward-mode AD).
  *
  * @copyright 2026 The Dedekind Authors
  * Licensed under the Apache License, Version 2.0.

--- a/src/main/modules/dedekind/numbers/floating_point.cppm
+++ b/src/main/modules/dedekind/numbers/floating_point.cppm
@@ -1,11 +1,7 @@
 /**
  * @file dedekind/numbers/floating_point.cppm
  * @partition :floating_point
- * @module dedekind.numbers:floating_point
- * @brief Level 4: The std::floating_point family — operator surface ✓ +
- *        operational ordered-field reading ✓, axiomatic ring / field /
- *        total order ✗ (IEEE 754 Honest Rejection: rounding breaks
- *        associativity; NaN breaks reflexivity).
+ * @brief Level 4: std::floating_point — IEEE 754 Honest Rejection.
  *
  * @copyright 2026 The Dedekind Authors
  * Licensed under the Apache License, Version 2.0.

--- a/src/main/modules/dedekind/numbers/ieee.cppm
+++ b/src/main/modules/dedekind/numbers/ieee.cppm
@@ -1,6 +1,5 @@
 /**
  * @file dedekind/numbers/ieee.cppm
- * @module dedekind.numbers.ieee
  * @brief Bridge from numerical carriers into the upstream IEEE core module.
  *
  * @copyright 2026 The Dedekind Authors

--- a/src/main/modules/dedekind/numbers/integral.cppm
+++ b/src/main/modules/dedekind/numbers/integral.cppm
@@ -1,10 +1,7 @@
 /**
  * @file dedekind/numbers/integral.cppm
  * @partition :integral
- * @module dedekind.numbers:integral
- * @brief Level 4: Umbrella note over @c std::integral —
- *        the union of three structurally-distinct algebras
- *        (@c std::unsigned_integral, @c std::signed_integral, @c bool).
+ * @brief Level 4: std::integral umbrella over uint / sint / bool.
  *
  * @copyright 2026 The Dedekind Authors
  * Licensed under the Apache License, Version 2.0.

--- a/src/main/modules/dedekind/numbers/lattice.cppm
+++ b/src/main/modules/dedekind/numbers/lattice.cppm
@@ -1,8 +1,7 @@
 /**
  * @file dedekind/numbers/lattice.cppm
  * @partition :lattice
- * @brief Level 9.6: First-class lattice species over continuous number
- *        systems — integer / Gaussian lattices in ℝ, ℂ, ℝⁿ, ℂⁿ.
+ * @brief Level 9.6: Integer / Gaussian lattices in ℝ, ℂ, ℝⁿ, ℂⁿ.
  *
  * @copyright 2026 The Dedekind Authors
  * Licensed under the Apache License, Version 2.0.

--- a/src/main/modules/dedekind/numbers/numbers.cppm
+++ b/src/main/modules/dedekind/numbers/numbers.cppm
@@ -1,6 +1,5 @@
 /**
  * @file numbers.cppm
- * @module dedekind.numbers
  * @brief Level -1 to 8: The Numerical Tower (ℕ ⊂ ℤ ⊂ ℚ ⊂ ℝ ⊂ ℂ).
  *
  * @copyright 2026 The Dedekind Authors

--- a/src/main/modules/dedekind/numbers/rational.cppm
+++ b/src/main/modules/dedekind/numbers/rational.cppm
@@ -1,9 +1,7 @@
 /**
  * @file dedekind/numbers/rational.cppm
  * @partition :rational
- * @module dedekind.numbers:rational
- * @brief Level 8: The Quotient Field ℚ — rationals as numerator/
- *        denominator pairs over an integer carrier.
+ * @brief Level 8: ℚ — rationals as numerator/denominator pairs.
  *
  * @copyright 2026 The Dedekind Authors
  * Licensed under the Apache License, Version 2.0.

--- a/src/main/modules/dedekind/numbers/real.cppm
+++ b/src/main/modules/dedekind/numbers/real.cppm
@@ -1,7 +1,6 @@
 /**
  * @file dedekind/numbers/real.cppm
  * @partition :real
- * @module dedekind.numbers:real
  * @brief Level 9: Minimal real wrapper for experimental reintegration.
  *
  * @copyright 2026 The Dedekind Authors

--- a/src/main/modules/dedekind/numbers/sint.cppm
+++ b/src/main/modules/dedekind/numbers/sint.cppm
@@ -1,10 +1,7 @@
 /**
  * @file dedekind/numbers/sint.cppm
  * @partition :sint
- * @module dedekind.numbers:sint
- * @brief Level 4: The std::signed_integral family — operator surface ✓,
- *        axiomatic ring ✗ (Honest Rejection: dual error-direction to
- *        :uint).
+ * @brief Level 4: std::signed_integral — Honest Rejection (UB-on-overflow).
  *
  * @copyright 2026 The Dedekind Authors
  * Licensed under the Apache License, Version 2.0.

--- a/src/main/modules/dedekind/numbers/symbolic.cppm
+++ b/src/main/modules/dedekind/numbers/symbolic.cppm
@@ -1,8 +1,7 @@
 /**
  * @file dedekind/numbers/symbolic.cppm
  * @partition :symbolic
- * @brief Level 9.4: Named symbolic constants — $\sqrt{2}$ and friends as
- *        intensional Dedekind cuts over ℚ.
+ * @brief Level 9.4: Symbolic constants ($\sqrt{2}$, …) as Dedekind cuts.
  *
  * @copyright 2026 The Dedekind Authors
  * Licensed under the Apache License, Version 2.0.

--- a/src/main/modules/dedekind/numbers/uint.cppm
+++ b/src/main/modules/dedekind/numbers/uint.cppm
@@ -1,10 +1,7 @@
 /**
  * @file dedekind/numbers/uint.cppm
  * @partition :uint
- * @module dedekind.numbers:uint
- * @brief Level 4: The std::unsigned_integral family — explicit textbook
- *        classification as ℤ/2^wℤ + universal machine→variant lift +
- *        Modular<N> / IsCyclic correspondence.
+ * @brief Level 4: std::unsigned_integral as ℤ/2^wℤ — modular ring, not ℕ.
  *
  * @copyright 2026 The Dedekind Authors
  * Licensed under the Apache License, Version 2.0.

--- a/src/main/modules/dedekind/optimization/optimization.cppm
+++ b/src/main/modules/dedekind/optimization/optimization.cppm
@@ -1,8 +1,6 @@
 /**
  * @file optimization.cppm
- * @module dedekind.optimization
- * @brief Level 13: Mathematical-programming problem classes as type-level
- *        reductions — the optimum becomes a typed constant at compile time.
+ * @brief Level 13: Mathematical programming — optimum as a typed constant.
  *
  * @copyright 2026 The Dedekind Authors
  * Licensed under the Apache License, Version 2.0.

--- a/src/main/modules/dedekind/order/order.cppm
+++ b/src/main/modules/dedekind/order/order.cppm
@@ -1,8 +1,6 @@
 /**
  * @file dedekind/order/order.cppm
- * @module dedekind.order
- * @brief Umbrella module for Level 1.5 — order relations and compile-time
- *        halfspace predicates.
+ * @brief Level 1.5: Order relations and compile-time halfspace predicates.
  *
  * @copyright 2026 The Dedekind Authors
  * Licensed under the Apache License, Version 2.0.

--- a/src/main/modules/dedekind/order/poset.cppm
+++ b/src/main/modules/dedekind/order/poset.cppm
@@ -1,8 +1,7 @@
 /**
  * @file dedekind/order/poset.cppm
  * @partition :poset
- * @brief Level 1.5: Relation concepts --- preorders, partial orders,
- *        directed sets, and chains.
+ * @brief Level 1.5: Preorders, partial orders, directed sets, chains.
  *
  * @copyright 2026 The Dedekind Authors
  * Licensed under the Apache License, Version 2.0.

--- a/src/main/modules/dedekind/order/total.cppm
+++ b/src/main/modules/dedekind/order/total.cppm
@@ -1,8 +1,7 @@
 /**
  * @file dedekind/order/total.cppm
  * @partition :total
- * @brief Level 1.5b: Total-order layer — strictly stronger than the
- *        partial-order content in @c :poset.
+ * @brief Level 1.5b: Total-order layer (stronger than @c :poset).
  *
  * @copyright 2026 The Dedekind Authors
  * Licensed under the Apache License, Version 2.0.

--- a/src/main/modules/dedekind/python/python.cppm
+++ b/src/main/modules/dedekind/python/python.cppm
@@ -1,6 +1,5 @@
 /**
  * @file dedekind/python/python.cppm
- * @module dedekind.python
  * @brief Level 12: Curated binding facade for external runtimes.
  *
  * @copyright 2026 The Dedekind Authors

--- a/src/main/modules/dedekind/sequences/sequences.cppm
+++ b/src/main/modules/dedekind/sequences/sequences.cppm
@@ -1,8 +1,6 @@
 /**
  * @file dedekind/sequences/sequences.cppm
- * @module dedekind.sequences
- * @brief Sequences and paths --- nets, Kleisli/co-Kleisli triples, and
- *        comonadic prefix-aggregates over directed-set domains.
+ * @brief Sequences, paths, and (co-)Kleisli triples over directed sets.
  *
  * @copyright 2026 The Dedekind Authors
  * Licensed under the Apache License, Version 2.0.

--- a/src/main/modules/dedekind/sets/boundaries.cppm
+++ b/src/main/modules/dedekind/sets/boundaries.cppm
@@ -6,7 +6,6 @@
  * Copyright 2026 The Dedekind Authors
  * Licensed under the Apache License, Version 2.0.
  *
- * @module dedekind.sets:boundaries
  * @dependency dedekind.ontology
  *
  * @section The_Structural_Limits: ⊥ and ⊤

--- a/src/main/modules/dedekind/sets/expressions.cppm
+++ b/src/main/modules/dedekind/sets/expressions.cppm
@@ -1,8 +1,7 @@
 /**
  * @file dedekind/sets/expressions.cppm
  * @partition :expressions
- * @brief Level 1.2: Set-Builder DSL -- comprehension, membership, Boolean
- * connectives, subsets, relations, functions and the power set.
+ * @brief Level 1.2: Set-builder DSL — comprehension + Boolean connectives.
  *
  * @copyright 2026 The Dedekind Authors
  * Licensed under the Apache License, Version 2.0.

--- a/src/main/modules/dedekind/sets/family.cppm
+++ b/src/main/modules/dedekind/sets/family.cppm
@@ -6,7 +6,6 @@
  * Copyright 2026 The Dedekind Authors
  * Licensed under the Apache License, Version 2.0.
  *
- * @module dedekind.sets:family
  * @dependency dedekind.ontology, dedekind.sets:boundaries
  *
  * @section The_Family: The Algebra of Collections

--- a/src/main/modules/dedekind/sets/relational.cppm
+++ b/src/main/modules/dedekind/sets/relational.cppm
@@ -1,8 +1,7 @@
 /**
  * @file dedekind/sets/relational.cppm
  * @partition :relational
- * @brief Level 1.3: Relational Algebra -- canonical combinators for Sets and
- * Relations.
+ * @brief Level 1.3: Relational Algebra — combinators for Sets and Relations.
  *
  * @copyright 2026 The Dedekind Authors
  * Licensed under the Apache License, Version 2.0.

--- a/src/main/modules/dedekind/sets/sets.cppm
+++ b/src/main/modules/dedekind/sets/sets.cppm
@@ -1,6 +1,5 @@
 /**
  * @file sets.cppm
- * @module dedekind.sets
  * @brief The Dedekind Set Model: Concrete Collections and Set Morphisms.
  *
  * Copyright 2026 The Dedekind Authors

--- a/src/main/modules/dedekind/sets/singleton.cppm
+++ b/src/main/modules/dedekind/sets/singleton.cppm
@@ -6,7 +6,6 @@
  * Copyright 2026 The Dedekind Authors
  * Licensed under the Apache License, Version 2.0.
  *
- * @module dedekind.sets:singleton
  * @dependency dedekind.ontology
  *
  * @section The_Singleton_Atom: Mereological Singularity

--- a/src/main/modules/dedekind/topology/topology.cppm
+++ b/src/main/modules/dedekind/topology/topology.cppm
@@ -1,8 +1,6 @@
 /**
  * @file dedekind/topology/topology.cppm
- * @module dedekind.topology
- * @brief Topology --- open-set predicates, neighbourhood filters, and
- *        continuity witnesses for the species atlas.
+ * @brief Open-sets, neighbourhood filters, and continuity witnesses.
  *
  * @copyright 2026 The Dedekind Authors
  * Licensed under the Apache License, Version 2.0.


### PR DESCRIPTION
## Summary

Doxygen's file-list page ([vincentk.github.io/dedekind/files.html](https://vincentk.github.io/dedekind/files.html)) showed empty descriptions for ~32 of ~63 partitions. Two interlocking causes; both fixed mechanically:

### 1. Non-standard `@module` tag

Doxygen does not recognise `@module` and silently consumes the brief (or trailing parser state) when one appears between `@file` and `@brief`. Every partition with a `@module` line in its file-level docblock had an empty rendered brief; every partition without it rendered fine.

Dropped `@module\ from all 33 files where it appeared. The actual module declaration lives at `export module dedekind.X:Y;` later in the file — the file-level `@module` reference was redundant doc-tag noise. Aligns with [CONTRIBUTING.md §"Doxygen header convention"](../blob/main/CONTRIBUTING.md#doxygen-header-convention) (which lists `@file`, `@partition`, `@brief`, …; no `@module`).

### 2. Multi-line `@brief` content

Where the brief content wrapped onto continuation lines (and survived clang-format), the file-list page truncated to empty. Collapsed each remaining multi-line \`@brief\` to a single short line ending in a period, fitting under clang-format's column limit so it stays single-line. Detailed level descriptions remain in the `@section` / `@details` blocks below.

### 3. Stray `@concept` in file header

`posetal.cppm` had a misplaced `@concept IsPosetal` between `@partition` and `@brief` that started a concept block early. Removed; concepts get their own docblocks at their declaration site.

## Result

Doxygen rebuild reports **0/63 empty briefs** (was 32/63).

## Test plan

- [x] \`make compile\` — green.
- [x] \`make doc\` — generated; verified empty-brief count via grep on \`files.html\`.
- [x] No code changes; doc-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)