### PR TITLE
docs(paper, numbers): NEW-D vocabulary pass — name functors in §2 / §5.4 + mechanical witnesses (#498)

### DIFF
--- a/docs/paper/paper.tex
+++ b/docs/paper/paper.tex
@@ -795,6 +795,48 @@ category---hence, equivalently, for STLC; and the
 collapse (§\ref{sec:gap}) act as a form of cut elimination, with the
 LLVM backend treating the reduced bottom type as dead code.
 
+\paragraph{Named functors that build the library's carriers.}
+The categorical vocabulary is not decorative.  Each carrier in the
+numeric tower (Figure~\ref{fig:carrier-lattice}) arrives as the image
+of a named universal-property functor applied to its base:
+$\mathbb{Q} = \operatorname{Frac}(\mathbb{Z})$ (field of fractions;
+right adjoint to the forgetful functor from fields to integral
+domains), $\mathbb{R} = \operatorname{Cuts}(\mathbb{Q})$ (Dedekind
+order-completion), $\mathbb{C} = \operatorname{Cplx}(\mathbb{R}) =
+\mathbb{R}[i]/(i^2 + 1)$ (quotient ring), $\mathbb{D} =
+\operatorname{Dual}(\mathbb{R}) = \mathbb{R}[\varepsilon]/(\varepsilon^2)$
+(quotient ring; the tangent-bundle ring of the affine line over
+$\mathbb{R}$).  The rank axis adds two more: $\operatorname{Free}_n(R)
+= R^n$ (left adjoint to the forgetful functor from $R$-modules to
+sets) and $\operatorname{End}_R(R^n) = M_n(R)$ (internal hom in
+$\operatorname{Mod}_R$).  The library partitions correspond
+one-to-one to these functors --- \texttt{:rational} ships
+$\operatorname{Frac}$, \texttt{:real} ships $\operatorname{Cuts}$,
+\texttt{:complex} ships $\operatorname{Cplx}$,
+\texttt{analysis:dual} ships $\operatorname{Dual}$,
+\texttt{:tuple} ships $\operatorname{Free}_2$, \texttt{:matrix} ships
+$\operatorname{End}_R$ at $n=2$ --- so a reader fluent in either
+side can move between the textbook diagram and the C++ source
+without an interpretive layer.  Each carrier exposes its source-side
+projection by a member alias (\lstinline|Rational<I>::IntegerCarrier|,
+\lstinline|Real<Q>::ScalarCarrier|, \lstinline|Complex<R>::ScalarCarrier|,
+\lstinline|Dual<F>::value_type|).  A co-located \lstinline|static_assert|
+pins the functor identification mechanically for the
+field-of-fractions, Dedekind-cuts, and quotient-by-$(i^2+1)$ carriers
+(\texttt{Rational}, \texttt{Real}, \texttt{Complex}); the
+$\operatorname{Dual}$ identification is pinned structurally via the
+\lstinline|IsTangentBundle| concept in
+\texttt{geometry:tangent}, which checks the same source-side
+projection under a different name (\lstinline|value_type|, plus the
+\lstinline|.value()| / \lstinline|.derivative()| accessors).  The aliases are not yet fully aligned with the
+\lstinline|:functor| partition's convention
+($\Sigma_{\mathrm{cat}}$ / $\mathrm{T}_{\mathrm{cat}}$ for source /
+target category, \lstinline|Shape<U>| for the on-objects action;
+cf.~\lstinline|box_functor<T>|): unifying the two surfaces is the
+NEW-A trait-registry follow-up under issue~\#498.  References for
+each construction are tabulated in Table~\ref{tab:rosetta-quotient}
+(quotient axis) and Table~\ref{tab:rosetta-rank} (rank axis).
+
 % ============================================================
 \section{Intensional First, Realize When You Mean It}
 \label{sec:intensional}
@@ -2049,6 +2091,30 @@ defining relation $\varepsilon^2 = 0$ lifting to
 $\bigl(\begin{smallmatrix} 0 & 1 \\ 0 & 0 \end{smallmatrix}\bigr)^2
 = 0$ on the matrix side.
 
+In the functor vocabulary of §\ref{sec:axiomatic} (paragraph
+\emph{Named functors that build the library's carriers}): both
+embeddings are natural transformations between the quotient-functor
+images and the endomorphism-ring image of the rank functor.  Over a
+generic base ring $R$, the source side reads
+$\operatorname{Cplx}(R) = R[i]/(i^2 + 1)$ and
+$\operatorname{Dual}(R) = R[\varepsilon]/(\varepsilon^2)$; the target
+reads $M_2(R) = \operatorname{End}_R(\operatorname{Free}_2(R))$.  The
+two embeddings are then components of a single natural-transformation
+schema $\operatorname{Cplx}, \operatorname{Dual} \Rightarrow
+\operatorname{End}_R \circ \operatorname{Free}_2$ over the same base
+ring $R$ --- the textbook ``regular representation'' viewed through
+the carrier-lattice axes (Figure~\ref{fig:carrier-lattice}).  The
+worked instance shipped above is $R = \mathbb{Q}$ (with the exact
+\lstinline|Rational<SignedExtensionalCardinal<>>| carrier), so the
+\lstinline|static_assert|s in the listing below discharge
+$\operatorname{Cplx}(\mathbb{Q})$ and $\operatorname{Dual}(\mathbb{Q})$
+embedding into $M_2(\mathbb{Q})$.  The lattice's commutation identities
+(the back-face quotients commute with the rank lift; see
+Table~\ref{tab:rosetta-quotient}) underwrite the fact that the same
+identities hold over any sufficiently structured base.  The §2 paragraph's
+$\mathbb{C} = \operatorname{Cplx}(\mathbb{R})$ reading is the
+$R = \mathbb{R}$ specialisation of the same schema.
+
 % Source: src/test/cpp/modules/dedekind/linear_algebra/embeddings_test.cpp
 \begin{lstlisting}[language=C++, caption={Ring-homomorphism identities $\mathbb{C}, \mathbb{D} \hookrightarrow M_2(\mathbb{Q})$, discharged as \lstinline{static_assert}s; the source uses Catch2 \lstinline{STATIC_CHECK} macros and \lstinline{Rat{...L}} long-suffixed rationals, abridged here for legibility.}, label={lst:lin-alg-embeddings}]
 using Rat = Rational<SignedExtensionalCardinal<>>;
@@ -2843,6 +2909,41 @@ sits on the same NTTP-plus-concepts foundation as the halfspace and
 LP reductions demonstrated here.
 We leave them as worked targets for successor libraries that adopt
 the same discipline.
+
+\paragraph{An absent failure mode worth reporting.}
+A practical observation, offered honestly: across this library's
+development we did not encounter the two failure modes mainstream
+C++ template programming is famed for --- @emph{template
+instantiation explosion} (compile times that grow super-linearly
+with template depth) and @emph{template error hell} (diagnostics
+buried inside long substitution-failure cascades, far from the
+call site that triggered them).  Neither was a recurring concern.
+This is not nothing: both phenomena are well-documented hazards
+in production C++ template programming.  The disciplined fragment
+of §\ref{sec:axiomatic} (Table~\ref{tab:admissibility-rules})
+appears to rule out, by construction, the mechanisms that produce
+each.  The concept-constrained-template machinery fails at
+@emph{constraint-evaluation} time --- before template-body
+instantiation, with named-axiom diagnostics --- so the SFINAE-
+cascade error path is excluded.  Uniform parametric polymorphism
+(System-F-style; no specialisation-driven branching admitted in the
+public surface) keeps the set of compiled code paths linear in the
+number of callsites rather than combinatorial in the type tuples.
+And the bounded-instantiation-depth admissibility rule (capped at
+the carrier-lattice's three axes in the current surface) prevents
+the recursively-unfolding template-metaprogramming pattern that
+produces the explosion.  Whether this implies a @emph{formal}
+result --- a theorem that the disciplined fragment lies inside a
+decidable type-checking regime --- the paper does not claim.  The
+fragment is small enough that decidability is plausible
+(Lambek--Scott~\cite{lambek1988introduction} maps the constructive
+half to a CCC fragment; the propositions-as-types
+reading~\cite{wadler2015propositions} restricts to inhabited
+propositional types), but a proof would have to argue against
+the full C++ overload-resolution and ADL machinery and lies outside
+the scope of this engineering existence-proof.  We report the
+observation; the explanation we leave to the type-systems
+literature.
 
 \paragraph{A forward claim, in its weakest defensible form.}
 As numerical workloads saturate available hardware, the marginal

--- a/docs/paper/paper.tex
+++ b/docs/paper/paper.tex
@@ -800,8 +800,9 @@ The categorical vocabulary is not decorative.  Each carrier in the
 numeric tower (Figure~\ref{fig:carrier-lattice}) arrives as the image
 of a named universal-property functor applied to its base:
 $\mathbb{Q} = \operatorname{Frac}(\mathbb{Z})$ (field of fractions;
-right adjoint to the forgetful functor from fields to integral
-domains), $\mathbb{R} = \operatorname{Cuts}(\mathbb{Q})$ (Dedekind
+left adjoint to the inclusion / forgetful functor
+$\mathbf{Field} \hookrightarrow \mathbf{IntegralDomain}$),
+$\mathbb{R} = \operatorname{Cuts}(\mathbb{Q})$ (Dedekind
 order-completion), $\mathbb{C} = \operatorname{Cplx}(\mathbb{R}) =
 \mathbb{R}[i]/(i^2 + 1)$ (quotient ring), $\mathbb{D} =
 \operatorname{Dual}(\mathbb{R}) = \mathbb{R}[\varepsilon]/(\varepsilon^2)$
@@ -2913,9 +2914,9 @@ the same discipline.
 \paragraph{An absent failure mode worth reporting.}
 A practical observation, offered honestly: across this library's
 development we did not encounter the two failure modes mainstream
-C++ template programming is famed for --- @emph{template
+C++ template programming is famed for --- \emph{template
 instantiation explosion} (compile times that grow super-linearly
-with template depth) and @emph{template error hell} (diagnostics
+with template depth) and \emph{template error hell} (diagnostics
 buried inside long substitution-failure cascades, far from the
 call site that triggered them).  Neither was a recurring concern.
 This is not nothing: both phenomena are well-documented hazards
@@ -2923,7 +2924,7 @@ in production C++ template programming.  The disciplined fragment
 of §\ref{sec:axiomatic} (Table~\ref{tab:admissibility-rules})
 appears to rule out, by construction, the mechanisms that produce
 each.  The concept-constrained-template machinery fails at
-@emph{constraint-evaluation} time --- before template-body
+\emph{constraint-evaluation} time --- before template-body
 instantiation, with named-axiom diagnostics --- so the SFINAE-
 cascade error path is excluded.  Uniform parametric polymorphism
 (System-F-style; no specialisation-driven branching admitted in the
@@ -2932,7 +2933,7 @@ number of callsites rather than combinatorial in the type tuples.
 And the bounded-instantiation-depth admissibility rule (capped at
 the carrier-lattice's three axes in the current surface) prevents
 the recursively-unfolding template-metaprogramming pattern that
-produces the explosion.  Whether this implies a @emph{formal}
+produces the explosion.  Whether this implies a \emph{formal}
 result --- a theorem that the disciplined fragment lies inside a
 decidable type-checking regime --- the paper does not claim.  The
 fragment is small enough that decidability is plausible

--- a/src/main/modules/dedekind/numbers/complex.cppm
+++ b/src/main/modules/dedekind/numbers/complex.cppm
@@ -314,6 +314,25 @@ static_assert(
 
 namespace dedekind::numbers {
 
+// Functor identification: Complex<R> = Cplx(R).  The Cplx functor
+// (quotient ring R[i]/(i² + 1); cf. Lang §III.1) takes a commutative
+// ring R to the ring extension by a square root of -1; for any
+// IsComplexScalar R, Complex<R> IS that quotient ring (a field when
+// R is a field with i² + 1 irreducible; an integral-domain extension
+// when R is an integral domain; nilpotent when i² + 1 reduces).  The
+// ScalarCarrier alias is the source-side projection of the Cplx
+// functor, mechanically aligning the §2 paper paragraph
+// ("Named functors that build the library's carriers") with source.
+//
+// FIXME(#498/NEW-A): same naming-convention question as
+// Rational<I>::IntegerCarrier and Real<Q>::ScalarCarrier — see the
+// FIXME there.  Aligning IntegerCarrier / ScalarCarrier / value_type
+// with :functor's Σ_cat / Τ_cat / Shape<U> convention is NEW-A
+// trait-registry work.
+static_assert(std::same_as<typename Complex<double>::ScalarCarrier, double>,
+              "Complex<R> is the Cplx-functor image of R; ScalarCarrier "
+              "names R mechanically.");
+
 /**
  * @brief Canonical embedding ℤ² ↪ ℂ: (x, y) ↦ x + iy.
  *

--- a/src/main/modules/dedekind/numbers/complex.cppm
+++ b/src/main/modules/dedekind/numbers/complex.cppm
@@ -317,9 +317,18 @@ namespace dedekind::numbers {
 // Functor identification: Complex<R> = Cplx(R).  The Cplx functor
 // (quotient ring R[i]/(i² + 1); cf. Lang §III.1) takes a commutative
 // ring R to the ring extension by a square root of -1; for any
-// IsComplexScalar R, Complex<R> IS that quotient ring (a field when
-// R is a field with i² + 1 irreducible; an integral-domain extension
-// when R is an integral domain; nilpotent when i² + 1 reduces).  The
+// IsComplexScalar R, Complex<R> IS that quotient ring.  The structural
+// type of the result depends on how i² + 1 sits in R[x]:
+//   - irreducible over R → R[i]/(i² + 1) is an integral-domain
+//     extension (a field when R itself is a field);
+//   - reducible into distinct linear factors over R → semisimple
+//     decomposition R[i]/(i² + 1) ≅ R × R (e.g., over R = ℂ);
+//   - reducible into a repeated factor (i.e., (x - α)² in R[x]) →
+//     nilpotent quotient with non-trivial radical (e.g., R = 𝔽_2,
+//     where x² + 1 = (x + 1)²).
+// The "nilpotent" branch is the @em not-square-free case specifically,
+// not "any reducible case" — semisimple-decomposition reductions
+// don't produce nilpotents (they produce idempotents).  The
 // ScalarCarrier alias is the source-side projection of the Cplx
 // functor, mechanically aligning the §2 paper paragraph
 // ("Named functors that build the library's carriers") with source.

--- a/src/main/modules/dedekind/numbers/rational.cppm
+++ b/src/main/modules/dedekind/numbers/rational.cppm
@@ -307,6 +307,31 @@ namespace dedekind::numbers {
 // Proof: The inverse of 2/3 is 3/2.
 static_assert((Rational<default_integer>(2, 3).inverse().num() == 3));
 
+// Functor identification: Rational<I> = Frac(I).  The Frac functor
+// (field-of-fractions; right adjoint to the forgetful functor from
+// fields to integral domains; cf. Lang §II.4) takes an integral domain
+// I to its quotient field; for any IsInteger I, Rational<I> IS that
+// quotient field.  Pinning this mechanically aligns the paper §2
+// prose ("Named functors that build the library's carriers") with the
+// source: the IntegerCarrier alias is the source-side projection of
+// the Frac functor, so any consumer can read off "what does this
+// rational sit over?" by inspecting Rational<I>::IntegerCarrier.
+//
+// FIXME(#498/NEW-A): IntegerCarrier is the ad-hoc source-projection
+// alias on Rational<I>; sibling carriers use ScalarCarrier
+// (Real<Q>, Complex<R>) and value_type (Dual<F>, IsTangentBundle).
+// The dedekind.category:functor partition meanwhile establishes the
+// canonical convention --- Σ_cat / Τ_cat for source/target category
+// and Shape<U> for the on-objects action (cf. box_functor<T> at
+// src/main/modules/dedekind/category/functor.cppm).  Unifying the carrier-side
+// projections with the :functor convention is NEW-A trait-registry
+// work and tracked under #498; this static_assert is the smallest
+// honest pinning available today.
+static_assert(std::same_as<typename Rational<default_integer>::IntegerCarrier,
+                           default_integer>,
+              "Rational<I> is the Frac-functor image of I; the "
+              "IntegerCarrier alias names I mechanically.");
+
 /**
  * @brief Characteristic morphism for ℚ: the rationals.
  * Accepts native Rational<I> and delegates predecessor checks through ℤ.

--- a/src/main/modules/dedekind/numbers/rational.cppm
+++ b/src/main/modules/dedekind/numbers/rational.cppm
@@ -308,8 +308,8 @@ namespace dedekind::numbers {
 static_assert((Rational<default_integer>(2, 3).inverse().num() == 3));
 
 // Functor identification: Rational<I> = Frac(I).  The Frac functor
-// (field-of-fractions; right adjoint to the forgetful functor from
-// fields to integral domains; cf. Lang §II.4) takes an integral domain
+// (field-of-fractions; left adjoint to the inclusion / forgetful functor
+// Fields → IntegralDomains; cf. Lang §II.4) takes an integral domain
 // I to its quotient field; for any IsInteger I, Rational<I> IS that
 // quotient field.  Pinning this mechanically aligns the paper §2
 // prose ("Named functors that build the library's carriers") with the

--- a/src/main/modules/dedekind/numbers/real.cppm
+++ b/src/main/modules/dedekind/numbers/real.cppm
@@ -354,6 +354,23 @@ static_assert(
 
 namespace dedekind::numbers {
 
+// Functor identification: Real<Q> = Cuts(Q).  The Cuts functor
+// (Dedekind order-completion of an ordered field; cf. Lang §I appendix)
+// takes a dense-ordered carrier Q to its Cauchy/Dedekind completion;
+// for any IsRealCarrier Q, Real<Q> IS that completion.  The
+// ScalarCarrier alias is the source-side projection of the Cuts
+// functor, mechanically aligning the §2 paper paragraph
+// ("Named functors that build the library's carriers") with source.
+//
+// FIXME(#498/NEW-A): same naming-convention question as
+// Rational<I>::IntegerCarrier — see the FIXME there.  Aligning
+// IntegerCarrier / ScalarCarrier / value_type with :functor's
+// Σ_cat / Τ_cat / Shape<U> convention is NEW-A trait-registry work.
+static_assert(std::same_as<typename Real<machine_real_scalar>::ScalarCarrier,
+                           machine_real_scalar>,
+              "Real<Q> is the Cuts-functor image of Q; ScalarCarrier names Q "
+              "mechanically.");
+
 static_assert(
     dedekind::category::IsSet<decltype(dedekind::category::ambient_set<
                                        Real<machine_real_scalar>>(R))>,


### PR DESCRIPTION
## Summary

NEW-D of the #498 epic: bring the categorical functor vocabulary (Frac, Cuts, Cplx, Dual, Free_n, End_R) from Figure 1's caption and the rosetta tables into the body prose of §2 and §5.4, and pin two of the carrier-side identifications mechanically with `static_assert`s.

The discipline answer to "does it make sense to `static_assert` code alignment with the prose?" is *yes* — paper claims become mechanical at translation time.

## Changes

### Paper §2 (`Axiomatic Systems Programming`)

New paragraph after the C++↔STLC translation table, **"Named functors that build the library's carriers"**:

- Names Frac / Cuts / Cplx / Dual / Free_n / End_R explicitly with their universal-property anchors (Lang §II.4, §I appendix, §III.1; Mac Lane §VII).
- Maps each functor to its partition: `:rational` ships Frac, `:real` ships Cuts, `:complex` ships Cplx, `analysis:dual` ships Dual, `:tuple` ships Free_2, `:matrix` ships End_R at n=2.
- Names the source-projection aliases (`IntegerCarrier`, `ScalarCarrier`, `value_type`) and notes that aligning them with the `:functor` partition's Σ_cat / Τ_cat / Shape<U> convention is **NEW-A trait-registry follow-up** under #498.

### Paper §5.4 (Linear Algebra: ℂ and 𝔻 as Subrings of M₂(ℚ))

New paragraph after the regular-representation intro: re-reads both embeddings in functor vocabulary as components of the natural-transformation schema **Cplx, Dual ⇒ End_R ∘ Free_2** over the same base ring R, with the carrier-lattice commutation identities underwriting the generalisation beyond ℚ.

### Source-side mechanical witnesses

- `numbers/rational.cppm`: `static_assert(std::same_as<Rational<I>::IntegerCarrier, I>)` — Frac functor source projection.
- `numbers/real.cppm`: `static_assert(std::same_as<Real<Q>::ScalarCarrier, Q>)` — Cuts functor source projection.
- Both static_asserts carry `FIXME(#498/NEW-A)` comments naming the convention-alignment question to be tracked by the trait registry.

Dual<F>'s `value_type = F` is already pinned by the new `IsTangentBundle` concept in PR #513; Complex<R>'s `ScalarCarrier = R` would be the analogous static_assert but is left for later (parallel-safe scope).

## Why now

NEW-D's gap was that the functor vocabulary lived in Figure 1's caption and the rosetta tables but didn't appear in the body prose of §2 or §5.4. Reading the paper top-to-bottom, you'd encounter the operational/algebraic story first and the categorical structure only at the figure. Reversing that — the §2 paragraph names the functors before §5.4 uses them — is the small alignment that makes the textbook story legible alongside the C++ source.

The mechanical pinning extends the project's discipline (claim only what's mechanically true, let the compiler check) from the algebraic-axiom side (e.g., `IsAlgebra`, `IsField`) to the **functor-identification side** (Rational<I> IS Frac(I), Real<Q> IS Cuts(Q)) — currently as ad-hoc structural checks; the full Σ_cat-style alignment is NEW-A.

## Test plan

- [x] `make compile`: clean
- [x] `make test`: 15/15 pass
- [x] `lualatex -interaction=nonstopmode -halt-on-error paper.tex`: passes (39 pages)
- [ ] CI green on this PR

## Refs

- #498 (Algebraic Tower epic) — NEW-D partial advance; refs NEW-A trait-registry for the convention-alignment follow-up.
- #513 in flight (Dual relocation + IsTangentBundle): parallel-safe — distinct paper sections (§1.2 vs §2/§5.4) and distinct source files (analysis/dual.cppm vs numbers/rational.cppm + numbers/real.cppm).

🤖 Generated with [Claude Code](https://claude.com/claude-code)