### PR TITLE
feat(algebra, numbers): IsHomomorphism + IsQuotientMorphism — Phase 2 of universal-algebra anchor (#506)

### DIFF
--- a/src/main/modules/dedekind/algebra/universal.cppm
+++ b/src/main/modules/dedekind/algebra/universal.cppm
@@ -66,6 +66,9 @@ module;
 
 export module dedekind.algebra:universal;
 
+import dedekind.category; // IsArrow, IsSurjective (composing IsHomomorphism /
+                          // IsQuotientMorphism; #506)
+
 namespace dedekind::algebra {
 
 // ---------------------------------------------------------------------------
@@ -131,6 +134,96 @@ concept IsOpOn = IsBinaryOpOn<T, Op> || IsUnaryOpOn<T, Op>;
  */
 export template <typename T, typename... Ops>
 concept IsAlgebra = std::regular<T> && (... && IsOpOn<T, Ops>);
+
+// ---------------------------------------------------------------------------
+// Phase 2: Homomorphisms — arrows between algebras (#506).
+// ---------------------------------------------------------------------------
+//
+// A homomorphism is an arrow @c f: @c A1 @c → @c A2 between two algebras
+// @c (A1, F1) and @c (A2, F2) that respects each operation in the family:
+// for every paired @c (op, @c op'), the law @c f(op(x, @c y)) @c == @c
+// op'(f(x), @c f(y)) holds (binary case; the unary / nullary cases are
+// analogous).
+//
+// In the textbook setting the law is a runtime equation; in the library
+// we pin it as an @b opt-in @b trait declaration --- @c
+// is_homomorphism_v<Arrow> @c = @c true --- and the engineer's honesty
+// obligation is to register the trait only when the runtime law holds.
+// This mirrors @c is_monic_arrow_v / @c is_epic_arrow_v (in
+// @c category:morphism), which carry the analogous monicity / epicity
+// declarations: the compiler trusts the user's declaration; the
+// algebraic-soul registry is the audit trail.
+//
+// The first slice (this PR) pins the @b unparameterised concept --- the
+// homomorphism trait does not name a specific @c (Op, @c Op') pair.
+// Per-operator-pair refinement (e.g.\ @c IsAdditiveHomomorphism,
+// @c IsMultiplicativeHomomorphism, @c IsRingHomomorphism @c =
+// @c IsAdditiveHomomorphism @c && @c IsMultiplicativeHomomorphism)
+// is a follow-on slice once we have at least one positive witness in
+// place (see #506 acceptance criteria).
+
+/**
+ * @brief User-declared homomorphism witness for an arrow type.
+ *
+ * @details A homomorphism is an arrow that respects each operation in
+ * the source algebra's family.  The runtime law cannot be verified at
+ * compile time in general (the law is a per-input equation); users
+ * specialise this trait to @c true to declare that a given arrow @b is
+ * a homomorphism.  The compiler trusts the declaration; the
+ * algebraic-soul registry is the audit trail.
+ *
+ * Mirrors @c category::is_monic_arrow_v / @c category::is_epic_arrow_v
+ * in declaration shape and discipline (#506).
+ */
+export template <typename Arrow>
+inline constexpr bool is_homomorphism_v = false;
+
+/**
+ * @concept IsHomomorphism
+ * @brief An arrow declared to be an algebra homomorphism (preserves the
+ *        operation family across two algebras).
+ *
+ * @details The opt-in trait @c is_homomorphism_v<Arrow> is the
+ * declaration; this concept is the gate-and-check that an arrow has
+ * been declared a homomorphism @b and is structurally an arrow
+ * (carries @c Domain / @c Codomain aliases through @c IsArrow).
+ *
+ * @section IsHomomorphism_Use
+ *
+ *   * @b Positive @b use: gate templated bodies whose correctness
+ *     depends on the homomorphism law (e.g.\ a quotient-construction
+ *     factory that needs to know its source arrow respects the algebra
+ *     ops).
+ *   * @b Witness: @c static_assert(IsHomomorphism<E>, ...) at the
+ *     declaration site of @c E pins the registry entry mechanically.
+ *
+ * @see Lang, @em Algebra (3rd ed.), §III.1 (homomorphisms of rings);
+ *      Mac Lane, @em Categories @em for @em the @em Working
+ *      @em Mathematician §III.1 (homomorphisms as morphisms in the
+ *      category of algebras).
+ */
+export template <typename Arrow>
+concept IsHomomorphism =
+    dedekind::category::IsArrow<Arrow> && is_homomorphism_v<Arrow>;
+
+/**
+ * @concept IsQuotientMorphism
+ * @brief An arrow declared to be the quotient morphism of an algebra
+ *        by a congruence: a surjective homomorphism.
+ *
+ * @details The textbook quotient morphism @c π: @c A @c → @c A/~ is
+ * a surjective homomorphism (it preserves the operations and is
+ * surjective onto the quotient algebra).  Composes the existing
+ * @c IsSurjective concept (in @c category:morphism, which is the
+ * pedagogical-accessibility synonym for @c IsEpicArrow) with
+ * @c IsHomomorphism above.
+ *
+ * @see Lang §III.1 (kernel-quotient-image factorisation, sometimes
+ *      called the first isomorphism theorem).
+ */
+export template <typename Arrow>
+concept IsQuotientMorphism =
+    IsHomomorphism<Arrow> && dedekind::category::IsSurjective<Arrow>;
 
 }  // namespace dedekind::algebra
 

--- a/src/main/modules/dedekind/algebra/universal.cppm
+++ b/src/main/modules/dedekind/algebra/universal.cppm
@@ -180,22 +180,44 @@ inline constexpr bool is_homomorphism_v = false;
 
 /**
  * @concept IsHomomorphism
- * @brief An arrow declared to be an algebra homomorphism (preserves the
- *        operation family across two algebras).
+ * @brief An arrow @b declared to be an algebra homomorphism via the
+ *        opt-in @c is_homomorphism_v trait.
  *
- * @details The opt-in trait @c is_homomorphism_v<Arrow> is the
- * declaration; this concept is the gate-and-check that an arrow has
- * been declared a homomorphism @b and is structurally an arrow
- * (carries @c Domain / @c Codomain aliases through @c IsArrow).
+ * @details Mathematically, a homomorphism is an arrow that preserves
+ * the operation family across two algebras (@c f(op(x, y)) @c == @c
+ * op'(f(x), f(y))).  This concept @b does @b not mechanically check
+ * that property: at the unparameterised slice landed in #506, the
+ * concept gates only on
+ *
+ *   * @c category::IsArrow<Arrow> --- structural shape: @c Domain /
+ *     @c Codomain aliases plus the call signature; @b and
+ *   * @c is_homomorphism_v<Arrow> --- the user's opt-in declaration.
+ *
+ * It does @b not verify that @c Domain or @c Codomain satisfy
+ * @c IsAlgebra, and it does @b not check the per-operation
+ * preservation law.  The declaration is the engineer's honesty
+ * obligation, with the algebraic-soul registry (the
+ * @c is_homomorphism_v specialisation) as the audit trail.  Same
+ * discipline as @c category::is_monic_arrow_v / @c is_epic_arrow_v
+ * (in @c category:morphism) — declarations of a property the compiler
+ * cannot verify in general.
  *
  * @section IsHomomorphism_Use
  *
  *   * @b Positive @b use: gate templated bodies whose correctness
  *     depends on the homomorphism law (e.g.\ a quotient-construction
- *     factory that needs to know its source arrow respects the algebra
- *     ops).
+ *     factory that wants to know its source arrow has been declared
+ *     to respect the algebra ops).
  *   * @b Witness: @c static_assert(IsHomomorphism<E>, ...) at the
- *     declaration site of @c E pins the registry entry mechanically.
+ *     declaration site of @c E pins the registry entry mechanically
+ *     so reviewers see the claim alongside the code that licenses it.
+ *
+ * Per-operator-pair refinements that @b do mechanically pair operations
+ * across @c Domain / @c Codomain (e.g.\ @c IsAdditiveHomomorphism,
+ * @c IsMultiplicativeHomomorphism, @c IsRingHomomorphism @c =
+ * @c IsAdditiveHomomorphism @c && @c IsMultiplicativeHomomorphism)
+ * are filed as a follow-on slice; those will tighten the gate beyond
+ * the present user-declaration form.
  *
  * @see Lang, @em Algebra (3rd ed.), §III.1 (homomorphisms of rings);
  *      Mac Lane, @em Categories @em for @em the @em Working
@@ -208,15 +230,21 @@ concept IsHomomorphism =
 
 /**
  * @concept IsQuotientMorphism
- * @brief An arrow declared to be the quotient morphism of an algebra
- *        by a congruence: a surjective homomorphism.
+ * @brief An arrow @b declared to be both a homomorphism (via
+ *        @c is_homomorphism_v) @b and surjective (via
+ *        @c category::is_epic_arrow_v).
  *
- * @details The textbook quotient morphism @c π: @c A @c → @c A/~ is
- * a surjective homomorphism (it preserves the operations and is
- * surjective onto the quotient algebra).  Composes the existing
- * @c IsSurjective concept (in @c category:morphism, which is the
- * pedagogical-accessibility synonym for @c IsEpicArrow) with
- * @c IsHomomorphism above.
+ * @details Mathematically, the canonical quotient morphism
+ * @c π: @c A @c → @c A/~ is a surjective homomorphism: it preserves
+ * the operations and hits every element of the quotient algebra.
+ * This concept is the @b structural / @b syntactic gate for
+ * "declared homomorphism + declared surjectivity"; it does @b not
+ * verify that the arrow is the canonical projection of any
+ * particular congruence, nor that the quotient algebra has been
+ * constructed.  It composes the two opt-in trait declarations
+ * @c is_homomorphism_v (above) and @c category::is_epic_arrow_v
+ * (in @c category:morphism, surfaced via the @c IsSurjective
+ * pedagogical synonym).
  *
  * @see Lang §III.1 (kernel-quotient-image factorisation, sometimes
  *      called the first isomorphism theorem).

--- a/src/main/modules/dedekind/numbers/rational.cppm
+++ b/src/main/modules/dedekind/numbers/rational.cppm
@@ -594,21 +594,30 @@ static_assert(
 
 namespace dedekind::algebra {
 
-// embed_ℤ_ℚ is a @b ring @b homomorphism: the field-of-fractions
-// inclusion @c ℤ @c ↪ @c Frac(ℤ) @c = @c ℚ preserves both ring
-// operations --- @c (n + m)/1 == @c n/1 + @c m/1 (additive law) and
-// @c (n * m)/1 == @c n/1 * @c m/1 (multiplicative law) --- by
-// definition of Rational arithmetic (numerator-aware reduction
-// preserves these on @c den == 1 inputs).  Pinned here as the first
-// positive witness for the @c is_homomorphism_v / @c IsHomomorphism
-// pair introduced in @c algebra:universal under #506.
+// embed_ℤ_ℚ is, mathematically, a @b ring @b homomorphism: the
+// field-of-fractions inclusion @c ℤ @c ↪ @c Frac(ℤ) @c = @c ℚ
+// preserves both ring operations --- @c (n + m)/1 == @c n/1 + @c m/1
+// (additive law) and @c (n * m)/1 == @c n/1 * @c m/1 (multiplicative
+// law) --- by definition of Rational arithmetic (numerator-aware
+// reduction preserves these on @c den == 1 inputs).  At the
+// @b trait-registry tier the @c is_homomorphism_v / @c IsHomomorphism
+// pair (introduced in @c algebra:universal under #506) is
+// @b unparameterised: it does not yet name a specific (Op, Op')
+// pair, so the registration here is the @b algebra-level homomorphism
+// witness (the strictly stronger ring-homomorphism reading lives in
+// the prose, awaiting per-axiom-tier refinements
+// @c IsAdditiveHomomorphism / @c IsMultiplicativeHomomorphism /
+// @c IsRingHomomorphism in a follow-on slice).  Pinned here as the
+// first positive @c is_homomorphism_v witness in the project.
 template <>
 inline constexpr bool
     is_homomorphism_v<std::decay_t<decltype(dedekind::numbers::embed_ℤ_ℚ<>)>> =
         true;
 static_assert(
     IsHomomorphism<std::decay_t<decltype(dedekind::numbers::embed_ℤ_ℚ<>)>>,
-    "embed_ℤ_ℚ (ℤ ↪ ℚ) is registered as a ring homomorphism.");
+    "embed_ℤ_ℚ (ℤ ↪ ℚ) is registered as an algebra homomorphism "
+    "(the strictly stronger ring-homomorphism reading lives in the "
+    "prose; the trait is intentionally unparameterised at this slice).");
 
 }  // namespace dedekind::algebra
 

--- a/src/main/modules/dedekind/numbers/rational.cppm
+++ b/src/main/modules/dedekind/numbers/rational.cppm
@@ -590,6 +590,30 @@ static_assert(
     IsInjective<std::decay_t<decltype(dedekind::numbers::embed_ℤ_ℚ<>)>>,
     "embed_ℤ_ℚ (ℤ ↪ ℚ) is registered injective.");
 
+}  // namespace dedekind::category
+
+namespace dedekind::algebra {
+
+// embed_ℤ_ℚ is a @b ring @b homomorphism: the field-of-fractions
+// inclusion @c ℤ @c ↪ @c Frac(ℤ) @c = @c ℚ preserves both ring
+// operations --- @c (n + m)/1 == @c n/1 + @c m/1 (additive law) and
+// @c (n * m)/1 == @c n/1 * @c m/1 (multiplicative law) --- by
+// definition of Rational arithmetic (numerator-aware reduction
+// preserves these on @c den == 1 inputs).  Pinned here as the first
+// positive witness for the @c is_homomorphism_v / @c IsHomomorphism
+// pair introduced in @c algebra:universal under #506.
+template <>
+inline constexpr bool
+    is_homomorphism_v<std::decay_t<decltype(dedekind::numbers::embed_ℤ_ℚ<>)>> =
+        true;
+static_assert(
+    IsHomomorphism<std::decay_t<decltype(dedekind::numbers::embed_ℤ_ℚ<>)>>,
+    "embed_ℤ_ℚ (ℤ ↪ ℚ) is registered as a ring homomorphism.");
+
+}  // namespace dedekind::algebra
+
+namespace dedekind::category {
+
 // Note: @c is_monic_arrow_v<embed_double_ℚ<I>> is intentionally NOT
 // registered.  embed_double_ℚ is a partial morphism (rejects NaN, ±∞,
 // and precision-overflow inputs) in the Cockett--Lack restriction-


### PR DESCRIPTION
## Summary

Closes #506.  Phase 2 of the universal-algebra anchor: arrows between algebras.

Phase 1 (PR #503 / commit ed85d1f) anchored the `(A, F)` pattern as `IsAlgebra<T, Ops...>` in `dedekind.algebra:universal`.  Phase 2 adds:

- `is_homomorphism_v<Arrow>` — opt-in trait declaration mirroring `category::is_monic_arrow_v` / `is_epic_arrow_v`.
- `IsHomomorphism<Arrow>` concept gating `IsArrow<Arrow> && is_homomorphism_v<Arrow>`.
- `IsQuotientMorphism<Arrow>` = `IsHomomorphism<Arrow> && IsSurjective<Arrow>` (textbook canonical projection π: A → A/~).
- First positive witness: `embed_ℤ_ℚ` registered as a ring homomorphism in `numbers/rational.cppm`, with a `static_assert` pinning the claim mechanically.

## Design choice — unparameterised first slice

The issue body offered two paths: (a) variadic op-zipping at the IsAlgebra level, (b) per-axiom-tier refinements (`IsRingHomomorphism = IsAdditiveHomomorphism && IsMultiplicativeHomomorphism`, etc.).

This PR ships the **unparameterised** form first (`is_homomorphism_v<Arrow>` = single trait, no `(Op, Op')` pair on the concept signature), matching the existing `is_monic_arrow_v` / `is_epic_arrow_v` pattern.  The runtime law `f(op(x, y)) == op'(f(x), f(y))` is the engineer's honesty obligation; the trait is the audit trail (same discipline as monicity / epicity declarations elsewhere in the project).

Per-operator-pair refinement is a follow-on slice — file under #506 follow-up if needed.  The first witness (`embed_ℤ_ℚ`) closes the issue's "at least one positive witness" acceptance criterion.

## Files touched

- `src/main/modules/dedekind/algebra/universal.cppm` — add `is_homomorphism_v` trait + `IsHomomorphism` / `IsQuotientMorphism` concepts (~85 lines including documentation).  Now imports `dedekind.category` for `IsArrow` / `IsSurjective`.
- `src/main/modules/dedekind/numbers/rational.cppm` — register `embed_ℤ_ℚ` as a homomorphism witness; `static_assert` pinning.

## Test plan

- [ ] CI: build-and-deploy on Linux clang-22 passes.
- [ ] All test binaries pass (no test-side changes needed for this slice).
- [ ] The `static_assert(IsHomomorphism<embed_ℤ_ℚ>)` in `rational.cppm` is the correctness gate; if compile breaks the trait declaration is wrong.

## Out of scope

- Per-operator-pair refinements (`IsAdditiveHomomorphism`, `IsRingHomomorphism`, ...) — follow-on slice.
- Additional homomorphism witnesses on other arrows (e.g.\ `embed_ℝ_ℂ`, `embed_𝔹_uint_`) — easy to add but not required for this slice's acceptance criteria.

🤖 Generated with [Claude Code](https://claude.com/claude-code)