### PR TITLE
chore(build): add make pr-status-all for cross-PR health sweeps

### DIFF
--- a/.github/copilot/housekeeping/pr-status-all.sh
+++ b/.github/copilot/housekeeping/pr-status-all.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# pr-status-all.sh — sweep ALL open PRs authored by the current user.
+#
+# Reports per PR:
+#   - mergeability state (MERGEABLE / CONFLICTING / UNKNOWN)
+#   - base ref
+#   - draft status
+#   - status-check rollup counts (grouped by conclusion)
+#   - unresolved-review-thread count (paginated; reliable beyond 100 threads)
+#
+# Read-only: does not push, merge, or modify any PR.
+#
+# Usage:
+#   pr-status-all.sh
+set -euo pipefail
+
+REPO="$(gh repo view --json nameWithOwner --jq .nameWithOwner)"
+OWNER="${REPO%/*}"
+NAME="${REPO#*/}"
+
+echo "Sweeping open PRs in ${REPO} ..."
+
+# Capture once; reuse for both the summary and the per-PR thread loop.
+PRS="$(gh pr list --author "@me" --state open \
+  --json number,title,baseRefName,isDraft,mergeable,statusCheckRollup)"
+
+printf '%s\n' "${PRS}" | jq -r '
+  .[]
+  | { n:.number,
+      base:.baseRefName,
+      draft:.isDraft,
+      merge:.mergeable,
+      title:(.title[0:70]),
+      checks: ( [.statusCheckRollup[]? | select(.conclusion!=null) | .conclusion]
+                | (sort | group_by(.) | map({(.[0]):length}) | add // {}) ) }
+  | "#\(.n) [\(.merge)\(if .draft then " DRAFT" else "" end) base=\(.base)] checks=\(.checks // {}) | \(.title)"
+'
+
+echo ""
+echo "Unresolved review threads per open PR ..."
+
+for n in $(printf '%s\n' "${PRS}" | jq -r '.[].number'); do
+  C="$(gh api graphql --paginate --slurp \
+        -F owner="${OWNER}" -F name="${NAME}" -F number="${n}" \
+        -f query='query($owner:String!, $name:String!, $number:Int!, $endCursor:String) {
+          repository(owner: $owner, name: $name) {
+            pullRequest(number: $number) {
+              reviewThreads(first: 100, after: $endCursor) {
+                nodes { isResolved }
+                pageInfo { hasNextPage endCursor }
+              }
+            }
+          }
+        }' 2>/dev/null \
+      | jq '[.[].data.repository.pullRequest.reviewThreads.nodes[]
+            | select(.isResolved == false)] | length' 2>/dev/null)"
+  printf "  #%-4s %s unresolved\n" "${n}" "${C:-?}"
+done

--- a/Makefile
+++ b/Makefile
@@ -278,6 +278,27 @@ pr-sync:
 	fi
 	gh pr checks || true
 
+# Sweep ALL open PRs authored by the current user: report each PR's
+# mergeability, base ref, draft status, status-check rollup, and
+# unresolved-review-thread count. Read-only.
+# Usage: make pr-status-all
+pr-status-all:
+	@REPO="$$(gh repo view --json nameWithOwner --jq .nameWithOwner)"; \
+	OWNER="$${REPO%/*}"; NAME="$${REPO#*/}"; \
+	echo "Sweeping open PRs in $$REPO ..."; \
+	gh pr list --author "@me" --state open --json number,title,baseRefName,isDraft,mergeable,statusCheckRollup \
+		--jq '.[] | {n:.number, base:.baseRefName, draft:.isDraft, merge:.mergeable, title:(.title[0:70]), checks:( [.statusCheckRollup[]? | select(.conclusion!=null) | .conclusion] | (group_by(.) | map({(.[0]):length}) | add // {}) ) }' \
+		| jq -r '"#\(.n) [\(.merge)\(if .draft then " DRAFT" else "" end) base=\(.base)] checks=\(.checks // {}) | \(.title)"'; \
+	echo ""; \
+	echo "Unresolved review threads per open PR ..."; \
+	for n in $$(gh pr list --author "@me" --state open --json number --jq '.[].number'); do \
+		C="$$(gh api graphql \
+			-F owner="$$OWNER" -F name="$$NAME" -F number="$$n" \
+			-f query='query($$owner:String!, $$name:String!, $$number:Int!) { repository(owner: $$owner, name: $$name) { pullRequest(number: $$number) { reviewThreads(first: 100) { nodes { isResolved } } } } }' \
+			--jq '.data.repository.pullRequest.reviewThreads.nodes | map(select(.isResolved == false)) | length' 2>/dev/null)"; \
+		printf "  #%-4s %s unresolved\n" "$$n" "$${C:-?}"; \
+	done
+
 # List inline PR review comments for the current PR (or PR=<number>).
 pr-review-comments:
 	@PR_NUM="$(PR)"; \

--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ _HOST_CORES := $(shell nproc 2>/dev/null || sysctl -n hw.ncpu 2>/dev/null || ech
 JOBS ?= $(shell j=$$(( $(_HOST_CORES) - 2 )); [ $$j -lt 2 ] && j=2; echo $$j)
 
 .PHONY: all clean compile test-compile test integration-test coverage python-coverage python-coverage-local ir-fixture-refresh ir-fixture-check format format-check install-hooks ci-install-doxygen-deps ci-install-report-deps doxygen dot doc report paper \
-	ci-history ci-main pr-init pr-status pr-checks pr-watch pr-sync pr-review-comments pr-review-unresolved pr-resolve-thread pr-resolve-threads \
+	ci-history ci-main pr-init pr-status pr-status-all pr-checks pr-watch pr-sync pr-review-comments pr-review-unresolved pr-resolve-thread pr-resolve-threads \
 	check-review-comments resolve-review-comment issue-list jupyter
 
 all: compile
@@ -280,24 +280,12 @@ pr-sync:
 
 # Sweep ALL open PRs authored by the current user: report each PR's
 # mergeability, base ref, draft status, status-check rollup, and
-# unresolved-review-thread count. Read-only.
+# unresolved-review-thread count. Read-only. Paginates over review
+# threads so the count is reliable even on PRs with > 100 threads.
+# Logic lives in .github/copilot/housekeeping/pr-status-all.sh.
 # Usage: make pr-status-all
 pr-status-all:
-	@REPO="$$(gh repo view --json nameWithOwner --jq .nameWithOwner)"; \
-	OWNER="$${REPO%/*}"; NAME="$${REPO#*/}"; \
-	echo "Sweeping open PRs in $$REPO ..."; \
-	gh pr list --author "@me" --state open --json number,title,baseRefName,isDraft,mergeable,statusCheckRollup \
-		--jq '.[] | {n:.number, base:.baseRefName, draft:.isDraft, merge:.mergeable, title:(.title[0:70]), checks:( [.statusCheckRollup[]? | select(.conclusion!=null) | .conclusion] | (group_by(.) | map({(.[0]):length}) | add // {}) ) }' \
-		| jq -r '"#\(.n) [\(.merge)\(if .draft then " DRAFT" else "" end) base=\(.base)] checks=\(.checks // {}) | \(.title)"'; \
-	echo ""; \
-	echo "Unresolved review threads per open PR ..."; \
-	for n in $$(gh pr list --author "@me" --state open --json number --jq '.[].number'); do \
-		C="$$(gh api graphql \
-			-F owner="$$OWNER" -F name="$$NAME" -F number="$$n" \
-			-f query='query($$owner:String!, $$name:String!, $$number:Int!) { repository(owner: $$owner, name: $$name) { pullRequest(number: $$number) { reviewThreads(first: 100) { nodes { isResolved } } } } }' \
-			--jq '.data.repository.pullRequest.reviewThreads.nodes | map(select(.isResolved == false)) | length' 2>/dev/null)"; \
-		printf "  #%-4s %s unresolved\n" "$$n" "$${C:-?}"; \
-	done
+	@bash .github/copilot/housekeeping/pr-status-all.sh
 
 # List inline PR review comments for the current PR (or PR=<number>).
 pr-review-comments:


### PR DESCRIPTION
## Summary

Adds a `make pr-status-all` target that sweeps every open PR authored by the current user and reports per PR: mergeability state, base ref, draft status, status-check rollup counts, and unresolved-review-thread count. Read-only.

Motivated by the recurring stacked-PR-rebase scenario (this paper-trim stack #487 → #488 → #489 → #490): when main advances multiple times, downstream stack PRs need their merge state, CI status, and review-thread state checked in one pass rather than via `gh pr view` per PR.

## Example output

```
Sweeping open PRs in vincentk/dedekind ...
#490 [MERGEABLE base=docs/issue-486-pass3-axiomatic-intensional] checks={...} | docs(paper): Pass 4 ...
#489 [MERGEABLE base=docs/issue-486-pass2-substantive-trim] checks={...} | docs(paper): Pass 3 ...
#488 [MERGEABLE base=main] checks={"SUCCESS":4} | docs(paper): Pass 2 substantive trim ...

Unresolved review threads per open PR ...
  #490  0 unresolved
  #489  0 unresolved
  #488  0 unresolved
```

## Test plan

- [x] `make pr-status-all` runs cleanly on the local repo.
- [x] No code changes; pure build-tooling addition.

🤖 Generated with [Claude Code](https://claude.com/claude-code)