### PR TITLE
feat(sets): SignedCardinality accepts std::floating_point sources (#399 unblocker)

### DIFF
--- a/src/main/modules/dedekind/sets/cardinality.cppm
+++ b/src/main/modules/dedekind/sets/cardinality.cppm
@@ -35,6 +35,7 @@ module;
 #include <cstddef>
 #include <functional>
 #include <limits>
+#include <stdexcept>
 #include <utility>
 #include <variant>
 
@@ -638,6 +639,54 @@ struct SignedExtensionalCardinal {
         magnitude_type{static_cast<typename magnitude_type::limb_type>(value)};
   }
 
+  /** @brief Construction from any floating-point source, single-limb only.
+   *
+   *  @details Truncates toward zero (the C++ \c static_cast<long_long>(F)
+   *  semantics).  NaN and ±∞ are out-of-band for the bounded
+   *  @c SignedExtensionalCardinal<N> carrier --- those values belong on
+   *  the variant @c SignedCardinality, which routes through
+   *  @c make_signed_cardinality(F) below.  In a constant-evaluation
+   *  context the compiler rejects NaN / ±∞ inputs as
+   *  not-a-constant-expression (constexpr cannot throw); at runtime the
+   *  same inputs trigger @c std::domain_error.  Single-limb only to
+   *  prevent silent truncation of multi-limb values, mirroring the
+   *  symmetric explicit @c operator F() above.
+   *
+   *  Intentionally non-explicit so floating-point values convert
+   *  implicitly into the variant @c SignedCardinality via the
+   *  single-alternative converting constructor of @c std::variant ---
+   *  the load-bearing path for @c bound<-21.0> on @c var<ℤ> after the
+   *  #399 retarget.  Negative pivots remain admissible via the
+   *  sign-aware branch below; ±0 collapse to canonical zero.
+   */
+  template <std::floating_point F>
+    requires(N == 1)
+  // NOLINTNEXTLINE(google-explicit-constructor)
+  constexpr SignedExtensionalCardinal(F value) : negative(false), magnitude() {
+    if (value != value) {  // NaN check (works in constexpr)
+      throw std::domain_error(
+          "SignedExtensionalCardinal<N>(F): NaN is out of band; route via "
+          "make_signed_cardinality(F) which lands on SignedCardinality{NaZ{}}");
+    }
+    constexpr F kInfinity = std::numeric_limits<F>::infinity();
+    if (value == kInfinity || value == -kInfinity) {
+      throw std::domain_error(
+          "SignedExtensionalCardinal<N>(F): ±infinity is out of band; route "
+          "via make_signed_cardinality(F) which lands on "
+          "SignedCardinality{±ℵ_0}");
+    }
+    if (value < F{0}) {
+      negative = true;
+      const auto magnitude_value = static_cast<long long>(-value);
+      magnitude = magnitude_type{
+          static_cast<typename magnitude_type::limb_type>(magnitude_value)};
+      return;
+    }
+    const auto magnitude_value = static_cast<long long>(value);
+    magnitude = magnitude_type{
+        static_cast<typename magnitude_type::limb_type>(magnitude_value)};
+  }
+
   constexpr friend bool operator==(
       const SignedExtensionalCardinal& lhs,
       const SignedExtensionalCardinal& rhs) noexcept {
@@ -903,6 +952,39 @@ constexpr int sc_sign(const SignedCardinality& v) noexcept {
 /** @brief Convenience constructor for finite signed values. */
 export template <std::integral S>
 constexpr SignedCardinality finite_signed_cardinality(S value) noexcept {
+  return SignedCardinality{SignedExtensionalCardinal<>{value}};
+}
+
+/** @brief Total factory @c F → @c SignedCardinality with the
+ *         IEEE-754 sentinels routed to the variant's structural
+ *         alternatives.
+ *
+ *  @details The mapping:
+ *    - @c NaN → @c SignedCardinality{NaZ{}}
+ *    - @c +∞ → @c SignedCardinality{PositiveInfinity{}}
+ *    - @c -∞ → @c SignedCardinality{NegativeInfinity{}}
+ *    - finite → @c SignedCardinality{SignedExtensionalCardinal<>{value}}
+ *      (truncated toward zero per the @c SignedExtensionalCardinal<1>
+ *      floating-point ctor)
+ *
+ *  This is the @b safe path for floating-point sources at the
+ *  variant ℤ-proxy.  The bare @c SignedExtensionalCardinal<>{F}
+ *  constructor refuses NaN / ±∞ as out-of-band; this factory
+ *  preserves the semantic distinction by routing them to the
+ *  appropriate variant alternative.
+ */
+export template <std::floating_point F>
+constexpr SignedCardinality make_signed_cardinality(F value) noexcept {
+  if (value != value) {
+    return SignedCardinality{NaZ{}};
+  }
+  constexpr F kInfinity = std::numeric_limits<F>::infinity();
+  if (value == kInfinity) {
+    return SignedCardinality{PositiveInfinity{}};
+  }
+  if (value == -kInfinity) {
+    return SignedCardinality{NegativeInfinity{}};
+  }
   return SignedCardinality{SignedExtensionalCardinal<>{value}};
 }
 

--- a/src/test/cpp/modules/dedekind/sets/signed_cardinality_test.cpp
+++ b/src/test/cpp/modules/dedekind/sets/signed_cardinality_test.cpp
@@ -14,12 +14,15 @@
 #include <catch2/catch_test_macros.hpp>
 #include <climits>
 #include <compare>
+#include <concepts>
+#include <limits>
 #include <variant>
 
 import dedekind.sets;
 
 using dedekind::sets::compare_signed;
 using dedekind::sets::finite_signed_cardinality;
+using dedekind::sets::make_signed_cardinality;
 using dedekind::sets::NaZ;
 using dedekind::sets::NegativeInfinity;
 using dedekind::sets::PositiveInfinity;
@@ -386,4 +389,83 @@ TEST_CASE(
     CHECK(0 < pos_inf);
     CHECK(0 > neg_inf);
   }
+}
+
+// ===========================================================================
+// Floating-point construction (#399 unblocker)
+// ===========================================================================
+
+TEST_CASE(
+    "SignedExtensionalCardinal<1>(F) — finite floating-point values truncate "
+    "toward zero",
+    "[sets][signed_cardinality][floating-point][construction]") {
+  // Positive finite: truncates the fractional part.
+  constexpr SignedExtensionalCardinal<> three_from_double{3.7};
+  STATIC_CHECK(three_from_double == SignedExtensionalCardinal<>{3});
+
+  // Negative finite: sign-correct, magnitude truncated.
+  constexpr SignedExtensionalCardinal<> minus_twentyone_from_double{-21.6};
+  STATIC_CHECK(minus_twentyone_from_double == SignedExtensionalCardinal<>{-21});
+
+  // Zero (both ±0.0 collapse to canonical zero).
+  constexpr SignedExtensionalCardinal<> zero_from_pos_zero{0.0};
+  constexpr SignedExtensionalCardinal<> zero_from_neg_zero{-0.0};
+  STATIC_CHECK(zero_from_pos_zero == SignedExtensionalCardinal<>{});
+  STATIC_CHECK(zero_from_neg_zero == SignedExtensionalCardinal<>{});
+
+  // float source as well as double.
+  constexpr SignedExtensionalCardinal<> seven_from_float{7.0f};
+  STATIC_CHECK(seven_from_float == SignedExtensionalCardinal<>{7});
+}
+
+TEST_CASE(
+    "make_signed_cardinality(F) — total factory routes IEEE-754 sentinels to "
+    "the variant alternatives",
+    "[sets][signed_cardinality][floating-point][factory]") {
+  SECTION("Finite finite values land on SignedExtensionalCardinal<> branch") {
+    constexpr auto five = make_signed_cardinality(5.0);
+    STATIC_CHECK(std::holds_alternative<SignedExtensionalCardinal<>>(five));
+    STATIC_CHECK(std::get<SignedExtensionalCardinal<>>(five) ==
+                 SignedExtensionalCardinal<>{5});
+  }
+  SECTION("+∞ lands on PositiveInfinity branch") {
+    constexpr auto pos_inf =
+        make_signed_cardinality(std::numeric_limits<double>::infinity());
+    STATIC_CHECK(std::holds_alternative<PositiveInfinity>(pos_inf));
+  }
+  SECTION("-∞ lands on NegativeInfinity branch") {
+    constexpr auto neg_inf =
+        make_signed_cardinality(-std::numeric_limits<double>::infinity());
+    STATIC_CHECK(std::holds_alternative<NegativeInfinity>(neg_inf));
+  }
+  SECTION("NaN lands on NaZ branch") {
+    constexpr auto naz =
+        make_signed_cardinality(std::numeric_limits<double>::quiet_NaN());
+    STATIC_CHECK(std::holds_alternative<NaZ>(naz));
+  }
+  SECTION("float overload routes the same way") {
+    constexpr auto pos_inf_f =
+        make_signed_cardinality(std::numeric_limits<float>::infinity());
+    STATIC_CHECK(std::holds_alternative<PositiveInfinity>(pos_inf_f));
+  }
+}
+
+TEST_CASE("SignedCardinality{F} — variant converting ctor on a finite source",
+          "[sets][signed_cardinality][floating-point][variant]") {
+  // The variant std::variant<SignedExtensionalCardinal<>, ±∞, NaZ> picks
+  // SignedExtensionalCardinal<> as the unique alternative whose ctor
+  // accepts double, so SignedCardinality{double} compiles for finite
+  // values.  This is the load-bearing path for halfspace.cppm's
+  // `convertible_to<decltype(V), element_of_t<Species>>` check after
+  // the #399 retarget.
+  constexpr SignedCardinality minus_twentyone = SignedCardinality{-21.0};
+  STATIC_CHECK(
+      std::holds_alternative<SignedExtensionalCardinal<>>(minus_twentyone));
+  STATIC_CHECK(std::get<SignedExtensionalCardinal<>>(minus_twentyone) ==
+               SignedExtensionalCardinal<>{-21});
+
+  // std::convertible_to<double, SignedCardinality> now holds —
+  // the architectural fact #399's ℤ-as-carrier slice depends on.
+  STATIC_CHECK(std::convertible_to<double, SignedCardinality>);
+  STATIC_CHECK(std::convertible_to<float, SignedCardinality>);
 }


### PR DESCRIPTION
## Summary

Two surfaces added to `dedekind.sets:cardinality` to make `std::convertible_to<double, SignedCardinality>` hold — the architectural fact the #399 ℤ-as-carrier slice depends on.

1. **`SignedExtensionalCardinal<1>(F)`** implicit ctor for `std::floating_point F`. Truncates toward zero on finite values; rejects NaN / ±∞ as out-of-band (constexpr: not-a-constant-expression at compile time; runtime: `std::domain_error`). Single-limb-only mirrors the symmetric explicit `operator F()` above.

2. **`make_signed_cardinality(F)`** total factory. Maps `NaN → NaZ`, `+∞ → PositiveInfinity`, `-∞ → NegativeInfinity`, finite → `SignedExtensionalCardinal<>{F}`. The safe path for floating-point sources at the variant ℤ-proxy.

## Why now

#399's ℤ-as-carrier slice (`ℤ = SignedCardinality`, parallel to `ℕ = Cardinality` post-#402) needs `std::convertible_to<double, SignedCardinality>` to hold so that [halfspace.cppm's Variable × Bound constraint](src/main/modules/dedekind/order/halfspace.cppm#L269-L283) admits real-valued bounds on integer carriers (the showcase 7 `var<ℤ> > bound<-21.0>` heterogeneous-pivot test).

Pre-this-PR convertibility was false because the variant's converting ctor had no single-alternative match for `double`; post this PR the `SignedExtensionalCardinal<>` alternative is the unique match.

## Test coverage

15 new assertions across 3 test cases:
- Finite `double` / `float` truncate toward zero (positive, negative, ±0)
- `make_signed_cardinality` routes IEEE-754 sentinels to the right variant alternatives (NaN, ±∞ via `std::holds_alternative` checks)
- Variant converting ctor: `SignedCardinality{-21.0}` lands on the `SignedExtensionalCardinal<>` branch with magnitude 21
- `static_assert(std::convertible_to<double, SignedCardinality>)` — the architectural fact #399 depends on

Full sets-test suite green (376 assertions / 57 cases); `ctest --parallel` green (15/15).

## Test plan

- [x] New floating-point test cases pass
- [x] Full sets-test suite passes (376 assertions / 57 cases)
- [x] `ctest --parallel` green (15/15)
- [x] No new warnings under `make -j8`
- [ ] Reviewer confirms NaN / ±∞ rejection semantics on the bare ctor are the right call (alternative: silently route via `make_signed_cardinality` from inside the ctor — rejected here as too magical)

🤖 Generated with [Claude Code](https://claude.com/claude-code)