### PR TITLE
chore(gitignore): add missing LaTeX build artefacts (docs/report/*.aux + .fls / .fdb_latexmk / .synctex.gz)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,12 +35,18 @@ build-runtime-bridges**
 **/dist/
 
 
+# LaTeX build artefacts (paper + report).
+# These are regenerated on every build; tracking them creates recurring
+# binary/textual merge conflicts on parallel paper-touching PRs.
 docs/paper/*.aux
 docs/paper/*.bbl
 docs/paper/*.bcf
 docs/paper/*.blg
+docs/paper/*.fdb_latexmk
+docs/paper/*.fls
 docs/paper/*.log
 docs/paper/*.out
+docs/paper/*.synctex.gz
 docs/paper/*.toc
 docs/paper/*.run.xml
 # Built artefact; published from main via the docs-and-pages CI job.
@@ -51,11 +57,15 @@ docs/paper/*.run.xml
 # the inline-comment form here landed at PR #514 but didn't actually
 # ignore paper.pdf for any consumer.)
 docs/paper/paper.pdf
+docs/report/*.aux
 docs/report/*.bbl
 docs/report/*.bcf
 docs/report/*.blg
+docs/report/*.fdb_latexmk
+docs/report/*.fls
 docs/report/*.log
 docs/report/*.out
+docs/report/*.synctex.gz
 docs/report/*.toc
 docs/report/*.run.xml
 docs/report/report.pdf


### PR DESCRIPTION
## Summary

Two .gitignore oversights from earlier work, surfacing as recurring `?? docs/report/report.aux` in `git status`:

- `docs/report/*.aux` was **flat-out missing** from the docs/report block — the list jumped from `*.run.xml` straight to `*.bbl` and never covered `.aux`.  Different mechanism from PR #514's inline-comment bug; same effect (the file was never matched).
- `*.fls` (LaTeX file list), `*.fdb_latexmk` (latexmk database), `*.synctex.gz` (SyncTeX index) were not ignored for either the paper or report block.  All three are regenerated on every build.

This PR adds the missing entries for both blocks plus a brief explanatory comment at the top.

## Test plan

- [x] `git check-ignore -v docs/report/report.aux` → `.gitignore:60:docs/report/*.aux` (matched)
- [x] `git check-ignore -v docs/paper/paper.aux` → `.gitignore:41:docs/paper/*.aux` (still matched after the restructure)
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)