### PR TITLE
refactor(category): audit + retarget consumer-side typename T::Domain to Dom<F> / Cod<F> per picking policy (closes #411)

### DIFF
--- a/src/main/modules/dedekind/category/functor.cppm
+++ b/src/main/modules/dedekind/category/functor.cppm
@@ -487,21 +487,26 @@ concept IsIterativeEndomorphism =
  * @concept IsFAlgebra
  * @brief A carrier `A` equipped with a structure map `F<A> -> A`.
  */
+// Per the picking policy in :morphism (#411): use Dom / Cod in
+// IsArrow-strict contexts; the IsArrow<Structure> guards cover the
+// precondition for both concepts below.
 export template <typename Carrier, typename Structure, typename Functor>
-concept IsFAlgebra = IsEndofunctor<Functor> && IsArrow<Structure> &&
-                     std::same_as<typename Structure::Domain,
-                                  typename Functor::template Shape<Carrier>> &&
-                     std::same_as<typename Structure::Codomain, Carrier>;
+concept IsFAlgebra =
+    IsEndofunctor<Functor> && IsArrow<Structure> &&
+    std::same_as<Dom<Structure>,
+                 typename Functor::template Shape<Carrier>> &&
+    std::same_as<Cod<Structure>, Carrier>;
 
 /**
  * @concept IsFCoalgebra
  * @brief A carrier `A` equipped with a structure map `A -> F<A>`.
  */
 export template <typename Carrier, typename Structure, typename Functor>
-concept IsFCoalgebra = IsEndofunctor<Functor> && IsArrow<Structure> &&
-                       std::same_as<typename Structure::Domain, Carrier> &&
-                       std::same_as<typename Structure::Codomain,
-                                    typename Functor::template Shape<Carrier>>;
+concept IsFCoalgebra =
+    IsEndofunctor<Functor> && IsArrow<Structure> &&
+    std::same_as<Dom<Structure>, Carrier> &&
+    std::same_as<Cod<Structure>,
+                 typename Functor::template Shape<Carrier>>;
 
 /**
  * @brief A concrete witness for an `F`-algebra.

--- a/src/main/modules/dedekind/category/functor.cppm
+++ b/src/main/modules/dedekind/category/functor.cppm
@@ -493,8 +493,7 @@ concept IsIterativeEndomorphism =
 export template <typename Carrier, typename Structure, typename Functor>
 concept IsFAlgebra =
     IsEndofunctor<Functor> && IsArrow<Structure> &&
-    std::same_as<Dom<Structure>,
-                 typename Functor::template Shape<Carrier>> &&
+    std::same_as<Dom<Structure>, typename Functor::template Shape<Carrier>> &&
     std::same_as<Cod<Structure>, Carrier>;
 
 /**
@@ -505,8 +504,7 @@ export template <typename Carrier, typename Structure, typename Functor>
 concept IsFCoalgebra =
     IsEndofunctor<Functor> && IsArrow<Structure> &&
     std::same_as<Dom<Structure>, Carrier> &&
-    std::same_as<Cod<Structure>,
-                 typename Functor::template Shape<Carrier>>;
+    std::same_as<Cod<Structure>, typename Functor::template Shape<Carrier>>;
 
 /**
  * @brief A concrete witness for an `F`-algebra.

--- a/src/main/modules/dedekind/category/pullback.cppm
+++ b/src/main/modules/dedekind/category/pullback.cppm
@@ -156,11 +156,12 @@ auto pullback(F_Raw&& f_raw, G_Raw&& g_raw) {
  * @tparam F The first parallel morphism f: A ⟶ B.
  * @tparam G The second parallel morphism g: A ⟶ B.
  */
+// Per the picking policy in :morphism (#411): use Dom / Cod in
+// IsArrow-strict contexts; the IsArrow<F> / IsArrow<G> guards above
+// cover the precondition.
 export template <typename E, typename F, typename G>
 concept IsEqualizer =
-    IsArrow<F> && IsArrow<G> &&
-    std::same_as<typename F::Domain, typename G::Domain> &&
-    std::same_as<typename F::Codomain, typename G::Codomain> &&
-    IsSubobject<E, typename F::Domain>;
+    IsArrow<F> && IsArrow<G> && std::same_as<Dom<F>, Dom<G>> &&
+    std::same_as<Cod<F>, Cod<G>> && IsSubobject<E, Dom<F>>;
 
 }  // namespace dedekind::category

--- a/src/main/modules/dedekind/category/small.cppm
+++ b/src/main/modules/dedekind/category/small.cppm
@@ -173,16 +173,19 @@ concept IsCategory = requires {
 
 /** @section Identity_Short_Circuits */
 
-// Law: id_A >> g = g
+// Law: id_A >> g = g.  Per the picking policy in :morphism (#411): use
+// Dom<G> in IsArrow-strict contexts; self-documents that the Domain comes
+// via the arrow shape.
 export template <typename T, IsArrow G>
-  requires std::same_as<T, typename G::Domain>
+  requires std::same_as<T, Dom<G>>
 constexpr auto operator>>(Identity<T>, G&& g) {
   return std::forward<G>(g);
 }
 
-// Law: f >> id_B = f
+// Law: f >> id_B = f.  Same picking-policy reasoning: Cod<F> in
+// IsArrow-strict contexts.
 export template <IsArrow F, typename T>
-  requires std::same_as<typename F::Codomain, T>
+  requires std::same_as<Cod<F>, T>
 constexpr auto operator>>(F&& f, Identity<T>) {
   return std::forward<F>(f);
 }


### PR DESCRIPTION
## Summary

Closes #411 (sub-issue of epic #374).

**Part 1 — picking-policy doc-block (canonical source of truth)** was landed in PR #468 (in `:morphism`, with cross-references to `:sets:boundaries::element_of_t`). Verified in place at `:morphism.cppm:94–119, 130, 255–262`.

**Part 2 — consumer-side retarget sweep** applied where the picking-policy benefit is real (clarity at `IsArrow`-strict / `IsCategory`-strict sites that don't already use `Dom / `Cod`):

| Partition | Site | Change |
|---|---|---|
| `:category:small` | `operator>>(Identity<T>, G&&)` / `operator>>(F&&, Identity<T>)` | `std::same_as<T, typename G::Domain>` → `std::same_as<T, Dom<G>>`; `std::same_as<typename F::Codomain, T>` → `std::same_as<Cod<F>, T>`. |
| `:category:pullback` | `IsEqualizer` concept | All three `F`/`G` domain/codomain comparisons retargeted (`F`/`G` are `IsArrow`-guarded above). |
| `:category:functor` | `IsFAlgebra` / `IsFCoalgebra` concepts | Same `IsArrow<Structure>` guard; `Domain` / `Codomain` comparisons retargeted. |

**Out of scope (per #411):**
- Producer-side \`using Domain = T;\` clauses (the defining clauses in species headers) left as-is.
- Bare \`typename T::Domain\` inside \`requires { typename T::Domain; }\` guards left as-is (the constraint is the explicit precondition).
- Nested arrow-of-category expressions (\`typename F::Σ_cat::Arrow::Domain\` in \`:natural\`) left as-is — \`Dom<typename F::Σ_cat::Arrow>\` is more verbose than the bare form, and the surrounding \`IsCategory<F::Σ_cat>\` / \`IsFunctor<F>\` already protect the nested access.

## Test plan

- [x] \`make compile\` — green.
- [x] No code changes; type-level identity refactor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)