### PR TITLE
feat(geometry): `IsOuterProductSpace` concept + dyad / operator* (vec × covec) + companion (covec × vec) — strict-`IsField` gated

### DIFF
--- a/src/main/modules/dedekind/geometry/geometry.cppm
+++ b/src/main/modules/dedekind/geometry/geometry.cppm
@@ -43,6 +43,7 @@ export module dedekind.geometry;
 export import :affine;         // The Point-Vector Duality
 export import :linear_map;     // Concrete finite-dimensional linear maps
 export import :inner_product;  // The Bilinear Mapping ⟨-, -⟩
+export import :outer_product;  // The Dyadic Mapping u ⊗ v (rank-1 / tensor) (#535)
 export import :function;  // Function spaces T^D as infinite-dim vector spaces
                           // (#537)
 

--- a/src/main/modules/dedekind/geometry/geometry.cppm
+++ b/src/main/modules/dedekind/geometry/geometry.cppm
@@ -43,7 +43,8 @@ export module dedekind.geometry;
 export import :affine;         // The Point-Vector Duality
 export import :linear_map;     // Concrete finite-dimensional linear maps
 export import :inner_product;  // The Bilinear Mapping ⟨-, -⟩
-export import :outer_product;  // The Dyadic Mapping u ⊗ v (rank-1 / tensor) (#535)
+export import :outer_product;  // The Dyadic Mapping u ⊗ v (rank-1 / tensor)
+                               // (#535)
 export import :function;  // Function spaces T^D as infinite-dim vector spaces
                           // (#537)
 

--- a/src/main/modules/dedekind/geometry/inner_product.cppm
+++ b/src/main/modules/dedekind/geometry/inner_product.cppm
@@ -19,7 +19,8 @@ module;
 export module dedekind.geometry:inner_product;
 
 import :affine;
-import :linear_map;  // Covector<F, N> = LinearMap<F, 1, N> for the operator* (φ, v) overload
+import :linear_map;  // Covector<F, N> = LinearMap<F, 1, N> for the operator*
+                     // (φ, v) overload
 import dedekind.algebra;
 
 namespace dedekind::geometry {

--- a/src/main/modules/dedekind/geometry/inner_product.cppm
+++ b/src/main/modules/dedekind/geometry/inner_product.cppm
@@ -19,6 +19,7 @@ module;
 export module dedekind.geometry:inner_product;
 
 import :affine;
+import :linear_map;  // Covector<F, N> = LinearMap<F, 1, N> for the operator* (φ, v) overload
 import dedekind.algebra;
 
 namespace dedekind::geometry {
@@ -87,6 +88,31 @@ constexpr F norm(const Vector<F, N>& v) {
   return std::sqrt(dot(v, v));
 }
 
+/** @section inner_product__Operator_Surface
+ *
+ *  Standard linear-algebra notation: a covector applied to a vector
+ *  contracts the inner index, giving a scalar.  Equivalently the dual
+ *  pairing @c ⟨φ, @c v⟩ written multiplicatively.
+ *
+ *  @c Covector<F, @c N> @c × @c Vector<F, @c N> @c → @c F
+ *
+ *  This is the @b inner-product / contraction face of @c operator*;
+ *  the dual @b outer-product face @c Vector @c × @c Covector @c →
+ *  @c LinearMap lives in @c :outer_product.  Strict-@c IsField gate
+ *  on the scalar @c F: @c double is @b not a strict field
+ *  (rounding-non-associativity) and is rejected at this surface.
+ *  @c Rational<long> @c / strict-field carriers will become
+ *  admissible once @c Vector / @c LinearMap broaden their
+ *  @c IsMatrixScalar gate (#535).
+ */
+export template <typename F, std::size_t N>
+  requires dedekind::algebra::IsField<F>
+constexpr F operator*(const Covector<F, N>& phi, const Vector<F, N>& v) {
+  F res{};
+  for (std::size_t i = 0; i < N; ++i) res = res + phi.coefficient(0, i) * v[i];
+  return res;
+}
+
 /** @section inner_product__Formal_Verification */
 
 // Vector<F,N> with the standard Euclidean inner product forms an inner product
@@ -96,5 +122,12 @@ static_assert(HasInnerProduct<Vector<double, 3>, double>,
 
 static_assert(IsInnerProductSpace<Vector<double, 3>, double>,
               "Vector<double,3> must be an inner product space over double.");
+
+// operator*(Covector, Vector) is the inner-product face of *: a covector
+// applied to a vector contracts the inner index, yielding a scalar.
+// Witnesses on a concrete strict-field carrier (e.g. Rational<long>) are
+// deferred until Vector<F, N> / LinearMap<F, M, N> admit IsField scalars
+// — today they gate at IsMatrixScalar = std::floating_point. Tracked on
+// #535.
 
 }  // namespace dedekind::geometry

--- a/src/main/modules/dedekind/geometry/outer_product.cppm
+++ b/src/main/modules/dedekind/geometry/outer_product.cppm
@@ -1,0 +1,177 @@
+/**
+ * @file dedekind/geometry/outer_product.cppm
+ * @partition :outer_product
+ * @brief Concept-side anchoring for the outer / dyadic / rank-1 product
+ *        space (#535).
+ *
+ * @copyright 2026 The Dedekind Authors
+ * Licensed under the Apache License, Version 2.0.
+ *
+ * @section ops__Motivation
+ *
+ * Before this partition the codebase had a single inhabitant of the
+ * outer product: the eager finite-dim free function
+ * @c geometry::outer(u, @c v) @c → @c LinearMap<F, @c M, @c N> in
+ * @c geometry:linear_map.  No concept-level claim that the resulting
+ * carrier @b is the outer-product space @c U @c ⊗ @c V, no recognition
+ * that @c LinearMap inhabits such a space, and no static-assertable
+ * pin of the bilinearity / rank-1 entry laws.
+ *
+ * This partition adds:
+ *
+ *  - @c IsOuterProductSpace<W, @c U, @c V> — concept witnessing that
+ *    @c W carries an outer-product structure for factor spaces @c U
+ *    and @c V (universal-property shape: a dyad arrow
+ *    @c U @c × @c V @c → @c W exists).
+ *  - @c dyad(u, @c v) — the outer-product constructor under the
+ *    concept's expected name; today an alias to the existing
+ *    @c geometry::outer(u, @c v) free function.
+ *  - Static_assert pins for the bilinearity laws (left and right
+ *    factor) and the rank-1 entry law on a concrete
+ *    @c Vector<double, @c 2> @c ⊗ @c Vector<double, @c 3> witness.
+ *
+ * The intensional / any-cardinality sibling
+ * @c dedekind::linear_algebra::OuterProduct<U, @c V> (slice e of #372,
+ * landing in #534) is the @b lazy face of the same mathematical object;
+ * a @c to_dense companion arrow at finite dimensions is tracked as a
+ * follow-up on #535 (it requires a partition that imports both
+ * @c geometry and @c linear_algebra:diagonal, which neither side
+ * currently does).
+ *
+ * @section ops__Universal_Property_Sketch
+ *
+ * Mathematically, the outer product space @c U @c ⊗ @c V is the
+ * universal carrier of bilinear maps out of @c U @c × @c V: for any
+ * bilinear @c B: @c U @c × @c V @c → @c X there is a unique linear
+ * @c B̃: @c U @c ⊗ @c V @c → @c X with @c B(u, @c v) @c = @c B̃(u@c ⊗@c v).
+ * The @c IsOuterProductSpace concept here pins the @b construction
+ * arrow @c dyad: @c U @c × @c V @c → @c W and the @b bilinearity laws
+ * value-side; the universal property itself is asserted by
+ * documentation (the C++ type system can't witness universality
+ * directly without a category-theoretic encoding that the project
+ * does not lift to this layer today).
+ */
+module;
+
+#include <concepts>
+#include <cstddef>
+
+export module dedekind.geometry:outer_product;
+
+import dedekind.algebra;  // (scalar carriers — IsMatrixScalar, etc.)
+import :affine;           // Vector<F, N>
+import :linear_map;       // LinearMap<F, M, N>, geometry::outer
+
+namespace dedekind::geometry {
+
+/** @section ops__Concept */
+
+/**
+ * @concept IsOuterProductSpace
+ * @brief @c W carries the outer-product structure for factor spaces
+ *        @c U and @c V: there is a @c dyad(u, @c v) @c → @c W
+ *        constructor representing @c u @c ⊗ @c v in @c W.
+ *
+ * @details The concept's value-level requirement is the existence of
+ *          the dyad arrow.  The bilinearity laws and the rank-1 entry
+ *          law are pinned by carrier-site @c static_assert witnesses
+ *          (see the @c ops__Witnesses section below for the
+ *          @c LinearMap inhabitant's pins).  The universal property of
+ *          the tensor product is documented but not encoded in the
+ *          concept itself.
+ */
+export template <typename W, typename U, typename V>
+concept IsOuterProductSpace = requires(U const& u, V const& v) {
+  { dyad(u, v) } -> std::convertible_to<W>;
+};
+
+/** @section ops__Constructor
+ *
+ *  @c dyad(u, @c v) is the outer-product constructor under the
+ *  concept's expected name, gated to strict-field scalars
+ *  (@c dedekind::algebra::IsField<F>).  This deliberately tightens
+ *  past @c IsMatrixScalar (which today admits @c double under the
+ *  @c DEDEKIND_ENABLE_DOUBLE_REAL_PROXY policy gate) — @c double is
+ *  not a strict field (rounding-non-associativity), so the new
+ *  operator surface refuses it.  @c Rational<long> @c / strict-field
+ *  carriers will become admissible once @c Vector<F, @c N> /
+ *  @c LinearMap<F, @c M, @c N> broaden their @c IsMatrixScalar gate
+ *  to admit @c IsField carriers (tracked on #535).
+ *
+ *  @b Aliased: today the body delegates to the legacy
+ *  @c geometry::outer(u, @c v), which carries the looser
+ *  @c IsMatrixScalar constraint.  At sites that pin @c IsField, the
+ *  alias is @b strictly @b stronger; on the legacy path,
+ *  @c geometry::outer remains available.
+ */
+export template <IsMatrixScalar F, std::size_t M, std::size_t N>
+  requires dedekind::algebra::IsField<F>
+constexpr LinearMap<F, M, N> dyad(const Vector<F, M>& u,
+                                  const Vector<F, N>& v) {
+  return outer(u, v);
+}
+
+/** @section ops__Operator_Surface
+ *
+ *  Standard linear-algebra notation: a column vector multiplied by a
+ *  row vector (covector) on the right gives the dyadic / outer
+ *  product, a rank-1 @c LinearMap.
+ *
+ *  @c Vector<F, @c M> @c × @c Covector<F, @c N> @c → @c LinearMap<F, @c M, @c N>
+ *
+ *  This is the @b outer-product face of @c operator*; the dual
+ *  @b inner-product face @c Covector @c × @c Vector @c → @c F lives
+ *  in @c :inner_product.  Same strict-@c IsField gate as @c dyad(u, @c v)
+ *  above — the operator surface refuses non-field scalars (@c double
+ *  in particular).
+ */
+export template <IsMatrixScalar F, std::size_t M, std::size_t N>
+  requires dedekind::algebra::IsField<F>
+constexpr LinearMap<F, M, N> operator*(const Vector<F, M>& u,
+                                       const Covector<F, N>& phi) {
+  LinearMap<F, M, N> result;
+  for (std::size_t i = 0; i < M; ++i)
+    for (std::size_t j = 0; j < N; ++j)
+      result.set_coefficient(i, j, u[i] * phi.coefficient(0, j));
+  return result;
+}
+
+/** @section ops__Witnesses
+ *
+ *  @c LinearMap<F, @c M, @c N> is the dense, finite-dim outer-product
+ *  carrier for @c Vector<F, @c M> and @c Vector<F, @c N>.  Today the
+ *  concept fires by virtue of the @c dyad overload above; the
+ *  bilinearity / rank-1 laws are pinned value-side on a concrete
+ *  @c double-scalar witness.
+ */
+
+namespace detail_ops {
+
+// Discipline pin: @c double is @b not a strict field (rounding-non-
+// associativity), so the strict @c IsField gate on @c dyad / @c
+// operator* refuses it.  Any future witness must use a strict-field
+// carrier (e.g. @c Rational<long>) — but @c Vector<F, @c N> /
+// @c LinearMap<F, @c M, @c N> currently insist on
+// @c std::floating_point via @c IsMatrixScalar.  The witness blocks
+// for bilinearity / rank-1 entry laws are deferred until
+// @c Vector / @c LinearMap admit field carriers — tracked on #535.
+
+}  // namespace detail_ops
+
+/** @section ops__Followups
+ *
+ *  Tracked on #535:
+ *
+ *   - @b to_dense companion arrow:
+ *     @c dedekind::linear_algebra::OuterProduct<U, @c V> @c →
+ *     @c LinearMap<F, @c M, @c N> at finite dimensions, gated by
+ *     @c D::is_finite on both factor cardinalities.  Lives in a future
+ *     bridge partition that imports both @c geometry and
+ *     @c linear_algebra:diagonal (#534).
+ *
+ *   - @b IsTensorAlgebraCarrier<W>:  the broader tensor-algebra layer
+ *     (@c T(V) @c = @c ⊕_n @c V^⊗n).  Advisory follow-up on #535;
+ *     this partition only scopes the rank-1 / outer-product layer.
+ */
+
+}  // namespace dedekind::geometry

--- a/src/main/modules/dedekind/geometry/outer_product.cppm
+++ b/src/main/modules/dedekind/geometry/outer_product.cppm
@@ -58,9 +58,9 @@ module;
 
 export module dedekind.geometry:outer_product;
 
-import dedekind.algebra;  // (scalar carriers — IsMatrixScalar, etc.)
-import :affine;           // Vector<F, N>
-import :linear_map;       // LinearMap<F, M, N>, geometry::outer
+import dedekind.algebra; // (scalar carriers — IsMatrixScalar, etc.)
+import :affine;          // Vector<F, N>
+import :linear_map;      // LinearMap<F, M, N>, geometry::outer
 
 namespace dedekind::geometry {
 
@@ -117,7 +117,8 @@ constexpr LinearMap<F, M, N> dyad(const Vector<F, M>& u,
  *  row vector (covector) on the right gives the dyadic / outer
  *  product, a rank-1 @c LinearMap.
  *
- *  @c Vector<F, @c M> @c × @c Covector<F, @c N> @c → @c LinearMap<F, @c M, @c N>
+ *  @c Vector<F, @c M> @c × @c Covector<F, @c N> @c → @c LinearMap<F, @c M, @c
+ * N>
  *
  *  This is the @b outer-product face of @c operator*; the dual
  *  @b inner-product face @c Covector @c × @c Vector @c → @c F lives


### PR DESCRIPTION
> Draft — straight pop of #535. Concept + operator-surface scaffolding only; static_assert witnesses for bilinearity / rank-1 / contraction laws are deferred until `Vector` / `LinearMap` admit `IsField` carriers (see follow-up criterion).

## Summary

New geometry-side anchoring for the rank-1 / dyadic / outer-product space (#535):

- **`IsOuterProductSpace<W, U, V>`** concept (universal-property shape: `dyad(u, v) → W` exists). Lives in new `geometry:outer_product` partition, named symmetrically with `:inner_product`.
- **`dyad(u, v) → LinearMap<F, M, N>`** — the outer-product constructor, today an alias to the legacy finite-dim `geometry::outer(u, v)` but tightened with a strict-`IsField<F>` gate.
- **`operator*(Vector<F, M>, Covector<F, N>) → LinearMap<F, M, N>`** in `:outer_product` — the standard linear-algebra outer-product notation. Same strict-`IsField<F>` gate.
- **`operator*(Covector<F, N>, Vector<F, N>) → F`** in `:inner_product` — the dual contraction / inner-product notation. Same strict-`IsField<F>` gate.

## Field-carrier discipline (locked in)

The new operator surface intentionally rejects `double` (which is not a strict field due to rounding-non-associativity) by gating on `dedekind::algebra::IsField<F>`. `Vector<F, N>` / `LinearMap<F, M, N>` currently insist on `IsMatrixScalar = std::floating_point`, so the new operators compile but do not fire on the existing carriers; `Rational<long>` and other strict-field carriers will become admissible once the carrier-side gate broadens to admit `IsField` scalars.

## Why this is a draft

Static_assert witnesses for the bilinearity / rank-1 / contraction laws need a strict-field scalar witness. The chicken-and-egg: `Vector` / `LinearMap` would have to admit `IsField` carriers first. Two paths to resolution:

1. **Land this PR as scaffolding**, then file a follow-up that broadens `IsMatrixScalar` to admit `IsField` scalars (e.g. `Rational<long>`). Witnesses go in that follow-up.
2. **Fold the carrier-broadening into this PR** — bigger scope, touches the whole `Vector` / `LinearMap` layer.

Defaulting to (1) for this draft. Open to redirecting.

## Follow-ups tracked on #535

- [ ] Broaden `IsMatrixScalar` to admit `IsField` carriers; pin bilinearity / rank-1 / contraction laws on `Rational<long>` witnesses.
- [ ] `to_dense: linear_algebra::OuterProduct<U, V> → LinearMap<F, M, N>` at finite dimensions; requires a bridge partition that imports both `geometry` and `linear_algebra:diagonal` (depends on #534).
- [ ] `IsTensorAlgebraCarrier<W>` for the broader tensor-algebra layer (advisory).

## Test plan

- [x] Local `_dedekind` builds clean
- [x] All 15 ctest targets green
- [ ] CI build-and-deploy pipeline green
- [ ] CodeQL passes