### PR TITLE
refactor(category): remove template-template parameters from :kleisli public surface (#508)

### DIFF
--- a/docs/paper/paper.tex
+++ b/docs/paper/paper.tex
@@ -616,16 +616,7 @@ No ADL-dependent dispatch except for textbook operator overloads. &
 Argument-dependent lookup is admitted only where the textbook reads
 \texttt{a + b} or \texttt{a == b} on library carriers; free-function
 calls in user code dispatch through explicit qualification. \\
-No template-template parameters in \lstinline|export|-qualified signatures.\footnote{One
-tracked exception at the time of writing: the \texttt{:kleisli} partition's
-\texttt{unit\_witness}, \texttt{counit\_witness}, \texttt{IsKleisliExtension},
-\texttt{IsCoKleisliExtension}, and \texttt{IsFrobenius} retain a
-\texttt{template <template <typename...> typename F, ...>} signature inherited from
-the early \texttt{Maybe}-monad work; the migration to the Hub pattern
-exhibited by \texttt{:functor} (\texttt{box\_functor<T>::Shape<U>} carrying
-higher-kindedness via a nested alias rather than via a template-template
-parameter at the call site) is tracked in issue~\#508 of the companion
-repository, and this footnote retires when that issue closes.} &
+No template-template parameters in \lstinline|export|-qualified signatures. &
 Higher-kinded structure is named at the level of concepts
 (\lstinline|IsFunctor<F>|, etc.), not by passing template-templates
 through public function signatures. \\

--- a/src/main/modules/dedekind/category/kleisli.cppm
+++ b/src/main/modules/dedekind/category/kleisli.cppm
@@ -58,6 +58,7 @@ module;
 #include <concepts>
 #include <functional>
 #include <ios>
+#include <utility>  // std::move / std::forward (kept self-contained per #521 review)
 
 export module dedekind.category:kleisli;
 

--- a/src/main/modules/dedekind/category/kleisli.cppm
+++ b/src/main/modules/dedekind/category/kleisli.cppm
@@ -61,6 +61,8 @@ module;
 
 export module dedekind.category:kleisli;
 
+import :functor;  // box_functor (canonical Hub for unit_witness/counit_witness;
+                  // #508)
 import :monad;
 import :small;
 import :morphism;
@@ -84,47 +86,70 @@ constexpr auto operator<<=(const Box<T>& b, Func&& f) {
 
 /** @section kleisli__The_Kleisli_Witnesses */
 
+// PR #508: removed template-template parameters from the public surface of
+// :kleisli to make the disciplined-fragment claim of the paper's
+// admissibility-rules table hold without exception.  The Hub indirection
+// follows the :functor precedent (PR introducing box_functor / maybe_functor
+// in :functor): higher-kindedness lives in a regular type's nested Shape<U>
+// alias rather than as a template-template parameter.  Carrier-side
+// specialisations in :sequences:path , :linear_algebra:tuple ,
+// :linear_algebra:matrix follow the same pattern, instantiating
+// unit_witness / counit_witness on box_functor<T> / path_functor<T> /
+// vec2_functor<T> / covec2_functor<T> / matrix2x2_functor<T>
+// (the canonical Hubs the *_functor partition already exports).
+
 /**
- * @brief unit_witness<F, T>: Generic Kleisli unit witness.
- * Lifts a value into the Kleisli extension.
+ * @brief unit_witness<Hub, T>: Generic Kleisli unit witness.
+ * Lifts a value into the Kleisli extension named by @c Hub::template Shape<T>.
+ *
+ * @tparam Hub A regular type carrying a nested @c Shape<U> alias; canonical
+ *             example is @c box_functor<U> from @c :functor.
+ * @tparam T   The value type.
  */
-export template <template <typename...> typename F, typename T>
+export template <typename Hub, typename T>
 struct unit_witness;
 
 export template <typename T>
-struct unit_witness<Box, T> final {
+struct unit_witness<box_functor<T>, T> final {
   constexpr auto operator()(T x) const { return Box<T>{std::move(x)}; }
 };
 
 /**
- * @brief counit_witness<F, T>: Generic Kleisli counit witness.
- * Samples a value from the co-Kleisli extension.
+ * @brief counit_witness<Hub, T>: Generic Kleisli counit witness.
+ * Samples a value from the co-Kleisli extension named by
+ * @c Hub::template Shape<T>.
  */
-export template <template <typename...> typename F, typename T>
+export template <typename Hub, typename T>
 struct counit_witness;
 
 export template <typename T>
-struct counit_witness<Box, T> final {
+struct counit_witness<box_functor<T>, T> final {
   constexpr T operator()(const Box<T>& b) const noexcept { return b.value; }
 };
 
 /** @section kleisli__Extension_Concepts */
 
-export template <template <typename...> typename F, typename T, typename U>
-concept IsKleisliExtension = requires(T x, F<T> box, std::function<F<U>(T)> f) {
-  { unit_witness<F, T>{}(x) } -> std::same_as<F<T>>;
-  { box >>= f } -> std::same_as<F<U>>;
-};
+export template <typename Hub, typename T, typename U>
+concept IsKleisliExtension =
+    requires(T x, typename Hub::template Shape<T> box,
+             std::function<typename Hub::template Shape<U>(T)> f) {
+      {
+        unit_witness<Hub, T>{}(x)
+      } -> std::same_as<typename Hub::template Shape<T>>;
+      { box >>= f } -> std::same_as<typename Hub::template Shape<U>>;
+    };
 
-export template <template <typename...> typename F, typename T, typename U>
-concept IsCoKleisliExtension = requires(F<T> box, std::function<U(F<T>)> f) {
-  { counit_witness<F, T>{}(box) } -> std::same_as<T>;
-  { box <<= f } -> std::same_as<F<U>>;
-};
+export template <typename Hub, typename T, typename U>
+concept IsCoKleisliExtension =
+    requires(typename Hub::template Shape<T> box,
+             std::function<U(typename Hub::template Shape<T>)> f) {
+      { counit_witness<Hub, T>{}(box) } -> std::same_as<T>;
+      { box <<= f } -> std::same_as<typename Hub::template Shape<U>>;
+    };
 
-export template <template <typename...> typename F, typename T, typename U>
+export template <typename Hub, typename T, typename U>
 concept IsFrobenius =
-    IsKleisliExtension<F, T, U> && IsCoKleisliExtension<F, T, U>;
+    IsKleisliExtension<Hub, T, U> && IsCoKleisliExtension<Hub, T, U>;
 
 /** @section kleisli__Kleisli_Operators */
 

--- a/src/main/modules/dedekind/linear_algebra/matrix.cppm
+++ b/src/main/modules/dedekind/linear_algebra/matrix.cppm
@@ -566,9 +566,14 @@ static_assert(
 
 namespace dedekind::category {
 
+// PR #508: unit_witness / counit_witness now take a Hub regular type
+// rather than a template-template parameter.  The existing
+// matrix2x2_functor<T> Hub above carries the @c Shape<U> alias the new
+// witness primary expects; reuse it directly.
+
 export template <typename T>
   requires std::regular<T> && dedekind::algebra::HasRingOperators<T>
-struct unit_witness<dedekind::linear_algebra::Matrix2x2V, T> final {
+struct unit_witness<dedekind::linear_algebra::matrix2x2_functor<T>, T> final {
   constexpr dedekind::linear_algebra::Matrix2x2V<T> operator()(T s) const {
     return {s, T{0}, T{0}, s};
   }
@@ -580,7 +585,7 @@ struct unit_witness<dedekind::linear_algebra::Matrix2x2V, T> final {
  */
 export template <typename T>
   requires std::regular<T> && dedekind::algebra::HasRingOperators<T>
-struct counit_witness<dedekind::linear_algebra::Matrix2x2V, T> final {
+struct counit_witness<dedekind::linear_algebra::matrix2x2_functor<T>, T> final {
   constexpr T operator()(
       const dedekind::linear_algebra::Matrix2x2V<T>& m) const {
     return m.m11;
@@ -591,11 +596,11 @@ struct counit_witness<dedekind::linear_algebra::Matrix2x2V, T> final {
 
 namespace dedekind::linear_algebra {
 
-static_assert(dedekind::category::unit_witness<Matrix2x2V, int>{}(7) ==
-                  Matrix2x2V<int>{7, 0, 0, 7},
+static_assert(dedekind::category::unit_witness<matrix2x2_functor<int>, int>{}(
+                  7) == Matrix2x2V<int>{7, 0, 0, 7},
               "Matrix2x2V η: scalar s ↦ s·I (scalar matrix in the centre of "
               "the matrix algebra; canonical ring embedding T ↪ M_2(T)).");
-static_assert(dedekind::category::counit_witness<Matrix2x2V, int>{}(
+static_assert(dedekind::category::counit_witness<matrix2x2_functor<int>, int>{}(
                   Matrix2x2V<int>{3, 5, 7, 9}) == 3,
               "Matrix2x2V ε: extract top-left corner (canonical projection "
               "M_2(T) → T).");

--- a/src/main/modules/dedekind/linear_algebra/tuple.cppm
+++ b/src/main/modules/dedekind/linear_algebra/tuple.cppm
@@ -282,9 +282,15 @@ static_assert(!dedekind::algebra::HasRingOperators<Covec2V<unsigned int>>,
  */
 namespace dedekind::category {
 
+// PR #508: unit_witness / counit_witness now take a Hub regular type
+// rather than a template-template parameter.  The existing
+// vec2_functor<T> / covec2_functor<T> Hubs (above in this partition)
+// already carry the @c Shape<U> alias the new witness primary expects;
+// reuse them directly.
+
 export template <typename T>
   requires std::regular<T> && dedekind::algebra::HasRingOperators<T>
-struct unit_witness<dedekind::linear_algebra::Vec2V, T> final {
+struct unit_witness<dedekind::linear_algebra::vec2_functor<T>, T> final {
   constexpr dedekind::linear_algebra::Vec2V<T> operator()(T s) const {
     return {s, s};
   }
@@ -292,7 +298,7 @@ struct unit_witness<dedekind::linear_algebra::Vec2V, T> final {
 
 export template <typename T>
   requires std::regular<T> && dedekind::algebra::HasRingOperators<T>
-struct unit_witness<dedekind::linear_algebra::Covec2V, T> final {
+struct unit_witness<dedekind::linear_algebra::covec2_functor<T>, T> final {
   constexpr dedekind::linear_algebra::Covec2V<T> operator()(T s) const {
     return {s, s};
   }
@@ -303,7 +309,7 @@ struct unit_witness<dedekind::linear_algebra::Covec2V, T> final {
  */
 export template <typename T>
   requires std::regular<T> && dedekind::algebra::HasRingOperators<T>
-struct counit_witness<dedekind::linear_algebra::Vec2V, T> final {
+struct counit_witness<dedekind::linear_algebra::vec2_functor<T>, T> final {
   constexpr T operator()(const dedekind::linear_algebra::Vec2V<T>& v) const {
     return v.x;
   }
@@ -313,13 +319,13 @@ struct counit_witness<dedekind::linear_algebra::Vec2V, T> final {
 
 namespace dedekind::linear_algebra {
 
-static_assert(dedekind::category::unit_witness<Vec2V, int>{}(7) ==
+static_assert(dedekind::category::unit_witness<vec2_functor<int>, int>{}(7) ==
                   Vec2V<int>{7, 7},
               "Vec2V η: scalar → diagonal broadcast.");
-static_assert(dedekind::category::counit_witness<Vec2V, int>{}(Vec2V<int>{
-                  3, 5}) == 3,
+static_assert(dedekind::category::counit_witness<vec2_functor<int>, int>{}(
+                  Vec2V<int>{3, 5}) == 3,
               "Vec2V ε: extract canonical first coordinate.");
-static_assert(dedekind::category::unit_witness<Covec2V, int>{}(2) ==
+static_assert(dedekind::category::unit_witness<covec2_functor<int>, int>{}(2) ==
                   Covec2V<int>{2, 2},
               "Covec2V η: scalar → diagonal broadcast.");
 

--- a/src/main/modules/dedekind/sequences/path.cppm
+++ b/src/main/modules/dedekind/sequences/path.cppm
@@ -472,17 +472,35 @@ constexpr auto forall(const Path<T, Cardinality>& path, Pred&& pred) {
 
 namespace dedekind::category {
 
+/**
+ * @brief Hub-tag carrying the @c Path<U> Shape<U> alias for the
+ *        unit_witness / counit_witness Kleisli registrations (#508).
+ *
+ * @details Mirrors @c box_functor in @c :functor: a regular type whose
+ * nested @c Shape<U> alias names the carrier this Hub stands for.  Used
+ * as the first template argument to @c unit_witness / @c counit_witness /
+ * @c IsKleisliExtension / @c IsCoKleisliExtension / @c IsFrobenius after
+ * the template-template removal in PR #508.  The outer @c T parameter
+ * carries the canonical pinned-Shape representative (@c Path<T>) so the
+ * Hub is well-formed at any concrete instantiation.
+ */
+export template <typename T>
+struct path_functor {
+  template <typename U>
+  using Shape = dedekind::sequences::Path<U>;
+};
+
 // Path participates in the Kleisli witness framework as an infinite constant
 // path for η and head sampling for ε.
 export template <typename T>
-struct unit_witness<dedekind::sequences::Path, T> final {
+struct unit_witness<path_functor<T>, T> final {
   constexpr auto operator()(T x) const {
     return dedekind::sequences::Path<T>{[x](std::size_t) { return x; }};
   }
 };
 
 export template <typename T>
-struct counit_witness<dedekind::sequences::Path, T> final {
+struct counit_witness<path_functor<T>, T> final {
   constexpr T operator()(const dedekind::sequences::Path<T>& p) const {
     return p.at(0);
   }
@@ -520,14 +538,14 @@ static_assert(
     std::input_iterator<decltype(std::declval<FinitePath<int>>().begin())>,
     "FinitePath<T>::begin() must yield a std::input_iterator.");
 
-static_assert(IsKleisliExtension<Path, int, long>,
+static_assert(IsKleisliExtension<path_functor<int>, int, long>,
               "Path must satisfy the Kleisli extension witness.");
 
-static_assert(IsCoKleisliExtension<Path, int, long>,
+static_assert(IsCoKleisliExtension<path_functor<int>, int, long>,
               "Path must satisfy the co-Kleisli extension witness.");
 
 static_assert(
-    IsFrobenius<Path, int, long>,
+    IsFrobenius<path_functor<int>, int, long>,
     "Path must satisfy the Frobenius witness (Kleisli + co-Kleisli).");
 
 }  // namespace dedekind::sequences

--- a/src/main/modules/dedekind/sequences/path.cppm
+++ b/src/main/modules/dedekind/sequences/path.cppm
@@ -473,19 +473,26 @@ constexpr auto forall(const Path<T, Cardinality>& path, Pred&& pred) {
 namespace dedekind::category {
 
 /**
- * @brief Hub-tag carrying the @c Path<U> Shape<U> alias for the
- *        unit_witness / counit_witness Kleisli registrations (#508).
+ * @brief Kleisli-only Hub-tag carrying the @c Path<U> Shape<U> alias
+ *        for the @c unit_witness / @c counit_witness registrations
+ *        (#508).
  *
- * @details Mirrors @c box_functor in @c :functor: a regular type whose
- * nested @c Shape<U> alias names the carrier this Hub stands for.  Used
- * as the first template argument to @c unit_witness / @c counit_witness /
- * @c IsKleisliExtension / @c IsCoKleisliExtension / @c IsFrobenius after
- * the template-template removal in PR #508.  The outer @c T parameter
- * carries the canonical pinned-Shape representative (@c Path<T>) so the
- * Hub is well-formed at any concrete instantiation.
+ * @details Deliberately @b not named @c path_functor: this type
+ * provides @c Shape<U> only — it does not model
+ * @c dedekind::category::IsFunctor (no @c Σ_cat / @c Τ_cat /
+ * @c ArrowKind / @c φ surface).  The fully-fledged @c box_functor /
+ * @c vec2_functor / @c covec2_functor / @c matrix2x2_functor Hubs in
+ * sibling partitions provide the IsFunctor surface; this Hub is
+ * scoped to the Kleisli witness registry only.  Renaming to
+ * @c path_kleisli_hub keeps the API surface consistent with the
+ * naming convention the project applies elsewhere (@c maybe_hub /
+ * @c box_hub for non-functor hubs).  Used as the first template
+ * argument to @c unit_witness / @c counit_witness /
+ * @c IsKleisliExtension / @c IsCoKleisliExtension / @c IsFrobenius
+ * after the template-template removal in #508.
  */
 export template <typename T>
-struct path_functor {
+struct path_kleisli_hub {
   template <typename U>
   using Shape = dedekind::sequences::Path<U>;
 };
@@ -493,14 +500,14 @@ struct path_functor {
 // Path participates in the Kleisli witness framework as an infinite constant
 // path for η and head sampling for ε.
 export template <typename T>
-struct unit_witness<path_functor<T>, T> final {
+struct unit_witness<path_kleisli_hub<T>, T> final {
   constexpr auto operator()(T x) const {
     return dedekind::sequences::Path<T>{[x](std::size_t) { return x; }};
   }
 };
 
 export template <typename T>
-struct counit_witness<path_functor<T>, T> final {
+struct counit_witness<path_kleisli_hub<T>, T> final {
   constexpr T operator()(const dedekind::sequences::Path<T>& p) const {
     return p.at(0);
   }
@@ -538,14 +545,14 @@ static_assert(
     std::input_iterator<decltype(std::declval<FinitePath<int>>().begin())>,
     "FinitePath<T>::begin() must yield a std::input_iterator.");
 
-static_assert(IsKleisliExtension<path_functor<int>, int, long>,
+static_assert(IsKleisliExtension<path_kleisli_hub<int>, int, long>,
               "Path must satisfy the Kleisli extension witness.");
 
-static_assert(IsCoKleisliExtension<path_functor<int>, int, long>,
+static_assert(IsCoKleisliExtension<path_kleisli_hub<int>, int, long>,
               "Path must satisfy the co-Kleisli extension witness.");
 
 static_assert(
-    IsFrobenius<path_functor<int>, int, long>,
+    IsFrobenius<path_kleisli_hub<int>, int, long>,
     "Path must satisfy the Frobenius witness (Kleisli + co-Kleisli).");
 
 }  // namespace dedekind::sequences

--- a/src/main/modules/dedekind/sequences/path.cppm
+++ b/src/main/modules/dedekind/sequences/path.cppm
@@ -473,41 +473,83 @@ constexpr auto forall(const Path<T, Cardinality>& path, Pred&& pred) {
 namespace dedekind::category {
 
 /**
- * @brief Kleisli-only Hub-tag carrying the @c Path<U> Shape<U> alias
- *        for the @c unit_witness / @c counit_witness registrations
- *        (#508).
+ * @brief The Path Functor — full @c IsFunctor model for the
+ *        @c Path<·> shape (#508 / PR #521 review).
  *
- * @details Deliberately @b not named @c path_functor: this type
- * provides @c Shape<U> only — it does not model
- * @c dedekind::category::IsFunctor (no @c Σ_cat / @c Τ_cat /
- * @c ArrowKind / @c φ surface).  The fully-fledged @c box_functor /
- * @c vec2_functor / @c covec2_functor / @c matrix2x2_functor Hubs in
- * sibling partitions provide the IsFunctor surface; this Hub is
- * scoped to the Kleisli witness registry only.  Renaming to
- * @c path_kleisli_hub keeps the API surface consistent with the
- * naming convention the project applies elsewhere (@c maybe_hub /
- * @c box_hub for non-functor hubs).  Used as the first template
- * argument to @c unit_witness / @c counit_witness /
- * @c IsKleisliExtension / @c IsCoKleisliExtension / @c IsFrobenius
- * after the template-template removal in #508.
+ * @details Models the categorical functor @c Set<T> @c → @c Set<Path<T>>:
+ * @c Shape<U> @c = @c Path<U> on objects, @c φ on arrows lifts a
+ * pointwise function @c T @c → @c U to @c Path<T> @c → @c Path<U>
+ * by composing each element through the original generator.
+ * Mirrors @c box_functor / @c maybe_functor in @c :functor.
+ *
+ * @section path__Frobenius_Reading
+ * Path is @b Frobenius — it carries both monadic and comonadic
+ * structure (per the partition's header note).  Under the
+ * categorical reading:
+ *   * @c path_functor is the underlying functor T (informal
+ *     "Set @c → @c Set" endofunctor; the strict @c IsEndofunctor
+ *     concept demands @c Σ_cat @c = @c Τ_cat which the
+ *     per-T-parameterised representation does not satisfy at
+ *     this Hub level — same convention as @c box_functor /
+ *     @c maybe_functor in @c :functor).
+ *   * @c unit_witness<path_functor<T>, T> is the @c T-component
+ *     of the natural transformation @c η: @c Id @c ⇒ @c T
+ *     (constant path @c λn.x).
+ *   * @c counit_witness<path_functor<T>, T> is the @c T-component
+ *     of the natural transformation @c ε: @c T @c ⇒ @c Id (head
+ *     sampling @c p.at(0)).
+ *   * Together these are the unit / counit of the Frobenius
+ *     monad-comonad on Path.  The downstream
+ *     @c IsFrobenius<path_functor<int>, int, long> static_assert
+ *     witnesses the Kleisli-side bracket shape mechanically.
  */
 export template <typename T>
-struct path_kleisli_hub {
+struct path_functor {
+  using ArrowKind = dedekind::category::hub_arrow_tag;
+  using Σ_cat = dedekind::category::Set<T>;
+  using Τ_cat = dedekind::category::Set<dedekind::sequences::Path<T>>;
+
+  using Domain = Σ_cat;
+  using Codomain = Τ_cat;
+
+  /** @brief F_obj: the type-constructor action of the functor. */
   template <typename U>
   using Shape = dedekind::sequences::Path<U>;
+
+  /** @brief F_mor (φ): pointwise lift of an arrow @c T @c → @c U
+   *         to @c Path<T> @c → @c Path<U>, by composition with
+   *         the source path's generator at each index. */
+  template <typename 𝗳>
+    requires dedekind::category::IsArrow<std::remove_cvref_t<𝗳>>
+  constexpr auto φ(𝗳&& f) const {
+    using ResultT = std::invoke_result_t<𝗳, T>;
+    return dedekind::category::arrow(
+        [f = std::forward<𝗳>(f)](dedekind::sequences::Path<T> const& p) {
+          return dedekind::sequences::Path<ResultT>{
+              [f, p](std::size_t n) { return std::invoke(f, p.at(n)); }};
+        });
+  }
+
+  /** @brief Action on the source-category object (Hub-arrow surface). */
+  constexpr Τ_cat operator()(const Σ_cat&) const noexcept { return {}; }
 };
+
+static_assert(dedekind::category::IsFunctor<path_functor<int>>,
+              "path_functor must satisfy IsFunctor — the Hub-pattern "
+              "consistency requirement that justifies the *_functor "
+              "naming alongside box_functor / maybe_functor / etc.");
 
 // Path participates in the Kleisli witness framework as an infinite constant
 // path for η and head sampling for ε.
 export template <typename T>
-struct unit_witness<path_kleisli_hub<T>, T> final {
+struct unit_witness<path_functor<T>, T> final {
   constexpr auto operator()(T x) const {
     return dedekind::sequences::Path<T>{[x](std::size_t) { return x; }};
   }
 };
 
 export template <typename T>
-struct counit_witness<path_kleisli_hub<T>, T> final {
+struct counit_witness<path_functor<T>, T> final {
   constexpr T operator()(const dedekind::sequences::Path<T>& p) const {
     return p.at(0);
   }
@@ -545,14 +587,14 @@ static_assert(
     std::input_iterator<decltype(std::declval<FinitePath<int>>().begin())>,
     "FinitePath<T>::begin() must yield a std::input_iterator.");
 
-static_assert(IsKleisliExtension<path_kleisli_hub<int>, int, long>,
+static_assert(IsKleisliExtension<path_functor<int>, int, long>,
               "Path must satisfy the Kleisli extension witness.");
 
-static_assert(IsCoKleisliExtension<path_kleisli_hub<int>, int, long>,
+static_assert(IsCoKleisliExtension<path_functor<int>, int, long>,
               "Path must satisfy the co-Kleisli extension witness.");
 
 static_assert(
-    IsFrobenius<path_kleisli_hub<int>, int, long>,
+    IsFrobenius<path_functor<int>, int, long>,
     "Path must satisfy the Frobenius witness (Kleisli + co-Kleisli).");
 
 }  // namespace dedekind::sequences

--- a/src/main/modules/dedekind/sequences/path.cppm
+++ b/src/main/modules/dedekind/sequences/path.cppm
@@ -473,75 +473,53 @@ constexpr auto forall(const Path<T, Cardinality>& path, Pred&& pred) {
 namespace dedekind::category {
 
 /**
- * @brief The Path Functor — full @c IsFunctor model for the
- *        @c Path<·> shape (#508 / PR #521 review).
+ * @brief The Path Hub for the @c Path<·> shape (#508 / PR #521 review).
  *
- * @details Models the categorical functor @c Set<T> @c → @c Set<Path<T>>:
- * @c Shape<U> @c = @c Path<U> on objects, @c φ on arrows lifts a
- * pointwise function @c T @c → @c U to @c Path<T> @c → @c Path<U>
- * by composing each element through the original generator.
- * Mirrors @c box_functor / @c maybe_functor in @c :functor.
+ * @details Carries the @c Shape<U> @c = @c Path<U> alias used by the
+ * Kleisli witness registry (@c unit_witness / @c counit_witness /
+ * @c IsKleisliExtension / @c IsCoKleisliExtension / @c IsFrobenius).
+ * Named @c path_functor for naming-convention parity with the sibling
+ * @c box_functor / @c maybe_functor / @c vec2_functor /
+ * @c matrix2x2_functor Hubs in other partitions.
+ *
+ * @section path__Functor_Limitation
+ * Unlike @c box_functor / @c maybe_functor — which DO satisfy
+ * @c dedekind::category::IsFunctor — @c path_functor deliberately
+ * does NOT.  Reason: @c Path<T> is itself an Arrow at the type level
+ * (carries @c Domain @c = @c std::size_t and @c Codomain @c = @c T,
+ * realising the textbook reading @c Path: @c ℕ @c → @c T).  This
+ * makes @c Morphism<Path<T>, Path<T>, ...> fail @c IsSpokeArrow
+ * (because @c Path<T> is an @c IsArrow domain), which in turn makes
+ * @c Set<Path<T>>::operator>>(Arrow, Arrow) — needed by
+ * @c IsCategory<Set<Path<T>>> — not resolve cleanly.  The standard
+ * Functor-on-Set machinery does not apply.  This is structural to
+ * Path's "is itself an arrow" nature and not a defect to be papered
+ * over.
  *
  * @section path__Frobenius_Reading
  * Path is @b Frobenius — it carries both monadic and comonadic
- * structure (per the partition's header note).  Under the
- * categorical reading:
- *   * @c path_functor is the underlying functor T (informal
- *     "Set @c → @c Set" endofunctor; the strict @c IsEndofunctor
- *     concept demands @c Σ_cat @c = @c Τ_cat which the
- *     per-T-parameterised representation does not satisfy at
- *     this Hub level — same convention as @c box_functor /
- *     @c maybe_functor in @c :functor).
- *   * @c unit_witness<path_functor<T>, T> is the @c T-component
- *     of the natural transformation @c η: @c Id @c ⇒ @c T
- *     (constant path @c λn.x).
+ * structure (per the partition's header note).  Under the categorical
+ * reading at the Kleisli-witness level:
+ *   * @c path_functor is the Hub-tag for the underlying functor T,
+ *     namely the type-constructor @c Path<·> on objects (no @c φ
+ *     reified at this level for the structural reason above).
+ *   * @c unit_witness<path_functor<T>, T> is the @c T-component of
+ *     the natural transformation @c η: @c Id @c ⇒ @c T (constant
+ *     path @c λn.x).
  *   * @c counit_witness<path_functor<T>, T> is the @c T-component
  *     of the natural transformation @c ε: @c T @c ⇒ @c Id (head
  *     sampling @c p.at(0)).
- *   * Together these are the unit / counit of the Frobenius
- *     monad-comonad on Path.  The downstream
- *     @c IsFrobenius<path_functor<int>, int, long> static_assert
- *     witnesses the Kleisli-side bracket shape mechanically.
+ *   * The downstream @c IsFrobenius<path_functor<int>, int, long>
+ *     static_assert witnesses the Kleisli-side bracket shape
+ *     mechanically — that's the right level to certify on Path.
  */
 export template <typename T>
 struct path_functor {
-  using ArrowKind = dedekind::category::hub_arrow_tag;
-  // CanonicalSetCCC is the exported set-CCC alias (Set<T> in :cartesian
-  // is not export-qualified for downstream consumers); follows the
-  // vec2_functor / matrix2x2_functor pattern in :linear_algebra.
-  using Σ_cat = dedekind::category::CanonicalSetCCC<T>;
-  using Τ_cat =
-      dedekind::category::CanonicalSetCCC<dedekind::sequences::Path<T>>;
-
-  using Domain = Σ_cat;
-  using Codomain = Τ_cat;
-
-  /** @brief F_obj: the type-constructor action of the functor. */
+  /** @brief F_obj: the type-constructor action of the functor.
+   *         The only Functor-shaped surface @c path_functor reifies. */
   template <typename U>
   using Shape = dedekind::sequences::Path<U>;
-
-  /** @brief F_mor (φ): pointwise lift of an arrow @c T @c → @c U
-   *         to @c Path<T> @c → @c Path<U>, by composition with
-   *         the source path's generator at each index. */
-  template <typename 𝗳>
-    requires dedekind::category::IsArrow<std::remove_cvref_t<𝗳>>
-  constexpr auto φ(𝗳&& f) const {
-    using ResultT = std::invoke_result_t<𝗳, T>;
-    return dedekind::category::arrow(
-        [f = std::forward<𝗳>(f)](dedekind::sequences::Path<T> const& p) {
-          return dedekind::sequences::Path<ResultT>{
-              [f, p](std::size_t n) { return std::invoke(f, p.at(n)); }};
-        });
-  }
-
-  /** @brief Action on the source-category object (Hub-arrow surface). */
-  constexpr Τ_cat operator()(const Σ_cat&) const noexcept { return {}; }
 };
-
-static_assert(dedekind::category::IsFunctor<path_functor<int>>,
-              "path_functor must satisfy IsFunctor — the Hub-pattern "
-              "consistency requirement that justifies the *_functor "
-              "naming alongside box_functor / maybe_functor / etc.");
 
 // Path participates in the Kleisli witness framework as an infinite constant
 // path for η and head sampling for ε.

--- a/src/main/modules/dedekind/sequences/path.cppm
+++ b/src/main/modules/dedekind/sequences/path.cppm
@@ -506,8 +506,12 @@ namespace dedekind::category {
 export template <typename T>
 struct path_functor {
   using ArrowKind = dedekind::category::hub_arrow_tag;
-  using Σ_cat = dedekind::category::Set<T>;
-  using Τ_cat = dedekind::category::Set<dedekind::sequences::Path<T>>;
+  // CanonicalSetCCC is the exported set-CCC alias (Set<T> in :cartesian
+  // is not export-qualified for downstream consumers); follows the
+  // vec2_functor / matrix2x2_functor pattern in :linear_algebra.
+  using Σ_cat = dedekind::category::CanonicalSetCCC<T>;
+  using Τ_cat =
+      dedekind::category::CanonicalSetCCC<dedekind::sequences::Path<T>>;
 
   using Domain = Σ_cat;
   using Codomain = Τ_cat;

--- a/src/test/cpp/modules/dedekind/category/kleisli_test.cpp
+++ b/src/test/cpp/modules/dedekind/category/kleisli_test.cpp
@@ -6,9 +6,9 @@ import dedekind.category;
 using namespace dedekind::category;
 
 TEST_CASE("Category: Kleisli Extension Concepts", "[category][kleisli]") {
-  STATIC_CHECK(IsKleisliExtension<Box, int, int>);
-  STATIC_CHECK(IsCoKleisliExtension<Box, int, int>);
-  STATIC_CHECK(IsFrobenius<Box, int, int>);
+  STATIC_CHECK(IsKleisliExtension<box_functor<int>, int, int>);
+  STATIC_CHECK(IsCoKleisliExtension<box_functor<int>, int, int>);
+  STATIC_CHECK(IsFrobenius<box_functor<int>, int, int>);
 }
 
 TEST_CASE("Category: Box Frobenius structure",
@@ -16,32 +16,32 @@ TEST_CASE("Category: Box Frobenius structure",
   Box<int> value{9};
 
   SECTION("Unit followed by counit returns the original value") {
-    auto boxed = unit_witness<Box, int>{}(value.value);
-    auto raw = counit_witness<Box, int>{}(boxed);
+    auto boxed = unit_witness<box_functor<int>, int>{}(value.value);
+    auto raw = counit_witness<box_functor<int>, int>{}(boxed);
     CHECK(raw == value.value);
   }
 
   SECTION("Kleisli right unit law: κ(ma, η) = ma") {
-    auto result = κ(value, unit_witness<Box, int>{});
+    auto result = κ(value, unit_witness<box_functor<int>, int>{});
     CHECK(result == value);
   }
 
   SECTION("Co-Kleisli right counit law: σ(wa, ε) = wa") {
-    auto result = σ(value, counit_witness<Box, int>{});
+    auto result = σ(value, counit_witness<box_functor<int>, int>{});
     CHECK(result == value);
   }
 
   SECTION("Bind then extract agrees with direct function result") {
     auto f = [](int x) { return Box<int>{x * 3}; };
     auto via_bind = κ(value, f);
-    CHECK(counit_witness<Box, int>{}(via_bind) ==
-          counit_witness<Box, int>{}(f(value.value)));
+    CHECK(counit_witness<box_functor<int>, int>{}(via_bind) ==
+          counit_witness<box_functor<int>, int>{}(f(value.value)));
   }
 
   SECTION("Extend then extract agrees with direct co-Kleisli result") {
     auto g = [](Box<int> b) { return b.value + 4; };
     auto via_extend = σ(value, g);
-    CHECK(counit_witness<Box, int>{}(via_extend) == g(value));
+    CHECK(counit_witness<box_functor<int>, int>{}(via_extend) == g(value));
   }
 }
 


### PR DESCRIPTION
## Summary

Closes #508.  Migrates the five export-qualified template-template signatures in `:kleisli` to the Hub-pattern indirection that `:functor` already exhibits, retiring the one tracked exception in the paper's admissibility-rules table (`tab:admissibility-rules`).

## Migration

```cpp
// Before:
export template <template <typename...> typename F, typename T>
struct unit_witness;
export template <typename T> struct unit_witness<Box, T> { ... };

// After:
export template <typename Hub, typename T> struct unit_witness;
export template <typename T> struct unit_witness<box_functor<T>, T> { ... };
```

The five exports retargeted:
1. `unit_witness<F, T>` primary + Box specialisation
2. `counit_witness<F, T>` primary + Box specialisation
3. `IsKleisliExtension<F, T, U>` concept
4. `IsCoKleisliExtension<F, T, U>` concept
5. `IsFrobenius<F, T, U>` concept

Hubs reused unchanged from existing partitions (each carries the canonical `template <typename U> using Shape = X<U>;` alias):

- `box_functor<T>` in `:functor`
- `vec2_functor<T>` / `covec2_functor<T>` in `:linear_algebra:tuple`
- `matrix2x2_functor<T>` in `:linear_algebra:matrix`
- `path_functor<T>` added in `:sequences:path` (new — Path didn't have a Hub before, so a minimal one was added next to the existing unit_witness/counit_witness specialisations)

## Files touched

| File | Change |
|---|---|
| `category/kleisli.cppm` | 5 exports migrated; `import :functor` added |
| `sequences/path.cppm` | New `path_functor<T>` Hub; specialisations + 3 static_asserts retargeted |
| `linear_algebra/tuple.cppm` | vec2/covec2 specialisations + 3 static_asserts |
| `linear_algebra/matrix.cppm` | matrix2x2 specialisation + 2 static_asserts |
| `test/category/kleisli_test.cpp` | 9 callsites retargeted |
| `docs/paper/paper.tex` | Footnote on `tab:admissibility-rules` retired |

## Verification

- `grep template-template src/main/modules/dedekind/category/kleisli.cppm` → empty.
- `grep template <template <` across `:kleisli` exports → empty.
- All `unit_witness` / `counit_witness` consumers in main + tests now spell their Hub explicitly.

## Test plan

- [ ] CI: build-and-deploy on Linux clang-22 passes.
- [ ] All 15 test binaries pass (kleisli_test, path_test, matrix_test, tuple_test specifically exercise the migrated witnesses).
- [ ] Paper builds (`make paper`) — the footnote retirement should not affect compilation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)