### PR TITLE
feat(category, linear_algebra, sequences): `operator[]` / `operator->` categorical anchors

### DIFF
--- a/src/main/modules/dedekind/category/cartesian.cppm
+++ b/src/main/modules/dedekind/category/cartesian.cppm
@@ -918,4 +918,48 @@ static_assert(!IsEquivalenceRelation<std::equal_to<double>, double>,
               "equivalence on double must opt-in site-locally with a NaN-"
               "exclusion clause.");
 
+// ---------------------------------------------------------------------------
+// operator[] — eval / CCC counit (#531, step 1).
+//
+// A C++ subscript expression @c s[i] on a fixed-size carrier @c Seq
+// indexed by @c Idx is, in CCC vocabulary (Mac Lane @em CWM §IV.6;
+// Pierce @em TAPL §29), the @b evaluation @b map @c eval: @c Idx
+// @c × @c Seq @c → @c Codomain — the counit of the function-type
+// adjunction @c (- @c × @c A) @c ⊣ @c (-)^A.  Equivalently after
+// currying, @c s @c : @c Idx @c → @c Codomain in @b Set, with
+// @c s[i] @c = @c eval(i, @c s).
+//
+// The codebase reifies this in two layers (mirroring the
+// @c Has*Operators / strict-concept split elsewhere):
+//
+//   1. @c HasSubscriptOperator<Seq, @c Idx> — purely syntactic
+//      operator-surface predicate.
+//   2. @c IsEvalArrow<Seq, @c Idx> — opt-in, witnesses the CCC-counit
+//      reading at the carrier site via @c is_eval_arrow_v.
+// ---------------------------------------------------------------------------
+
+/** @concept HasSubscriptOperator
+ *  @brief Syntactic check: @c s[i] compiles for @c Seq, @c Idx.
+ */
+export template <typename Seq, typename Idx>
+concept HasSubscriptOperator = requires(Seq const& s, Idx i) {
+  { s[i] };
+};
+
+/** @brief @c is_eval_arrow_v<Seq, @c Idx>: opt-in marker that the
+ *         carrier's @c operator[] realises the CCC eval counit.
+ *         Default false; specialise to @c true at the carrier site
+ *         (@c FinitePath<T>, @c Vec2V<T>, …) when the
+ *         subscript-as-eval reading holds. */
+export template <typename Seq, typename Idx>
+inline constexpr bool is_eval_arrow_v = false;
+
+/** @concept IsEvalArrow
+ *  @brief @c Seq exposes @c operator[Idx] and the carrier site has
+ *         declared it as the CCC eval counit (Mac Lane CWM §IV.6).
+ */
+export template <typename Seq, typename Idx>
+concept IsEvalArrow =
+    HasSubscriptOperator<Seq, Idx> && is_eval_arrow_v<Seq, Idx>;
+
 }  // namespace dedekind::category

--- a/src/main/modules/dedekind/category/kleisli.cppm
+++ b/src/main/modules/dedekind/category/kleisli.cppm
@@ -388,9 +388,7 @@ concept HasComonadicExtendOperators =
  *  @brief Syntactic check: @c m.operator->() compiles for @c M.
  */
 export template <typename M>
-concept HasArrowDereferenceOperator = requires(M const& m) {
-  m.operator->();
-};
+concept HasArrowDereferenceOperator = requires(M const& m) { m.operator->(); };
 
 /** @brief @c is_kleisli_deref_v<M>: opt-in marker that the carrier's
  *         @c operator-> realises Kleisli dereference (for monadic

--- a/src/main/modules/dedekind/category/kleisli.cppm
+++ b/src/main/modules/dedekind/category/kleisli.cppm
@@ -360,4 +360,53 @@ concept HasComonadicExtendOperators =
       { wa << std::forward<F>(f) };
     };
 
+// ---------------------------------------------------------------------------
+// operator-> — Kleisli dereference / comonadic extract (#531, step 1).
+//
+// A C++ arrow-dereference expression @c m->member on a monadic /
+// comonadic carrier has two CT readings depending on the carrier
+// shape:
+//
+//   * @b Comonadic carrier (e.g. @c Box<T>, future smart-pointer-like
+//     comonads): @c m->member @c ≡ @c ε(m).member, where
+//     @c ε: @c W<A> @c → @c A is the comonadic @b extract (Mac Lane
+//     @em CWM §VI; Wadler 1992 @em Comprehending @em Monads).
+//   * @b Monadic carrier with partial dereference (e.g. @c Maybe<T>):
+//     @c m->member is Kleisli sugar — well-defined when the monadic
+//     value is "present", behaviour on absence is carrier-specific
+//     (UB / throw / sentinel).
+//
+// Both readings share the operator surface; the codebase reifies them
+// in the two-layer @c Has*Operators / strict-concept pattern:
+//
+//   1. @c HasArrowDereferenceOperator<M> — purely syntactic.
+//   2. @c IsKleisliDeref<M> — opt-in, witnesses the categorical
+//      reading at the carrier site via @c is_kleisli_deref_v.
+// ---------------------------------------------------------------------------
+
+/** @concept HasArrowDereferenceOperator
+ *  @brief Syntactic check: @c m.operator->() compiles for @c M.
+ */
+export template <typename M>
+concept HasArrowDereferenceOperator = requires(M const& m) {
+  m.operator->();
+};
+
+/** @brief @c is_kleisli_deref_v<M>: opt-in marker that the carrier's
+ *         @c operator-> realises Kleisli dereference (for monadic
+ *         carriers like @c Maybe<T>) or comonadic extract @c ε
+ *         (for comonadic carriers like @c Box<T>).  Default false;
+ *         specialise to @c true at the carrier site. */
+export template <typename M>
+inline constexpr bool is_kleisli_deref_v = false;
+
+/** @concept IsKleisliDeref
+ *  @brief @c M exposes @c operator-> and the carrier site has
+ *         declared it as Kleisli dereference / comonadic extract
+ *         (Mac Lane CWM §VI; Wadler 1992).
+ */
+export template <typename M>
+concept IsKleisliDeref =
+    HasArrowDereferenceOperator<M> && is_kleisli_deref_v<M>;
+
 }  // namespace dedekind::category

--- a/src/main/modules/dedekind/linear_algebra/mat2x2.cppm
+++ b/src/main/modules/dedekind/linear_algebra/mat2x2.cppm
@@ -491,17 +491,26 @@ struct Matrix2x2V {
 
   /** @brief Indexed projection: @c m[i] @c = @c row(i), so @c m[i][j]
    *         resolves to the textbook entry @c m_{ij} via the row's own
-   *         eval counit.  Categorical reading: the curried form of the
-   *         binary CCC eval @c eval: @c (T^2)^{2} @c × @c 2 @c × @c 2
-   *         @c → @c T at the matrix-shape carrier.  @c Idx is gated by
-   *         @c dedekind::order::IsDirectedSet — same algebraic
-   *         net-domain anchor as @c Vec2V::operator[].
+   *         eval counit.  Out-of-range @c i yields the zero row (same
+   *         semantics as @c row()).  Categorical reading: the curried
+   *         form of the binary CCC eval @c eval: @c (T^2)^{2} @c ×
+   *         @c 2 @c × @c 2 @c → @c T at the matrix-shape carrier.
+   *         @c Idx is gated by @c dedekind::order::IsDirectedSet — same
+   *         algebraic net-domain anchor as @c Vec2V::operator[].
+   *
+   *  @note The composed expression @c m[i][j] is safe as a value
+   *        expression: @c m[i] returns a @c Covec2V<T> by value, and
+   *        @c Covec2V::operator[] returns @c T by value (lifetime
+   *        extension applies to the prvalue chain).  Binding the
+   *        intermediate @c m[i] to a reference and *then* indexing
+   *        @c .operator[] is also safe (reference-bound temporary
+   *        lives for the full statement).
    */
   template <typename Idx>
     requires dedekind::order::IsDirectedSet<Idx> &&
-             std::convertible_to<Idx, bool>
+             std::convertible_to<Idx, std::size_t>
   constexpr row_type operator[](Idx const& i) const {
-    return static_cast<bool>(i) ? row(1) : row(0);
+    return row(static_cast<std::size_t>(i));
   }
 
   /** @brief Matrix transpose: reflect across the main diagonal. */
@@ -995,10 +1004,14 @@ static_assert(orth_R90 * col_e2 == -col_e1);
  */
 namespace dedekind::category {
 
-template <typename T>
+// Parametric in @c Idx, constrained to match @c Matrix2x2V::operator[]
+// exactly so the raw trait does not say @c true for indices the
+// carrier would refuse.
+template <typename T, typename Idx>
+  requires dedekind::order::IsDirectedSet<Idx> &&
+           std::convertible_to<Idx, std::size_t>
 inline constexpr bool
-    is_eval_arrow_v<dedekind::linear_algebra::Matrix2x2V<T>, std::size_t> =
-        true;
+    is_eval_arrow_v<dedekind::linear_algebra::Matrix2x2V<T>, Idx> = true;
 
 }  // namespace dedekind::category
 
@@ -1008,6 +1021,10 @@ static_assert(
     dedekind::category::IsEvalArrow<Matrix2x2V<unsigned int>, std::size_t>,
     "Matrix2x2V<T>::operator[] is the CCC eval counit at the row index "
     "(Mac Lane CWM §IV.6).");
+static_assert(
+    dedekind::category::IsEvalArrow<Matrix2x2V<unsigned int>, unsigned int>,
+    "Matrix2x2V<T>::operator[] accepts unsigned int as a net-domain index "
+    "(parametric Idx, gated by IsDirectedSet + convertible_to<size_t>).");
 
 namespace detail_op {
 inline constexpr Matrix2x2V<unsigned int> opm{1u, 2u, 3u, 4u};
@@ -1015,6 +1032,9 @@ static_assert(opm[0][0] == 1u, "m[0][0] = m11.");
 static_assert(opm[0][1] == 2u, "m[0][1] = m12.");
 static_assert(opm[1][0] == 3u, "m[1][0] = m21.");
 static_assert(opm[1][1] == 4u, "m[1][1] = m22.");
+// Out-of-range row: m[2] is the zero row (matches row(2) semantics).
+static_assert(opm[2u][0] == 0u, "m[2][0] = 0u (out-of-range row is zero).");
+static_assert(opm[2u][1] == 0u, "m[2][1] = 0u (out-of-range row is zero).");
 }  // namespace detail_op
 
 }  // namespace dedekind::linear_algebra

--- a/src/main/modules/dedekind/linear_algebra/mat2x2.cppm
+++ b/src/main/modules/dedekind/linear_algebra/mat2x2.cppm
@@ -74,11 +74,11 @@ export module dedekind.linear_algebra:mat2x2;
 import dedekind.algebra; // HasRingOperators, HasFieldOperators, HasVectorSpaceOperators
 import dedekind.category; // IsFunctor / Set / arrow (for matrix2x2_functor witness)
 import dedekind.numbers; // Rational<Z> for the ℚ carrier
-import dedekind.order;   // IsDirectedSet — algebraic gate on operator[] index domain (any net domain)
-import dedekind.sets;    // Finite cardinality tag (for dimension_type)
-import :basis;           // is_endomorphism_ring_v trait declaration
-import :contracts;       // matrix / vector / orientation concepts
-import :vec2;            // Vec2 (NTTP), Vec2V / Covec2V (value-level)
+import dedekind.order; // IsDirectedSet — algebraic gate on operator[] index domain (any net domain)
+import dedekind.sets; // Finite cardinality tag (for dimension_type)
+import :basis;        // is_endomorphism_ring_v trait declaration
+import :contracts;    // matrix / vector / orientation concepts
+import :vec2;         // Vec2 (NTTP), Vec2V / Covec2V (value-level)
 
 namespace dedekind::linear_algebra {
 
@@ -997,7 +997,8 @@ namespace dedekind::category {
 
 template <typename T>
 inline constexpr bool
-    is_eval_arrow_v<dedekind::linear_algebra::Matrix2x2V<T>, std::size_t> = true;
+    is_eval_arrow_v<dedekind::linear_algebra::Matrix2x2V<T>, std::size_t> =
+        true;
 
 }  // namespace dedekind::category
 

--- a/src/main/modules/dedekind/linear_algebra/mat2x2.cppm
+++ b/src/main/modules/dedekind/linear_algebra/mat2x2.cppm
@@ -1009,7 +1009,7 @@ namespace dedekind::category {
 // carrier would refuse.
 template <typename T, typename Idx>
   requires dedekind::order::IsDirectedSet<Idx> &&
-           std::convertible_to<Idx, std::size_t>
+               std::convertible_to<Idx, std::size_t>
 inline constexpr bool
     is_eval_arrow_v<dedekind::linear_algebra::Matrix2x2V<T>, Idx> = true;
 

--- a/src/main/modules/dedekind/linear_algebra/mat2x2.cppm
+++ b/src/main/modules/dedekind/linear_algebra/mat2x2.cppm
@@ -74,6 +74,7 @@ export module dedekind.linear_algebra:mat2x2;
 import dedekind.algebra; // HasRingOperators, HasFieldOperators, HasVectorSpaceOperators
 import dedekind.category; // IsFunctor / Set / arrow (for matrix2x2_functor witness)
 import dedekind.numbers; // Rational<Z> for the ℚ carrier
+import dedekind.order;   // IsDirectedSet — algebraic gate on operator[] index domain (any net domain)
 import dedekind.sets;    // Finite cardinality tag (for dimension_type)
 import :basis;           // is_endomorphism_ring_v trait declaration
 import :contracts;       // matrix / vector / orientation concepts
@@ -486,6 +487,21 @@ struct Matrix2x2V {
     if (i == 0) return {m11, m12};
     if (i == 1) return {m21, m22};
     return {};
+  }
+
+  /** @brief Indexed projection: @c m[i] @c = @c row(i), so @c m[i][j]
+   *         resolves to the textbook entry @c m_{ij} via the row's own
+   *         eval counit.  Categorical reading: the curried form of the
+   *         binary CCC eval @c eval: @c (T^2)^{2} @c × @c 2 @c × @c 2
+   *         @c → @c T at the matrix-shape carrier.  @c Idx is gated by
+   *         @c dedekind::order::IsDirectedSet — same algebraic
+   *         net-domain anchor as @c Vec2V::operator[].
+   */
+  template <typename Idx>
+    requires dedekind::order::IsDirectedSet<Idx> &&
+             std::convertible_to<Idx, bool>
+  constexpr row_type operator[](Idx const& i) const {
+    return static_cast<bool>(i) ? row(1) : row(0);
   }
 
   /** @brief Matrix transpose: reflect across the main diagonal. */
@@ -967,5 +983,37 @@ static_assert(orth_R90 * col_e1 == col_e2);
 static_assert(orth_R90 * col_e2 == -col_e1);
 
 }  // namespace detail
+
+}  // namespace dedekind::linear_algebra
+
+/** @section matrix__Categorical_Anchor_For_Subscript
+ *
+ *  Pin the @c category:cartesian opt-in marker (#531) on @c Matrix2x2V<T>:
+ *  the matrix subscript @c m[i] realises the CCC eval counit at the
+ *  outer index, with the row's own @c operator[] closing @c m[i][j] over
+ *  the inner index — together yielding the textbook entry @c m_{ij}.
+ */
+namespace dedekind::category {
+
+template <typename T>
+inline constexpr bool
+    is_eval_arrow_v<dedekind::linear_algebra::Matrix2x2V<T>, std::size_t> = true;
+
+}  // namespace dedekind::category
+
+namespace dedekind::linear_algebra {
+
+static_assert(
+    dedekind::category::IsEvalArrow<Matrix2x2V<unsigned int>, std::size_t>,
+    "Matrix2x2V<T>::operator[] is the CCC eval counit at the row index "
+    "(Mac Lane CWM §IV.6).");
+
+namespace detail_op {
+inline constexpr Matrix2x2V<unsigned int> opm{1u, 2u, 3u, 4u};
+static_assert(opm[0][0] == 1u, "m[0][0] = m11.");
+static_assert(opm[0][1] == 2u, "m[0][1] = m12.");
+static_assert(opm[1][0] == 3u, "m[1][0] = m21.");
+static_assert(opm[1][1] == 4u, "m[1][1] = m22.");
+}  // namespace detail_op
 
 }  // namespace dedekind::linear_algebra

--- a/src/main/modules/dedekind/linear_algebra/vec2.cppm
+++ b/src/main/modules/dedekind/linear_algebra/vec2.cppm
@@ -528,13 +528,13 @@ namespace dedekind::category {
 // @c true for @c Idx the carrier would refuse to instantiate.
 template <typename T, typename Idx>
   requires dedekind::order::IsDirectedSet<Idx> &&
-           std::convertible_to<Idx, std::size_t>
+               std::convertible_to<Idx, std::size_t>
 inline constexpr bool is_eval_arrow_v<dedekind::linear_algebra::Vec2V<T>, Idx> =
     true;
 
 template <typename T, typename Idx>
   requires dedekind::order::IsDirectedSet<Idx> &&
-           std::convertible_to<Idx, std::size_t>
+               std::convertible_to<Idx, std::size_t>
 inline constexpr bool
     is_eval_arrow_v<dedekind::linear_algebra::Covec2V<T>, Idx> = true;
 

--- a/src/main/modules/dedekind/linear_algebra/vec2.cppm
+++ b/src/main/modules/dedekind/linear_algebra/vec2.cppm
@@ -148,7 +148,11 @@ struct Vec2V {
     return {a.x * s, a.y * s};
   }
 
-  /** @brief Indexed projection: @c v[0] @c = @c v.x, @c v[1] @c = @c v.y.
+  /** @brief Indexed projection. Semantics match @c row()/@c column() in
+   *         the matrix family: @c i=0 returns @c x, @c i=1 returns @c y,
+   *         out-of-range returns @c T{} (the zero element).  Returned by
+   *         value to avoid the @c m[i][j]-style dangling-reference trap
+   *         when binding to a reference.
    *
    *  Categorical reading (Mac Lane CWM §IV.6): the subscript @c v[i] is
    *  the CCC eval counit @c ε: @c (T^2)^{2} @c × @c 2 @c → @c T applied
@@ -157,21 +161,21 @@ struct Vec2V {
    *  trait below pins the categorical reading at the carrier site.
    *
    *  @c Idx is gated by @c dedekind::order::IsDirectedSet — the
-   *  algebraic predicate that picks out @b net @b domains (cf.\
+   *  algebraic predicate that picks out @b net @b domains (compare
    *  @c sequences:net's @c IsNet, which requires
-   *  @c IsDirectedSet<typename N::Domain>).  This admits @c bool,
-   *  @c std::size_t / @c int / @c unsigned, @c ℕ, and any future
-   *  intensional cardinal as a valid index — keeping the eval surface
-   *  intensional in the index theory.  The bool-convertibility clause
-   *  picks the binary "first vs.\ rest" projection at this 2-cell
-   *  carrier; richer @c Idx types collapse to @c {0, ≠0} at the
-   *  carrier surface.
+   *  @c IsDirectedSet on @c N::Domain).  Conversion to
+   *  @c std::size_t names the index numerically and admits @c bool,
+   *  @c int, @c unsigned, @c std::size_t, @c ℕ, and any future
+   *  intensional cardinal that converts.
    */
   template <typename Idx>
     requires dedekind::order::IsDirectedSet<Idx> &&
-             std::convertible_to<Idx, bool>
-  constexpr T const& operator[](Idx const& i) const {
-    return static_cast<bool>(i) ? y : x;
+             std::convertible_to<Idx, std::size_t>
+  constexpr T operator[](Idx const& i) const {
+    const std::size_t s = static_cast<std::size_t>(i);
+    if (s == 0) return x;
+    if (s == 1) return y;
+    return T{};
   }
 
   /** @brief Named-pair view via @c operator->.
@@ -233,17 +237,18 @@ struct Covec2V {
     return {a.x * s, a.y * s};
   }
 
-  /** @brief Indexed projection: @c v[0] @c = @c v.x, @c v[1] @c = @c v.y.
-   *
-   *  Same CCC eval-counit reading and @c IsDirectedSet-gated
-   *  parametric @c Idx (any net domain) as @c Vec2V::operator[]; pinned
-   *  via @c is_eval_arrow_v below.
+  /** @brief Indexed projection.  Same row-style semantics as
+   *         @c Vec2V::operator[]: @c i=0 returns @c x, @c i=1 returns
+   *         @c y, out-of-range returns @c T{}.  Returned by value.
    */
   template <typename Idx>
     requires dedekind::order::IsDirectedSet<Idx> &&
-             std::convertible_to<Idx, bool>
-  constexpr T const& operator[](Idx const& i) const {
-    return static_cast<bool>(i) ? y : x;
+             std::convertible_to<Idx, std::size_t>
+  constexpr T operator[](Idx const& i) const {
+    const std::size_t s = static_cast<std::size_t>(i);
+    if (s == 0) return x;
+    if (s == 1) return y;
+    return T{};
   }
 
   /** @brief Transpose to the dual vector: row → column. */
@@ -515,16 +520,21 @@ static_assert(is_free_module_v<Covec2V<unsigned int>, unsigned int, 2>,
  */
 namespace dedekind::category {
 
-// Parametric in @c Idx: any net domain (any @c IsDirectedSet) that
-// satisfies the syntactic @c HasSubscriptOperator gate fires the
-// CCC-counit reading.  The double gate @c IsEvalArrow keeps the
-// surface honest for non-bool-convertible @c Idx where the carrier's
-// own template @c requires-clause refuses to instantiate.
+// Parametric in @c Idx, but constrained to match the carrier's
+// @c operator[] requires-clause exactly: any net domain that the
+// carrier actually accepts fires the CCC-counit reading.  Constraining
+// the partial spec (rather than letting the @c HasSubscriptOperator
+// concept gate alone) keeps the raw trait honest — it does not say
+// @c true for @c Idx the carrier would refuse to instantiate.
 template <typename T, typename Idx>
+  requires dedekind::order::IsDirectedSet<Idx> &&
+           std::convertible_to<Idx, std::size_t>
 inline constexpr bool is_eval_arrow_v<dedekind::linear_algebra::Vec2V<T>, Idx> =
     true;
 
 template <typename T, typename Idx>
+  requires dedekind::order::IsDirectedSet<Idx> &&
+           std::convertible_to<Idx, std::size_t>
 inline constexpr bool
     is_eval_arrow_v<dedekind::linear_algebra::Covec2V<T>, Idx> = true;
 

--- a/src/main/modules/dedekind/linear_algebra/vec2.cppm
+++ b/src/main/modules/dedekind/linear_algebra/vec2.cppm
@@ -58,10 +58,10 @@ export module dedekind.linear_algebra:vec2;
 
 import dedekind.algebra; // HasRingOperators, HasVectorSpaceOperators (upstream)
 import dedekind.category; // IsFunctor / Set / arrow (for vec2_functor witnesses)
-import dedekind.order;    // IsDirectedSet — algebraic gate on the operator[] index domain (any net domain works)
-import dedekind.sets; // Finite tag — the cardinal the tuple dimension lives in
-import :basis;        // is_free_module_v trait declaration
-import :contracts;    // ColumnOrientation, RowOrientation tags
+import dedekind.order; // IsDirectedSet — algebraic gate on the operator[] index domain (any net domain works)
+import dedekind.sets;  // Finite tag — the cardinal the tuple dimension lives in
+import :basis;         // is_free_module_v trait declaration
+import :contracts;     // ColumnOrientation, RowOrientation tags
 
 namespace dedekind::linear_algebra {
 
@@ -521,16 +521,16 @@ namespace dedekind::category {
 // surface honest for non-bool-convertible @c Idx where the carrier's
 // own template @c requires-clause refuses to instantiate.
 template <typename T, typename Idx>
-inline constexpr bool
-    is_eval_arrow_v<dedekind::linear_algebra::Vec2V<T>, Idx> = true;
+inline constexpr bool is_eval_arrow_v<dedekind::linear_algebra::Vec2V<T>, Idx> =
+    true;
 
 template <typename T, typename Idx>
 inline constexpr bool
     is_eval_arrow_v<dedekind::linear_algebra::Covec2V<T>, Idx> = true;
 
 template <typename T>
-inline constexpr bool
-    is_kleisli_deref_v<dedekind::linear_algebra::Vec2V<T>> = true;
+inline constexpr bool is_kleisli_deref_v<dedekind::linear_algebra::Vec2V<T>> =
+    true;
 
 }  // namespace dedekind::category
 
@@ -540,16 +540,14 @@ namespace dedekind::linear_algebra {
 // domains: @c bool (the binary directed set), @c unsigned @c int (the
 // canonical primitive carrier under modular @c IsRing), and @c int.
 // Future intensional @c ℕ slots in here without touching the carrier.
-static_assert(
-    dedekind::category::IsEvalArrow<Vec2V<unsigned int>, bool>,
-    "Vec2V<T>::operator[] accepts bool as a net-domain index.");
+static_assert(dedekind::category::IsEvalArrow<Vec2V<unsigned int>, bool>,
+              "Vec2V<T>::operator[] accepts bool as a net-domain index.");
 static_assert(
     dedekind::category::IsEvalArrow<Vec2V<unsigned int>, unsigned int>,
     "Vec2V<T>::operator[] is the CCC eval counit (Mac Lane CWM §IV.6); "
     "Idx is gated algebraically by IsDirectedSet.");
-static_assert(
-    dedekind::category::IsEvalArrow<Vec2V<unsigned int>, int>,
-    "Vec2V<T>::operator[] accepts int as a net-domain index.");
+static_assert(dedekind::category::IsEvalArrow<Vec2V<unsigned int>, int>,
+              "Vec2V<T>::operator[] accepts int as a net-domain index.");
 static_assert(
     dedekind::category::IsEvalArrow<Covec2V<unsigned int>, unsigned int>,
     "Covec2V<T>::operator[] is the CCC eval counit (row-vector dual).");

--- a/src/main/modules/dedekind/linear_algebra/vec2.cppm
+++ b/src/main/modules/dedekind/linear_algebra/vec2.cppm
@@ -58,6 +58,7 @@ export module dedekind.linear_algebra:vec2;
 
 import dedekind.algebra; // HasRingOperators, HasVectorSpaceOperators (upstream)
 import dedekind.category; // IsFunctor / Set / arrow (for vec2_functor witnesses)
+import dedekind.order;    // IsDirectedSet — algebraic gate on the operator[] index domain (any net domain works)
 import dedekind.sets; // Finite tag — the cardinal the tuple dimension lives in
 import :basis;        // is_free_module_v trait declaration
 import :contracts;    // ColumnOrientation, RowOrientation tags
@@ -147,6 +148,49 @@ struct Vec2V {
     return {a.x * s, a.y * s};
   }
 
+  /** @brief Indexed projection: @c v[0] @c = @c v.x, @c v[1] @c = @c v.y.
+   *
+   *  Categorical reading (Mac Lane CWM §IV.6): the subscript @c v[i] is
+   *  the CCC eval counit @c ε: @c (T^2)^{2} @c × @c 2 @c → @c T applied
+   *  to @c (v, @c i).  Equivalently the curried form @c v: @c 2 @c → @c T
+   *  in @b Set, with @c v[i] @c = @c eval(v, @c i).  The @c is_eval_arrow_v
+   *  trait below pins the categorical reading at the carrier site.
+   *
+   *  @c Idx is gated by @c dedekind::order::IsDirectedSet — the
+   *  algebraic predicate that picks out @b net @b domains (cf.\
+   *  @c sequences:net's @c IsNet, which requires
+   *  @c IsDirectedSet<typename N::Domain>).  This admits @c bool,
+   *  @c std::size_t / @c int / @c unsigned, @c ℕ, and any future
+   *  intensional cardinal as a valid index — keeping the eval surface
+   *  intensional in the index theory.  The bool-convertibility clause
+   *  picks the binary "first vs.\ rest" projection at this 2-cell
+   *  carrier; richer @c Idx types collapse to @c {0, ≠0} at the
+   *  carrier surface.
+   */
+  template <typename Idx>
+    requires dedekind::order::IsDirectedSet<Idx> &&
+             std::convertible_to<Idx, bool>
+  constexpr T const& operator[](Idx const& i) const {
+    return static_cast<bool>(i) ? y : x;
+  }
+
+  /** @brief Named-pair view via @c operator->.
+   *
+   *  Returns a proxy whose members @c _1 / @c fst alias @c x and @c _2 /
+   *  @c snd alias @c y.  Mirrors the textbook left/right projection of
+   *  the homogeneous pair @c T² and the Pierce-style first/second tuple
+   *  destructors.  Categorical reading: @c v->_1 reads as the comonadic
+   *  extract on the canonical first projection (Wadler 1992).
+   */
+  struct ArrowView {
+    T const& _1;
+    T const& _2;
+    T const& fst;
+    T const& snd;
+    constexpr ArrowView const* operator->() const { return this; }
+  };
+  constexpr ArrowView operator->() const { return ArrowView{x, y, x, y}; }
+
   /** @brief Transpose to the dual covector: column → row. */
   constexpr Covec2V<T> transpose() const;
 };
@@ -187,6 +231,19 @@ struct Covec2V {
   }
   friend constexpr Covec2V operator*(const Covec2V& a, const T& s) {
     return {a.x * s, a.y * s};
+  }
+
+  /** @brief Indexed projection: @c v[0] @c = @c v.x, @c v[1] @c = @c v.y.
+   *
+   *  Same CCC eval-counit reading and @c IsDirectedSet-gated
+   *  parametric @c Idx (any net domain) as @c Vec2V::operator[]; pinned
+   *  via @c is_eval_arrow_v below.
+   */
+  template <typename Idx>
+    requires dedekind::order::IsDirectedSet<Idx> &&
+             std::convertible_to<Idx, bool>
+  constexpr T const& operator[](Idx const& i) const {
+    return static_cast<bool>(i) ? y : x;
   }
 
   /** @brief Transpose to the dual vector: row → column. */
@@ -445,5 +502,78 @@ static_assert(is_free_module_v<Vec2V<unsigned int>, unsigned int, 2>,
 static_assert(is_free_module_v<Covec2V<unsigned int>, unsigned int, 2>,
               "Covec2V<T> is a free T-module of rank 2 (the row-vector "
               "dual to Vec2V<T>).");
+
+}  // namespace dedekind::linear_algebra
+
+/** @section vec2__Categorical_Anchors_For_Operators
+ *
+ *  Pin the @c category:cartesian / @c category:kleisli opt-in markers
+ *  (#531) on the homogeneous-pair carriers: @c Vec2V<T> and @c Covec2V<T>
+ *  realise the CCC eval counit through @c operator[]; @c Vec2V<T> also
+ *  realises comonadic extract @c ε through @c operator-> via the
+ *  @c ArrowView proxy (first / second projection of the pair).
+ */
+namespace dedekind::category {
+
+// Parametric in @c Idx: any net domain (any @c IsDirectedSet) that
+// satisfies the syntactic @c HasSubscriptOperator gate fires the
+// CCC-counit reading.  The double gate @c IsEvalArrow keeps the
+// surface honest for non-bool-convertible @c Idx where the carrier's
+// own template @c requires-clause refuses to instantiate.
+template <typename T, typename Idx>
+inline constexpr bool
+    is_eval_arrow_v<dedekind::linear_algebra::Vec2V<T>, Idx> = true;
+
+template <typename T, typename Idx>
+inline constexpr bool
+    is_eval_arrow_v<dedekind::linear_algebra::Covec2V<T>, Idx> = true;
+
+template <typename T>
+inline constexpr bool
+    is_kleisli_deref_v<dedekind::linear_algebra::Vec2V<T>> = true;
+
+}  // namespace dedekind::category
+
+namespace dedekind::linear_algebra {
+
+// Witness the CCC eval-counit reading across multiple algebraic net
+// domains: @c bool (the binary directed set), @c unsigned @c int (the
+// canonical primitive carrier under modular @c IsRing), and @c int.
+// Future intensional @c ℕ slots in here without touching the carrier.
+static_assert(
+    dedekind::category::IsEvalArrow<Vec2V<unsigned int>, bool>,
+    "Vec2V<T>::operator[] accepts bool as a net-domain index.");
+static_assert(
+    dedekind::category::IsEvalArrow<Vec2V<unsigned int>, unsigned int>,
+    "Vec2V<T>::operator[] is the CCC eval counit (Mac Lane CWM §IV.6); "
+    "Idx is gated algebraically by IsDirectedSet.");
+static_assert(
+    dedekind::category::IsEvalArrow<Vec2V<unsigned int>, int>,
+    "Vec2V<T>::operator[] accepts int as a net-domain index.");
+static_assert(
+    dedekind::category::IsEvalArrow<Covec2V<unsigned int>, unsigned int>,
+    "Covec2V<T>::operator[] is the CCC eval counit (row-vector dual).");
+static_assert(
+    dedekind::category::IsKleisliDeref<Vec2V<unsigned int>>,
+    "Vec2V<T>::operator-> realises comonadic extract on the homogeneous "
+    "pair (first / second projection via the ArrowView proxy; "
+    "Wadler 1992).");
+
+// Value-level witnesses for the operator surface.
+namespace detail_op {
+inline constexpr Vec2V<unsigned int> opv{3u, 7u};
+static_assert(opv[0u] == 3u, "Vec2V::operator[](0u) returns x.");
+static_assert(opv[1u] == 7u, "Vec2V::operator[](1u) returns y.");
+static_assert(opv[false] == 3u, "Vec2V::operator[](false) returns x.");
+static_assert(opv[true] == 7u, "Vec2V::operator[](true) returns y.");
+static_assert(opv->_1 == 3u, "Vec2V::operator->::_1 is the first projection.");
+static_assert(opv->_2 == 7u, "Vec2V::operator->::_2 is the second projection.");
+static_assert(opv->fst == 3u, "Vec2V::operator->::fst aliases _1.");
+static_assert(opv->snd == 7u, "Vec2V::operator->::snd aliases _2.");
+
+inline constexpr Covec2V<unsigned int> opcv{4u, 9u};
+static_assert(opcv[0u] == 4u, "Covec2V::operator[](0u) returns x.");
+static_assert(opcv[1u] == 9u, "Covec2V::operator[](1u) returns y.");
+}  // namespace detail_op
 
 }  // namespace dedekind::linear_algebra

--- a/src/main/modules/dedekind/numbers/uint.cppm
+++ b/src/main/modules/dedekind/numbers/uint.cppm
@@ -256,6 +256,11 @@ static_assert(dedekind::order::IsTotallyOrdered<unsigned int>,
               "unsigned int is axiomatically totally ordered.");
 static_assert(dedekind::order::IsDirectedSet<unsigned int>,
               "unsigned int is a directed set (net domain).");
+static_assert(dedekind::order::IsDirectedSet<unsigned long>,
+              "unsigned long is a directed set (net domain).");
+static_assert(dedekind::order::IsDirectedSet<std::size_t>,
+              "std::size_t is a directed set (net domain) — anchors the "
+              "default C++ subscript Idx as a bona fide algebraic index.");
 
 // Bitwise / lattice operator surface — std::unsigned_integral carries
 // the four bitwise operators, satisfying the syntactic-shape concept

--- a/src/main/modules/dedekind/sequences/path.cppm
+++ b/src/main/modules/dedekind/sequences/path.cppm
@@ -607,6 +607,25 @@ static_assert(
     std::input_iterator<decltype(std::declval<FinitePath<int>>().begin())>,
     "FinitePath<T>::begin() must yield a std::input_iterator.");
 
+// Juliet-posture witness (#531): the @c std::ranges API produces bona
+// fide library sequences via the @c from_range adapter — every
+// @c std::ranges::input_range round-trips into @c FinitePath<T>, i.e.\
+// into the @c IsFiniteSequence concept.  The intensional / lazy
+// std::ranges surface is anchored in the library's sequence layer at
+// the type level; the actual conversion is runtime, but the conceptual
+// commitment is decidable as a @c static_assert.
+static_assert(
+    IsFiniteSequence<decltype(from_range(std::declval<std::vector<int>>()))>,
+    "from_range over a std::ranges::input_range produces a FinitePath, "
+    "a bona fide IsFiniteSequence — anchors std::ranges output in the "
+    "library's sequence concept hierarchy (Juliet posture).");
+static_assert(
+    IsFiniteSequence<
+        decltype(from_range(std::declval<std::ranges::iota_view<int, int>>()))>,
+    "from_range over a std::ranges::iota_view (the lazy / intensional "
+    "view) produces a FinitePath, lifting the std::views::iota surface "
+    "into the library's sequence layer (Juliet posture).");
+
 static_assert(IsKleisliExtension<path_functor<int>, int, long>,
               "Path must satisfy the Kleisli extension witness.");
 

--- a/src/main/modules/dedekind/sequences/path.cppm
+++ b/src/main/modules/dedekind/sequences/path.cppm
@@ -608,12 +608,15 @@ static_assert(
     "FinitePath<T>::begin() must yield a std::input_iterator.");
 
 // Juliet-posture witness (#531): the @c std::ranges API produces bona
-// fide library sequences via the @c from_range adapter — every
-// @c std::ranges::input_range round-trips into @c FinitePath<T>, i.e.\
-// into the @c IsFiniteSequence concept.  The intensional / lazy
-// std::ranges surface is anchored in the library's sequence layer at
-// the type level; the actual conversion is runtime, but the conceptual
-// commitment is decidable as a @c static_assert.
+// fide library sequences via the @c from_range adapter — any
+// @b finite @c std::ranges::input_range round-trips (when iterated to
+// completion) into @c FinitePath<T>, i.e. into the
+// @c IsFiniteSequence concept.  The intensional / lazy std::ranges
+// surface is anchored in the library's sequence layer at the type
+// level.  The static_asserts below decide the type-level commitment;
+// the actual materialisation of an infinite range would not terminate
+// at runtime — the witness is about the @em type carrying the
+// sequence concept, not about iterating arbitrary ranges.
 static_assert(
     IsFiniteSequence<decltype(from_range(std::declval<std::vector<int>>()))>,
     "from_range over a std::ranges::input_range produces a FinitePath, "


### PR DESCRIPTION
## Summary

First slice of #531 — categorical anchoring of the C++ subscript and arrow-dereference operators, plus concrete carrier instantiations on the homogeneous-pair / matrix family and a Juliet-posture witness on the `std::ranges` adapter.

### Scaffolding (category partition)

- `category:cartesian`: `HasSubscriptOperator<Seq, Idx>`, `is_eval_arrow_v<Seq, Idx>` (default false), `IsEvalArrow<Seq, Idx>` — pins the operator-`[]` reading as the CCC eval counit (Mac Lane CWM §IV.6; Pierce TAPL §29).
- `category:kleisli`: `HasArrowDereferenceOperator<M>`, `is_kleisli_deref_v<M>`, `IsKleisliDeref<M>` — pins the operator-`->` reading as Kleisli dereference / comonadic extract ε (Mac Lane CWM §VI; Wadler 1992).

Two-layer reification matching the codebase's `Has*Operators` / strict-concept split: syntactic gate first, opt-in algebraic claim second.

### Concrete carriers (linear_algebra partition)

- `Vec2V<T>::operator[](Idx)` — CCC eval counit, with Idx gated by `dedekind::order::IsDirectedSet` (any net domain: bool / int / unsigned / size_t / future ℕ) and `convertible_to<size_t>`. Same gate on `Covec2V<T>` and `Matrix2x2V<T>`. Semantics match `row()`/`column()`: `i=0` returns first cell, `i=1` returns second, out-of-range returns `T{}`. Returned by value to avoid the `m[i][j]` dangling-reference trap.
- `Vec2V<T>::operator->()` — comonadic extract via an `ArrowView` proxy with members `_1` / `_2` / `fst` / `snd` (first / second projection of the homogeneous pair).
- Parametric `is_eval_arrow_v` / `is_kleisli_deref_v` registrations carry the same constraints as `operator[]` (so the raw trait does not say `true` for indices the carrier would refuse). `IsEvalArrow` / `IsKleisliDeref` witnesses across multiple Idx types (bool, unsigned, int, size_t).

### Algebraic anchor (numbers partition)

- `IsDirectedSet<std::size_t>` static_assert in `numbers/uint.cppm` — anchors the default C++ subscript Idx as a bona fide net domain in our books, alongside the existing `unsigned int` / `unsigned long` witnesses.

### Juliet-posture witness (sequences partition)

- `from_range` over `std::vector<int>` and `std::ranges::iota_view<int, int>` produces `IsFiniteSequence` — anchors the lazy / intensional `std::ranges` API in the library's sequence concept hierarchy. The conceptual commitment is decidable as a `static_assert`; the actual conversion is runtime, and infinite ranges would not terminate when iterated to completion (the witness is about the *type* carrying the sequence concept).

### Follow-up: type-level dimensions

The current contract for out-of-range `Vec2V[i]` / `Matrix2x2V[i][j]` is a runtime fallback to `T{}` (matching the existing `row()`/`column()` semantics). The cleaner endgame is to lift matrix dimensions to halfspace bounds on ℕ so that out-of-range becomes a *type-level* failure. Tracked in #372, which I extended with a halfspace-on-ℕ framing as the natural sequel to this PR's parametric `operator[](Idx)`.

## Test plan

- [x] Local `_dedekind` builds clean
- [x] All 15 ctest targets green
- [x] Static_asserts: per-(Idx) acceptance + out-of-range zero contract on `Matrix2x2V[2u][...]`
- [ ] CI build-and-deploy pipeline green
- [ ] CodeQL passes
