### PR TITLE
refactor(category, morphism): sharpen IsSpokeArrow / IsHubArrow discriminator (#525)

### DIFF
--- a/src/main/modules/dedekind/category/morphism.cppm
+++ b/src/main/modules/dedekind/category/morphism.cppm
@@ -141,29 +141,84 @@ export template <IsArrow F>
 using Cod = typename std::remove_cvref_t<F>::Codomain;
 
 /**
- * @concept IsHubArrow
- * @brief Higher-order arrow whose Domain/Codomain are themselves arrows.
- * @details In the hub/spoke vocabulary, a "hub" arrow acts on spokes as its
- *          objects. Functors are the canonical example: they map arrows in one
- *          category to arrows in another category.
+ * @concept IsCategoryShape
+ * @brief Structural prefix of @c dedekind::category::IsCategory: a type
+ *        carrying the identifying category-shaped aliases @c ::Arrow,
+ *        @c ::Species, @c ::Id.
+ *
+ * @details The full @c IsCategory in @c :small refines this with
+ * behavioural checks (@c id_c factory, @c f @c >> @c g internal
+ * closure, etc.).  At this layer we only need the structural test to
+ * answer the question "is this thing a @b category" for purposes of
+ * hub/spoke discrimination.  Full @c IsCategory cannot be referenced
+ * here because @c :small imports @c :morphism (cycle), and because
+ * @c IsCategory recursively uses @c f @c >> @c g which is the very
+ * operator we are gating.  The structural prefix is the load-bearing
+ * piece for routing — it identifies the @b argument-shape of a
+ * functor (a thing taking a category, not an object), which is the
+ * single distinction the hub/spoke split needs to make (#525).
  */
 export template <typename T>
-concept IsHubArrow = IsArrow<T> && IsArrow<Dom<T>> && IsArrow<Cod<T>>;
+concept IsCategoryShape = requires {
+  typename std::remove_cvref_t<T>::Arrow;
+  typename std::remove_cvref_t<T>::Species;
+  typename std::remove_cvref_t<T>::Id;
+};
+
+/**
+ * @concept IsHubArrow
+ * @brief Higher-order arrow whose Domain/Codomain are categories
+ *        (functors and similar arrows-between-categories; #525).
+ * @details In the hub/spoke vocabulary, a "hub" arrow acts on
+ *          categories as its objects: it is an arrow @b between
+ *          categories, not within one.  Functors are the canonical
+ *          example.  The @c IsCategoryShape prefix detects the
+ *          identifying @c ::Arrow / @c ::Species / @c ::Id alias
+ *          surface; the prior structural-proxy form
+ *          (@c IsArrow<Dom<T>>) over-fired on object-level types
+ *          that happen to expose @c Domain / @c Codomain aliases
+ *          for unrelated reasons (e.g., @c Path<T> = sequence
+ *          @c ℕ → @c T at the type level).
+ */
+export template <typename T>
+concept IsHubArrow =
+    IsArrow<T> && IsCategoryShape<Dom<T>> && IsCategoryShape<Cod<T>>;
 
 /**
  * @concept IsSpokeArrow
- * @brief Object-level arrow whose Domain/Codomain are not arrows.
- * @details A "spoke" arrow connects ordinary species-level objects. Generic
- *          categorical composition in this partition is intentionally limited
- *          to spoke arrows so higher-order composition can be owned by the
- *          appropriate bridge partitions.
+ * @brief Object-level arrow whose Domain/Codomain are @b not
+ *        categories (#525 sharpening).
+ * @details A "spoke" arrow connects ordinary species-level objects
+ *          @b within a category.  The discriminator is "Domain is
+ *          not a category-shaped thing" (@c !IsCategoryShape<Dom<T>>);
+ *          this is the formal expression of "this isn't a functor".
+ *          Generic categorical composition in this partition is
+ *          intentionally limited to spoke arrows so higher-order
+ *          composition (functor @c ∘ functor in @b Cat) can be
+ *          owned by the appropriate bridge partitions.
  *
- * If a type advertises `using ArrowKind = hub_arrow_tag;`, it is excluded
- * from `IsSpokeArrow` even if its Domain/Codomain are object-level labels.
+ * @section morphism__Spoke_Discriminator_Sharpening
+ * Pre-#525 the discriminator read @c !IsArrow<Dom<T>> — a structural
+ * proxy that worked coincidentally for functor-Hubs (whose Domain is
+ * a @c IsCategory<C> witness, which trivially satisfies @c IsArrow
+ * via @c Cat::Arrow), but over-fired on object-level carriers that
+ * happen to expose @c Domain / @c Codomain aliases for unrelated
+ * reasons.  The canonical example is @c Path<T>, which models the
+ * textbook reading "a sequence is a function @c ℕ @c → @c T" by
+ * declaring @c Domain @c = @c std::size_t and a call operator —
+ * making @c IsArrow<Path<T>> @b true at the type level even though
+ * @c Path<T> is plainly an @b object (not a category-to-category
+ * arrow).  The sharpened discriminator @c !IsCategoryShape<Dom<T>>
+ * stops the over-fire while preserving the original intent: hub
+ * arrows are arrows between categories.
+ *
+ * If a type advertises @c using @c ArrowKind @c = @c hub_arrow_tag;
+ * it is still excluded from @c IsSpokeArrow as a manual override.
  */
 export template <typename T>
 concept IsSpokeArrow =
-    IsArrow<T> && !IsArrow<Dom<T>> && !IsArrow<Cod<T>> && !requires {
+    IsArrow<T> && !IsCategoryShape<Dom<T>> && !IsCategoryShape<Cod<T>> &&
+    !requires {
       requires std::same_as<typename std::remove_cvref_t<T>::ArrowKind,
                             hub_arrow_tag>;
     };

--- a/src/main/modules/dedekind/category/morphism.cppm
+++ b/src/main/modules/dedekind/category/morphism.cppm
@@ -55,86 +55,165 @@ import :species;
 namespace dedekind::category {
 
 // ---------------------------------------------------------------------------
-// Hub / Spoke architecture (clarified under #525)
+// Morphisms vs functors in a single-species universe (clarified under #525)
 // ---------------------------------------------------------------------------
 //
-// @section Single_Species_Commitment
+// This block reads in two registers — categorical (morphism / functor)
+// and architectural (spoke / hub).  The categorical content drives the
+// design; the architectural vocabulary is the C++23 realisation of it.
 //
-// The dedekind category model is @b single-species by design: a category
-// @c 𝒞 in this codebase is realised as a struct (e.g.\ @c Set<T>) whose
-// objects are values of a single C++ type @c T (the @c Species), and
-// whose arrows are @c Morphism<T, T, ...> instances.  This is a
-// pragmatic restriction for the disciplined-template fragment: modeling
-// polymorphic-collection-of-species categories would require runtime
-// type-erasure (existentials, type-erased object containers) that the
-// project's System-F-flavoured admissibility rules
-// (Table~\ref{tab:admissibility-rules} in @c paper.tex) deliberately
-// exclude.
+// @section Single_Species_Universe
 //
-// Concrete consequences:
-//   * @c Set<int> is the category whose objects are values of type
-//     @c int and whose arrows are @c Morphism<int, int, ...>.
-//   * @c Set<Box<int>> is a @b different category — same structural
-//     definition, distinct species.
-//   * @c Set<Path<int>> is a category whose objects are sequences
-//     @c ℕ @c → @c int (treated as objects in @b Set, exactly per the
-//     CCC reading where function spaces are first-class objects).
-//   * Functors @c F: @c 𝒞 @c → @c 𝒟 are realised as @b Hub types
-//     (@c box_functor, @c maybe_functor, etc.) carrying
-//     @c Σ_cat / @c Τ_cat aliases that name the source / target
-//     categories explicitly.
+// The dedekind category model is @b single-species by design.  A
+// category @c 𝒞 in this codebase has @b objects drawn from a single
+// C++ type — its @c Species — and @b morphisms drawn from a single
+// C++ type — its @c Arrow.  In code this looks like
 //
-// @section Arrows_Within_vs_Between_Categories
+//   struct Set<T> {                   // The category of T-valued things.
+//     using Species = T;              //   Objects: values of type T.
+//     using Arrow = Morphism<T, T, std::function<T(T)>>;  //   Morphisms.
+//     using Id = SetId<T>;
+//     ...
+//   };
 //
-// Composition of arrows comes in two flavours that must @b not be
-// conflated at the dispatch level:
+// This restriction is pragmatic, not principled.  In the textbook
+// presentation a category's collection of objects is a class whose
+// elements may belong to different types; modeling that polymorphism
+// in C++23 would require runtime type-erasure (existentials,
+// type-erased object containers), which the project's System-F-flavoured
+// admissibility rules (Table~\ref{tab:admissibility-rules} in
+// @c paper.tex) deliberately exclude.  The single-species commitment
+// is the price of the disciplined-template fragment.
 //
-//   1. @b Spoke @b composition — composition of arrows @b within a
-//      single category.  Given @c f: @c a → @c b and @c g: @c b → @c c
-//      both in @c 𝒞 (so @c a, @c b, @c c are @c 𝒞.Species values),
-//      @c f @c >> @c g is the textbook composition @c a → @c c in @c 𝒞.
-//   2. @b Hub @b composition — composition of arrows @b between
-//      categories.  Given functors @c F: @c 𝒞 → @c 𝒟 and @c G: @c 𝒟 → @c ℰ
-//      (so @c F.Σ_cat = @c 𝒞, @c F.Τ_cat = @c 𝒟, etc.), @c F @c >> @c G
-//      is functor composition @c 𝒞 → @c ℰ in @b Cat (the category of
-//      categories).
+// Concrete instances of this pattern in the codebase:
+//   * @c Set<int> — the category whose objects are int values and
+//     whose morphisms are functions @c int @c → @c int.
+//   * @c Set<Box<int>> — a @b different category, same structural
+//     shape, distinct species.
+//   * @c Set<Path<int>> — a category whose objects are sequences
+//     @c ℕ @c → @c int.  Path<int> is an OBJECT in this category,
+//     even though Path is itself an arrow at the meta-level (every
+//     sequence IS a function ℕ → T) — exactly the CCC reading where
+//     function spaces are first-class objects in @b Set.
 //
-// These are different operations on different categories.  At the
-// dispatch level they need separate routes — otherwise a generic
-// @c operator>> overload sees both flavours and either resolves
-// ambiguously or misroutes.  The @c spoke_arrow_tag / @c hub_arrow_tag
-// tags below + the @c IsSpokeArrow / @c IsHubArrow concepts further down
-// implement that routing: object-level @c operator>> in this partition
-// gates on @c IsSpokeArrow; hub-level composition (functor composition,
-// natural-transformation composition, etc.) is owned by the bridge
-// partitions (@c :functor, @c :natural).
+// @section Morphisms_within_a_Category
 //
-// @section Hub_Spoke_Discriminator (#525)
+// A morphism in @c 𝒞 is an arrow @c f: @c a → @c b where @c a, @c b
+// are objects of @c 𝒞 (i.e., @c 𝒞.Species values).  Composition of
+// morphisms is internal: given @c f: @c a → @c b and @c g: @c b → @c c
+// in @c 𝒞, the composite @c g @c ∘ @c f: @c a → @c c is also a
+// morphism in @c 𝒞.  This is the closure axiom: a category is closed
+// under composition of its own morphisms.
 //
-// The spoke discriminator is "Domain is not a category-shaped thing"
-// (i.e.\ @c !IsCategoryShape<Dom<T>>), expressing the formal definition
-// of arrow-within-a-category: a spoke arrow's @b Domain is an object,
-// not a category.  Pre-#525 the discriminator used the structural-proxy
-// @c !IsArrow<Dom<T>> on the implicit theory that an arrow whose Domain
-// is itself an arrow is probably a hub.  That proxy worked
-// coincidentally for functor-Hubs (whose Domain is a category and
-// therefore has @c Cat::Arrow, satisfying @c IsArrow) but over-fired on
-// object-level types that happen to expose @c Domain / @c Codomain
-// aliases for @b unrelated reasons — the canonical example is
-// @c Path<T>, which carries @c Domain @c = @c std::size_t to model the
-// textbook reading "a sequence is a function @c ℕ @c → @c T".  The
-// post-#525 discriminator @c IsCategoryShape (defined just below
-// @c IsArrow) tests for the identifying category aliases (@c ::Arrow,
-// @c ::Species, @c ::Id) directly — asking the right question rather
-// than the structural proxy.
+// In code, @c 𝒞.Arrow instances ARE the morphisms.  In the dispatch
+// vocabulary below they are called @b spoke @b arrows, because in the
+// hub/spoke architecture they are arrows that connect ordinary
+// (object-level) endpoints — the spokes of the wheel, with the
+// category itself as the hub.  The fish @c f @c >> @c g (sugar for
+// @c g @c ∘ @c f) is the operator surface for spoke composition.
+//
+// @section Functors_between_Categories
+//
+// A functor @c F: @c 𝒞 → @c 𝒟 is, mathematically, a structure-
+// preserving map between two categories.  It has two parts:
+//
+//   * @b F_obj: an action on objects, taking @c 𝒞.Species @c → @c 𝒟.Species.
+//     In code this is @c F::template @c Shape<U> (the type-constructor
+//     part: @c box_functor<T>::Shape<U> @c = @c Box<U>, etc.).
+//   * @b F_mor: an action on morphisms, taking @c 𝒞.Arrow @c → @c 𝒟.Arrow,
+//     with @c F(g @c ∘ @c f) @c = @c F(g) @c ∘ @c F(f) and
+//     @c F(id_a) @c = @c id_{F(a)}.  In code this is @c F.φ(f) (the
+//     morphic-lift method on the functor Hub).
+//
+// Because functors are themselves arrows — they are the arrows of
+// @b Cat, the category of categories — they have their own
+// composition: given @c F: @c 𝒞 → @c 𝒟 and @c G: @c 𝒟 → @c ℰ, the
+// composite @c G @c ∘ @c F: @c 𝒞 → @c ℰ is a functor (a morphism in
+// @b Cat).  This is a @b different operation than morphism
+// composition within a single category — different category, different
+// composition law, different concrete realisation.
+//
+// In the architecture vocabulary below, functors are called @b hub
+// @b arrows: their endpoints are categories (the source / target
+// labels @c Σ_cat / @c Τ_cat that hub types like @c box_functor
+// expose), so they sit "above" the spoke arrows that connect objects
+// within a single category.  The fish @c F @c >> @c G (sugar for
+// @c G @c ∘ @c F) at the hub level is functor composition; that
+// operator is owned by @c :functor, not by this partition.
+//
+// @section Three_Composition_Shapes
+//
+// Together these give @b three distinct operator-@c >> shapes the
+// codebase uses:
+//
+//   1. @b Morphism @c >> @b Morphism (spoke @c >> spoke) —
+//      composition of arrows within a category.  Owned by this
+//      partition (@c :morphism, line ~565).  Requires
+//      @c IsSpokeArrow on both sides + matching middle types.
+//   2. @b Functor @c >> @b Functor (hub @c >> hub) — composition in
+//      @b Cat.  Owned by @c :functor (the @c composite_functor
+//      machinery).  Requires @c IsFunctor on both sides +
+//      @c F::Τ_cat @c == @c G::Σ_cat (so the source/target categories
+//      of the chain match up).
+//   3. @b Functor @c >> @b Morphism (hub @c >> spoke) — @b not
+//      composition; instead a syntactic-sugar reuse of @c >> for the
+//      @b functorial @b action on arrows (i.e.\ @c F.φ(f) /
+//      @c fmap @c F @c f).  Owned by @c :functor.  Categorically,
+//      this is the F_mor part of the functor applied to an arrow in
+//      the source category, returning an arrow in the target
+//      category.  It is not "composition" in the same sense as (1)
+//      and (2); the operator-symbol overlap is for ergonomics in the
+//      Haskell idiom (@c functor @c <$> @c arrow), not for
+//      categorical uniformity.  Reader beware: @c F @c >> @c f does
+//      @b not mean "compose F with f as morphisms in the same
+//      category" — that would be ill-typed, since F's codomain is a
+//      category and f's domain is an object.
+//
+// The fourth combination, @b Morphism @c >> @b Functor (spoke @c >>
+// hub), has no categorical reading and no overload exists.  Such an
+// expression fails to compile.
+//
+// @section Discriminator (#525)
+//
+// The split between (1) and (2)/(3) at dispatch time hinges on a
+// single question: @b is @b the @b Domain @b a @b category?
+//
+//   * If yes — Domain has @c ::Arrow / @c ::Species / @c ::Id aliases
+//     identifying it as a category — the arrow is a functor
+//     (between categories): a hub.
+//   * If no — Domain is an object — the arrow is a morphism (within a
+//     category): a spoke.
+//
+// The codebase realises this question structurally as
+// @c IsCategoryShape<Dom<T>>, defined further down.  @c IsCategoryShape
+// is the structural prefix of the full @c IsCategory in @c :small —
+// here we only need the shape to make the routing decision; the
+// behavioural axioms (composition closure, identity laws) are not
+// needed at this layer.
+//
+// Pre-#525 the discriminator used @c !IsArrow<Dom<T>> as a structural
+// proxy for "Domain isn't a category".  This worked coincidentally
+// for functor-Hubs (whose Domain is a category and therefore has
+// @c Cat::Arrow, satisfying @c IsArrow) but over-fired on object-level
+// types that happen to expose @c Domain / @c Codomain aliases for
+// unrelated reasons.  The canonical example: @c Path<T> declares
+// @c Domain @c = @c std::size_t to model the textbook reading "a
+// sequence is a function @c ℕ @c → @c T", which makes
+// @c IsArrow<Path<T>> trivially true even though @c Path<T> is an
+// @b object in @b Set, not a category.  The post-#525 form
+// @c !IsCategoryShape<Dom<T>> asks the right question and the
+// over-fire stops.
 //
 // @section Manual_Override
 //
 // In addition to the structural test, types may opt in / out manually
 // via @c using @c ArrowKind @c = @c spoke_arrow_tag; or
 // @c hub_arrow_tag; .  Today the @c hub_arrow_tag opt-out is the
-// load-bearing override (functor Hubs use it); @c spoke_arrow_tag is a
-// reserved spoke-marker for parallel future opt-in cases.
+// load-bearing override (functor Hubs use it to forcibly exclude
+// themselves from spoke routing); @c spoke_arrow_tag is a reserved
+// spoke-marker for parallel future opt-in cases (a type that wants
+// to participate in spoke composition despite an unusual Domain
+// shape, etc.).
 // ---------------------------------------------------------------------------
 
 /**

--- a/src/main/modules/dedekind/category/morphism.cppm
+++ b/src/main/modules/dedekind/category/morphism.cppm
@@ -217,14 +217,15 @@ namespace dedekind::category {
 // ---------------------------------------------------------------------------
 
 /**
- * @brief Marker tag for ordinary object-level arrows (spoke arrows).
+ * @brief Marker tag reserved for ordinary object-level arrows (spoke arrows).
  *
- * @details Attach as @c using @c ArrowKind @c = @c spoke_arrow_tag; when
- * a type should @b explicitly participate in spoke-level operator routing
- * (composition @b within a category).  In practice the structural
- * discriminator @c IsSpokeArrow (further down) catches the typical case
- * automatically; this tag is the manual override for types that carry
- * an unusual surface and want to be classified as spokes.
+ * @details Currently @b reserved: @c IsSpokeArrow does not check for
+ * @c ArrowKind @c = @c spoke_arrow_tag as an opt-in.  The structural
+ * discriminator @c !IsCategoryShape<Dom<T>> already catches the typical
+ * spoke case automatically, so no opt-in is needed in practice.  This
+ * tag is kept as a parallel slot to @c hub_arrow_tag so a future opt-in
+ * mechanism (e.g., for a type whose Domain is unusually category-shaped
+ * but should still route as a spoke) can be added symmetrically.
  *
  * See the architecture block above for the single-species design context.
  */

--- a/src/main/modules/dedekind/category/morphism.cppm
+++ b/src/main/modules/dedekind/category/morphism.cppm
@@ -54,21 +54,116 @@ import :species;
 
 namespace dedekind::category {
 
+// ---------------------------------------------------------------------------
+// Hub / Spoke architecture (clarified under #525)
+// ---------------------------------------------------------------------------
+//
+// @section Single_Species_Commitment
+//
+// The dedekind category model is @b single-species by design: a category
+// @c 𝒞 in this codebase is realised as a struct (e.g.\ @c Set<T>) whose
+// objects are values of a single C++ type @c T (the @c Species), and
+// whose arrows are @c Morphism<T, T, ...> instances.  This is a
+// pragmatic restriction for the disciplined-template fragment: modeling
+// polymorphic-collection-of-species categories would require runtime
+// type-erasure (existentials, type-erased object containers) that the
+// project's System-F-flavoured admissibility rules
+// (Table~\ref{tab:admissibility-rules} in @c paper.tex) deliberately
+// exclude.
+//
+// Concrete consequences:
+//   * @c Set<int> is the category whose objects are values of type
+//     @c int and whose arrows are @c Morphism<int, int, ...>.
+//   * @c Set<Box<int>> is a @b different category — same structural
+//     definition, distinct species.
+//   * @c Set<Path<int>> is a category whose objects are sequences
+//     @c ℕ @c → @c int (treated as objects in @b Set, exactly per the
+//     CCC reading where function spaces are first-class objects).
+//   * Functors @c F: @c 𝒞 @c → @c 𝒟 are realised as @b Hub types
+//     (@c box_functor, @c maybe_functor, etc.) carrying
+//     @c Σ_cat / @c Τ_cat aliases that name the source / target
+//     categories explicitly.
+//
+// @section Arrows_Within_vs_Between_Categories
+//
+// Composition of arrows comes in two flavours that must @b not be
+// conflated at the dispatch level:
+//
+//   1. @b Spoke @b composition — composition of arrows @b within a
+//      single category.  Given @c f: @c a → @c b and @c g: @c b → @c c
+//      both in @c 𝒞 (so @c a, @c b, @c c are @c 𝒞.Species values),
+//      @c f @c >> @c g is the textbook composition @c a → @c c in @c 𝒞.
+//   2. @b Hub @b composition — composition of arrows @b between
+//      categories.  Given functors @c F: @c 𝒞 → @c 𝒟 and @c G: @c 𝒟 → @c ℰ
+//      (so @c F.Σ_cat = @c 𝒞, @c F.Τ_cat = @c 𝒟, etc.), @c F @c >> @c G
+//      is functor composition @c 𝒞 → @c ℰ in @b Cat (the category of
+//      categories).
+//
+// These are different operations on different categories.  At the
+// dispatch level they need separate routes — otherwise a generic
+// @c operator>> overload sees both flavours and either resolves
+// ambiguously or misroutes.  The @c spoke_arrow_tag / @c hub_arrow_tag
+// tags below + the @c IsSpokeArrow / @c IsHubArrow concepts further down
+// implement that routing: object-level @c operator>> in this partition
+// gates on @c IsSpokeArrow; hub-level composition (functor composition,
+// natural-transformation composition, etc.) is owned by the bridge
+// partitions (@c :functor, @c :natural).
+//
+// @section Hub_Spoke_Discriminator (#525)
+//
+// The spoke discriminator is "Domain is not a category-shaped thing"
+// (i.e.\ @c !IsCategoryShape<Dom<T>>), expressing the formal definition
+// of arrow-within-a-category: a spoke arrow's @b Domain is an object,
+// not a category.  Pre-#525 the discriminator used the structural-proxy
+// @c !IsArrow<Dom<T>> on the implicit theory that an arrow whose Domain
+// is itself an arrow is probably a hub.  That proxy worked
+// coincidentally for functor-Hubs (whose Domain is a category and
+// therefore has @c Cat::Arrow, satisfying @c IsArrow) but over-fired on
+// object-level types that happen to expose @c Domain / @c Codomain
+// aliases for @b unrelated reasons — the canonical example is
+// @c Path<T>, which carries @c Domain @c = @c std::size_t to model the
+// textbook reading "a sequence is a function @c ℕ @c → @c T".  The
+// post-#525 discriminator @c IsCategoryShape (defined just below
+// @c IsArrow) tests for the identifying category aliases (@c ::Arrow,
+// @c ::Species, @c ::Id) directly — asking the right question rather
+// than the structural proxy.
+//
+// @section Manual_Override
+//
+// In addition to the structural test, types may opt in / out manually
+// via @c using @c ArrowKind @c = @c spoke_arrow_tag; or
+// @c hub_arrow_tag; .  Today the @c hub_arrow_tag opt-out is the
+// load-bearing override (functor Hubs use it); @c spoke_arrow_tag is a
+// reserved spoke-marker for parallel future opt-in cases.
+// ---------------------------------------------------------------------------
+
 /**
- * @brief Marker tag for ordinary object-level arrows.
- * @details Attach as `using ArrowKind = spoke_arrow_tag;` when a type should
- * participate in spoke-level operator routing.
+ * @brief Marker tag for ordinary object-level arrows (spoke arrows).
+ *
+ * @details Attach as @c using @c ArrowKind @c = @c spoke_arrow_tag; when
+ * a type should @b explicitly participate in spoke-level operator routing
+ * (composition @b within a category).  In practice the structural
+ * discriminator @c IsSpokeArrow (further down) catches the typical case
+ * automatically; this tag is the manual override for types that carry
+ * an unusual surface and want to be classified as spokes.
+ *
+ * See the architecture block above for the single-species design context.
  */
 export struct spoke_arrow_tag {};
 
 /**
  * @brief Marker tag for hub-level arrows (e.g., functor hubs).
- * @details Attach as `using ArrowKind = hub_arrow_tag;` to opt out of
- * spoke-level composition overloads in this partition.
  *
- * This keeps `:morphism` decoupled from downstream naming conventions while
- * still allowing higher-level partitions (such as `:functor`) to route
- * overload resolution explicitly.
+ * @details Attach as @c using @c ArrowKind @c = @c hub_arrow_tag; to
+ * opt out of spoke-level composition overloads.  Hub arrows are arrows
+ * @b between categories (functors, natural transformations, etc.); they
+ * compose by their own rules in bridge partitions (@c :functor,
+ * @c :natural).
+ *
+ * The opt-out keeps @c :morphism decoupled from downstream naming
+ * conventions while still letting higher-level partitions route
+ * overload resolution explicitly.  See the architecture block above
+ * for the dispatch rationale.
  */
 export struct hub_arrow_tag {};
 

--- a/src/main/modules/dedekind/sequences/path.cppm
+++ b/src/main/modules/dedekind/sequences/path.cppm
@@ -548,19 +548,19 @@ static_assert(IsSequence<Path<int>>, "Path must satisfy the sequence concept.");
 // Discriminator-sharpening witness (#525).  Path<int> is itself an
 // IsArrow at the type level (it carries Domain = std::size_t and a
 // call operator, modelling the textbook reading "a sequence is a
-// function ℕ → T").  Pre-#525 the IsSpokeArrow definition used
-// !IsArrow<Dom<T>> as a structural proxy for "Domain isn't a
-// category" — which over-fired here, classifying
-// Morphism<Path<int>, Path<int>, ...> as NOT a SpokeArrow even
-// though Path<int>'s Domain is std::size_t (an object, not a
-// category).  Post-#525 the discriminator uses
-// !IsCategoryShape<Dom<T>>, asking the right question: is the
-// Domain a category-shaped thing?  std::size_t isn't (no
-// ::Arrow / ::Species / ::Id aliases), so Morphism<Path,Path,...>
-// IS a SpokeArrow under the new definition.  This static_assert
-// pins the fix mechanically; if the discriminator ever regresses,
-// it surfaces here at the load-bearing case that motivated the
-// sharpening.
+// function ℕ → T").  The load-bearing distinction the #525 fix
+// makes is between "Path<int> is an arrow" (true: it has Domain,
+// Codomain, call operator) and "Path<int> is category-shaped"
+// (false: no ::Arrow / ::Species / ::Id aliases — Path<int> is an
+// object, not a category-to-category arrow).  Pre-#525 the
+// IsSpokeArrow discriminator read !IsArrow<Dom<T>> — but the
+// Morphism here has Dom = Path<int>, which IS an arrow, so the
+// proxy mis-classified Morphism<Path,Path,...> as NOT a SpokeArrow.
+// Post-#525 the discriminator reads !IsCategoryShape<Dom<T>>, which
+// returns false for Path<int> (it has no category-shape aliases),
+// so the Morphism IS a SpokeArrow.  This static_assert pins the fix
+// mechanically; if the discriminator ever regresses, it surfaces
+// here at the load-bearing case that motivated the sharpening.
 namespace _path_525 {
 using PathArrow = dedekind::category::CanonicalSetCCC<Path<int>>::Arrow;
 // Morphism<Path<int>, Path<int>, std::function<Path<int>(Path<int>)>> —
@@ -578,7 +578,9 @@ static_assert(dedekind::category::IsSpokeArrow<PathArrow>,
               "Morphism<Path<int>, Path<int>, ...> is a SpokeArrow under "
               "the #525 sharpening (Dom = Path<int>, which is not a "
               "category-shaped thing). Pre-#525 this static_assert would "
-              "IsArrow.");
+              "have failed because Path<int> satisfies IsArrow at the "
+              "type level, and the old !IsArrow<Dom<T>> discriminator "
+              "therefore mis-classified the Morphism as non-spoke.");
 }  // namespace _path_525
 
 static_assert(IsFiniteSequence<FinitePath<int>>,

--- a/src/main/modules/dedekind/sequences/path.cppm
+++ b/src/main/modules/dedekind/sequences/path.cppm
@@ -545,6 +545,41 @@ using namespace dedekind::category;
 /** @section path__Formal_Verification */
 static_assert(IsSequence<Path<int>>, "Path must satisfy the sequence concept.");
 
+// Discriminator-sharpening witness (#525).  Path<int> is itself an
+// IsArrow at the type level (it carries Domain = std::size_t and a
+// call operator, modelling the textbook reading "a sequence is a
+// function ℕ → T").  Pre-#525 the IsSpokeArrow definition used
+// !IsArrow<Dom<T>> as a structural proxy for "Domain isn't a
+// category" — which over-fired here, classifying
+// Morphism<Path<int>, Path<int>, ...> as NOT a SpokeArrow even
+// though Path<int>'s Domain is std::size_t (an object, not a
+// category).  Post-#525 the discriminator uses
+// !IsCategoryShape<Dom<T>>, asking the right question: is the
+// Domain a category-shaped thing?  std::size_t isn't (no
+// ::Arrow / ::Species / ::Id aliases), so Morphism<Path,Path,...>
+// IS a SpokeArrow under the new definition.  This static_assert
+// pins the fix mechanically; if the discriminator ever regresses,
+// it surfaces here at the load-bearing case that motivated the
+// sharpening.
+namespace _path_525 {
+using PathArrow =
+    dedekind::category::Set<Path<int>>::Arrow;  // Morphism<Path<int>,
+                                                // Path<int>, fn(Path)>
+static_assert(dedekind::category::IsArrow<Path<int>>,
+              "Path<int> is itself an IsArrow at the type level "
+              "(Domain = size_t, Codomain = T, call operator).");
+static_assert(!dedekind::category::IsCategoryShape<Path<int>>,
+              "Path<int> is NOT a category-shaped thing — it has no "
+              "::Arrow / ::Species / ::Id aliases.  This is the "
+              "distinction the #525 discriminator-sharpening makes.");
+static_assert(dedekind::category::IsSpokeArrow<PathArrow>,
+              "Morphism<Path<int>, Path<int>, ...> is a SpokeArrow under "
+              "the #525 sharpening (Dom = Path<int>, which is not a "
+              "category-shaped thing). Pre-#525 this static_assert would "
+              "have failed because Path<int> structurally satisfied "
+              "IsArrow.");
+}  // namespace _path_525
+
 static_assert(IsFiniteSequence<FinitePath<int>>,
               "FinitePath must satisfy the finite sequence concept.");
 

--- a/src/main/modules/dedekind/sequences/path.cppm
+++ b/src/main/modules/dedekind/sequences/path.cppm
@@ -562,9 +562,11 @@ static_assert(IsSequence<Path<int>>, "Path must satisfy the sequence concept.");
 // it surfaces here at the load-bearing case that motivated the
 // sharpening.
 namespace _path_525 {
-using PathArrow =
-    dedekind::category::Set<Path<int>>::Arrow;  // Morphism<Path<int>,
-                                                // Path<int>, fn(Path)>
+using PathArrow = dedekind::category::CanonicalSetCCC<Path<int>>::Arrow;
+// Morphism<Path<int>, Path<int>, std::function<Path<int>(Path<int>)>> —
+// CanonicalSetCCC<X> is the exported alias for the in-cartesian Set<X>
+// type (Set itself is not export-qualified).  Same precedent as the
+// vec2_functor / matrix2x2_functor Hubs in :linear_algebra.
 static_assert(dedekind::category::IsArrow<Path<int>>,
               "Path<int> is itself an IsArrow at the type level "
               "(Domain = size_t, Codomain = T, call operator).");
@@ -576,7 +578,6 @@ static_assert(dedekind::category::IsSpokeArrow<PathArrow>,
               "Morphism<Path<int>, Path<int>, ...> is a SpokeArrow under "
               "the #525 sharpening (Dom = Path<int>, which is not a "
               "category-shaped thing). Pre-#525 this static_assert would "
-              "have failed because Path<int> structurally satisfied "
               "IsArrow.");
 }  // namespace _path_525
 


### PR DESCRIPTION
## Summary

Closes #525.  Triggered by PR #521 (the @c path_functor IsFunctor attempt that surfaced the over-fire).

Refines the hub/spoke discrimination in @c :morphism to ask the right question — "is the Domain a category-shaped thing?" — instead of the structural-proxy "does the Domain expose any arrow-shaped surface?".  See #525 for the diagnosis chain.

## Changes

### `:morphism`
- New @c IsCategoryShape concept: structural prefix of @c dedekind::category::IsCategory checking the identifying type aliases (@c ::Arrow / @c ::Species / @c ::Id).  Lives in @c :morphism so the hub/spoke routing can use it without crossing the @c :morphism @c ↔ @c :small dependency boundary.  The full @c IsCategory in @c :small refines this with behavioural checks (id_c factory + f >> g internal closure); those can't be referenced from @c :morphism because of the import cycle and because @c IsCategory's own body uses @c f @c >> @c g — the very operator the discriminator gates.
- @c IsSpokeArrow refined: replace @c !IsArrow<Dom<T>> / @c !IsArrow<Cod<T>> with @c !IsCategoryShape<Dom<T>> / @c !IsCategoryShape<Cod<T>>.  Manual @c hub_arrow_tag opt-out preserved.
- @c IsHubArrow refined symmetrically: @c IsCategoryShape<Dom<T>> @c && @c IsCategoryShape<Cod<T>>.  (This concept was dormant in the codebase pre-#525; only fires for actual functors now.)

### `:sequences:path`
- Three witness static_asserts pinning the discriminator's correctness at the load-bearing case: 
  - @c IsArrow<Path<int>> — Path is itself arrow-shaped (the property that misfired pre-#525).
  - @c !IsCategoryShape<Path<int>> — Path is NOT category-shaped (the distinction the new discriminator makes).
  - @c IsSpokeArrow<Set<Path<int>>::Arrow> — fires under the #525 sharpening; would have failed pre-#525.

## Out of scope

- **Restoring the full @c path_functor IsFunctor surface** — that's the ultimate downstream witness, but @c path_functor lives in #521's branch (which is in-flight).  When #521 lands, this branch rebases and the @c path_functor restoration follows naturally.  Until then, the three witnesses above pin the discriminator's correctness at the load-bearing case.
- **@c Set<T>::Arrow's friend @c operator>> in @c :cartesian** — becomes potentially redundant under the new definition (the free spoke-only @c >> in @c :morphism now resolves for Path-domain Morphisms too).  Leaving in place for now; cleanup is its own slice if/when audit confirms redundancy.
- **Moving hub/spoke discriminators downstream of @c :morphism** (so they can use full @c IsCategory rather than the structural prefix) — possible follow-up if the structural prefix proves insufficient.

## Test plan

- [ ] CI: build-and-deploy on Linux clang-22 passes.
- [ ] All 15 test suites pass.
- [ ] All existing @c IsCategory<Set<X>> static_asserts continue to fire.
- [ ] All existing @c IsFunctor<F> static_asserts (@c box_functor, @c maybe_functor, @c trace_functor, @c identity_functor, @c vec2_functor, @c covec2_functor, @c matrix2x2_functor) continue to fire.
- [ ] The three new witnesses in @c :sequences:path fire.
- [ ] Audit ~10 @c IsSpokeArrow / @c IsHubArrow callsites to confirm none rely on the @c IsArrow-based reading semantically (vs as routing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)