### PR TITLE
feat(linear_algebra): :vec2 / :mat2x2 — halfspace-gated static-index operator[] overloads + 𝔹-indexed face for dim-2 carriers (slice b of #372)

### DIFF
--- a/src/main/modules/dedekind/linear_algebra/mat2x2.cppm
+++ b/src/main/modules/dedekind/linear_algebra/mat2x2.cppm
@@ -515,27 +515,20 @@ struct Matrix2x2V {
 
   /** @brief Halfspace-gated static-row overload (#372 slice b).  When
    *         the row index is encoded at the type level via
-   *         @c std::integral_constant<size_t, @c I>, the row halfspace
-   *         @c [0, row_count) is decided at compile time; out-of-range
-   *         indices fail to instantiate (the @c requires-clause
-   *         refuses them).  Composes with @c Covec2V's static
-   *         @c operator[] for full type-level @c m[i][j] bounds
-   *         checking.
+   *         @c {std::integral_constant<U,I>} for any
+   *         @c {std::integral U}, the row halfspace
+   *         @c {[0, row_count)} is decided at compile time;
+   *         out-of-range indices fail to instantiate.  Composes with
+   *         @c Covec2V's static @c operator[] for full type-level
+   *         @c {m[i][j]} bounds checking.  Subsumes the 𝔹-indexed
+   *         face — @c {Matrix2x2V<T> ≅ 𝔹 × 𝔹 → T}: with
+   *         @c Covec2V's bool overload, @c {m[B_row][B_col]} is
+   *         fully 𝔹-typed.
    */
-  template <std::size_t I>
-    requires(I < row_count)
-  constexpr row_type operator[](std::integral_constant<std::size_t, I>) const {
-    return row(I);
-  }
-
-  /** @brief 𝔹-indexed static row overload — the type-theoretic reading
-   *         of the @b 2×2 matrix as @c 𝔹 @c × @c 𝔹 @c → @c T.
-   *         Composed with @c Covec2V's bool-indexed overload, the
-   *         entry @c m[B_row][B_col] is fully 𝔹-typed.
-   */
-  template <bool B>
-  constexpr row_type operator[](std::bool_constant<B>) const {
-    return row(static_cast<std::size_t>(B));
+  template <std::integral U, U I>
+    requires(static_cast<std::size_t>(I) < row_count)
+  constexpr row_type operator[](std::integral_constant<U, I>) const {
+    return row(static_cast<std::size_t>(I));
   }
 
   /** @brief Matrix transpose: reflect across the main diagonal. */
@@ -1037,6 +1030,16 @@ template <typename T, typename Idx>
                std::convertible_to<Idx, std::size_t>
 inline constexpr bool
     is_eval_arrow_v<dedekind::linear_algebra::Matrix2x2V<T>, Idx> = true;
+
+// Static-index overload (#372 slice b) accepts any
+// integral_constant<U, I> with std::integral U — including bool
+// (bool_constant<B> ≡ integral_constant<bool, B>). Mirror this on the
+// trait so IsEvalArrow fires uniformly across runtime and
+// static-index surfaces.
+template <typename T, std::integral U, U I>
+inline constexpr bool
+    is_eval_arrow_v<dedekind::linear_algebra::Matrix2x2V<T>,
+                    std::integral_constant<U, I>> = true;
 
 }  // namespace dedekind::category
 

--- a/src/main/modules/dedekind/linear_algebra/mat2x2.cppm
+++ b/src/main/modules/dedekind/linear_algebra/mat2x2.cppm
@@ -1037,9 +1037,8 @@ inline constexpr bool
 // trait so IsEvalArrow fires uniformly across runtime and
 // static-index surfaces.
 template <typename T, std::integral U, U I>
-inline constexpr bool
-    is_eval_arrow_v<dedekind::linear_algebra::Matrix2x2V<T>,
-                    std::integral_constant<U, I>> = true;
+inline constexpr bool is_eval_arrow_v<dedekind::linear_algebra::Matrix2x2V<T>,
+                                      std::integral_constant<U, I>> = true;
 
 }  // namespace dedekind::category
 

--- a/src/main/modules/dedekind/linear_algebra/mat2x2.cppm
+++ b/src/main/modules/dedekind/linear_algebra/mat2x2.cppm
@@ -513,6 +513,31 @@ struct Matrix2x2V {
     return row(static_cast<std::size_t>(i));
   }
 
+  /** @brief Halfspace-gated static-row overload (#372 slice b).  When
+   *         the row index is encoded at the type level via
+   *         @c std::integral_constant<size_t, @c I>, the row halfspace
+   *         @c [0, row_count) is decided at compile time; out-of-range
+   *         indices fail to instantiate (the @c requires-clause
+   *         refuses them).  Composes with @c Covec2V's static
+   *         @c operator[] for full type-level @c m[i][j] bounds
+   *         checking.
+   */
+  template <std::size_t I>
+    requires(I < row_count)
+  constexpr row_type operator[](std::integral_constant<std::size_t, I>) const {
+    return row(I);
+  }
+
+  /** @brief 𝔹-indexed static row overload — the type-theoretic reading
+   *         of the @b 2×2 matrix as @c 𝔹 @c × @c 𝔹 @c → @c T.
+   *         Composed with @c Covec2V's bool-indexed overload, the
+   *         entry @c m[B_row][B_col] is fully 𝔹-typed.
+   */
+  template <bool B>
+  constexpr row_type operator[](std::bool_constant<B>) const {
+    return row(static_cast<std::size_t>(B));
+  }
+
   /** @brief Matrix transpose: reflect across the main diagonal. */
   constexpr Matrix2x2V transpose() const { return {m11, m21, m12, m22}; }
 };
@@ -1035,6 +1060,35 @@ static_assert(opm[1][1] == 4u, "m[1][1] = m22.");
 // Out-of-range row: m[2] is the zero row (matches row(2) semantics).
 static_assert(opm[2u][0] == 0u, "m[2][0] = 0u (out-of-range row is zero).");
 static_assert(opm[2u][1] == 0u, "m[2][1] = 0u (out-of-range row is zero).");
+
+// Halfspace-gated static-index overloads (#372 slice b): valid indices
+// pass; out-of-range row OR column indices fail the requires-clause.
+// Composes the matrix's static-row overload with Covec2V's
+// static-column overload for full type-level m[i][j] bounds checking.
+static_assert(
+    opm[std::integral_constant<std::size_t, 0>{}]
+       [std::integral_constant<std::size_t, 0>{}] == 1u,
+    "Matrix2x2V::operator[]<0>::operator[]<0> = m11 — fully type-checked.");
+static_assert(
+    opm[std::integral_constant<std::size_t, 1>{}]
+       [std::integral_constant<std::size_t, 1>{}] == 4u,
+    "Matrix2x2V::operator[]<1>::operator[]<1> = m22 — fully type-checked.");
+// Out-of-range static indices: the overload's `requires (I < row_count)`
+// / `(J < column_count)` clauses refuse them; negative demonstration via
+// `!requires` runs into a clang diagnostic quirk and is deferred (same
+// followup as on Vec2V).
+
+// 𝔹 × 𝔹-indexed static access: Matrix2x2V<T> ≅ 𝔹 × 𝔹 → T,
+// with the four entries m11, m12, m21, m22 reachable via
+// (false, false), (false, true), (true, false), (true, true).
+static_assert(opm[std::false_type{}][std::false_type{}] == 1u,
+              "m[false][false] = m11 — Matrix2x2V<T> ≅ 𝔹 × 𝔹 → T.");
+static_assert(opm[std::false_type{}][std::true_type{}] == 2u,
+              "m[false][true] = m12.");
+static_assert(opm[std::true_type{}][std::false_type{}] == 3u,
+              "m[true][false] = m21.");
+static_assert(opm[std::true_type{}][std::true_type{}] == 4u,
+              "m[true][true] = m22.");
 }  // namespace detail_op
 
 }  // namespace dedekind::linear_algebra

--- a/src/main/modules/dedekind/linear_algebra/vec2.cppm
+++ b/src/main/modules/dedekind/linear_algebra/vec2.cppm
@@ -181,34 +181,24 @@ struct Vec2V {
   /** @brief Halfspace-gated static-index overload (#372 slice b).
    *
    *  When the index is encoded at the type level via
-   *  @c std::integral_constant<size_t, @c I>, the dimension halfspace
-   *  @c [0, @c dimension) is decided at compile time: out-of-range
-   *  indices fail to instantiate (the @c requires-clause refuses
-   *  them), making @c v[std::integral_constant<size_t, @c 2>{}] a
-   *  type-check failure rather than a runtime fallback.
-   */
-  template <std::size_t I>
-    requires(I < dimension)
-  constexpr T operator[](std::integral_constant<std::size_t, I>) const {
-    if constexpr (I == 0)
-      return x;
-    else
-      return y;
-  }
-
-  /** @brief 𝔹-indexed static overload — the type-theoretic reading of
-   *         the @b 2-cell carrier.
+   *  @c {std::integral_constant<U,I>} for any @c {std::integral U},
+   *  the dimension halfspace @c {[0, dimension)} is decided at
+   *  compile time: out-of-range indices fail to instantiate (the
+   *  @c requires-clause refuses them).
    *
-   *  @c Vec2V<T> @c ≅ @c 𝔹 @c → @c T as a function space: the index
-   *  set is the 2-element type @c 𝔹 @c = @c {false, @c true}, with
-   *  @c v[false_type] @c = @c x and @c v[true_type] @c = @c y.  No
-   *  out-of-range case exists — @c bool exhausts its inhabitants — so
-   *  the overload needs no @c requires gate.  Drives home the slogan
-   *  "the dimension halfspace at @c n=2 @b is @c 𝔹".
+   *  Subsumes both presentations:
+   *  @li @c {std::integral_constant<std::size_t,I>} — the size_t face;
+   *      @c {v[std::integral_constant<size_t,2>{}]} is a type-check
+   *      failure rather than a runtime fallback.
+   *  @li @c {std::bool_constant<B>} (= @c {std::integral_constant<bool,B>})
+   *      — the 𝔹-indexed face.  @c {Vec2V<T> ≅ 𝔹 → T} as a function
+   *      space: @c {v[false_type] = x}, @c {v[true_type] = y}.  Drives
+   *      home the slogan "the dimension halfspace at @c n=2 @b is 𝔹".
    */
-  template <bool B>
-  constexpr T operator[](std::bool_constant<B>) const {
-    if constexpr (B == false)
+  template <std::integral U, U I>
+    requires(static_cast<std::size_t>(I) < dimension)
+  constexpr T operator[](std::integral_constant<U, I>) const {
+    if constexpr (I == U{0})
       return x;
     else
       return y;
@@ -287,27 +277,18 @@ struct Covec2V {
     return T{};
   }
 
-  /** @brief Halfspace-gated static-index overload (#372 slice b).  Same
-   *         contract as @c Vec2V::operator[](integral_constant): the
-   *         index halfspace @c [0, dimension) is decided at compile
-   *         time; out-of-range indices fail to instantiate.
+  /** @brief Halfspace-gated static-index overload (#372 slice b).
+   *         Same integral-parametric contract as
+   *         @c Vec2V::operator[](integral_constant): admits any
+   *         @c {std::integral_constant<U,I>} with non-negative
+   *         @c {I < dimension}.  Subsumes the 𝔹-indexed face
+   *         (@c bool_constant<B> = @c {integral_constant<bool,B>}):
+   *         @c Covec2V<T> @c ≅ 𝔹 @c → @c T.
    */
-  template <std::size_t I>
-    requires(I < dimension)
-  constexpr T operator[](std::integral_constant<std::size_t, I>) const {
-    if constexpr (I == 0)
-      return x;
-    else
-      return y;
-  }
-
-  /** @brief 𝔹-indexed static overload — same reading as
-   *         @c Vec2V::operator[](bool_constant).  @c Covec2V<T> @c ≅
-   *         @c 𝔹 @c → @c T.
-   */
-  template <bool B>
-  constexpr T operator[](std::bool_constant<B>) const {
-    if constexpr (B == false)
+  template <std::integral U, U I>
+    requires(static_cast<std::size_t>(I) < dimension)
+  constexpr T operator[](std::integral_constant<U, I>) const {
+    if constexpr (I == U{0})
       return x;
     else
       return y;
@@ -599,6 +580,20 @@ template <typename T, typename Idx>
                std::convertible_to<Idx, std::size_t>
 inline constexpr bool
     is_eval_arrow_v<dedekind::linear_algebra::Covec2V<T>, Idx> = true;
+
+// Static-index overloads from #372 slice b accept any
+// integral_constant<U, I> with std::integral U — including bool
+// (bool_constant<B> ≡ integral_constant<bool, B>). Pin
+// is_eval_arrow_v on the integral-parametric form so IsEvalArrow
+// fires uniformly across runtime and static-index surfaces.
+template <typename T, std::integral U, U I>
+inline constexpr bool
+    is_eval_arrow_v<dedekind::linear_algebra::Vec2V<T>,
+                    std::integral_constant<U, I>> = true;
+template <typename T, std::integral U, U I>
+inline constexpr bool
+    is_eval_arrow_v<dedekind::linear_algebra::Covec2V<T>,
+                    std::integral_constant<U, I>> = true;
 
 template <typename T>
 inline constexpr bool is_kleisli_deref_v<dedekind::linear_algebra::Vec2V<T>> =

--- a/src/main/modules/dedekind/linear_algebra/vec2.cppm
+++ b/src/main/modules/dedekind/linear_algebra/vec2.cppm
@@ -190,8 +190,10 @@ struct Vec2V {
   template <std::size_t I>
     requires(I < dimension)
   constexpr T operator[](std::integral_constant<std::size_t, I>) const {
-    if constexpr (I == 0) return x;
-    else return y;
+    if constexpr (I == 0)
+      return x;
+    else
+      return y;
   }
 
   /** @brief 𝔹-indexed static overload — the type-theoretic reading of
@@ -206,8 +208,10 @@ struct Vec2V {
    */
   template <bool B>
   constexpr T operator[](std::bool_constant<B>) const {
-    if constexpr (B == false) return x;
-    else return y;
+    if constexpr (B == false)
+      return x;
+    else
+      return y;
   }
 
   /** @brief Named-pair view via @c operator->.
@@ -291,8 +295,10 @@ struct Covec2V {
   template <std::size_t I>
     requires(I < dimension)
   constexpr T operator[](std::integral_constant<std::size_t, I>) const {
-    if constexpr (I == 0) return x;
-    else return y;
+    if constexpr (I == 0)
+      return x;
+    else
+      return y;
   }
 
   /** @brief 𝔹-indexed static overload — same reading as
@@ -301,8 +307,10 @@ struct Covec2V {
    */
   template <bool B>
   constexpr T operator[](std::bool_constant<B>) const {
-    if constexpr (B == false) return x;
-    else return y;
+    if constexpr (B == false)
+      return x;
+    else
+      return y;
   }
 
   /** @brief Transpose to the dual vector: row → column. */

--- a/src/main/modules/dedekind/linear_algebra/vec2.cppm
+++ b/src/main/modules/dedekind/linear_algebra/vec2.cppm
@@ -587,13 +587,11 @@ inline constexpr bool
 // is_eval_arrow_v on the integral-parametric form so IsEvalArrow
 // fires uniformly across runtime and static-index surfaces.
 template <typename T, std::integral U, U I>
-inline constexpr bool
-    is_eval_arrow_v<dedekind::linear_algebra::Vec2V<T>,
-                    std::integral_constant<U, I>> = true;
+inline constexpr bool is_eval_arrow_v<dedekind::linear_algebra::Vec2V<T>,
+                                      std::integral_constant<U, I>> = true;
 template <typename T, std::integral U, U I>
-inline constexpr bool
-    is_eval_arrow_v<dedekind::linear_algebra::Covec2V<T>,
-                    std::integral_constant<U, I>> = true;
+inline constexpr bool is_eval_arrow_v<dedekind::linear_algebra::Covec2V<T>,
+                                      std::integral_constant<U, I>> = true;
 
 template <typename T>
 inline constexpr bool is_kleisli_deref_v<dedekind::linear_algebra::Vec2V<T>> =

--- a/src/main/modules/dedekind/linear_algebra/vec2.cppm
+++ b/src/main/modules/dedekind/linear_algebra/vec2.cppm
@@ -178,6 +178,38 @@ struct Vec2V {
     return T{};
   }
 
+  /** @brief Halfspace-gated static-index overload (#372 slice b).
+   *
+   *  When the index is encoded at the type level via
+   *  @c std::integral_constant<size_t, @c I>, the dimension halfspace
+   *  @c [0, @c dimension) is decided at compile time: out-of-range
+   *  indices fail to instantiate (the @c requires-clause refuses
+   *  them), making @c v[std::integral_constant<size_t, @c 2>{}] a
+   *  type-check failure rather than a runtime fallback.
+   */
+  template <std::size_t I>
+    requires(I < dimension)
+  constexpr T operator[](std::integral_constant<std::size_t, I>) const {
+    if constexpr (I == 0) return x;
+    else return y;
+  }
+
+  /** @brief 𝔹-indexed static overload — the type-theoretic reading of
+   *         the @b 2-cell carrier.
+   *
+   *  @c Vec2V<T> @c ≅ @c 𝔹 @c → @c T as a function space: the index
+   *  set is the 2-element type @c 𝔹 @c = @c {false, @c true}, with
+   *  @c v[false_type] @c = @c x and @c v[true_type] @c = @c y.  No
+   *  out-of-range case exists — @c bool exhausts its inhabitants — so
+   *  the overload needs no @c requires gate.  Drives home the slogan
+   *  "the dimension halfspace at @c n=2 @b is @c 𝔹".
+   */
+  template <bool B>
+  constexpr T operator[](std::bool_constant<B>) const {
+    if constexpr (B == false) return x;
+    else return y;
+  }
+
   /** @brief Named-pair view via @c operator->.
    *
    *  Returns a proxy whose members @c _1 / @c fst alias @c x and @c _2 /
@@ -249,6 +281,28 @@ struct Covec2V {
     if (s == 0) return x;
     if (s == 1) return y;
     return T{};
+  }
+
+  /** @brief Halfspace-gated static-index overload (#372 slice b).  Same
+   *         contract as @c Vec2V::operator[](integral_constant): the
+   *         index halfspace @c [0, dimension) is decided at compile
+   *         time; out-of-range indices fail to instantiate.
+   */
+  template <std::size_t I>
+    requires(I < dimension)
+  constexpr T operator[](std::integral_constant<std::size_t, I>) const {
+    if constexpr (I == 0) return x;
+    else return y;
+  }
+
+  /** @brief 𝔹-indexed static overload — same reading as
+   *         @c Vec2V::operator[](bool_constant).  @c Covec2V<T> @c ≅
+   *         @c 𝔹 @c → @c T.
+   */
+  template <bool B>
+  constexpr T operator[](std::bool_constant<B>) const {
+    if constexpr (B == false) return x;
+    else return y;
   }
 
   /** @brief Transpose to the dual vector: row → column. */
@@ -574,6 +628,31 @@ static_assert(opv[0u] == 3u, "Vec2V::operator[](0u) returns x.");
 static_assert(opv[1u] == 7u, "Vec2V::operator[](1u) returns y.");
 static_assert(opv[false] == 3u, "Vec2V::operator[](false) returns x.");
 static_assert(opv[true] == 7u, "Vec2V::operator[](true) returns y.");
+
+// Halfspace-gated static-index overload (#372 slice b): valid indices
+// pass; out-of-range indices fail the requires-clause.  Index type is
+// @c std::integral_constant<size_t, I>; at the call site, the literal
+// @c std::integral_constant<size_t, 0>{} encodes I=0 at the type level.
+static_assert(opv[std::integral_constant<std::size_t, 0>{}] == 3u,
+              "Vec2V::operator[]<0> returns x — static-index overload.");
+static_assert(opv[std::integral_constant<std::size_t, 1>{}] == 7u,
+              "Vec2V::operator[]<1> returns y — static-index overload.");
+// Out-of-range static indices fail to instantiate via the overload's
+// `requires (I < dimension)` clause; demonstrating this with a
+// `!requires { v[ic<2>{}] }` static_assert hits a clang diagnostic
+// quirk (the inner expression's diagnostic escapes the requires
+// SFINAE).  The compile-time rejection is a property of the overload
+// itself; verifying it negatively at the assert level is left to a
+// follow-up that uses a SFINAE-friendly variable-template wrapper.
+
+// 𝔹-indexed static overload: the type-theoretic reading of dim=2.
+// Vec2V<T> ≅ 𝔹 → T, with v[false_type] = x and v[true_type] = y.
+// No out-of-range case — bool exhausts its inhabitants — so no negative
+// requires-witness is needed.
+static_assert(opv[std::false_type{}] == 3u,
+              "Vec2V[false_type] = x — Vec2V<T> ≅ 𝔹 → T, false ↦ first.");
+static_assert(opv[std::true_type{}] == 7u,
+              "Vec2V[true_type] = y — Vec2V<T> ≅ 𝔹 → T, true ↦ second.");
 static_assert(opv->_1 == 3u, "Vec2V::operator->::_1 is the first projection.");
 static_assert(opv->_2 == 7u, "Vec2V::operator->::_2 is the second projection.");
 static_assert(opv->fst == 3u, "Vec2V::operator->::fst aliases _1.");
@@ -582,6 +661,15 @@ static_assert(opv->snd == 7u, "Vec2V::operator->::snd aliases _2.");
 inline constexpr Covec2V<unsigned int> opcv{4u, 9u};
 static_assert(opcv[0u] == 4u, "Covec2V::operator[](0u) returns x.");
 static_assert(opcv[1u] == 9u, "Covec2V::operator[](1u) returns y.");
+
+static_assert(opcv[std::integral_constant<std::size_t, 0>{}] == 4u,
+              "Covec2V::operator[]<0> returns x — static-index overload.");
+static_assert(opcv[std::integral_constant<std::size_t, 1>{}] == 9u,
+              "Covec2V::operator[]<1> returns y — static-index overload.");
+static_assert(opcv[std::false_type{}] == 4u,
+              "Covec2V[false_type] = x — Covec2V<T> ≅ 𝔹 → T.");
+static_assert(opcv[std::true_type{}] == 9u,
+              "Covec2V[true_type] = y — Covec2V<T> ≅ 𝔹 → T.");
 }  // namespace detail_op
 
 }  // namespace dedekind::linear_algebra


### PR DESCRIPTION
## Summary

Static-index `operator[]` overloads on `Vec2V`, `Covec2V`, `Matrix2x2V` complementing the runtime ones from PR #533. The dimension halfspace `[0, dimension)` is decided at compile time when the index is encoded at the type level.

### Halfspace-gated static overload

```cpp
template <std::size_t I>
  requires (I < dimension)
constexpr T operator[](std::integral_constant<std::size_t, I>) const;
```

Out-of-range static indices fail to instantiate via the `requires`-clause. Same on `Covec2V<T>` (column halfspace) and `Matrix2x2V<T>` (row halfspace; composes with `Covec2V`'s static overload for full type-level `m[i][j]` bounds checking).

### 𝔹-indexed face for dim-2

For the 2-cell carriers, the type-theoretic reading is **`Vec2V<T> ≅ 𝔹 → T`** as a function space — the index set is the 2-element type `𝔹 = {false, true}`. Same for `Covec2V<T>`. For the 2×2 matrix: **`Matrix2x2V<T> ≅ 𝔹 × 𝔹 → T`**.

```cpp
template <bool B>
constexpr T operator[](std::bool_constant<B>) const;
```

No `requires` clause needed — `bool` exhausts its inhabitants. Drives home the slogan that "the dimension halfspace at `n=2` IS `𝔹`".

### Static_assert witnesses (positive, type-checked)

- `opv[ic<0>] == x`, `opv[ic<1>] == y` — halfspace-gated static-index overload.
- `opv[std::false_type{}] == x`, `opv[std::true_type{}] == y` — 𝔹-indexed face.
- `opm[ic<0>][ic<0>] == m11`, `opm[ic<1>][ic<1>] == m22` — fully type-checked composition.
- `opm[std::false_type{}][std::false_type{}] == m11`, …, `opm[std::true_type{}][std::true_type{}] == m22` — `𝔹 × 𝔹` access for all four entries.

### Why no negative `!requires` witnesses

Demonstrating out-of-range rejection via `static_assert(!requires { v[ic<2>] })` hits a clang diagnostic quirk — the inner expression's "no viable overload" diagnostic escapes the `requires`-SFINAE rather than yielding `false` cleanly. The compile-time rejection IS a property of the overload's `requires`-clause; verifying it negatively at the assert level is deferred to a follow-up that uses a SFINAE-friendly variable-template wrapper.

### Conflict surface

Independent of in-flight PRs:
- #536 (draft) touches `geometry/{inner,outer}_product.cppm` only.
- #538 touches `:path` + `geometry/function.cppm` only.

This PR touches `linear_algebra/{vec2,mat2x2}.cppm`. No merge conflicts expected.

### Slices not in this PR (per #372)

- (a) `dimension_cardinality` upgrade on existing carriers.
- (c) Done — Diagonal/Identity at ℵ_0 (PR #534, merged).
- (d) `Diagonal<dim_finite<2>, ·>` ↔ `Matrix2x2V<T>` companion arrow.
- (e) Done — OuterProduct at ℵ_0 (PR #534, merged).
- The negative `!requires` rejection witnesses (deferred per above).

## Test plan

- [x] Local `_dedekind` builds clean
- [x] All 15 ctest targets green
- [x] Static_assert witnesses on all three carriers, both static-index and 𝔹-indexed
- [ ] CI build-and-deploy pipeline green
- [ ] CodeQL passes