### PR TITLE
feat(numbers, sets, order): retarget default_integer to SignedExtensionalCardinal<> — unblock IsField on Rational<default_integer> (#499)

### DIFF
--- a/src/main/modules/dedekind/numbers/integer.cppm
+++ b/src/main/modules/dedekind/numbers/integer.cppm
@@ -150,15 +150,19 @@ export using extensional_integer = int;
  * @brief Default integer carrier used by downstream numeric layers.
  *
  * @details Intentionally an alias so the default can be retargeted in one
- * place. Current choice is the machine signed integer (syntactically IsInteger,
- * operationally correct for arithmetic that stays in range).
- *
- * @note The natural-number carrier `ExtensionalCardinal<>` satisfies IsInteger
- * and forms a total ring (IsRing), but is unsigned — negative rationals need
- * a signed carrier. A future `SignedExtensionalCardinal<N>` is the intended
- * long-term retarget. See rational.cppm for `RationalPolynomial` (Q[x]).
+ * place.  Current choice is @c SignedExtensionalCardinal<> --- the
+ * variant signed-integer-by-fiat carrier whose arithmetic is total
+ * (sign-magnitude with periodic wrap, no UB).  This makes the default
+ * @c Rational<default_integer> participate in the strict @c IsRing
+ * chain (and so @c IsField), via the @c SignedExtensionalCardinal<>
+ * @c IsInteger pinning.  The previous default was machine @c int,
+ * which @b syntactically satisfies @c IsInteger but @b not
+ * @c IsMagma (signed-overflow UB), blocking any axiomatic ring/field
+ * proof on @c Rational<int> at the @c IsTotal certificate.  The
+ * machine alias @c extensional_integer remains @c int for callsites
+ * that genuinely want the IEEE-style machine carrier.
  */
-export using default_integer = extensional_integer;
+export using default_integer = SignedExtensionalCardinal<>;
 
 // FIXME(#379): the *Like cluster below is a candidate for the
 // retire-Like surgery phase that follows the alignment sweep.

--- a/src/main/modules/dedekind/numbers/rational.cppm
+++ b/src/main/modules/dedekind/numbers/rational.cppm
@@ -78,6 +78,24 @@ class Rational {
   constexpr Rational(Z n)
       : first(n), second(Z{1}) {}  // NOLINT(google-explicit-constructor)
 
+  /** @brief Embedding of any standard integral as a rational n/1, in @b one
+   *  user-defined conversion.
+   *
+   *  @details Without this constructor, building a @c Rational<Z> from an
+   *  @c int literal would require two UDCs (@c int → @c Z → @c Rational<Z>),
+   *  which C++ does not permit in implicit-conversion chains.  This template
+   *  collapses both steps into a single UDC so that @c Real<Rational<Z>>{1}
+   *  works for any @c Z whose constructor accepts a built-in integral
+   *  (canonical example post-retarget: @c Z = @c SignedExtensionalCardinal<>,
+   *  whose @c S → @c SEC<> constructor is itself a one-UDC step).  Required
+   *  for the @c HasGroupOperatorsMul @c T{1} witness on @c ExactReal<>
+   *  (#499 / default_integer retarget).
+   */
+  template <std::integral S>
+    requires(!std::same_as<S, Z>)
+  constexpr Rational(S n)  // NOLINT(google-explicit-constructor)
+      : first(Z{n}), second(Z{1}) {}
+
   /** @section rational__The_Simplification_Morphism */
   constexpr void simplify() {
     if (second == Z{0}) throw std::domain_error("Rational: Division by zero.");
@@ -305,7 +323,9 @@ namespace dedekind::numbers {
 /** @section rational__Formal_Verification */
 
 // Proof: The inverse of 2/3 is 3/2.
-static_assert((Rational<default_integer>(2, 3).inverse().num() == 3));
+static_assert((Rational<default_integer>(default_integer{2}, default_integer{3})
+                   .inverse()
+                   .num() == default_integer{3}));
 
 // Functor identification: Rational<I> = Frac(I).  The Frac functor
 // (field-of-fractions; left adjoint to the inclusion / forgetful functor

--- a/src/main/modules/dedekind/numbers/rational.cppm
+++ b/src/main/modules/dedekind/numbers/rational.cppm
@@ -97,9 +97,10 @@ class Rational {
    *    * @c Real<Rational<Z>>{1} for the @c HasGroupOperatorsMul
    *      @c T{1} witness on @c ExactReal<>;
    *    * @c Rational<Z>{2} for the @c (a @c + @c b) @c / @c T{2}
-   *      midpoint expression in the @c IsDense concept (post-#520
-   *      reformulation that uses @c T{2} instead of bare-int
-   *      @c 2 to keep the carrier in control of its own value-2);
+   *      midpoint expression in the @c IsDense concept (the @c T{2}
+   *      reformulation, landed under this PR, replaces the previous
+   *      bare-int @c 2 so the carrier is in control of its own
+   *      value-2);
    *    * generally, any context where an @c int literal lifts into
    *      @c Rational<Z> across one UDC.
    *

--- a/src/main/modules/dedekind/numbers/rational.cppm
+++ b/src/main/modules/dedekind/numbers/rational.cppm
@@ -74,7 +74,15 @@ class Rational {
   constexpr Rational(Z num, Z den) : first(num), second(den) { simplify(); }
 
   /** @brief Embedding of an integer as a rational n/1.
-   *  Implicit to allow `(a + b) / Z{2}` in IsDense checks. */
+   *  Implicit to allow @c Rational<Z>{Z_value} to flow into the
+   *  @c (a @c + @c b) @c / @c T{2} midpoint expression that the
+   *  @c IsDense concept (in @c order:completeness) requires.
+   *  When @c T = @c Rational<Z>, @c T{2} resolves through the
+   *  @c Rational(std::integral) overload below (@c int → @c Rational<Z>
+   *  in one UDC), bypassing the two-UDC chain
+   *  @c int @c → @c Z @c → @c Rational<Z> that C++ would otherwise
+   *  reject.  This @c Rational(Z) form remains the canonical embedding
+   *  when the caller already has a @c Z value in hand. */
   constexpr Rational(Z n)
       : first(n), second(Z{1}) {}  // NOLINT(google-explicit-constructor)
 
@@ -84,12 +92,23 @@ class Rational {
    *  @details Without this constructor, building a @c Rational<Z> from an
    *  @c int literal would require two UDCs (@c int → @c Z → @c Rational<Z>),
    *  which C++ does not permit in implicit-conversion chains.  This template
-   *  collapses both steps into a single UDC so that @c Real<Rational<Z>>{1}
-   *  works for any @c Z whose constructor accepts a built-in integral
-   *  (canonical example post-retarget: @c Z = @c SignedExtensionalCardinal<>,
-   *  whose @c S → @c SEC<> constructor is itself a one-UDC step).  Required
-   *  for the @c HasGroupOperatorsMul @c T{1} witness on @c ExactReal<>
-   *  (#499 / default_integer retarget).
+   *  collapses both steps into a single UDC, enabling:
+   *
+   *    * @c Real<Rational<Z>>{1} for the @c HasGroupOperatorsMul
+   *      @c T{1} witness on @c ExactReal<>;
+   *    * @c Rational<Z>{2} for the @c (a @c + @c b) @c / @c T{2}
+   *      midpoint expression in the @c IsDense concept (post-#520
+   *      reformulation that uses @c T{2} instead of bare-int
+   *      @c 2 to keep the carrier in control of its own value-2);
+   *    * generally, any context where an @c int literal lifts into
+   *      @c Rational<Z> across one UDC.
+   *
+   *  Canonical example post-retarget: @c Z @c = @c
+   *  SignedExtensionalCardinal<>, whose @c S → @c SEC<> constructor
+   *  is itself a one-UDC step.  Required for the
+   *  @c HasGroupOperatorsMul / @c IsDense witnesses to fire on
+   *  @c Real<Rational<default_integer>> (#499 / default_integer
+   *  retarget).
    */
   template <std::integral S>
     requires(!std::same_as<S, Z>)

--- a/src/main/modules/dedekind/numbers/real.cppm
+++ b/src/main/modules/dedekind/numbers/real.cppm
@@ -295,15 +295,15 @@ namespace dedekind::numbers {
 export template <IsInteger I = default_integer,
                  IsRealCarrier S = machine_real_scalar>
 inline constexpr auto embed_ℚ_ℝ =
-    arrow<Rational<I>, Real<S>>([](const Rational<I>& q) noexcept {
+    arrow<Rational<I>, Real<S>>([](const Rational<I>& q) {
       auto to_real_scalar = [](const I& z) -> S {
         // Detect @b static-castability rather than just implicit
         // convertibility: a carrier may expose @c explicit
         // @c operator @c S, which makes @c static_cast<S>(z) valid
-        // even when @c std::convertible_to<I, S> is false.  PR #520
-        // review follow-up: this captures both the implicit-conversion
-        // case (built-in @c int @c → @c double) and the
-        // explicit-conversion-operator case uniformly.
+        // even when @c std::convertible_to<I, S> is false.  This
+        // captures both the implicit-conversion case (built-in
+        // @c int @c → @c double) and the explicit-conversion-operator
+        // case uniformly.
         if constexpr (requires { static_cast<S>(z); }) {
           return static_cast<S>(z);
         } else {

--- a/src/main/modules/dedekind/numbers/real.cppm
+++ b/src/main/modules/dedekind/numbers/real.cppm
@@ -297,13 +297,31 @@ export template <IsInteger I = default_integer,
 inline constexpr auto embed_ℚ_ℝ =
     arrow<Rational<I>, Real<S>>([](const Rational<I>& q) noexcept {
       auto to_real_scalar = [](const I& z) -> S {
-        if constexpr (std::convertible_to<I, S>) {
+        // Detect @b static-castability rather than just implicit
+        // convertibility: a carrier may expose @c explicit
+        // @c operator @c S, which makes @c static_cast<S>(z) valid
+        // even when @c std::convertible_to<I, S> is false.  PR #520
+        // review follow-up: this captures both the implicit-conversion
+        // case (built-in @c int @c → @c double) and the
+        // explicit-conversion-operator case uniformly.
+        if constexpr (requires { static_cast<S>(z); }) {
           return static_cast<S>(z);
         } else {
-          // Variant carrier path: extract via the documented int bridge,
-          // then widen to S.  Lossy by design at the variant-int step
-          // (multi-limb values truncate to single-limb int) AND at the
-          // int-to-float step (above 2^53 the IEEE rounding fires).
+          // Variant carrier path: the variant integer is first
+          // extracted via its documented @c operator @c int (a
+          // signed-integral conversion, gated separately on the
+          // variant), then widened to @c S.  Lossy by design at the
+          // variant-int step (multi-limb values truncate to
+          // single-limb int) AND at the int-to-float step (above 2^53
+          // IEEE rounding fires).  We require the int bridge exists;
+          // if neither path is available, the static_assert below
+          // surfaces a diagnostic at the right spot rather than an
+          // opaque template substitution failure.
+          static_assert(
+              requires { static_cast<int>(z); },
+              "embed_ℚ_ℝ requires either static_cast<S>(I) or "
+              "static_cast<int>(I) to be valid; provide one or "
+              "the other on the integer carrier I.");
           return static_cast<S>(static_cast<int>(z));
         }
       };

--- a/src/main/modules/dedekind/numbers/real.cppm
+++ b/src/main/modules/dedekind/numbers/real.cppm
@@ -276,12 +276,38 @@ namespace dedekind::numbers {
 /**
  * @brief Machine realization arrow ℚ ↪ ℝ: Rational<I> → Real<S>.
  * @details Converts a rational p/q to the closest IEEE 754 value of type S.
+ *
+ * @section Carrier_Bridge_Locality
+ * The integer-to-IEEE conversion @c static_cast<S>(q.num()) is the lossy
+ * step.  When @c I is a built-in (@c int, @c long, ...), the standard
+ * float-from-int conversion fires.  When @c I is a variant exact carrier
+ * (@c SignedExtensionalCardinal<>, etc.) which deliberately does @b not
+ * export an @c operator @c double (to keep the variant carriers free of
+ * IEEE coupling), the lossy bridge is implemented here at the
+ * @b call-site rather than upstream: the variant integer is first
+ * extracted as a built-in @c int via its @c operator @c int (single-limb,
+ * the canonical retarget instance) and then promoted to @c S via
+ * standard widening.  This keeps the IEEE-coupling local to the arrow
+ * that owns the lossy semantics, matching the structural-Platonist
+ * directive that variant carriers do not advertise machine-numeric
+ * conversions they do not need.
  */
 export template <IsInteger I = default_integer,
                  IsRealCarrier S = machine_real_scalar>
 inline constexpr auto embed_ℚ_ℝ =
     arrow<Rational<I>, Real<S>>([](const Rational<I>& q) noexcept {
-      return Real<S>{static_cast<S>(q.num()) / static_cast<S>(q.den())};
+      auto to_real_scalar = [](const I& z) -> S {
+        if constexpr (std::convertible_to<I, S>) {
+          return static_cast<S>(z);
+        } else {
+          // Variant carrier path: extract via the documented int bridge,
+          // then widen to S.  Lossy by design at the variant-int step
+          // (multi-limb values truncate to single-limb int) AND at the
+          // int-to-float step (above 2^53 the IEEE rounding fires).
+          return static_cast<S>(static_cast<int>(z));
+        }
+      };
+      return Real<S>{to_real_scalar(q.num()) / to_real_scalar(q.den())};
     });
 
 /**

--- a/src/main/modules/dedekind/order/completeness.cppm
+++ b/src/main/modules/dedekind/order/completeness.cppm
@@ -87,11 +87,20 @@ concept IsDiscrete = IsArchimedean<T> && requires(T x) {
 /**
  * @concept IsDense
  * @brief A property where a midpoint always exists (a < c < b).
+ *
+ * @details The midpoint is computed as @c (a + b) / T{2} rather than
+ * @c (a + b) / 2 so that the @b carrier itself supplies the value
+ * @c 2 (via the @c T{2} structural constructor), rather than relying
+ * on mixed-type @c T-vs-int arithmetic.  This matters for variant
+ * exact carriers (@c SignedExtensionalCardinal<>, @c Rational<...> over
+ * such) which do not implicitly inter-operate with literal @c int ---
+ * forcing the carrier to construct its own @c 2 keeps the concept
+ * honest across both built-in (@c int, @c double) and exact carriers.
  */
 export template <typename T>
 concept IsDense =
     IsTotallyOrdered<T> && !IsDiscrete<T> && requires(const T a, const T b) {
-      { (a + b) / 2 } -> std::convertible_to<T>;
+      { (a + b) / T{2} } -> std::convertible_to<T>;
     };
 
 /**

--- a/src/main/modules/dedekind/sets/cardinality.cppm
+++ b/src/main/modules/dedekind/sets/cardinality.cppm
@@ -686,7 +686,8 @@ struct SignedExtensionalCardinal {
    *  heterogeneous form directly on @c SEC makes it a strictly better
    *  match (no UDC on the @c SEC side), letting callers write
    *  @c q.num() @c > @c 0 and similar without explicit
-   *  @c default_integer{0} lifts.  PR #520 review follow-up.
+   *  @c default_integer{0} lifts.  Mirrors the heterogeneous
+   *  @c operator== above for the ordering side.
    */
   template <std::integral T>
   constexpr friend std::strong_ordering operator<=>(

--- a/src/main/modules/dedekind/sets/cardinality.cppm
+++ b/src/main/modules/dedekind/sets/cardinality.cppm
@@ -673,6 +673,32 @@ struct SignedExtensionalCardinal {
     return SignedExtensionalCardinal{lhs} == rhs;
   }
 
+  /** @brief Heterogeneous ordering with built-in integrals.
+   *
+   *  @details Mirrors the heterogeneous @c operator== above for the
+   *  ordering side (@c <, @c <=, @c >, @c >=).  Without these
+   *  overloads, comparisons like @c q.num() @c > @c 0 (where
+   *  @c q.num() returns @c SEC<> after the @c default_integer
+   *  retarget, and @c 0 is an @c int literal) trigger the same
+   *  ambiguity the equality side resolved: @c operator<=>(SEC, SEC)
+   *  via @c int @c → @c SEC versus @c operator<=>(SignedCardinality,
+   *  int) via @c SEC @c → @c SignedCardinality.  Providing the
+   *  heterogeneous form directly on @c SEC makes it a strictly better
+   *  match (no UDC on the @c SEC side), letting callers write
+   *  @c q.num() @c > @c 0 and similar without explicit
+   *  @c default_integer{0} lifts.  PR #520 review follow-up.
+   */
+  template <std::integral T>
+  constexpr friend std::strong_ordering operator<=>(
+      const SignedExtensionalCardinal& lhs, T rhs) noexcept {
+    return lhs <=> SignedExtensionalCardinal{rhs};
+  }
+  template <std::integral T>
+  constexpr friend std::strong_ordering operator<=>(
+      T lhs, const SignedExtensionalCardinal& rhs) noexcept {
+    return SignedExtensionalCardinal{lhs} <=> rhs;
+  }
+
   constexpr friend std::strong_ordering operator<=>(
       const SignedExtensionalCardinal& lhs,
       const SignedExtensionalCardinal& rhs) noexcept {

--- a/src/main/modules/dedekind/sets/cardinality.cppm
+++ b/src/main/modules/dedekind/sets/cardinality.cppm
@@ -648,6 +648,31 @@ struct SignedExtensionalCardinal {
     return lhs.negative == rhs.negative && lhs.magnitude == rhs.magnitude;
   }
 
+  /** @brief Heterogeneous equality with built-in integrals.
+   *
+   *  @details Without this overload the comparison @c SEC<> @c == @c int
+   *  is ambiguous: both @c operator==(SEC, SEC) (after the implicit
+   *  @c int @c → @c SEC constructor) and @c operator==(SignedCardinality,
+   *  int) (after the implicit @c SEC @c → @c SignedCardinality variant
+   *  conversion) match in one user-defined conversion.  Providing the
+   *  heterogeneous form directly on @c SEC makes it a strictly better
+   *  match (no UDC required on the @c SEC side), resolving the ambiguity
+   *  without forcing call-sites to write @c SEC<>{N} just to compare
+   *  against an @c int literal.  Symmetric overload below covers
+   *  @c int @c == @c SEC.  Required by the @c default_integer retarget
+   *  to @c SEC<> (#499 / paper-side ℚ-as-IsField unblock).
+   */
+  template <std::integral T>
+  constexpr friend bool operator==(const SignedExtensionalCardinal& lhs,
+                                   T rhs) noexcept {
+    return lhs == SignedExtensionalCardinal{rhs};
+  }
+  template <std::integral T>
+  constexpr friend bool operator==(
+      T lhs, const SignedExtensionalCardinal& rhs) noexcept {
+    return SignedExtensionalCardinal{lhs} == rhs;
+  }
+
   constexpr friend std::strong_ordering operator<=>(
       const SignedExtensionalCardinal& lhs,
       const SignedExtensionalCardinal& rhs) noexcept {

--- a/src/test/cpp/modules/dedekind/numbers/starters_test.cpp
+++ b/src/test/cpp/modules/dedekind/numbers/starters_test.cpp
@@ -66,7 +66,8 @@ TEST_CASE("Numbers: starter universes construct from ambient values",
 
   constexpr auto q = var<ℚ>;
   constexpr auto rationals = Set{q % Q};
-  static_assert(rationals(Rational<int>{1, 2}) == Ternary::True);
+  static_assert(rationals(Rational<default_integer>{
+                    default_integer{1}, default_integer{2}}) == Ternary::True);
 
   constexpr auto r = var<ℝ>;
   constexpr auto reals = Set{r % R};
@@ -105,8 +106,10 @@ TEST_CASE("Numbers: starter universes satisfy lattice identities",
     constexpr auto q = var<ℚ>;
     const auto U = Set{q % Q};
     const auto O = !U;
-    CHECK((U | O)(Rational<int>{1, 3}) == Ternary::True);
-    CHECK((U & O)(Rational<int>{1, 3}) == Ternary::False);
+    CHECK((U | O)(Rational<default_integer>{
+              default_integer{1}, default_integer{3}}) == Ternary::True);
+    CHECK((U & O)(Rational<default_integer>{
+              default_integer{1}, default_integer{3}}) == Ternary::False);
   }
 
   {

--- a/src/test/cpp/modules/dedekind/numbers/tower_test.cpp
+++ b/src/test/cpp/modules/dedekind/numbers/tower_test.cpp
@@ -52,13 +52,18 @@ static_assert(std::same_as<Dom<std::decay_t<decltype(embed_𝕂3_ℤ_)>>, Ternar
 static_assert(std::same_as<Cod<std::decay_t<decltype(embed_𝕂3_ℤ_)>>,
                            dedekind::sets::SignedCardinality>);
 
-// embed_ℤ_ℚ<> / embed_ℚ_ℝ<> default-instantiate over default_integer
-// (= SignedExtensionalCardinal<> post-#499 retarget), not machine_integer.
+// embed_ℤ_ℚ<> takes a machine_integer (the source-side type is hardwired
+// in the arrow definition, independent of the I template parameter) and
+// returns a Rational<I> with I = default_integer post-#499 retarget
+// (default_integer = SignedExtensionalCardinal<>).
 static_assert(
-    std::same_as<Dom<std::decay_t<decltype(embed_ℤ_ℚ<>)>>, default_integer>);
+    std::same_as<Dom<std::decay_t<decltype(embed_ℤ_ℚ<>)>>, machine_integer>);
 static_assert(std::same_as<Cod<std::decay_t<decltype(embed_ℤ_ℚ<>)>>,
                            Rational<default_integer>>);
 
+// embed_ℚ_ℝ<> default-instantiates with I = default_integer (so the source
+// is Rational<default_integer> = Rational<SignedExtensionalCardinal<>>)
+// and S = machine_real_scalar.
 static_assert(std::same_as<Dom<std::decay_t<decltype(embed_ℚ_ℝ<>)>>,
                            Rational<default_integer>>);
 static_assert(std::same_as<Cod<std::decay_t<decltype(embed_ℚ_ℝ<>)>>,

--- a/src/test/cpp/modules/dedekind/numbers/tower_test.cpp
+++ b/src/test/cpp/modules/dedekind/numbers/tower_test.cpp
@@ -52,13 +52,15 @@ static_assert(std::same_as<Dom<std::decay_t<decltype(embed_𝕂3_ℤ_)>>, Ternar
 static_assert(std::same_as<Cod<std::decay_t<decltype(embed_𝕂3_ℤ_)>>,
                            dedekind::sets::SignedCardinality>);
 
+// embed_ℤ_ℚ<> / embed_ℚ_ℝ<> default-instantiate over default_integer
+// (= SignedExtensionalCardinal<> post-#499 retarget), not machine_integer.
 static_assert(
-    std::same_as<Dom<std::decay_t<decltype(embed_ℤ_ℚ<>)>>, machine_integer>);
+    std::same_as<Dom<std::decay_t<decltype(embed_ℤ_ℚ<>)>>, default_integer>);
 static_assert(std::same_as<Cod<std::decay_t<decltype(embed_ℤ_ℚ<>)>>,
-                           Rational<machine_integer>>);
+                           Rational<default_integer>>);
 
 static_assert(std::same_as<Dom<std::decay_t<decltype(embed_ℚ_ℝ<>)>>,
-                           Rational<machine_integer>>);
+                           Rational<default_integer>>);
 static_assert(std::same_as<Cod<std::decay_t<decltype(embed_ℚ_ℝ<>)>>,
                            Real<machine_real_scalar>>);
 
@@ -206,10 +208,13 @@ TEST_CASE("Tower: ℤ ↪ ℚ via embed_ℤ_ℚ", "[numbers][tower][embedding]")
 // ---------------------------------------------------------------------------
 
 TEST_CASE("Tower: ℚ ↪ ℝ via embed_ℚ_ℝ", "[numbers][tower][embedding]") {
-  // Embedding preserves value: 3/1 -> 3.0.
-  CHECK(embed_ℚ_ℝ<>(Rational<machine_integer>{3, 1}).resolve() == 3.0);
-  CHECK(embed_ℚ_ℝ<>(Rational<machine_integer>{1, 2}).resolve() == 0.5);
-  CHECK(embed_ℚ_ℝ<>(Rational<machine_integer>{-7, 4}).resolve() == -1.75);
+  // Embedding preserves value: 3/1 -> 3.0.  embed_ℚ_ℝ<> defaults its
+  // integer carrier to default_integer (SignedExtensionalCardinal<>
+  // post-#499 retarget); construct via the default_integer factory.
+  using D = default_integer;
+  CHECK(embed_ℚ_ℝ<>(Rational<D>{D{3}, D{1}}).resolve() == 3.0);
+  CHECK(embed_ℚ_ℝ<>(Rational<D>{D{1}, D{2}}).resolve() == 0.5);
+  CHECK(embed_ℚ_ℝ<>(Rational<D>{D{-7}, D{4}}).resolve() == -1.75);
 }
 
 // ---------------------------------------------------------------------------
@@ -494,10 +499,12 @@ TEST_CASE("Tower: inter-species set membership via embeddings",
 
   // Compose 𝔹 ↪ ℕ ↪ ℤ ↪ ℚ and test against a ℚ+ predicate.
   // Rational<> is not an ETCS species, so use Set<> directly.
-  const auto positive_pred = [](const Rational<machine_integer>& q) {
-    return q.num() > 0;
+  // embed_ℤ_ℚ<> default-instantiates over default_integer (SEC<>
+  // post-#499 retarget); the predicate-set type parameter must match.
+  const auto positive_pred = [](const Rational<default_integer>& q) {
+    return q.num() > default_integer{0};
   };
-  const Set<Rational<machine_integer>, ClassicalLogic, decltype(positive_pred)>
+  const Set<Rational<default_integer>, ClassicalLogic, decltype(positive_pred)>
       positive_rationals{positive_pred};
 
   const auto embed_𝔹_ℚ = [](bool b) {


### PR DESCRIPTION
## Summary

Closes #499 (paper-side ℚ-as-IsField unblock, originally tracked under the canonical species symbols epic).  Retargets `default_integer` from machine `int` to the variant exact carrier `SignedExtensionalCardinal<>`, so that `Rational<default_integer>` participates in the strict `IsRing` / `IsField` chain rather than dying at the `IsMagma` step (`int`'s signed-overflow UB blocks the chain one step in).

This was the "sand in the engine" the in-flight discussion identified: the comment at `integer.cppm:144-159` already named the intended retarget as a long-term plan, and `SignedExtensionalCardinal<>` was already shipped, `IsInteger`-pinned, and total-by-fiat.

## Motivation

The structurally-Platonist commitment requires the canonical ℚ to satisfy axiomatic `IsField`.  Pre-retarget, the chain failed because:

- `Rational<default_integer> = Rational<int>` (alias chain).
- `int` satisfies `IsInteger` syntactically but is **not** `IsMagma` (signed overflow is UB).
- `IsRing` ← `IsAdditiveGroup` ← `IsGroup` ← `IsMonoid` ← `IsSemigroup` ← `IsMagma` — so `IsRing<Rational<int>>` is unreachable.
- `IsField<Rational<int>>` follows: the strongest categorical claim on the canonical ℚ was blocked by the carrier choice.

Post-retarget, `Rational<default_integer> = Rational<SignedExtensionalCardinal<>>`, which IS in `IsRing` (the variant carrier is total-by-fiat under sign-magnitude wrap), so the strict ℚ-as-IsField proof is reachable.  This is the prerequisite for the paper's Figure 1 / functor-vocabulary work to make claims about ℚ that hold under the strict reading rather than only the operational one.

## Files touched

| File | Change |
|---|---|
| `numbers/integer.cppm` | The one-line retarget: `default_integer = SignedExtensionalCardinal<>`.  `extensional_integer = int` retained as the machine alias for callsites that genuinely want IEEE-style integer arithmetic. |
| `order/completeness.cppm` | `IsDense` rewritten from `(a + b) / 2` to `(a + b) / T{2}`.  The literal `2` baked in mixed-`int` arithmetic that exact carriers can't support; using `T{2}` lets the carrier supply its own value of 2 via the structural constructor.  Concept-level fix that benefits any future variant-carrier consumer of `IsDense`. |
| `numbers/rational.cppm` | `Rational(std::integral)` constructor template added so `Rational<Z>{1}` works in one user-defined conversion (without it, the chain `int → Z → Rational<Z>` is two UDCs which C++ rejects implicitly).  Unblocks `Real<Rational<Z>>{1}` for the `HasGroupOperatorsMul T{1}` witness on `ExactReal<>`. |
| `numbers/real.cppm` | `embed_ℚ_ℝ` arrow body extended with a call-site-local lossy bridge for variant integer carriers.  Per the design directive "if absolutely necessary, prefer to implement near the call-site, so it does not pollute the upstream" — the variant carrier itself does NOT get an IEEE-coupling `operator double`; the lossy step is local to the arrow that owns the lossy semantics.  Detection switched to `requires { static_cast<S>(z); }` (catches both implicit conversions and explicit conversion operators) per review. |
| `sets/cardinality.cppm` | Heterogeneous `operator==(SEC, std::integral)` and `operator<=>(SEC, std::integral)` added on `SignedExtensionalCardinal<>` to resolve the ambiguity between `SEC == SEC` (after `int → SEC` UDC) and `SignedCardinality == int` (after `SEC → SignedCardinality` variant UDC) — and the ordering equivalent so `q.num() > 0` works without `default_integer{0}` lifts. |
| `test/.../rational_test.cpp` | Lifts: literal `int`s replaced with `default_integer{N}` where the variant carrier's stricter type discipline rejects implicit interop. |
| `test/.../starters_test.cpp`, `tower_test.cpp` | Carrier-type updates: `Rational<machine_integer>` → `Rational<default_integer>` in the test fixtures that exercise the `embed_ℚ_ℝ` chain.  `embed_ℤ_ℚ<>`'s Domain remains `machine_integer` (the arrow's source-side type is hardwired in its definition); the Codomain follows `default_integer`. |

## Verification

- `make compile` ✓
- `make test` — 100% (15/15) ✓
- `codecov/patch` ✓ — all modified coverable lines are covered.
- `codecov/project` ✓
- All 7 SUCCESS / 2 SKIPPED checks green.

## Test plan

- [x] CI green on Linux clang-22 (`build-and-deploy`).
- [x] All 15 test binaries pass.
- [x] Coverage delta within tolerance.
- [x] Three review threads addressed (heterogeneous `<=>` on SEC, ctor doc alignment, `static_cast` detection in `embed_ℚ_ℝ`).

## Out of scope

- Adding the `static_assert(IsField<Rational<default_integer>, ...>)` witness — the chain now compiles, but the explicit pin is its own slice (the `Rational<I>` partition has historically used `HasFieldOperators` as the operational witness; the strict-`IsField` static_assert lands once the algebraic-soul registry is comfortable with the new chain).  Filed as follow-up for the next PR in the #498 epic.
- Cascade through specialised consumers (`Modular<N>`, `Polynomial<R>`, etc.) that may benefit from the same retarget pattern — separate slices.
- Eliminating `machine_integer` aliases in test fixtures that explicitly want `int` — those are intentional, not regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)