### PR TITLE
feat(category, kleisli): is_kleisli_arrow_v + IsKleisliArrow scaffolding — IsDefaultHubTag-constrained, with opt-in witness (step 1 of #380)

### DIFF
--- a/src/main/modules/dedekind/category/kleisli.cppm
+++ b/src/main/modules/dedekind/category/kleisli.cppm
@@ -58,6 +58,7 @@ module;
 #include <concepts>
 #include <functional>
 #include <ios>
+#include <optional>  // std::nullopt — used by the _kleisli_arrow_witness_380 skeleton
 #include <utility>  // std::move / std::forward (kept self-contained per #521 review)
 
 export module dedekind.category:kleisli;

--- a/src/main/modules/dedekind/category/kleisli.cppm
+++ b/src/main/modules/dedekind/category/kleisli.cppm
@@ -407,4 +407,29 @@ export template <typename M>
 concept IsKleisliDeref =
     HasArrowDereferenceOperator<M> && is_kleisli_deref_v<M>;
 
+/**
+ * @brief User-declared "Kleisli arrow" witness (#380, step 1).
+ * @details A Kleisli arrow lives in the Kleisli category of a monad
+ *          @c M: it has shape @c e: @c A @c → @c M<B>.  The @c M slot
+ *          is the @b monad-hub @b tag of the monad in question
+ *          (@c maybe_hub_tag, @c box_hub_tag, etc.) — i.e.\ a tag type
+ *          that names which Kleisli category the arrow inhabits, not
+ *          the class template itself.  Default @c false; opt-in by
+ *          specialising to @c true at the @c (E, M) pair.  Pairs with
+ *          the composition / fmap machinery above; this trait only
+ *          declares membership in the Kleisli category, it does not
+ *          implement composition.
+ */
+export template <typename E, typename M>
+inline constexpr bool is_kleisli_arrow_v = false;
+
+/**
+ * @concept IsKleisliArrow
+ * @brief An arrow declared to live in the Kleisli category indexed by
+ *        the monad-hub tag @c M.
+ * @details Opt-in via @c is_kleisli_arrow_v<E, M> @c = @c true.
+ */
+export template <typename E, typename M>
+concept IsKleisliArrow = IsArrow<E> && is_kleisli_arrow_v<E, M>;
+
 }  // namespace dedekind::category

--- a/src/main/modules/dedekind/category/kleisli.cppm
+++ b/src/main/modules/dedekind/category/kleisli.cppm
@@ -64,6 +64,7 @@ export module dedekind.category:kleisli;
 
 import :functor;  // box_functor (canonical Hub for unit_witness/counit_witness;
                   // #508)
+import :natural;  // IsDefaultHubTag — type-checked constraint on the Kleisli M slot
 import :monad;
 import :small;
 import :morphism;
@@ -409,27 +410,73 @@ concept IsKleisliDeref =
 
 /**
  * @brief User-declared "Kleisli arrow" witness (#380, step 1).
- * @details A Kleisli arrow lives in the Kleisli category of a monad
- *          @c M: it has shape @c e: @c A @c → @c M<B>.  The @c M slot
- *          is the @b monad-hub @b tag of the monad in question
- *          (@c maybe_hub_tag, @c box_hub_tag, etc.) — i.e.\ a tag type
- *          that names which Kleisli category the arrow inhabits, not
- *          the class template itself.  Default @c false; opt-in by
- *          specialising to @c true at the @c (E, M) pair.  Pairs with
- *          the composition / fmap machinery above; this trait only
- *          declares membership in the Kleisli category, it does not
- *          implement composition.
+ * @details A Kleisli arrow lives in the Kleisli category indexed by a
+ *          monad-hub tag @c M.  Its underlying map has shape
+ *          @c e: @c A @c → @c T<B>, where @c T is the monadic carrier
+ *          shape selected by the hub tag (@c Maybe for
+ *          @c maybe_hub_tag, @c Box for @c box_hub_tag, @c Identity for
+ *          @c identity_hub_tag).  The @c M slot is the
+ *          @b monad-hub @b tag itself — a tag type that names which
+ *          Kleisli category the arrow inhabits — not the class template.
+ *          Constrained by @c IsDefaultHubTag to make the connection
+ *          type-checked; downstream code can extend by adding new tags
+ *          to the @c IsDefaultHubTag disjunction in @c :natural.
+ *          Default @c false; opt-in by specialising to @c true at the
+ *          @c (E, M) pair.  Pairs with the composition / fmap
+ *          machinery above; this trait only declares membership in the
+ *          Kleisli category, it does not implement composition.
  */
 export template <typename E, typename M>
+  requires IsDefaultHubTag<M>
 inline constexpr bool is_kleisli_arrow_v = false;
 
 /**
  * @concept IsKleisliArrow
  * @brief An arrow declared to live in the Kleisli category indexed by
- *        the monad-hub tag @c M.
+ *        the monad-hub tag @c M (constrained by @c IsDefaultHubTag).
  * @details Opt-in via @c is_kleisli_arrow_v<E, M> @c = @c true.
  */
 export template <typename E, typename M>
-concept IsKleisliArrow = IsArrow<E> && is_kleisli_arrow_v<E, M>;
+concept IsKleisliArrow =
+    IsArrow<E> && IsDefaultHubTag<M> && is_kleisli_arrow_v<E, M>;
+
+namespace _kleisli_arrow_witness_380 {
+
+// Witness skeleton (#380 step 1): a hand-rolled arrow E with shape
+// @c A @c → @c Maybe<B> opts in to @c IsKleisliArrow<E, maybe_hub_tag>
+// via the @c is_kleisli_arrow_v specialisation below.  Demonstrates the
+// end-to-end pattern step 2 of #380 will apply to real
+// @c try_realize_to_<primitive> arrows: declare the arrow, register
+// the trait, recover @c IsKleisliArrow at the use site.
+struct toy_partial_realize {
+  using ArrowKind = spoke_arrow_tag;
+  using Domain = int;
+  using Codomain = Maybe<int>;
+  constexpr Maybe<int> operator()(int n) const {
+    return n >= 0 ? Maybe<int>{n} : std::nullopt;
+  }
+};
+
+}  // namespace _kleisli_arrow_witness_380
+
+template <>
+inline constexpr bool
+    is_kleisli_arrow_v<_kleisli_arrow_witness_380::toy_partial_realize,
+                       maybe_hub_tag> = true;
+
+namespace _kleisli_arrow_witness_380 {
+
+static_assert(IsArrow<toy_partial_realize>,
+              "Witness arrow shape: A → Maybe<B> qualifies as IsArrow.");
+static_assert(
+    IsKleisliArrow<toy_partial_realize, maybe_hub_tag>,
+    "Opt-in via is_kleisli_arrow_v<E, maybe_hub_tag> = true lifts the "
+    "arrow into the IsKleisliArrow concept.");
+static_assert(
+    !IsKleisliArrow<toy_partial_realize, box_hub_tag>,
+    "Opt-in is per-(E, M) pair: a Maybe-shaped Kleisli arrow does not "
+    "automatically inhabit the Box Kleisli category.");
+
+}  // namespace _kleisli_arrow_witness_380
 
 }  // namespace dedekind::category

--- a/src/main/modules/dedekind/category/kleisli.cppm
+++ b/src/main/modules/dedekind/category/kleisli.cppm
@@ -64,7 +64,8 @@ export module dedekind.category:kleisli;
 
 import :functor;  // box_functor (canonical Hub for unit_witness/counit_witness;
                   // #508)
-import :natural;  // IsDefaultHubTag — type-checked constraint on the Kleisli M slot
+import :natural;  // IsDefaultHubTag — type-checked constraint on the Kleisli M
+                  // slot
 import :monad;
 import :small;
 import :morphism;
@@ -460,9 +461,8 @@ struct toy_partial_realize {
 }  // namespace _kleisli_arrow_witness_380
 
 template <>
-inline constexpr bool
-    is_kleisli_arrow_v<_kleisli_arrow_witness_380::toy_partial_realize,
-                       maybe_hub_tag> = true;
+inline constexpr bool is_kleisli_arrow_v<
+    _kleisli_arrow_witness_380::toy_partial_realize, maybe_hub_tag> = true;
 
 namespace _kleisli_arrow_witness_380 {
 

--- a/src/main/modules/dedekind/category/morphism.cppm
+++ b/src/main/modules/dedekind/category/morphism.cppm
@@ -1042,91 +1042,26 @@ static_assert(IsBijective<Identity<int>>,
               "Identity.");
 
 // ---------------------------------------------------------------------------
-// Inter-carrier arrow class taxonomy (#380, step 1).
+// Inter-carrier arrow class taxonomy (#380).
 //
-// The library distinguishes three classes of arrows that move values
-// between carriers:
+// The textbook arrow classes that name themselves cleanly in this
+// partition are the @b monic / @b epic pair (already declared above
+// as @c is_monic_arrow_v / @c is_epic_arrow_v + @c IsMonicArrow /
+// @c IsEpicArrow).  The other two classes #380 enumerates have homes
+// downstream where their textbook reading is direct:
 //
-//   (a)/(c) Total injection       e: A ↣ B          @c is_monic_arrow_v
-//   (b₁)    Sentinel realisation  e: A → B (sentinel on out-of-range)
-//                                                   @c is_realisation_arrow_v
-//   (b₂)    Kleisli partial       e: A → M B        @c is_kleisli_arrow_v
-//
-// The total-injection slot is already covered above by
-// @c is_monic_arrow_v (epicity, @c is_epic_arrow_v, is the orthogonal
-// surjectivity property — companion in the categorical zoo, not part
-// of the total-injection class itself).  This block adds the two
-// missing slots so each class has its own opt-in trait + concept; the
-// audit / decorate sweep that pins concrete @c realize_to_* and
-// @c try_realize_to_* arrows to the right class is step 2 of #380.
-//
-// @note The (b₁) slot's name avoids @c IsTotalArrow because that
-// concept is already taken (in @c :total) for an unrelated property
-// of morphisms over hazard-free domains.  The realisation reading
-// stresses the @b purpose (exact ↦ primitive realisation with
-// sentinel) rather than the totality property.
+//   * @b Kleisli @b arrow (@c e: @c A @c → @c M<B>) — declared as
+//     @c is_kleisli_arrow_v<E, M> + @c IsKleisliArrow<E, M> in
+//     @c dedekind.category:kleisli, where the composition / fmap
+//     machinery already lives.
+//   * @b Sentinel @b realisation (@c e: @c A @c → @c B, total with
+//     a documented sentinel for out-of-range inputs) — deferred to a
+//     downstream partition (likely co-located with the
+//     @c realize_to_<primitive> family in @c dedekind.numbers) when
+//     step 2 of #380 lands.  No clean Pierce-style textbook name
+//     applies, so the trait is intentionally not declared at the
+//     @c :morphism layer.
 // ---------------------------------------------------------------------------
-
-/**
- * @brief User-declared "sentinel realisation" witness for an arrow type.
- * @details A sentinel realisation is an arrow @c e: @c A @c → @c B that
- *          never reports absence — it always returns a value of @c B,
- *          but its contract carries a documented @b sentinel for inputs
- *          that have no faithful image (e.g., @c realize_to_size_t
- *          returning @c std::numeric_limits<std::size_t>::max() on
- *          overflow).  Default @c false; opt-in by specialising to
- *          @c true on arrows whose totality + sentinel is part of the
- *          contract.  Distinct from @c is_monic_arrow_v (injection) and
- *          @c is_kleisli_arrow_v (partial-via-monad).
- */
-export template <typename E>
-inline constexpr bool is_realisation_arrow_v = false;
-
-/**
- * @concept IsRealisationArrow
- * @brief An arrow declared to be a sentinel realisation: total with a
- *        documented sentinel for out-of-range inputs.
- * @details Opt-in via @c is_realisation_arrow_v<E> @c = @c true.  The
- *          intended use is the @c realize_to_<primitive> family of arrows
- *          (#380): exact → primitive realisations whose contract includes
- *          a sentinel for out-of-range inputs (these arrows are total but
- *          @b not injective, so the plain @c → arrow rather than @c ↪
- *          is correct).
- */
-export template <typename E>
-concept IsRealisationArrow = IsArrow<E> && is_realisation_arrow_v<E>;
-
-/**
- * @brief User-declared "Kleisli arrow" witness for an arrow type.
- * @details A Kleisli arrow lives in the Kleisli category of a monad
- *          @c M: it has shape @c e: @c A @c → @c M<B>.  The @c M slot
- *          is the @b Kleisli @b hub @b tag of the monad in question
- *          (@c maybe_hub_tag, @c box_hub_tag, etc.) — i.e.\ a tag
- *          type that names which Kleisli category the arrow inhabits,
- *          not the class template @c std::optional itself.  In the
- *          library today partial realisations are the dominant
- *          consumer (e.g., a @c try_realize_to_size_t returning
- *          @c std::optional<size_t> would opt in via
- *          @c is_kleisli_arrow_v<F, maybe_hub_tag> @c = @c true).
- *          Default @c false; opt-in by specialising to @c true at the
- *          @c (E, M) pair.
- *
- *          Pairs with the @c dedekind.category:kleisli partition's
- *          composition / fmap machinery; this trait only declares
- *          membership in the Kleisli category, it does not implement
- *          composition.
- */
-export template <typename E, typename M>
-inline constexpr bool is_kleisli_arrow_v = false;
-
-/**
- * @concept IsKleisliArrow
- * @brief An arrow declared to live in the Kleisli category indexed by
- *        the monad-hub tag @c M.
- * @details Opt-in via @c is_kleisli_arrow_v<E, M> @c = @c true.
- */
-export template <typename E, typename M>
-concept IsKleisliArrow = IsArrow<E> && is_kleisli_arrow_v<E, M>;
 
 // ---------------------------------------------------------------------------
 // Fish-operator concept tier (closes part of #450).

--- a/src/main/modules/dedekind/category/morphism.cppm
+++ b/src/main/modules/dedekind/category/morphism.cppm
@@ -1042,6 +1042,80 @@ static_assert(IsBijective<Identity<int>>,
               "Identity.");
 
 // ---------------------------------------------------------------------------
+// Inter-carrier arrow class taxonomy (#380, step 1).
+//
+// The library distinguishes three classes of arrows that move values
+// between carriers:
+//
+//   (a)/(c) Total injection           e: A ↣ B          @c is_monic_arrow_v
+//   (b₁)    Total realisation         e: A → B (sentinel-carrying)
+//                                                       @c is_total_arrow_v
+//   (b₂)    Kleisli partial           e: A → M B (M a monad — typically
+//                                                 @c std::optional / @c Maybe)
+//                                                       @c is_kleisli_arrow_v
+//
+// The total-injection slot is already covered above by @c is_monic_arrow_v
+// (and its companion @c is_epic_arrow_v).  This block adds the two
+// missing slots so each class has its own opt-in trait + concept; the
+// audit / decorate sweep that pins concrete @c realize_to_* and
+// @c try_realize_to_* arrows to the right class is step 2 of #380.
+// ---------------------------------------------------------------------------
+
+/**
+ * @brief User-declared "total realisation" witness for an arrow type.
+ * @details A total realisation is an arrow @c e: @c A @c → @c B that
+ *          never reports absence — it always returns a value of @c B,
+ *          but its contract carries a documented @b sentinel for inputs
+ *          that have no faithful image (e.g., @c realize_to_size_t
+ *          returning @c std::numeric_limits<std::size_t>::max() on
+ *          overflow).  Default @c false; opt-in by specialising to
+ *          @c true on arrows whose totality + sentinel is part of the
+ *          contract.  Distinct from @c is_monic_arrow_v (injection) and
+ *          @c is_kleisli_arrow_v (partial-via-monad).
+ */
+export template <typename E>
+inline constexpr bool is_total_arrow_v = false;
+
+/**
+ * @concept IsTotalArrow
+ * @brief An arrow declared to be a total realisation with a documented
+ *        sentinel.
+ * @details Opt-in via @c is_total_arrow_v<E> @c = @c true.  The intended
+ *          use is the @c realize_to_<primitive> family of arrows
+ *          (#380): exact ↪ primitive realisations whose contract includes
+ *          a sentinel for out-of-range inputs.
+ */
+export template <typename E>
+concept IsTotalArrow = IsArrow<E> && is_total_arrow_v<E>;
+
+/**
+ * @brief User-declared "Kleisli arrow" witness for an arrow type.
+ * @details A Kleisli arrow lives in the Kleisli category of a monad
+ *          @c M: it has shape @c e: @c A @c → @c M<B>.  In the library
+ *          today this is overwhelmingly @c M @c = @c std::optional /
+ *          @c Maybe, used for partial realisations (e.g.,
+ *          @c try_realize_to_size_t returning @c std::optional<size_t>).
+ *          Default @c false; opt-in by specialising to @c true at the
+ *          @c (E, M) pair.
+ *
+ *          Pairs with the @c dedekind.category:kleisli partition's
+ *          composition / fmap machinery; this trait only declares
+ *          membership in the Kleisli category, it does not implement
+ *          composition.
+ */
+export template <typename E, typename M>
+inline constexpr bool is_kleisli_arrow_v = false;
+
+/**
+ * @concept IsKleisliArrow
+ * @brief An arrow declared to live in the Kleisli category of monad
+ *        @c M.
+ * @details Opt-in via @c is_kleisli_arrow_v<E, @c M> @c = @c true.
+ */
+export template <typename E, typename M>
+concept IsKleisliArrow = IsArrow<E> && is_kleisli_arrow_v<E, M>;
+
+// ---------------------------------------------------------------------------
 // Fish-operator concept tier (closes part of #450).
 //
 // The project's operator surface for arrow composition / monadic bind /

--- a/src/main/modules/dedekind/category/morphism.cppm
+++ b/src/main/modules/dedekind/category/morphism.cppm
@@ -1047,12 +1047,10 @@ static_assert(IsBijective<Identity<int>>,
 // The library distinguishes three classes of arrows that move values
 // between carriers:
 //
-//   (a)/(c) Total injection           e: A ↣ B          @c is_monic_arrow_v
-//   (b₁)    Total realisation         e: A → B (sentinel-carrying)
-//                                                       @c is_total_arrow_v
-//   (b₂)    Kleisli partial           e: A → M B (M a monad — typically
-//                                                 @c std::optional / @c Maybe)
-//                                                       @c is_kleisli_arrow_v
+//   (a)/(c) Total injection       e: A ↣ B          @c is_monic_arrow_v
+//   (b₁)    Sentinel realisation  e: A → B (sentinel on out-of-range)
+//                                                   @c is_realisation_arrow_v
+//   (b₂)    Kleisli partial       e: A → M B        @c is_kleisli_arrow_v
 //
 // The total-injection slot is already covered above by
 // @c is_monic_arrow_v (epicity, @c is_epic_arrow_v, is the orthogonal
@@ -1061,11 +1059,17 @@ static_assert(IsBijective<Identity<int>>,
 // missing slots so each class has its own opt-in trait + concept; the
 // audit / decorate sweep that pins concrete @c realize_to_* and
 // @c try_realize_to_* arrows to the right class is step 2 of #380.
+//
+// @note The (b₁) slot's name avoids @c IsTotalArrow because that
+// concept is already taken (in @c :total) for an unrelated property
+// of morphisms over hazard-free domains.  The realisation reading
+// stresses the @b purpose (exact ↦ primitive realisation with
+// sentinel) rather than the totality property.
 // ---------------------------------------------------------------------------
 
 /**
- * @brief User-declared "total realisation" witness for an arrow type.
- * @details A total realisation is an arrow @c e: @c A @c → @c B that
+ * @brief User-declared "sentinel realisation" witness for an arrow type.
+ * @details A sentinel realisation is an arrow @c e: @c A @c → @c B that
  *          never reports absence — it always returns a value of @c B,
  *          but its contract carries a documented @b sentinel for inputs
  *          that have no faithful image (e.g., @c realize_to_size_t
@@ -1076,21 +1080,21 @@ static_assert(IsBijective<Identity<int>>,
  *          @c is_kleisli_arrow_v (partial-via-monad).
  */
 export template <typename E>
-inline constexpr bool is_total_arrow_v = false;
+inline constexpr bool is_realisation_arrow_v = false;
 
 /**
- * @concept IsTotalArrow
- * @brief An arrow declared to be a total realisation with a documented
- *        sentinel.
- * @details Opt-in via @c is_total_arrow_v<E> @c = @c true.  The intended
- *          use is the @c realize_to_<primitive> family of arrows
+ * @concept IsRealisationArrow
+ * @brief An arrow declared to be a sentinel realisation: total with a
+ *        documented sentinel for out-of-range inputs.
+ * @details Opt-in via @c is_realisation_arrow_v<E> @c = @c true.  The
+ *          intended use is the @c realize_to_<primitive> family of arrows
  *          (#380): exact → primitive realisations whose contract includes
  *          a sentinel for out-of-range inputs (these arrows are total but
  *          @b not injective, so the plain @c → arrow rather than @c ↪
  *          is correct).
  */
 export template <typename E>
-concept IsTotalArrow = IsArrow<E> && is_total_arrow_v<E>;
+concept IsRealisationArrow = IsArrow<E> && is_realisation_arrow_v<E>;
 
 /**
  * @brief User-declared "Kleisli arrow" witness for an arrow type.

--- a/src/main/modules/dedekind/category/morphism.cppm
+++ b/src/main/modules/dedekind/category/morphism.cppm
@@ -1054,8 +1054,10 @@ static_assert(IsBijective<Identity<int>>,
 //                                                 @c std::optional / @c Maybe)
 //                                                       @c is_kleisli_arrow_v
 //
-// The total-injection slot is already covered above by @c is_monic_arrow_v
-// (and its companion @c is_epic_arrow_v).  This block adds the two
+// The total-injection slot is already covered above by
+// @c is_monic_arrow_v (epicity, @c is_epic_arrow_v, is the orthogonal
+// surjectivity property — companion in the categorical zoo, not part
+// of the total-injection class itself).  This block adds the two
 // missing slots so each class has its own opt-in trait + concept; the
 // audit / decorate sweep that pins concrete @c realize_to_* and
 // @c try_realize_to_* arrows to the right class is step 2 of #380.
@@ -1082,8 +1084,10 @@ inline constexpr bool is_total_arrow_v = false;
  *        sentinel.
  * @details Opt-in via @c is_total_arrow_v<E> @c = @c true.  The intended
  *          use is the @c realize_to_<primitive> family of arrows
- *          (#380): exact ↪ primitive realisations whose contract includes
- *          a sentinel for out-of-range inputs.
+ *          (#380): exact → primitive realisations whose contract includes
+ *          a sentinel for out-of-range inputs (these arrows are total but
+ *          @b not injective, so the plain @c → arrow rather than @c ↪
+ *          is correct).
  */
 export template <typename E>
 concept IsTotalArrow = IsArrow<E> && is_total_arrow_v<E>;
@@ -1091,10 +1095,15 @@ concept IsTotalArrow = IsArrow<E> && is_total_arrow_v<E>;
 /**
  * @brief User-declared "Kleisli arrow" witness for an arrow type.
  * @details A Kleisli arrow lives in the Kleisli category of a monad
- *          @c M: it has shape @c e: @c A @c → @c M<B>.  In the library
- *          today this is overwhelmingly @c M @c = @c std::optional /
- *          @c Maybe, used for partial realisations (e.g.,
- *          @c try_realize_to_size_t returning @c std::optional<size_t>).
+ *          @c M: it has shape @c e: @c A @c → @c M<B>.  The @c M slot
+ *          is the @b Kleisli @b hub @b tag of the monad in question
+ *          (@c maybe_hub_tag, @c box_hub_tag, etc.) — i.e.\ a tag
+ *          type that names which Kleisli category the arrow inhabits,
+ *          not the class template @c std::optional itself.  In the
+ *          library today partial realisations are the dominant
+ *          consumer (e.g., a @c try_realize_to_size_t returning
+ *          @c std::optional<size_t> would opt in via
+ *          @c is_kleisli_arrow_v<F, maybe_hub_tag> @c = @c true).
  *          Default @c false; opt-in by specialising to @c true at the
  *          @c (E, M) pair.
  *
@@ -1108,9 +1117,9 @@ inline constexpr bool is_kleisli_arrow_v = false;
 
 /**
  * @concept IsKleisliArrow
- * @brief An arrow declared to live in the Kleisli category of monad
- *        @c M.
- * @details Opt-in via @c is_kleisli_arrow_v<E, @c M> @c = @c true.
+ * @brief An arrow declared to live in the Kleisli category indexed by
+ *        the monad-hub tag @c M.
+ * @details Opt-in via @c is_kleisli_arrow_v<E, M> @c = @c true.
  */
 export template <typename E, typename M>
 concept IsKleisliArrow = IsArrow<E> && is_kleisli_arrow_v<E, M>;


### PR DESCRIPTION
## Summary

Step 1 of #380 (inter-carrier arrow naming convention): introduces the `is_kleisli_arrow_v<E, M>` trait variable + companion `IsKleisliArrow<E, M>` concept in `dedekind.category:kleisli`, where the composition / fmap / Kleisli-bind machinery already lives.

| Class | Trait | Home |
|---|---|---|
| (a)/(c) Total injection — `e: A ↣ B` | `is_monic_arrow_v` | `:morphism` (existing) |
| (b₁) Sentinel-realisation arrow | _deferred_ — "realization" isn't a Pierce-textbook term; will be declared in a downstream partition co-located with the actual `realize_to_*` arrows when step 2 audits them | — |
| (b₂) Kleisli partial — `e: A → T<B>` (with hub tag M) | `is_kleisli_arrow_v<E, M>` (new) | `:kleisli` |

## What's in the slice

- `is_kleisli_arrow_v<E, M>` (default `false`) + `IsKleisliArrow<E, M>` concept in `:kleisli`.
- `M` is constrained by `IsDefaultHubTag` (from `:natural`) — the type-checked connection between the trait and the codebase's hub-tag taxonomy (`maybe_hub_tag` / `box_hub_tag` / `identity_hub_tag`). Downstream code extends by adding new tags to the `IsDefaultHubTag` disjunction.
- Docs clarify the shape: `e: A → T<B>` where `T` is the monadic carrier shape selected by the hub tag `M` (e.g. `T = Maybe` for `M = maybe_hub_tag`). `M` itself is the tag, not the class template — addressing the previous Copilot inconsistency between "M is a tag" and "shape is A → M<B>".
- Opt-in witness skeleton `_kleisli_arrow_witness_380` demonstrates the end-to-end pattern step 2 will apply: declare a hand-rolled `Maybe`-shaped arrow → register `is_kleisli_arrow_v<E, maybe_hub_tag> = true` → recover `IsKleisliArrow<E, maybe_hub_tag>` at the use site. Static_asserts also pin per-`(E, M)` opt-in (the same arrow does NOT inhabit the `Box` Kleisli category).

## What's NOT in this slice

- No `is_total_arrow_v` and no realisation trait — the (b₁) realisation slot is deferred per review feedback (no Pierce-textbook anchor).
- No specialisations on real `try_realize_to_*` arrows yet — that audit / decorate sweep is step 2 of #380.

## Test plan

- [x] Local `_dedekind` builds clean
- [x] All 15 ctest targets green
- [x] Static_assert witnesses (per-`(E, M)` opt-in + per-tag rejection)
- [ ] CI build-and-deploy passes