### PR TITLE
feat(geometry, sequences): `IsFunctionSpace<W, D, T>` + `Path<T>` as the canonical `ℵ_0`-indexed inhabitant

### DIFF
--- a/src/main/modules/dedekind/geometry/function.cppm
+++ b/src/main/modules/dedekind/geometry/function.cppm
@@ -1,7 +1,8 @@
 /**
  * @file dedekind/geometry/function.cppm
  * @partition :function
- * @brief Concept anchoring for function spaces — functions on infinite domains as infinite-dimensional vectors (#537 slice 1).
+ * @brief Concept anchoring for function spaces — functions on infinite domains
+ * as infinite-dimensional vectors (#537 slice 1).
  *
  * @copyright 2026 The Dedekind Authors
  * Licensed under the Apache License, Version 2.0.
@@ -76,8 +77,8 @@ module;
 
 export module dedekind.geometry:function;
 
-import dedekind.sequences;  // Path<T, Cardinality> — the canonical infinite-dim function-space inhabitant
-import dedekind.sets;       // ℵ_0 — the canonical infinite cardinality
+import dedekind.sequences; // Path<T, Cardinality> — the canonical infinite-dim function-space inhabitant
+import dedekind.sets; // ℵ_0 — the canonical infinite cardinality
 
 namespace dedekind::geometry {
 
@@ -112,29 +113,27 @@ namespace dedekind::geometry {
  * pin the laws value-side in a follow-up.
  */
 export template <typename W, typename D, typename T>
-concept IsFunctionSpace = requires(W const& f, W const& g, D const& d,
-                                   T const& s) {
-  /** Eval: a function-space inhabitant is callable on the domain. */
-  { f(d) } -> std::convertible_to<T>;
-  /** Pointwise addition closes the carrier. */
-  { f + g } -> std::convertible_to<W>;
-  /** Scalar multiplication closes the carrier. */
-  { s* f } -> std::convertible_to<W>;
-};
+concept IsFunctionSpace =
+    requires(W const& f, W const& g, D const& d, T const& s) {
+      /** Eval: a function-space inhabitant is callable on the domain. */
+      { f(d) } -> std::convertible_to<T>;
+      /** Pointwise addition closes the carrier. */
+      { f + g } -> std::convertible_to<W>;
+      /** Scalar multiplication closes the carrier. */
+      { s * f } -> std::convertible_to<W>;
+    };
 
 /** @section function__Witnesses */
 
 // Path<T, ℵ_0> — the canonical ℵ_0-dimensional function-space
 // inhabitant.  Witnesses the concept at int / unsigned int (the
 // canonical primitive carrier under modular arithmetic).
-static_assert(
-    IsFunctionSpace<dedekind::sequences::Path<int>, std::size_t, int>,
-    "Path<int> (cardinality ℵ_0) is a function space ℕ → int: "
-    "eval / pointwise + / scalar · all close on the carrier.");
-static_assert(
-    IsFunctionSpace<dedekind::sequences::Path<unsigned int>, std::size_t,
-                    unsigned int>,
-    "Path<unsigned int> is a function space ℕ → unsigned int.");
+static_assert(IsFunctionSpace<dedekind::sequences::Path<int>, std::size_t, int>,
+              "Path<int> (cardinality ℵ_0) is a function space ℕ → int: "
+              "eval / pointwise + / scalar · all close on the carrier.");
+static_assert(IsFunctionSpace<dedekind::sequences::Path<unsigned int>,
+                              std::size_t, unsigned int>,
+              "Path<unsigned int> is a function space ℕ → unsigned int.");
 
 // FinitePath<T> — the finite cardinal sibling.  Same operator surface
 // (with min-extent semantics on +); same function-space inhabitation.

--- a/src/main/modules/dedekind/geometry/function.cppm
+++ b/src/main/modules/dedekind/geometry/function.cppm
@@ -1,7 +1,7 @@
 /**
  * @file dedekind/geometry/function.cppm
  * @partition :function
- * @brief Concept anchoring for function spaces (functions on infinite domains as infinite-dimensional vectors) — #537 slice 1.
+ * @brief Concept anchoring for function spaces — #537 slice 1.
  *
  * @copyright 2026 The Dedekind Authors
  * Licensed under the Apache License, Version 2.0.

--- a/src/main/modules/dedekind/geometry/function.cppm
+++ b/src/main/modules/dedekind/geometry/function.cppm
@@ -1,0 +1,160 @@
+/**
+ * @file dedekind/geometry/function.cppm
+ * @partition :function
+ * @brief Concept anchoring for function spaces — functions on infinite domains as infinite-dimensional vectors (#537 slice 1).
+ *
+ * @copyright 2026 The Dedekind Authors
+ * Licensed under the Apache License, Version 2.0.
+ *
+ * @section function__Motivation
+ *
+ * A function @c f: @c D @c → @c T over an infinite domain @c D
+ * (typically @c ℕ or @c ℝ) is morally an @b infinite-dimensional
+ * @b vector — its components are the values @c f(d) indexed by
+ * @c d @c ∈ @c D.  The codebase already has rule-based intensional
+ * carriers that play this role at the algebraic / sequence layer:
+ *
+ *  - @c dedekind::sequences::Path<T, @c Cardinality> — domain
+ *    @c std::size_t @c (≅ @c ℕ when @c Cardinality @c = @c ℵ_0),
+ *    codomain @c T.
+ *  - @c dedekind::linear_algebra::Diagonal<D, @c F>'s rule type @c F
+ *    (#534) — itself an @c IsArrow with a scalar codomain, hence a
+ *    function-space inhabitant.
+ *  - @c dedekind::linear_algebra::OuterProduct<U, @c V>'s factor
+ *    types @c U and @c V (#534) — same reading.
+ *
+ * This partition adds the concept-side anchoring:
+ *
+ *  - @c IsFunctionSpace<W, @c D, @c T> — concept witnessing that
+ *    @c W carries the structural commitments of a function space:
+ *    eval @c f(d), pointwise @c +, scalar @c · (vector-space
+ *    operations under @c T as the scalar field).
+ *  - @c Path<T, @c ℵ_0> registered as
+ *    @c IsFunctionSpace<Path<T>, @c std::size_t, @c T> via the
+ *    pointwise operators added in @c sequences:path under this issue.
+ *
+ * @section function__Pairing_With_Inner_And_Outer_Product
+ *
+ * Function spaces are the natural inhabitant of @c L²-flavoured
+ * inner / outer products at infinite dimension.  @c :inner_product
+ * already carries @c HasInnerProduct<V, @c F> @c / @c IsInnerProductSpace
+ * for finite-dim @c Vector<F, @c N>; the obvious follow-up is an
+ * @c L²(ℕ) @c / @c L²(D) carrier whose inner product is a series
+ * @c ⟨f, @c g⟩ @c = @c Σ_{d∈D} @c f(d) @c · @c g(d) (subject to
+ * summability).  The summability question is deferred to a measure-
+ * theoretic follow-up; this partition only scopes the @b vector-space
+ * surface (eval, @c +, scalar @c ·) without committing to a measure.
+ *
+ * @section function__Why_Geometry
+ *
+ * Three plausible homes were weighed in #537:
+ * @c geometry:function_space (chosen here, named symmetrically with
+ * @c :inner_product and @c :outer_product), @c linear_algebra:function_space
+ * (pairs with the @c :diagonal carrier), and @c analysis:function_space
+ * (pairs with future measure / convergence content).  The geometric
+ * home wins on partition naming consistency and on the natural pairing
+ * with the existing inner / outer-product anchorings.
+ *
+ * Wikipedia: Function space, Sequence space, L^p space
+ *
+ * @note "Le but général de l'analyse, c'est de soumettre tous les
+ *  phénomènes au calcul, et de réduire ainsi à des problèmes
+ *  d'algèbre les questions les plus difficiles de la mécanique et
+ *  de l'astronomie."
+ *       [Trans: "The general aim of analysis is to subject all
+ *       phenomena to calculation, and so reduce the most difficult
+ *       questions of mechanics and astronomy to problems of algebra."]
+ *       — Joseph Fourier, @em Théorie @em analytique @em de @em la
+ *       @em chaleur (1822), Discours préliminaire.  The function-
+ *       space anchoring here lifts that Fourier-style "function as
+ *       infinite vector" reading into the type system.
+ */
+module;
+
+#include <concepts>
+#include <cstddef>
+
+export module dedekind.geometry:function;
+
+import dedekind.sequences;  // Path<T, Cardinality> — the canonical infinite-dim function-space inhabitant
+import dedekind.sets;       // ℵ_0 — the canonical infinite cardinality
+
+namespace dedekind::geometry {
+
+/** @section function__Concept */
+
+/**
+ * @concept IsFunctionSpace
+ * @brief @c W is a function space @c T^D — eval @c f(d), pointwise
+ *        @c +, and scalar @c · over @c T.
+ *
+ * @tparam W  Carrier type representing the function space.
+ * @tparam D  Domain type (the index / argument type; @c std::size_t
+ *            for @c ℕ-indexed function spaces, future
+ *            @c IsExtensionalCardinal carriers for richer domains).
+ * @tparam T  Codomain / scalar field type.
+ *
+ * @details The concept value-side requires three operations:
+ *
+ *  - @b Eval: @c f(d) yields a @c T-convertible value.
+ *  - @b Pointwise @c +: @c f @c + @c g closes the carrier.
+ *  - @b Scalar @c ·: @c s @c · @c f closes the carrier (left
+ *    multiplication; carriers MAY also expose right multiplication
+ *    @c f @c · @c s but it is not required by the concept).
+ *
+ * The pointwise / scalar laws (associativity of @c +, distributivity
+ * over @c ·, identity elements) are documented but not encoded in
+ * this concept.  Pinning them as @c static_asserts requires
+ * value-level witnesses on a constexpr-friendly inhabitant; today
+ * @c sequences::Path<T> uses @c std::function and is not constexpr,
+ * so the witness story is at the type level (concept inhabitation).
+ * Constexpr inhabitants (e.g. @c Diagonal<D, @c F>'s rule type) can
+ * pin the laws value-side in a follow-up.
+ */
+export template <typename W, typename D, typename T>
+concept IsFunctionSpace = requires(W const& f, W const& g, D const& d,
+                                   T const& s) {
+  /** Eval: a function-space inhabitant is callable on the domain. */
+  { f(d) } -> std::convertible_to<T>;
+  /** Pointwise addition closes the carrier. */
+  { f + g } -> std::convertible_to<W>;
+  /** Scalar multiplication closes the carrier. */
+  { s* f } -> std::convertible_to<W>;
+};
+
+/** @section function__Witnesses */
+
+// Path<T, ℵ_0> — the canonical ℵ_0-dimensional function-space
+// inhabitant.  Witnesses the concept at int / unsigned int (the
+// canonical primitive carrier under modular arithmetic).
+static_assert(
+    IsFunctionSpace<dedekind::sequences::Path<int>, std::size_t, int>,
+    "Path<int> (cardinality ℵ_0) is a function space ℕ → int: "
+    "eval / pointwise + / scalar · all close on the carrier.");
+static_assert(
+    IsFunctionSpace<dedekind::sequences::Path<unsigned int>, std::size_t,
+                    unsigned int>,
+    "Path<unsigned int> is a function space ℕ → unsigned int.");
+
+// FinitePath<T> — the finite cardinal sibling.  Same operator surface
+// (with min-extent semantics on +); same function-space inhabitation.
+static_assert(
+    IsFunctionSpace<dedekind::sequences::FinitePath<int>, std::size_t, int>,
+    "FinitePath<int> is a function space [0, N) → int — finite-dim "
+    "function space, but the same intensional operator surface as Path.");
+
+/** @section function__Followups
+ *
+ *  Tracked on #537:
+ *
+ *   - Register @c Diagonal<D, @c F>'s rule type @c F structurally as
+ *     a function-space inhabitant once the @c IsArrow surface gets
+ *     pointwise @c + / scalar @c ·.
+ *   - Extend the concept with @c IsFunctionSpaceVectorSpace adding
+ *     the additive identity @c 0_F and laws.
+ *   - @c L²(ℕ) carrier with summable inner product
+ *     @c ⟨f, @c g⟩ @c = @c Σ @c f(d) @c · @c g(d); deferred until the
+ *     measure / summability story arrives in @c analysis.
+ */
+
+}  // namespace dedekind::geometry

--- a/src/main/modules/dedekind/geometry/function.cppm
+++ b/src/main/modules/dedekind/geometry/function.cppm
@@ -1,8 +1,7 @@
 /**
  * @file dedekind/geometry/function.cppm
  * @partition :function
- * @brief Concept anchoring for function spaces — functions on infinite domains
- * as infinite-dimensional vectors (#537 slice 1).
+ * @brief Concept anchoring for function spaces (functions on infinite domains as infinite-dimensional vectors) — #537 slice 1.
  *
  * @copyright 2026 The Dedekind Authors
  * Licensed under the Apache License, Version 2.0.
@@ -49,9 +48,9 @@
  * @section function__Why_Geometry
  *
  * Three plausible homes were weighed in #537:
- * @c geometry:function_space (chosen here, named symmetrically with
- * @c :inner_product and @c :outer_product), @c linear_algebra:function_space
- * (pairs with the @c :diagonal carrier), and @c analysis:function_space
+ * @c geometry:function (chosen here, named symmetrically with
+ * @c :inner_product and @c :outer_product), @c linear_algebra:function
+ * (pairs with the @c :diagonal carrier), and @c analysis:function
  * (pairs with future measure / convergence content).  The geometric
  * home wins on partition naming consistency and on the natural pairing
  * with the existing inner / outer-product anchorings.
@@ -117,10 +116,13 @@ concept IsFunctionSpace =
     requires(W const& f, W const& g, D const& d, T const& s) {
       /** Eval: a function-space inhabitant is callable on the domain. */
       { f(d) } -> std::convertible_to<T>;
-      /** Pointwise addition closes the carrier. */
-      { f + g } -> std::convertible_to<W>;
-      /** Scalar multiplication closes the carrier. */
-      { s * f } -> std::convertible_to<W>;
+      /** Pointwise addition closes the carrier strictly (no proxy /
+       *  promoted return type — same convention as
+       *  @c geometry::IsAffine and
+       *  @c algebra::HasVectorSpaceOperators). */
+      { f + g } -> std::same_as<W>;
+      /** Scalar multiplication closes the carrier strictly. */
+      { s * f } -> std::same_as<W>;
     };
 
 /** @section function__Witnesses */

--- a/src/main/modules/dedekind/geometry/geometry.cppm
+++ b/src/main/modules/dedekind/geometry/geometry.cppm
@@ -43,7 +43,8 @@ export module dedekind.geometry;
 export import :affine;         // The Point-Vector Duality
 export import :linear_map;     // Concrete finite-dimensional linear maps
 export import :inner_product;  // The Bilinear Mapping ⟨-, -⟩
-export import :function;       // Function spaces T^D as infinite-dim vector spaces (#537)
+export import :function;  // Function spaces T^D as infinite-dim vector spaces
+                          // (#537)
 
 /** @section geometry__Metric_Completion */
 export import :euclidean;  // The Normed Space (L2-Topology)

--- a/src/main/modules/dedekind/geometry/geometry.cppm
+++ b/src/main/modules/dedekind/geometry/geometry.cppm
@@ -43,6 +43,7 @@ export module dedekind.geometry;
 export import :affine;         // The Point-Vector Duality
 export import :linear_map;     // Concrete finite-dimensional linear maps
 export import :inner_product;  // The Bilinear Mapping ⟨-, -⟩
+export import :function;       // Function spaces T^D as infinite-dim vector spaces (#537)
 
 /** @section geometry__Metric_Completion */
 export import :euclidean;  // The Normed Space (L2-Topology)

--- a/src/main/modules/dedekind/sequences/path.cppm
+++ b/src/main/modules/dedekind/sequences/path.cppm
@@ -182,6 +182,62 @@ struct Path {
   /** @section path__Sequence_Interface */
   constexpr T at(std::size_t i) const { return generator(i); }
 
+  /** @section path__Pointwise_Operators
+   *
+   *  @c Path<T, @c Card> is a function space @c T^ℕ (or @c T^[0..N)
+   *  in the finite case): pointwise @c +, scalar @c ·, and unary @c -
+   *  give the vector-space surface a function space carries.  This is
+   *  the operator anchor for #537's @c IsFunctionSpace<W, @c D, @c T>
+   *  concept.  Each operation produces a fresh @c Path whose
+   *  generator captures the operands intensionally — no eager
+   *  materialisation of values.
+   */
+
+  friend constexpr Path operator+(Path const& a, Path const& b) {
+    auto gen = [a, b](std::size_t i) { return a.at(i) + b.at(i); };
+    if constexpr (IsFiniteMagnitude<Cardinality>) {
+      return Path{gen, std::min(a.size(), b.size())};
+    } else {
+      return Path{gen};
+    }
+  }
+
+  friend constexpr Path operator-(Path const& a, Path const& b) {
+    auto gen = [a, b](std::size_t i) { return a.at(i) - b.at(i); };
+    if constexpr (IsFiniteMagnitude<Cardinality>) {
+      return Path{gen, std::min(a.size(), b.size())};
+    } else {
+      return Path{gen};
+    }
+  }
+
+  friend constexpr Path operator-(Path const& a) {
+    auto gen = [a](std::size_t i) { return -a.at(i); };
+    if constexpr (IsFiniteMagnitude<Cardinality>) {
+      return Path{gen, a.size()};
+    } else {
+      return Path{gen};
+    }
+  }
+
+  friend constexpr Path operator*(T const& s, Path const& a) {
+    auto gen = [s, a](std::size_t i) { return s * a.at(i); };
+    if constexpr (IsFiniteMagnitude<Cardinality>) {
+      return Path{gen, a.size()};
+    } else {
+      return Path{gen};
+    }
+  }
+
+  friend constexpr Path operator*(Path const& a, T const& s) {
+    auto gen = [s, a](std::size_t i) { return a.at(i) * s; };
+    if constexpr (IsFiniteMagnitude<Cardinality>) {
+      return Path{gen, a.size()};
+    } else {
+      return Path{gen};
+    }
+  }
+
   /**
    * @section path__Kleisli_Triple
    * @brief Bind (>>=): m >>= f.

--- a/src/main/modules/dedekind/sequences/path.cppm
+++ b/src/main/modules/dedekind/sequences/path.cppm
@@ -184,7 +184,7 @@ struct Path {
 
   /** @section path__Pointwise_Operators
    *
-   *  @c Path<T, @c Card> is a function space @c T^ℕ (or @c T^[0..N)
+   *  @c Path<T, @c Cardinality> is a function space @c T^ℕ (or @c T^[0..N)
    *  in the finite case): pointwise @c +, scalar @c ·, and unary @c -
    *  give the vector-space surface a function space carries.  This is
    *  the operator anchor for #537's @c IsFunctionSpace<W, @c D, @c T>

--- a/src/test/cpp/modules/dedekind/sequences/path_test.cpp
+++ b/src/test/cpp/modules/dedekind/sequences/path_test.cpp
@@ -169,8 +169,8 @@ TEST_CASE("Sequences: The Path to Continuity",
 
     auto sum = a + b;
     REQUIRE(sum.at(0) == 0);
-    REQUIRE(sum.at(3) == 33);   // 3 + 30
-    REQUIRE(sum.at(7) == 77);   // 7 + 70
+    REQUIRE(sum.at(3) == 33);  // 3 + 30
+    REQUIRE(sum.at(7) == 77);  // 7 + 70
 
     auto diff = b - a;
     REQUIRE(diff.at(0) == 0);

--- a/src/test/cpp/modules/dedekind/sequences/path_test.cpp
+++ b/src/test/cpp/modules/dedekind/sequences/path_test.cpp
@@ -158,4 +158,61 @@ TEST_CASE("Sequences: The Path to Continuity",
     REQUIRE(hit.at(4) == true);   // prefix [42..46]: 46 > 45
     REQUIRE(hit.at(9) == true);   // absorbing: remains true
   }
+
+  // Pointwise function-space operators on Path<T> (#537 slice 1).
+  // These exercise the +, -, unary -, and scalar * overloads added so
+  // Path<T> participates in the IsFunctionSpace<·, std::size_t, T>
+  // concept.
+  SECTION("Path<T>: pointwise + / - / unary - on infinite cardinality") {
+    Path<ℤ> a{[](std::size_t n) -> ℤ { return static_cast<ℤ>(n); }};
+    Path<ℤ> b{[](std::size_t n) -> ℤ { return static_cast<ℤ>(n) * 10; }};
+
+    auto sum = a + b;
+    REQUIRE(sum.at(0) == 0);
+    REQUIRE(sum.at(3) == 33);   // 3 + 30
+    REQUIRE(sum.at(7) == 77);   // 7 + 70
+
+    auto diff = b - a;
+    REQUIRE(diff.at(0) == 0);
+    REQUIRE(diff.at(3) == 27);  // 30 - 3
+    REQUIRE(diff.at(7) == 63);  // 70 - 7
+
+    auto neg = -a;
+    REQUIRE(neg.at(0) == 0);
+    REQUIRE(neg.at(5) == -5);
+  }
+
+  SECTION("Path<T>: scalar multiplication, both sides") {
+    Path<ℤ> a{[](std::size_t n) -> ℤ { return static_cast<ℤ>(n) + 1; }};
+
+    auto left = ℤ{3} * a;
+    REQUIRE(left.at(0) == 3);   // 3 * 1
+    REQUIRE(left.at(4) == 15);  // 3 * 5
+
+    auto right = a * ℤ{4};
+    REQUIRE(right.at(0) == 4);   // 1 * 4
+    REQUIRE(right.at(2) == 12);  // 3 * 4
+  }
+
+  SECTION("FinitePath<T>: + extent uses min(a.size(), b.size())") {
+    FinitePath<ℤ> a{[](std::size_t n) -> ℤ { return static_cast<ℤ>(n); },
+                    /*size=*/5};
+    FinitePath<ℤ> b{[](std::size_t n) -> ℤ { return static_cast<ℤ>(n) * 100; },
+                    /*size=*/3};
+
+    auto sum = a + b;
+    REQUIRE(sum.size() == 3);  // min(5, 3)
+    REQUIRE(sum.at(0) == 0);
+    REQUIRE(sum.at(1) == 101);
+    REQUIRE(sum.at(2) == 202);
+  }
+
+  SECTION("FinitePath<T>: empty operand on + gives empty path") {
+    FinitePath<ℤ> a{[](std::size_t n) -> ℤ { return static_cast<ℤ>(n); },
+                    /*size=*/4};
+    FinitePath<ℤ> empty{[](std::size_t) -> ℤ { return 0; }, /*size=*/0};
+
+    auto sum = a + empty;
+    REQUIRE(sum.size() == 0);  // min(4, 0) = 0; empty operand absorbs.
+  }
 }

--- a/src/test/cpp/modules/dedekind/sequences/path_test.cpp
+++ b/src/test/cpp/modules/dedekind/sequences/path_test.cpp
@@ -215,4 +215,42 @@ TEST_CASE("Sequences: The Path to Continuity",
     auto sum = a + empty;
     REQUIRE(sum.size() == 0);  // min(4, 0) = 0; empty operand absorbs.
   }
+
+  SECTION("FinitePath<T>: binary - extent uses min(a.size(), b.size())") {
+    FinitePath<ℤ> a{[](std::size_t n) -> ℤ { return static_cast<ℤ>(n) * 100; },
+                    /*size=*/3};
+    FinitePath<ℤ> b{[](std::size_t n) -> ℤ { return static_cast<ℤ>(n); },
+                    /*size=*/5};
+
+    auto diff = a - b;
+    REQUIRE(diff.size() == 3);  // min(3, 5)
+    REQUIRE(diff.at(0) == 0);
+    REQUIRE(diff.at(1) == 99);   // 100 - 1
+    REQUIRE(diff.at(2) == 198);  // 200 - 2
+  }
+
+  SECTION("FinitePath<T>: unary - preserves extent") {
+    FinitePath<ℤ> a{[](std::size_t n) -> ℤ { return static_cast<ℤ>(n); },
+                    /*size=*/4};
+
+    auto neg = -a;
+    REQUIRE(neg.size() == 4);  // unary - preserves a.size()
+    REQUIRE(neg.at(0) == 0);
+    REQUIRE(neg.at(3) == -3);
+  }
+
+  SECTION("FinitePath<T>: scalar * preserves extent (left and right)") {
+    FinitePath<ℤ> a{[](std::size_t n) -> ℤ { return static_cast<ℤ>(n) + 1; },
+                    /*size=*/3};
+
+    auto left = ℤ{5} * a;
+    REQUIRE(left.size() == 3);  // scalar * preserves a.size()
+    REQUIRE(left.at(0) == 5);
+    REQUIRE(left.at(2) == 15);
+
+    auto right = a * ℤ{2};
+    REQUIRE(right.size() == 3);  // a * scalar preserves a.size()
+    REQUIRE(right.at(0) == 2);
+    REQUIRE(right.at(2) == 6);
+  }
 }


### PR DESCRIPTION
## Summary

First slice of #537 — concept-side anchoring for **function spaces** (functions on infinite domains as infinite-dimensional vectors), and the operator-side anchoring on the existing intensional carrier `sequences::Path<T>`.

### New `geometry:function` partition

- `IsFunctionSpace<W, D, T>` concept: eval `f(d)`, pointwise `+`, scalar `s · f` over `T` as the scalar field. Named symmetrically with `:inner_product` / `:outer_product` (#535).
- The vector-space laws (associativity of `+`, distributivity over `·`, identity elements) are documented but not encoded — pinning them as `static_assert`s requires a constexpr-friendly inhabitant; deferred to a follow-up on #537.

### Pointwise operators on `Path<T, Cardinality>`

- `+` / `-` (binary), unary `-`, scalar `*` (left + right) — each closes the carrier and produces a fresh `Path` whose generator captures the operands intensionally. No eager materialisation; the operations work uniformly at finite and ℵ_0 cardinality.
- Finite-cardinality `+` / `-` use `min(a.size(), b.size())` for the result extent (function-space addition is well-defined on the intersection of the two domains); infinite-cardinality drops the extent.

### Static_assert witnesses (concept inhabitation)

- `IsFunctionSpace<Path<int>, std::size_t, int>` — the canonical ℵ_0-indexed inhabitant.
- `IsFunctionSpace<Path<unsigned int>, std::size_t, unsigned int>` — the modular-ring carrier.
- `IsFunctionSpace<FinitePath<int>, std::size_t, int>` — finite-dim sibling, same operator surface.

`Path<T>`'s generator uses `std::function` and is not constexpr, so value-level laws are deferred to a constexpr-friendly inhabitant (e.g. `Diagonal<D, F>`'s rule type from #534) — tracked as a follow-up on #537.

### Slices not in this PR (per #537)

- Register `Diagonal<D, F>`'s rule type `F` structurally as a function-space inhabitant (#534 dependency).
- `IsFunctionSpaceVectorSpace` extension with the additive identity and the laws.
- `L²(ℕ)` carrier with summable inner product `⟨f, g⟩ = Σ f(d) · g(d)`; deferred until the measure / summability story arrives in `analysis`.

## Test plan

- [x] Local `_dedekind` builds clean
- [x] All 15 ctest targets green
- [x] Concept-inhabitation static_asserts on `Path<int>` / `Path<unsigned int>` / `FinitePath<int>`
- [ ] CI build-and-deploy pipeline green
- [ ] CodeQL passes