### PR TITLE
docs: fix 17 mismatched @file tags in partition headers

### DIFF
--- a/src/main/modules/dedekind/algebra/division.cppm
+++ b/src/main/modules/dedekind/algebra/division.cppm
@@ -1,5 +1,5 @@
 /**
- * @file algebra:division.cppm
+ * @file dedekind/algebra/division.cppm
  * @partition :division
  * @brief Level 3.3: The Euclidean Engine (Division Rings and Domains).
  *

--- a/src/main/modules/dedekind/algebra/field.cppm
+++ b/src/main/modules/dedekind/algebra/field.cppm
@@ -1,5 +1,5 @@
 /**
- * @file ontology:algebra.cppm
+ * @file dedekind/algebra/field.cppm
  * @partition :algebra
  * @brief Level 3: The Rules of Harmony (Groups, Rings, and Fields).
  *

--- a/src/main/modules/dedekind/algebra/group.cppm
+++ b/src/main/modules/dedekind/algebra/group.cppm
@@ -1,5 +1,5 @@
 /**
- * @file algebra:group.cppm
+ * @file dedekind/algebra/group.cppm
  * @partition :group
  * @brief Level 3.1: The Symmetry of Numbers (ℤ, ℚ*).
  *

--- a/src/main/modules/dedekind/algebra/modules.cppm
+++ b/src/main/modules/dedekind/algebra/modules.cppm
@@ -1,5 +1,5 @@
 /**
- * @file algebra:modules.cppm
+ * @file dedekind/algebra/modules.cppm
  * @partition :modules
  * @brief Level 3.6: The Linear Synthesis (Modules and Vector Spaces).
  *

--- a/src/main/modules/dedekind/algebra/monoid.cppm
+++ b/src/main/modules/dedekind/algebra/monoid.cppm
@@ -1,5 +1,5 @@
 /**
- * @file algebra:monoid.cppm
+ * @file dedekind/algebra/monoid.cppm
  * @partition :monoid
  * @brief Level 3.0a: The Additive and Multiplicative Monoids (ℕ).
  *

--- a/src/main/modules/dedekind/algebra/ring.cppm
+++ b/src/main/modules/dedekind/algebra/ring.cppm
@@ -1,5 +1,5 @@
 /**
- * @file algebra:ring.cppm
+ * @file dedekind/algebra/ring.cppm
  * @partition :ring
  * @brief Level 3.2: The Rules of Harmony (The Semiring Synthesis).
  *

--- a/src/main/modules/dedekind/linear_algebra/backends.cppm
+++ b/src/main/modules/dedekind/linear_algebra/backends.cppm
@@ -1,5 +1,5 @@
 /**
- * @file linear_algebra:backends.cppm
+ * @file dedekind/linear_algebra/backends.cppm
  * @partition :backends
  * @brief Backend capability contracts for linear algebra realization layers.
  *

--- a/src/main/modules/dedekind/linear_algebra/contracts.cppm
+++ b/src/main/modules/dedekind/linear_algebra/contracts.cppm
@@ -1,5 +1,5 @@
 /**
- * @file linear_algebra:contracts.cppm
+ * @file dedekind/linear_algebra/contracts.cppm
  * @partition :contracts
  * @brief Rank-nullity and matrix-structural compile-time contracts.
  *

--- a/src/main/modules/dedekind/linear_algebra/graphblas.cppm
+++ b/src/main/modules/dedekind/linear_algebra/graphblas.cppm
@@ -1,5 +1,5 @@
 /**
- * @file linear_algebra:graphblas.cppm
+ * @file dedekind/linear_algebra/graphblas.cppm
  * @partition :graphblas
  * @brief GraphBLAS-facing adapter stub for contract conformance checks.
  *

--- a/src/main/modules/dedekind/numbers/boolean.cppm
+++ b/src/main/modules/dedekind/numbers/boolean.cppm
@@ -1,5 +1,5 @@
 /**
- * @file ontology:numbers.cppm
+ * @file dedekind/numbers/boolean.cppm
  * @brief Formal definition of the Boolean system 𝔹 within the numeric ontology.
  *
  * Copyright 2026 The Dedekind Authors

--- a/src/main/modules/dedekind/numbers/natural.cppm
+++ b/src/main/modules/dedekind/numbers/natural.cppm
@@ -1,5 +1,5 @@
 /**
- * @file ontology:numbers.cppm
+ * @file dedekind/numbers/natural.cppm
  * @brief Level 4: The Dictionary of Species (The Registry).
  *
  * Copyright 2026 The Dedekind Authors

--- a/src/main/modules/dedekind/numbers/scalars.cppm
+++ b/src/main/modules/dedekind/numbers/scalars.cppm
@@ -1,5 +1,5 @@
 /**
- * @file ontology:numbers.cppm
+ * @file dedekind/numbers/scalars.cppm
  * @brief Semirings as the formal algebraic basis for scalar number systems.
  *
  * Copyright 2026 The Dedekind Authors

--- a/src/main/modules/dedekind/sequences/net.cppm
+++ b/src/main/modules/dedekind/sequences/net.cppm
@@ -1,5 +1,5 @@
 /**
- * @file ontology:sequences.cppm
+ * @file dedekind/sequences/net.cppm
  * @partition :sequences
  * @brief Level 2.5: The Path (The Morphism of Enumeration).
  *

--- a/src/main/modules/dedekind/sets/cardinality.cppm
+++ b/src/main/modules/dedekind/sets/cardinality.cppm
@@ -1,5 +1,5 @@
 /**
- * @file sets/cardinality.cppm
+ * @file dedekind/sets/cardinality.cppm
  * @partition :cardinality
  * @brief Cardinality types and the Extensional N-limb cardinal carrier.
  *

--- a/src/main/modules/dedekind/sets/mereology.cppm
+++ b/src/main/modules/dedekind/sets/mereology.cppm
@@ -1,5 +1,5 @@
 /**
- * @file ontology:mereology.cppm
+ * @file dedekind/sets/mereology.cppm
  * @brief Level 1: The Rules of Presence (Topos-Aware Sets).
  *
  * Copyright 2026 The Dedekind Authors

--- a/src/main/modules/dedekind/topology/interval.cppm
+++ b/src/main/modules/dedekind/topology/interval.cppm
@@ -1,5 +1,5 @@
 /**
- * @file ontology:topology.cppm
+ * @file dedekind/topology/interval.cppm
  * @partition :shapes
  * @brief Level 3.1: Topological Mereology (Rays and Intervals).
  *

--- a/src/main/modules/dedekind/topology/neighborhood.cppm
+++ b/src/main/modules/dedekind/topology/neighborhood.cppm
@@ -1,5 +1,5 @@
 /**
- * @file ontology:topology.cppm
+ * @file dedekind/topology/neighborhood.cppm
  * @brief Level 3: The Rules of Continuity (Neighborhoods, Limits, and Cuts).
  *
  * Copyright 2026 The Dedekind Authors


### PR DESCRIPTION
## Summary

Follow-up to PR #477. Per CONTRIBUTING.md item 1 (Doxygen header convention): "@file — path-qualified, matching the actual file location." 17 partition file-level docblocks carried `@file` tags that did not match their actual paths (leftovers from earlier partition naming, surfaced by Copilot's review on PR #477):

- `algebra/{division, field, group, modules, monoid, ring}.cppm`
- `linear_algebra/{backends, contracts, graphblas}.cppm`
- `morphologies/archimedean.cppm` (was `@file ontology:morphologies.cppm\ — the original Copilot finding)
- `numbers/{boolean, natural, scalars}.cppm`
- `sequences/net.cppm`
- `sets/{cardinality, mereology}.cppm`
- `topology/{interval, neighborhood}.cppm`

## Test plan

- [x] \`make compile\` — green.
- [x] \`make doc\` — 0/63 empty briefs on the rendered file-list page (preserved from PR #477).
- [x] No code changes; doc-tag-only sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)