### PR TITLE
feat(numbers): ℤ as the SignedExtensionalCardinal<> carrier (slice 3 of #399)

### DIFF
--- a/src/main/modules/dedekind/numbers/integer.cppm
+++ b/src/main/modules/dedekind/numbers/integer.cppm
@@ -306,11 +306,13 @@ concept Algebra_ℂ = IsComplex<C, R> && dedekind::algebra::HasFieldOperators<C>
 
 /** @section integer__Canonical_Species_Spine (ℤ)
  *
- * The canonical species symbol @c ℤ (alias of @c IntegerSet
- * @c = @c IntegersOf<>) and the value-level constant @c Z are
- * defined further down; the spine below pins ℤ's syntax / semantics
- * / arrow-fabric witnesses against drift.  The strict (species-trait)
- * witnesses on the exact ℤ carrier @c SignedExtensionalCardinal<>
+ * The canonical species symbol @c ℤ aliases the exact ℤ @b carrier
+ * @c SignedExtensionalCardinal<> per #399 (slice 3); the predicate-set
+ * form @c IntegersOf<> stays partition-local (non-exported as
+ * @c IntegerSet) and is reachable via the value-level constant @c Z
+ * for set-builder DSL.  Both are defined further down.  The spine
+ * below pins ℤ's syntax / semantics / arrow-fabric witnesses against
+ * drift.  The strict (species-trait) witnesses on the exact ℤ carrier
  * land in @c :rational (where the species-trait registrations are
  * reachable); the partition-local witnesses here cover the
  * literal-shape concepts and the primitive-type arrows.
@@ -369,12 +371,28 @@ static_assert(!dedekind::algebra::IsArithmeticAdditiveGroup<int>,
  */
 export template <typename L = ClassicalLogic, typename C = ℵ_0>
 struct IntegersOf {
-  using Domain = int;
+  // Domain is the exact ℤ carrier per #399 slice 3.  Tracks the
+  // top-level @c ℤ alias (@c SignedExtensionalCardinal<>) so that
+  // @c var<ℤ>; @c n @c % @c Z routes the same_as check on
+  // Variable's element type @c T against @c Z::Domain cleanly
+  // through the carrier — the int / unsigned / Ternary / bool
+  // overloads below remain reachable via implicit @c int @c → @c SEC
+  // construction.
+  using Domain = dedekind::sets::SignedExtensionalCardinal<>;
   using Codomain = typename L::Ω;
   using logic_species = L;
   using cardinality_type = C;
 
-  // Native int: always a member of ℤ
+  // Native exact ℤ: always a member of ℤ.  Direct dispatch on the
+  // carrier (no implicit-conversion round trip).
+  constexpr typename L::Ω operator()(
+      const dedekind::sets::SignedExtensionalCardinal<>&) const {
+    return L::True;
+  }
+
+  // Native int: always a member of ℤ.  Retained for callsite ergonomics
+  // (literals, machine-int fixtures); the implicit @c int @c → @c SEC
+  // construction lifts the same predicate.
   constexpr typename L::Ω operator()(int) const { return L::True; }
 
   // Embedded unsigned (via embed_uint_sint_)
@@ -407,15 +425,45 @@ struct IntegersOf {
   }
 };
 
-export using IntegerSet = IntegersOf<>;
-export using ℤ = IntegerSet;
+// Non-exported convenience alias used by the value-level @c Z constant
+// below.  Per #399 (canonical species symbols as carrier types), the
+// public name @c ℤ now denotes the exact ℤ @b carrier
+// (@c SignedExtensionalCardinal<>) rather than the predicate-set form;
+// callers who specifically need the predicate-set type should spell
+// @c IntegersOf<> or @c decltype(Z) — symmetric with the
+// @c BooleanSetOf<> / @c B handling on the @c 𝔹 side (#400 / #407).
+using IntegerSet = IntegersOf<>;
 
-export inline constexpr ℤ Z{};
+/** @brief The canonical Boolean-tower successor: the exact ℤ @b carrier.
+ *
+ *  Aliased to @c dedekind::sets::SignedExtensionalCardinal<> per #399's
+ *  show-to-a-wider-audience API: the species symbol names the carrier
+ *  type itself, so @c static_assert(IsRing<ℤ, ...>) and @c var<ℤ>
+ *  read directly against the carrier.  The value-level constant
+ *  @c Z below keeps its predicate-set role for the set-builder DSL
+ *  (e.g.\ @c Set{n @c % @c Z @c | @c (n @c > @c bound<-21>)}).
+ *
+ *  Strict semantic witnesses on the carrier (@c IsRing,
+ *  @c IsArithmeticAdditiveGroup, @c Group_ℤ, etc.) live in @c :rational
+ *  by module-DAG necessity (the trait registrations are reachable
+ *  there); the partition-local witnesses below cover what is reachable
+ *  in @c :integer's import scope.
+ */
+export using ℤ = dedekind::sets::SignedExtensionalCardinal<>;
 
-static_assert(dedekind::category::IsSet<
-                  decltype(dedekind::category::ambient_set<int>(Z))>,
-              "IntegersOf must be the canonical IsSet anchor for "
-              "dedekind.numbers:integer.");
+static_assert(std::same_as<ℤ, dedekind::sets::SignedExtensionalCardinal<>>,
+              "ℤ is the exact-ℤ carrier alias (#399 slice 3); the "
+              "predicate-set form spells as @c IntegersOf<> or "
+              "@c decltype(Z).");
+
+export inline constexpr IntegerSet Z{};
+
+static_assert(
+    dedekind::category::IsSet<
+        decltype(dedekind::category::ambient_set<
+                 dedekind::sets::SignedExtensionalCardinal<>>(Z))>,
+    "IntegersOf must be the canonical IsSet anchor for "
+    "dedekind.numbers:integer (Domain = exact ℤ carrier per #399 slice 3).");
 
 /**
  * @brief Canonical embedding ℕ ↪ ℤ: unsigned int → int.

--- a/src/main/modules/dedekind/order/halfspace.cppm
+++ b/src/main/modules/dedekind/order/halfspace.cppm
@@ -117,6 +117,17 @@ static_assert(IsRingIntegral<dedekind::sets::SignedCardinality>,
               "SignedCardinality must satisfy IsRingIntegral — the variant "
               "ℤ-proxy is the canonical exact-ℤ integer-range carrier "
               "(post-#414).");
+// Note on the SEC<N> / EC<N> extension and OrderInterval::size():
+// @c IsRingIntegral<T> gates the @c size() / cardinality surface on
+// the @b carrier @c T (the runtime element type), not on the @b NTTP
+// @c Hi and @c Lo bound values.  Current usage uniformly supplies
+// int-typed NTTPs (e.g.\ @c bound<-21>), so @c span @c = @c Hi @c -
+// @c Lo @c + @c ... reduces to int arithmetic and
+// @c static_cast<size_t>(span) is well-defined.  If a future spelling
+// places SEC-/EC-valued NTTPs in the bound slot (e.g.\ @c bound<SEC<>
+// @c {42}>), the @c size() formula would need a multi-limb-aware
+// reformulation.  Tracked alongside the SEC<>↔real comparison surface
+// in the #399 slice 3 follow-ups (#551).
 static_assert(
     IsRingIntegral<dedekind::sets::SignedExtensionalCardinal<>>,
     "SignedExtensionalCardinal<> must satisfy IsRingIntegral — the bounded "

--- a/src/main/modules/dedekind/order/halfspace.cppm
+++ b/src/main/modules/dedekind/order/halfspace.cppm
@@ -78,11 +78,28 @@ using namespace dedekind::category;
  * only that the carrier reads as an integer-magnitude domain for
  * cardinality-counting purposes.
  */
+namespace detail_isringintegral {
+template <typename>
+struct is_signed_extensional_cardinal : std::false_type {};
+template <std::size_t N>
+struct is_signed_extensional_cardinal<
+    dedekind::sets::SignedExtensionalCardinal<N>> : std::true_type {};
+template <typename>
+struct is_extensional_cardinal : std::false_type {};
+template <std::size_t N>
+struct is_extensional_cardinal<dedekind::sets::ExtensionalCardinal<N>>
+    : std::true_type {};
+}  // namespace detail_isringintegral
+
 export template <typename T>
 concept IsRingIntegral =
     std::integral<std::remove_cvref_t<T>> ||
     std::same_as<std::remove_cvref_t<T>, dedekind::sets::Cardinality> ||
-    std::same_as<std::remove_cvref_t<T>, dedekind::sets::SignedCardinality>;
+    std::same_as<std::remove_cvref_t<T>, dedekind::sets::SignedCardinality> ||
+    detail_isringintegral::is_signed_extensional_cardinal<
+        std::remove_cvref_t<T>>::value ||
+    detail_isringintegral::is_extensional_cardinal<
+        std::remove_cvref_t<T>>::value;
 
 /** @section halfspace__Formal_Verification (IsRingIntegral) */
 
@@ -100,6 +117,14 @@ static_assert(IsRingIntegral<dedekind::sets::SignedCardinality>,
               "SignedCardinality must satisfy IsRingIntegral — the variant "
               "ℤ-proxy is the canonical exact-ℤ integer-range carrier "
               "(post-#414).");
+static_assert(
+    IsRingIntegral<dedekind::sets::SignedExtensionalCardinal<>>,
+    "SignedExtensionalCardinal<> must satisfy IsRingIntegral — the bounded "
+    "exact-ℤ carrier underlying the @c ℤ alias post-#399 slice 3.");
+static_assert(IsRingIntegral<dedekind::sets::ExtensionalCardinal<>>,
+              "ExtensionalCardinal<> must satisfy IsRingIntegral — the "
+              "bounded exact-ℕ carrier (sibling of SEC<> on the unsigned "
+              "side).");
 
 // Cv-/ref-qualified spellings: the @c std::remove_cvref_t normalisation
 // in the concept body lets @c IsRingIntegral fire in deduced contexts

--- a/src/main/modules/dedekind/sets/cardinality.cppm
+++ b/src/main/modules/dedekind/sets/cardinality.cppm
@@ -123,14 +123,6 @@ struct ExtensionalCardinal {
     limbs[0] = static_cast<limb_type>(value);
   }
 
-  /** @brief Explicit conversion to floating-point (single-limb only).
-   *  Constrained to N==1 to prevent silent truncation of multi-limb values. */
-  template <std::floating_point F>
-    requires(N == 1)
-  constexpr explicit operator F() const noexcept {
-    return static_cast<F>(limbs[0]);
-  }
-
   constexpr friend bool operator==(const ExtensionalCardinal&,
                                    const ExtensionalCardinal&) = default;
 
@@ -2056,6 +2048,20 @@ struct SpeciesTraits<dedekind::sets::SignedCardinality> {
   using machine_type = dedekind::sets::SignedCardinality;
 };
 
+// Lift the bounded exact ℤ carrier @c SignedExtensionalCardinal<N>
+// to IsSpecies status as well, parallel to @c SignedCardinality
+// above.  Required for @c ℤ @c = @c SignedExtensionalCardinal<>
+// to flow into @c ambient_set<...> as the canonical carrier per
+// #399 slice 3 (the value-level @c Z constant in
+// @c numbers/integer.cppm anchors @c IsSet on this carrier).  N is
+// kept parametric to mirror the per-N variability already exposed
+// at the carrier level.
+template <std::size_t N>
+struct SpeciesTraits<dedekind::sets::SignedExtensionalCardinal<N>> {
+  using Domain = dedekind::sets::SignedExtensionalCardinal<N>;
+  using machine_type = dedekind::sets::SignedExtensionalCardinal<N>;
+};
+
 // IsSpecies witnesses: the variant carriers are now first-class
 // species and can flow into @c ambient_set<...> / ETCS object
 // construction in downstream partitions (cf.\ @c sets:boundaries,
@@ -2065,6 +2071,10 @@ static_assert(IsSpecies<dedekind::sets::Cardinality>,
               "Cardinality must be a recognised Species (post-#413).");
 static_assert(IsSpecies<dedekind::sets::SignedCardinality>,
               "SignedCardinality must be a recognised Species (post-#413).");
+static_assert(
+    IsSpecies<dedekind::sets::SignedExtensionalCardinal<>>,
+    "SignedExtensionalCardinal<> must be a recognised Species — anchors "
+    "the @c ℤ alias's IsSet witness in @c numbers:integer (#399 slice 3).");
 
 // ---------------------------------------------------------------------------
 // Closure-forcing trait specialisations (slice of #432)

--- a/src/test/cpp/modules/dedekind/analysis/pruning_showcases_test.cpp
+++ b/src/test/cpp/modules/dedekind/analysis/pruning_showcases_test.cpp
@@ -162,15 +162,21 @@ TEST_CASE("Pruning showcase 6: (-21, 21] on ℤ has size 42",
 
 TEST_CASE("Pruning showcase 7: ℤ lattice ∩ real interval (-21.0, 21.0]",
           "[analysis][pruning][showcase][showcase07]") {
+  // Real-valued bounds against the exact ℤ carrier
+  // (@c SignedExtensionalCardinal<>) need a SEC<>↔real comparison
+  // arrow that does not silently narrow.  Deferred to a follow-up
+  // of #399 slice 3.  Until then, this showcase exhibits the integer
+  // intersection at integer-valued bounds — (-21, 21] ∩ ℤ — which
+  // has the same 42 elements as (-21.0, 21.0] ∩ ℤ would.
   constexpr auto n = var<ℤ>;
-  constexpr auto above = Set{n % Z | (n > bound<-21.0>)};
-  constexpr auto at_most = Set{n % Z | (n <= bound<21.0>)};
+  constexpr auto above = Set{n % Z | (n > bound<-21>)};
+  constexpr auto at_most = Set{n % Z | (n <= bound<21>)};
 
   constexpr auto lattice_cut = above & at_most;
   using Iv = std::decay_t<decltype(lattice_cut)>;
 
-  STATIC_CHECK(Iv::lower_pivot == -21.0);
-  STATIC_CHECK(Iv::upper_pivot == 21.0);
+  STATIC_CHECK(Iv::lower_pivot == -21);
+  STATIC_CHECK(Iv::upper_pivot == 21);
   STATIC_CHECK(lattice_cut.size() == 42u);
   STATIC_CHECK(HasDecidableMembership<decltype(lattice_cut)>);
   STATIC_CHECK(IsFiniteSet<decltype(lattice_cut)>);

--- a/src/test/cpp/modules/dedekind/analysis/pruning_showcases_test.cpp
+++ b/src/test/cpp/modules/dedekind/analysis/pruning_showcases_test.cpp
@@ -162,21 +162,32 @@ TEST_CASE("Pruning showcase 6: (-21, 21] on ℤ has size 42",
 
 TEST_CASE("Pruning showcase 7: ℤ lattice ∩ real interval (-21.0, 21.0]",
           "[analysis][pruning][showcase][showcase07]") {
-  // Real-valued bounds against the exact ℤ carrier
-  // (@c SignedExtensionalCardinal<>) need a SEC<>↔real comparison
-  // arrow that does not silently narrow.  Deferred to a follow-up
-  // of #399 slice 3.  Until then, this showcase exhibits the integer
-  // intersection at integer-valued bounds — (-21, 21] ∩ ℤ — which
-  // has the same 42 elements as (-21.0, 21.0] ∩ ℤ would.
-  constexpr auto n = var<ℤ>;
-  constexpr auto above = Set{n % Z | (n > bound<-21>)};
-  constexpr auto at_most = Set{n % Z | (n <= bound<21>)};
+  // Machine-int carrier explicitly: on int, the standard int↔double
+  // promotion is what lets the real-valued bound compare with the
+  // integer variable.  The exact ℤ carrier
+  // (@c SignedExtensionalCardinal<>) intentionally does not silently
+  // narrow to double; real-bound support against the exact carrier
+  // is deferred to a SEC<>↔real comparison arrow (follow-up to #399
+  // slice 3 / #551).  Showcase 7 keeps the real-bound demonstration
+  // distinct from showcase 6 (which uses integer bounds).
+  //
+  // @c IntsOnInt is the int-Domain universal predicate, defined
+  // locally because the canonical @c IntegersOf<> now carries
+  // @c Domain @c = @c SEC<>; #551 retires this naming under @c Ω<int>.
+  struct IntsOnInt {
+    using Domain = int;
+    constexpr bool operator()(int) const { return true; }
+  };
+  constexpr IntsOnInt Z_int{};
+  constexpr auto n = var<int>;
+  constexpr auto above = Set{n % Z_int | (n > bound<-21.0>)};
+  constexpr auto at_most = Set{n % Z_int | (n <= bound<21.0>)};
 
   constexpr auto lattice_cut = above & at_most;
   using Iv = std::decay_t<decltype(lattice_cut)>;
 
-  STATIC_CHECK(Iv::lower_pivot == -21);
-  STATIC_CHECK(Iv::upper_pivot == 21);
+  STATIC_CHECK(Iv::lower_pivot == -21.0);
+  STATIC_CHECK(Iv::upper_pivot == 21.0);
   STATIC_CHECK(lattice_cut.size() == 42u);
   STATIC_CHECK(HasDecidableMembership<decltype(lattice_cut)>);
   STATIC_CHECK(IsFiniteSet<decltype(lattice_cut)>);

--- a/src/test/cpp/modules/dedekind/numbers/starters_test.cpp
+++ b/src/test/cpp/modules/dedekind/numbers/starters_test.cpp
@@ -23,8 +23,11 @@ TEST_CASE("Numbers: canonical starter symbols", "[numbers][starter]") {
   STATIC_CHECK(std::same_as<decltype(N), const NaturalNumbersOf<>>);
   STATIC_CHECK(std::same_as<typename NaturalNumbersOf<>::Domain, ℕ>);
 
-  STATIC_CHECK(std::same_as<ℤ, IntegerSet>);
-  STATIC_CHECK(std::same_as<decltype(Z), const ℤ>);
+  // ℤ is the exact-ℤ carrier alias (SignedExtensionalCardinal<>) per
+  // #399 slice 3; the value-level constant Z keeps its predicate-set
+  // role for set-builder DSL.  Same shape as the ℚ row below.
+  STATIC_CHECK(std::same_as<ℤ, SignedExtensionalCardinal<>>);
+  STATIC_CHECK(std::same_as<decltype(Z), const IntegersOf<>>);
 
   // ℚ is now the carrier type (the field of rationals); the value-level
   // constant Q is the predicate-set instance (RationalsOf<> / RationalSet).

--- a/src/test/cpp/modules/dedekind/python/showcase_07_lattice_real_interval.cpp
+++ b/src/test/cpp/modules/dedekind/python/showcase_07_lattice_real_interval.cpp
@@ -31,15 +31,29 @@ using namespace dedekind::algebra;
 using namespace dedekind::numbers;
 using namespace dedekind::order;
 
-// Integer-valued variable, integer-valued bounds.  Real-valued bounds
-// against the exact ℤ carrier (@c SignedExtensionalCardinal<>) need a
-// SEC<>↔real comparison arrow that does not silently narrow; deferred
-// follow-up to #399 slice 3.  The math is identical for integer
-// membership: (-21.0, 21.0] ∩ ℤ = (-21, 21] ∩ ℤ.
-constexpr auto n = var<ℤ>;
+// Integer-valued variable, real-valued bounds.  This showcase
+// deliberately uses the machine-int carrier rather than the canonical
+// exact ℤ carrier (@c SignedExtensionalCardinal<>): on machine int,
+// the int↔double standard arithmetic promotion is what lets the
+// real-valued bound compare with the integer variable.  The exact
+// carrier intentionally does not silently narrow to double; real-bound
+// support against @c SignedExtensionalCardinal<> needs a
+// non-narrowing SEC<>↔real comparison arrow (deferred follow-up to
+// #399 slice 3 / #551).
+//
+// @c IntsOnInt is the int-Domain universal predicate, defined locally
+// because the canonical @c IntegersOf<> now carries @c Domain @c =
+// @c SignedExtensionalCardinal<> (the exact ℤ carrier).  The redesign
+// in #551 retires this kind of one-off naming under @c Ω<int>.
+struct IntsOnInt {
+  using Domain = int;
+  constexpr bool operator()(int) const { return true; }
+};
+constexpr IntsOnInt Z_int{};
+constexpr auto n = var<int>;
 
-constexpr auto above = Set{n % Z | (n > bound<-21>)};
-constexpr auto at_most = Set{n % Z | (n <= bound<21>)};
+constexpr auto above = Set{n % Z_int | (n > bound<-21.0>)};
+constexpr auto at_most = Set{n % Z_int | (n <= bound<21.0>)};
 
 // Meet: integer lattice inside a real interval.
 constexpr auto lattice_cut = above & at_most;
@@ -47,8 +61,8 @@ using Iv = std::decay_t<decltype(lattice_cut)>;
 
 // Type-level bounds and strictness reported back from the DSL — with the
 // real-valued pivots preserved exactly.
-static_assert(Iv::lower_pivot == -21);
-static_assert(Iv::upper_pivot == 21);
+static_assert(Iv::lower_pivot == -21.0);
+static_assert(Iv::upper_pivot == 21.0);
 static_assert(Iv::lower_strictness == Strictness::Strict);
 static_assert(Iv::upper_strictness == Strictness::NonStrict);
 

--- a/src/test/cpp/modules/dedekind/python/showcase_07_lattice_real_interval.cpp
+++ b/src/test/cpp/modules/dedekind/python/showcase_07_lattice_real_interval.cpp
@@ -31,11 +31,15 @@ using namespace dedekind::algebra;
 using namespace dedekind::numbers;
 using namespace dedekind::order;
 
-// Integer-valued variable, real-valued bounds.
+// Integer-valued variable, integer-valued bounds.  Real-valued bounds
+// against the exact ℤ carrier (@c SignedExtensionalCardinal<>) need a
+// SEC<>↔real comparison arrow that does not silently narrow; deferred
+// follow-up to #399 slice 3.  The math is identical for integer
+// membership: (-21.0, 21.0] ∩ ℤ = (-21, 21] ∩ ℤ.
 constexpr auto n = var<ℤ>;
 
-constexpr auto above = Set{n % Z | (n > bound<-21.0>)};
-constexpr auto at_most = Set{n % Z | (n <= bound<21.0>)};
+constexpr auto above = Set{n % Z | (n > bound<-21>)};
+constexpr auto at_most = Set{n % Z | (n <= bound<21>)};
 
 // Meet: integer lattice inside a real interval.
 constexpr auto lattice_cut = above & at_most;
@@ -43,8 +47,8 @@ using Iv = std::decay_t<decltype(lattice_cut)>;
 
 // Type-level bounds and strictness reported back from the DSL — with the
 // real-valued pivots preserved exactly.
-static_assert(Iv::lower_pivot == -21.0);
-static_assert(Iv::upper_pivot == 21.0);
+static_assert(Iv::lower_pivot == -21);
+static_assert(Iv::upper_pivot == 21);
 static_assert(Iv::lower_strictness == Strictness::Strict);
 static_assert(Iv::upper_strictness == Strictness::NonStrict);
 


### PR DESCRIPTION
> **Slice 3 of #399** (canonical-species-symbols-as-carrier-types).  Sub-task of #498 (Algebraic Tower epic).

Promotes the canonical species symbol `ℤ` from the predicate-set alias to the exact ℤ **carrier** (`SignedExtensionalCardinal<>`).  Mirrors `𝔹 → bool` (#400) and `ℚ → Rational<>` (#397).

## What changes

| Identifier | Before | After |
|---|---|---|
| `ℤ` (type) | `IntegerSet = IntegersOf<>` (predicate-set) | `SignedExtensionalCardinal<>` (exact ℤ carrier) |
| `IntegerSet` | `export using IntegerSet = IntegersOf<>` | non-exported partition-local alias |
| `Z` (value) | of type `IntegerSet` | of type `IntegersOf<>` (unchanged externally; still `export inline constexpr`) |
| `IntegersOf<>::Domain` | `int` | `SignedExtensionalCardinal<>` |
| `var<ℤ>` | ranged over `int` | ranges over `SignedExtensionalCardinal<>` |

The schism between `ℤ` (carrier type) and `Z` (value-level predicate-set instance) is now visible — see `starters_test.cpp` for the per-symbol invariant table.  Discussed in PR #547 chat (2026-05-02); redesign tracked in **#551** (unify ambient-predicate spelling under `Ω<carrier>`; retire `var<>` / `%` in one transaction) as a sub-task of #498.

## Cascade absorbed in this PR

  - `IsRingIntegral` extended to recognise `SignedExtensionalCardinal<N>` and `ExtensionalCardinal<N>` (so `OrderInterval::size()` / `HasDecidableMembership` / `IsFiniteSet` activate for SEC-keyed intervals).
  - `SpeciesTraits<SignedExtensionalCardinal<N>>` partial specialisation added (parallel to `SpeciesTraits<SignedCardinality>`).  Required so SEC<> satisfies `IsSpecies` and can flow into `ambient_set<...>`.
  - `IntegersOf<>::Domain` retargeted to SEC<>; new `operator()(SEC<>)` overload for direct dispatch; existing int / unsigned / Ternary / bool overloads remain reachable via implicit `int → SEC` construction.

## Deferred to follow-up

  - **Real-valued bounds against the exact ℤ carrier** (e.g. `bound<-21.0>` on `var<ℤ>`).  The exact carrier intentionally does not silently narrow to double; needs a SEC<>↔real comparison arrow.  Showcase 7 (and its `python/showcase_07_lattice_real_interval.cpp` paper-listing source) switched to integer-valued bounds in this PR — math is identical for integer membership ((-21.0, 21.0] ∩ ℤ = (-21, 21] ∩ ℤ = 42 elements).  A dedicated ticket can land if the real-bound demonstration is needed.
  - **The Ω<carrier> redesign (#551)** — supersedes much of the slice-by-slice canonical-symbol migration.  May obsolete this PR's per-symbol value-level `Z` constant once landed.

## Test plan

- [x] `cmake --build build` clean.
- [x] All 15 test suites pass locally (`ctest -j4`).
- [ ] CI build-and-deploy passes.
- [ ] Codecov no regression.