### PR TITLE
feat(sets): #551 — Ω<carrier> ambient redesign (Phase 1 + 2a-c, sweep pending)

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,9 +22,9 @@ It defines an embedded domain-specific language (eDSL) for mathematics with the 
 // Cardinality-1 reduction: an intensional set over a transfinite
 // carrier collapses to a named extensional Singleton — at compile
 // time, with no lambdas, no predicate erasure.
-constexpr auto n        = var<ℕ>;
-constexpr auto gt_three = Set{n % N | (n > bound<3>)};
-constexpr auto lt_five  = Set{n % N | (n < bound<5>)};
+constexpr auto n        = element<Ω<ℕ>>;
+constexpr auto gt_three = Set{n | (n > bound<3>)};
+constexpr auto lt_five  = Set{n | (n < bound<5>)};
 
 constexpr Singleton<4> in_between = gt_three & lt_five;   // ≡ {4}
 static_assert(in_between == Singleton<4>{});

--- a/README.md
+++ b/README.md
@@ -22,19 +22,19 @@ It defines an embedded domain-specific language (eDSL) for mathematics with the 
 // Cardinality-1 reduction: an intensional set over a transfinite
 // carrier collapses to a named extensional Singleton — at compile
 // time, with no lambdas, no predicate erasure.
-constexpr auto n        = element<Ω<ℕ>>;
-constexpr auto gt_three = Set{n | (n > bound<3>)};
-constexpr auto lt_five  = Set{n | (n < bound<5>)};
+constexpr auto n    = element<Ω<ℕ>>;
+constexpr auto gt_3 = Set{n | n > bound<3>};
+constexpr auto lt_5 = Set{n | n < bound<5>};
 
-constexpr Singleton<4> in_between = gt_three & lt_five;   // ≡ {4}
+constexpr Singleton<4> in_between = gt_3 & lt_5;   // ≡ {4}
 static_assert(in_between == Singleton<4>{});
 
 // The parent Sets carry NONE of the three computability tiers; the
 // reduced Singleton carries ALL THREE.  The intersection IS the
 // theorem: { n ∈ ℕ | n > 3 } ∩ { n ∈ ℕ | n < 5 } = {4}.
-static_assert(!HasDecidableMembership<decltype(gt_three)>);
-static_assert(!IsFiniteSet<decltype(gt_three)>);
-static_assert(!IsCompileTimeEnumerable<decltype(gt_three)>);
+static_assert(!HasDecidableMembership<decltype(gt_3)>);
+static_assert(!IsFiniteSet<decltype(gt_3)>);
+static_assert(!IsCompileTimeEnumerable<decltype(gt_3)>);
 
 static_assert(HasDecidableMembership<decltype(in_between)>);
 static_assert(IsFiniteSet<decltype(in_between)>);

--- a/src/main/modules/dedekind/algebra/boolean.cppm
+++ b/src/main/modules/dedekind/algebra/boolean.cppm
@@ -15,17 +15,20 @@
  * - `𝔹`: canonical Unicode symbol for the Boolean @b carrier (= @c bool).
  *   Per #399 / #400 (show-to-a-wider-audience API), the species symbol
  *   names the carrier type itself rather than a predicate-set alias;
- *   @c static_assert(IsField<𝔹, bit_xor, bit_and>) and @c var<𝔹> read
- *   directly against the carrier.
- * - `BooleanSetOf<L, C>`: parameterised predicate-set template alias for
- *   `UniversalSet<bool, L, C>`.  The default form `BooleanSetOf<>` is the
- * canonical predicate-set type for the Boolean ambient species; this is the
- *   public template alias to spell when a callsite needs the type
- *   itself (e.g.\ in a static_assert).
- * - `B`: value-level universal Boolean predicate-set, of type
- *   `BooleanSetOf<>`, used as the right-hand-side of the membership
- *   operator in set-builder DSL (e.g.\ @c Set{b @c % @c B @c | @c (b
- *   @c == @c true)}).
+ *   @c static_assert(IsField<𝔹, bit_xor, bit_and>) and
+ *   @c element<Ω<𝔹>> read directly against the carrier.
+ * - `BooleanSetOf<L, C>` ≡ `UniversalSet<bool, L, C>`: parameterised
+ *   predicate-set template alias.  Bool is the @b bottom of the algebraic
+ *   tower, so the characteristic morphism χ_𝔹 of 𝔹-as-subobject coincides
+ *   with the universe Ω<bool> (no proper ambient super-object); the alias
+ *   makes this collapse explicit.  Contrast with @c NaturalNumbersOf,
+ *   @c IntegersOf, @c RationalsOf, @c RealsOf, @c ComplexesOf,
+ *   @c DualSetOf, where χ_T : tower-ambient → Ω is a non-trivial
+ *   classifier with multi-overload cross-carrier embedding-aware
+ *   membership (e.g.\ @c N(-7) returns @c False because -7 ∈ ℤ does not
+ *   land in ℕ ↪ ℤ).
+ * - `B`: value-level instance @c BooleanSetOf<>{}, named for paper-listing
+ *   readability and direct membership-test calls (e.g.\ @c B(true)).
  * - `BooleanSet` (non-exported): an internal convenience alias for
  *   `BooleanSetOf<>` used inside this partition.  Not part of the
  *   public surface — external callers should spell `BooleanSetOf<>` or
@@ -37,10 +40,9 @@
  * identities, absorbers, and distributivity). The test suite validates this
  * alignment explicitly.
  *
- * Element scouts are intentionally local (e.g. `auto b = var<BooleanSetOf<>>;`
- * or equivalently `auto b = var<decltype(B)>;` --- both spellings reach the
- * same predicate-set type) to avoid global name shadowing in downstream
- * code.
+ * Element scouts are post-#551 spelled @c element<Ω<𝔹>> (BoundScout factory
+ * over the bool universe); the legacy @c var<...> family was retired in
+ * Phase 2e.3 of the Ω-ambient redesign.
  *
  * @note "La matematica non e una collezione di trucchi: e grammatica delle
  * forme." (Mathematics is not a bag of tricks; it is a grammar of forms.) —

--- a/src/main/modules/dedekind/algebra/boolean.cppm
+++ b/src/main/modules/dedekind/algebra/boolean.cppm
@@ -18,8 +18,8 @@
  *   @c static_assert(IsField<𝔹, bit_xor, bit_and>) and @c var<𝔹> read
  *   directly against the carrier.
  * - `BooleanSetOf<L, C>`: parameterised predicate-set template alias for
- *   `UniversalSet<bool, L, C>`.  The default form `BooleanSetOf<>` is the canonical
- *   predicate-set type for the Boolean ambient species; this is the
+ *   `UniversalSet<bool, L, C>`.  The default form `BooleanSetOf<>` is the
+ * canonical predicate-set type for the Boolean ambient species; this is the
  *   public template alias to spell when a callsite needs the type
  *   itself (e.g.\ in a static_assert).
  * - `B`: value-level universal Boolean predicate-set, of type

--- a/src/main/modules/dedekind/algebra/boolean.cppm
+++ b/src/main/modules/dedekind/algebra/boolean.cppm
@@ -18,7 +18,7 @@
  *   @c static_assert(IsField<𝔹, bit_xor, bit_and>) and @c var<𝔹> read
  *   directly against the carrier.
  * - `BooleanSetOf<L, C>`: parameterised predicate-set template alias for
- *   `Ω<bool, L, C>`.  The default form `BooleanSetOf<>` is the canonical
+ *   `UniversalSet<bool, L, C>`.  The default form `BooleanSetOf<>` is the canonical
  *   predicate-set type for the Boolean ambient species; this is the
  *   public template alias to spell when a callsite needs the type
  *   itself (e.g.\ in a static_assert).
@@ -59,7 +59,7 @@ using namespace dedekind::sets;
 
 export template <typename L = dedekind::category::ClassicalLogic,
                  typename C = Finite>
-using BooleanSetOf = Ω<bool, L, C>;
+using BooleanSetOf = UniversalSet<bool, L, C>;
 
 // Non-exported convenience alias used by the value-level B constant
 // below.  The exported public surface is `BooleanSetOf<L, C>` (the
@@ -75,7 +75,7 @@ using BooleanSet = BooleanSetOf<>;
  *  (@c bool, @c ∨, @c ∧), the Galois field 𝔽₂ (@c bool, @c ⊕, @c ∧),
  *  the order lattice — are witnessed at this partition and at
  *  @c numbers:boolean.  The predicate-set role moves to the
- *  unambiguously-named @c BooleanSet (alias of @c Ω<bool>).
+ *  unambiguously-named @c BooleanSet (alias of @c UniversalSet<bool>).
  */
 export using 𝔹 = bool;
 

--- a/src/main/modules/dedekind/analysis/dual.cppm
+++ b/src/main/modules/dedekind/analysis/dual.cppm
@@ -260,7 +260,7 @@ static_assert(
 
 export template <typename F = double, typename L = ClassicalLogic,
                  typename C = ℶ_1>
-using DualSetOf = Ω<Dual<F>, L, C>;
+using DualSetOf = UniversalSet<Dual<F>, L, C>;
 
 export using DualSet = DualSetOf<>;
 export using 𝔻 = DualSet;

--- a/src/main/modules/dedekind/geometry/lattice.cppm
+++ b/src/main/modules/dedekind/geometry/lattice.cppm
@@ -81,7 +81,7 @@ using namespace dedekind::category;
 // preserves the geometry contract (Species with @c Domain @c = @c
 // unsigned @c int).
 export using NaturalLatticeSet = NaturalNumbersOf<>;
-export using IntegerLatticeSet = Ω<int>;
+export using IntegerLatticeSet = UniversalSet<int>;
 export using IntegerLatticeScalar = typename IntegerLatticeSet::Domain;
 export using IntegerLatticePoint2D =
     std::pair<IntegerLatticeScalar, IntegerLatticeScalar>;
@@ -134,10 +134,10 @@ struct LatticeFactory<NaturalLatticeSet> {
 };
 
 template <std::signed_integral I>
-struct LatticeFactory<Ω<I>> {
+struct LatticeFactory<UniversalSet<I>> {
   constexpr auto line() const {
     auto k = var_for_type<I>;
-    return Set{k % Ω<I>{}};
+    return Set{k % UniversalSet<I>{}};
   }
 
   constexpr auto plane() const {

--- a/src/main/modules/dedekind/geometry/lattice.cppm
+++ b/src/main/modules/dedekind/geometry/lattice.cppm
@@ -121,10 +121,10 @@ struct LatticeFactory;
 template <>
 struct LatticeFactory<NaturalLatticeSet> {
   constexpr auto line() const {
-    auto k = var<ℕ>;
-    // Every unsigned value is in ℕ by construction post-#401; the
-    // predicate-set N is the universal classifier for unsigned values.
-    return Set{k % N};
+    auto k = element<Ω<ℕ>>;
+    // Every Cardinality value is in ℕ by construction post-#401;
+    // the universal-set @c Ω<ℕ> is the canonical classifier here.
+    return Set{k};
   }
 
   constexpr auto plane() const {

--- a/src/main/modules/dedekind/geometry/lattice.cppm
+++ b/src/main/modules/dedekind/geometry/lattice.cppm
@@ -136,7 +136,7 @@ struct LatticeFactory<NaturalLatticeSet> {
 template <std::signed_integral I>
 struct LatticeFactory<UniversalSet<I>> {
   constexpr auto line() const {
-    auto k = var_for_type<I>;
+    auto k = element<Ω<I>>;
     return Set{k % UniversalSet<I>{}};
   }
 
@@ -179,7 +179,7 @@ export constexpr auto integer_lattice_2d() {
  * @return A Set<NaturalLatticePoint2D, TernaryLogic, ...>.
  */
 export constexpr auto square_natural_grid(unsigned int n) {
-  auto p = var_for_type<NaturalLatticePoint2D>;
+  auto p = element<Ω<NaturalLatticePoint2D>>;
   const auto unbounded = natural_lattice_2d();
   return Set{p % unbounded | [n](const NaturalLatticePoint2D& q) {
     return (q.first < n) && (q.second < n);
@@ -195,7 +195,7 @@ export constexpr auto square_natural_grid(unsigned int n) {
  */
 export constexpr auto square_integer_grid(IntegerLatticeScalar lower,
                                           IntegerLatticeScalar upper) {
-  auto p = var_for_type<IntegerLatticePoint2D>;
+  auto p = element<Ω<IntegerLatticePoint2D>>;
   const auto unbounded = integer_lattice_2d();
   return Set{p % unbounded | [lower, upper](const IntegerLatticePoint2D& q) {
     return (q.first >= lower) && (q.first < upper) && (q.second >= lower) &&

--- a/src/main/modules/dedekind/numbers/boolean.cppm
+++ b/src/main/modules/dedekind/numbers/boolean.cppm
@@ -132,9 +132,10 @@ static_assert(std::same_as<𝔹, bool>, "𝔹 is the bool carrier (post-#400).")
 //      participate as a set, lift the carrier through
 //      @c BooleanSetOf<> / @c FiniteBooleanSetOf<>; the IsSet anchor
 //      in (1) below witnesses exactly that lift.
-static_assert(std::same_as<typename UniversalSet<bool>::Domain, 𝔹>,
-              "UniversalSet<bool>::Domain is the bool carrier 𝔹 — predicate-set's "
-              "underlying element type IS the carrier.");
+static_assert(
+    std::same_as<typename UniversalSet<bool>::Domain, 𝔹>,
+    "UniversalSet<bool>::Domain is the bool carrier 𝔹 — predicate-set's "
+    "underlying element type IS the carrier.");
 static_assert(std::same_as<typename FiniteBooleanSetOf<>::Domain, 𝔹>,
               "FiniteBooleanSetOf<>::Domain is the bool carrier 𝔹.");
 

--- a/src/main/modules/dedekind/numbers/boolean.cppm
+++ b/src/main/modules/dedekind/numbers/boolean.cppm
@@ -121,7 +121,7 @@ concept Is_B = std::same_as<E, bool> && requires(const M& m) {
 // (0) Carrier-type witness: 𝔹 names the carrier itself.
 static_assert(std::same_as<𝔹, bool>, "𝔹 is the bool carrier (post-#400).");
 
-// (0a) Relationship between 𝔹 (the carrier) and Ω<bool> (the
+// (0a) Relationship between 𝔹 (the carrier) and UniversalSet<bool> (the
 //      predicate-set / characteristic-function wrapper).  The
 //      predicate-set's @c Domain @b is the carrier, and the
 //      @c FiniteBooleanSetOf<> alias from this partition is the
@@ -132,8 +132,8 @@ static_assert(std::same_as<𝔹, bool>, "𝔹 is the bool carrier (post-#400).")
 //      participate as a set, lift the carrier through
 //      @c BooleanSetOf<> / @c FiniteBooleanSetOf<>; the IsSet anchor
 //      in (1) below witnesses exactly that lift.
-static_assert(std::same_as<typename Ω<bool>::Domain, 𝔹>,
-              "Ω<bool>::Domain is the bool carrier 𝔹 — predicate-set's "
+static_assert(std::same_as<typename UniversalSet<bool>::Domain, 𝔹>,
+              "UniversalSet<bool>::Domain is the bool carrier 𝔹 — predicate-set's "
               "underlying element type IS the carrier.");
 static_assert(std::same_as<typename FiniteBooleanSetOf<>::Domain, 𝔹>,
               "FiniteBooleanSetOf<>::Domain is the bool carrier 𝔹.");

--- a/src/main/modules/dedekind/numbers/complex.cppm
+++ b/src/main/modules/dedekind/numbers/complex.cppm
@@ -461,8 +461,11 @@ constexpr auto embed_grid_ℂ(
     const dedekind::sets::Set<dedekind::geometry::IntegerLatticePoint2D, L, P>&
         grid) {
   using namespace dedekind::sets;
-  auto c = var<ℂ>;
-  return Set{c % C | [grid](const Complex<double>& z) {
+  // FIXME(#399 slice 4-6): once ℂ becomes a carrier alias for
+  // Complex<...>, switch to @c element<Ω<ℂ>>; for now ℂ is still the
+  // predicate-set type.
+  auto c = element<Ω<Complex<double>>>;
+  return Set{c | [grid](const Complex<double>& z) {
     const double re = z.real();
     const double im = z.imag();
     dedekind::geometry::IntegerLatticeScalar x =

--- a/src/main/modules/dedekind/numbers/lattice.cppm
+++ b/src/main/modules/dedekind/numbers/lattice.cppm
@@ -149,8 +149,10 @@ struct LatticeFactory<R, 1> {
   }
 
   constexpr auto bounded(int n) const {
-    auto r = var<ℝ>;
-    return Set{r % R | [n](const Real<double>& x) {
+    // FIXME(#399 slice 4-6): once ℝ becomes a carrier alias, switch
+    // to @c element<Ω<ℝ>>; for now ℝ is still the predicate-set type.
+    auto r = element<Ω<Real<double>>>;
+    return Set{r | [n](const Real<double>& x) {
       const double v = x.resolve();
       if (!detail::is_integral_coordinate(v)) return false;
       return (v >= 0.0) && (v < static_cast<double>(n));

--- a/src/main/modules/dedekind/numbers/mandelbrot.cppm
+++ b/src/main/modules/dedekind/numbers/mandelbrot.cppm
@@ -218,11 +218,10 @@ export template <IsComplexScalar R, typename EscapeCriterion>
 constexpr auto M_N(std::size_t max_iter, EscapeCriterion criterion,
                    KleenePolicy policy = KleenePolicy::Inclusive) {
   const auto kleene = M_kleene_N<R>(max_iter, criterion);
-  auto c = var<ComplexesOf<R>>;
-  return Set{c % ComplexesOf<R>{} |
-             classify([kleene, policy](const Complex<R>& x) {
-               return collapse_ternary(kleene(x), policy);
-             }).χ};
+  auto c = element<Ω<Complex<R>>>;
+  return Set{c | classify([kleene, policy](const Complex<R>& x) {
+                   return collapse_ternary(kleene(x), policy);
+                 }).χ};
 }
 
 /**

--- a/src/main/modules/dedekind/numbers/natural.cppm
+++ b/src/main/modules/dedekind/numbers/natural.cppm
@@ -190,8 +190,8 @@ static_assert(std::same_as<ℕ, dedekind::sets::Cardinality>,
 
 // (0a) Relationship between ℕ (the carrier) and NaturalNumbersOf<>
 //      (the predicate-set / classifier).  The predicate-set's @c Domain
-//      @b is the carrier — same shape as the 𝔹 ↔ UniversalSet<bool> relationship
-//      from #400.  IsSet<ℕ> itself does @b not fire (carrier types
+//      @b is the carrier — same shape as the 𝔹 ↔ UniversalSet<bool>
+//      relationship from #400.  IsSet<ℕ> itself does @b not fire (carrier types
 //      carry no predicate-set surface); to participate as a set, lift
 //      through the predicate-set.
 static_assert(std::same_as<typename NaturalNumbersOf<>::Domain, ℕ>,

--- a/src/main/modules/dedekind/numbers/natural.cppm
+++ b/src/main/modules/dedekind/numbers/natural.cppm
@@ -190,7 +190,7 @@ static_assert(std::same_as<ℕ, dedekind::sets::Cardinality>,
 
 // (0a) Relationship between ℕ (the carrier) and NaturalNumbersOf<>
 //      (the predicate-set / classifier).  The predicate-set's @c Domain
-//      @b is the carrier — same shape as the 𝔹 ↔ Ω<bool> relationship
+//      @b is the carrier — same shape as the 𝔹 ↔ UniversalSet<bool> relationship
 //      from #400.  IsSet<ℕ> itself does @b not fire (carrier types
 //      carry no predicate-set surface); to participate as a set, lift
 //      through the predicate-set.

--- a/src/main/modules/dedekind/numbers/symbolic.cppm
+++ b/src/main/modules/dedekind/numbers/symbolic.cppm
@@ -39,7 +39,7 @@ using namespace dedekind::category;
 
 export template <typename Q>
 constexpr auto Sqrt2_Symbolic() {
-  const dedekind::sets::Ω<Q, TernaryLogic> universe{};
+  const dedekind::sets::UniversalSet<Q, TernaryLogic> universe{};
   // Lower-cut prototype encoded as an ETCS subobject over Q.
   return ambient_set<Q>([universe](const Q& q) {
     if constexpr (std::floating_point<Q>) {
@@ -69,7 +69,7 @@ inline constexpr bool is_transcendental_v = false;
 export template <typename R>
   requires std::regular<R>
 constexpr auto TranscendentalSet() {
-  const dedekind::sets::Ω<R> universe{};
+  const dedekind::sets::UniversalSet<R> universe{};
   return ambient_set<R>([universe](const R& x) constexpr {
     return universe(x) && is_transcendental_v<R>;
   });

--- a/src/main/modules/dedekind/order/halfspace.cppm
+++ b/src/main/modules/dedekind/order/halfspace.cppm
@@ -11,13 +11,13 @@
  * pivot is carried in the predicate's TYPE as a non-type template parameter,
  * which is what lets `(n > bound<5>) && (n < bound<3>)` collapse structurally
  * to an empty predicate at compile time. Contrast with the lambda-returning
- * variable operators in `dedekind.sets`, which erase the pivot into a closure.
+ * scout operators in `dedekind.sets`, which erase the pivot into a closure.
  *
  * @section halfspace__DSL_Surface
  *
- *     inline constexpr auto n = var<ℕ>;
- *     inline constexpr auto big   = Set{n % N | (n > bound<5>)};
- *     inline constexpr auto small = Set{n % N | (n < bound<3>)};
+ *     inline constexpr auto n = element<Ω<ℕ>>;
+ *     inline constexpr auto big   = Set{n | (n > bound<5>)};
+ *     inline constexpr auto small = Set{n | (n < bound<3>)};
  *     // (big ∩ small) = ∅  — witnessed at compile time via structured_and
  *
  * Wikipedia: Half-space (geometry), Separating hyperplane theorem,
@@ -300,78 +300,11 @@ struct OrderInterval {
   using cardinality_type = std::conditional_t<is_integer_range, Finite, ℵ_0>;
 };
 
-/** @section halfspace__Halfspace_Variable_DSL — Variable<S> × Bound<V> →
- * Halfspace. */
-
-export template <typename Species, auto V>
-  requires std::convertible_to<decltype(V),
-                               dedekind::sets::element_of_t<Species>> &&
-           // Reject negative signed pivots on unsigned carriers: the
-           // implicit signed→unsigned conversion would wrap (-1 → UINT_MAX)
-           // and produce nonsense semantics (`x > -1` becomes `x > UINT_MAX`,
-           // which is False for every reachable x).  Real-valued bounds
-           // (e.g. bound<-21.0> on var<ℝ>) remain admissible because
-           // signed_integral excludes floating-point types.
-           (!std::unsigned_integral<dedekind::sets::element_of_t<Species>> ||
-            !std::signed_integral<decltype(V)> || V >= 0)
-constexpr auto operator>(const Variable<Species>&, Bound<V>) {
-  using T = dedekind::sets::element_of_t<Species>;
-  return Halfspace<T, V, Direction::Upward, Strictness::Strict>{};
-}
-
-export template <typename Species, auto V>
-  requires std::convertible_to<decltype(V),
-                               dedekind::sets::element_of_t<Species>> &&
-           // Reject negative signed pivots on unsigned carriers: the
-           // implicit signed→unsigned conversion would wrap (-1 → UINT_MAX)
-           // and produce nonsense semantics (`x > -1` becomes `x > UINT_MAX`,
-           // which is False for every reachable x).  Real-valued bounds
-           // (e.g. bound<-21.0> on var<ℝ>) remain admissible because
-           // signed_integral excludes floating-point types.
-           (!std::unsigned_integral<dedekind::sets::element_of_t<Species>> ||
-            !std::signed_integral<decltype(V)> || V >= 0)
-constexpr auto operator>=(const Variable<Species>&, Bound<V>) {
-  using T = dedekind::sets::element_of_t<Species>;
-  return Halfspace<T, V, Direction::Upward, Strictness::NonStrict>{};
-}
-
-export template <typename Species, auto V>
-  requires std::convertible_to<decltype(V),
-                               dedekind::sets::element_of_t<Species>> &&
-           // Reject negative signed pivots on unsigned carriers: the
-           // implicit signed→unsigned conversion would wrap (-1 → UINT_MAX)
-           // and produce nonsense semantics (`x > -1` becomes `x > UINT_MAX`,
-           // which is False for every reachable x).  Real-valued bounds
-           // (e.g. bound<-21.0> on var<ℝ>) remain admissible because
-           // signed_integral excludes floating-point types.
-           (!std::unsigned_integral<dedekind::sets::element_of_t<Species>> ||
-            !std::signed_integral<decltype(V)> || V >= 0)
-constexpr auto operator<(const Variable<Species>&, Bound<V>) {
-  using T = dedekind::sets::element_of_t<Species>;
-  return Halfspace<T, V, Direction::Downward, Strictness::Strict>{};
-}
-
-export template <typename Species, auto V>
-  requires std::convertible_to<decltype(V),
-                               dedekind::sets::element_of_t<Species>> &&
-           // Reject negative signed pivots on unsigned carriers: the
-           // implicit signed→unsigned conversion would wrap (-1 → UINT_MAX)
-           // and produce nonsense semantics (`x > -1` becomes `x > UINT_MAX`,
-           // which is False for every reachable x).  Real-valued bounds
-           // (e.g. bound<-21.0> on var<ℝ>) remain admissible because
-           // signed_integral excludes floating-point types.
-           (!std::unsigned_integral<dedekind::sets::element_of_t<Species>> ||
-            !std::signed_integral<decltype(V)> || V >= 0)
-constexpr auto operator<=(const Variable<Species>&, Bound<V>) {
-  using T = dedekind::sets::element_of_t<Species>;
-  return Halfspace<T, V, Direction::Downward, Strictness::NonStrict>{};
-}
-
 /** @section halfspace__Halfspace_BoundScout_DSL — BoundScout<auto> × Bound<V>
  *  → Halfspace.
  *
- * Mirror of the Variable<Species> × Bound<V> overloads above, for the
- * post-#551 NTTP-parameterised scout BoundScout<auto Ambient>.  Same
+ * Free-function overloads on the post-#551 NTTP-parameterised scout
+ * @c BoundScout<auto @c Ambient>.  Same
  * Halfspace<T, V, D, S> result type; downstream collapse machinery
  * (structured_and on halfspace pairs) is unchanged. */
 
@@ -471,7 +404,7 @@ constexpr auto structured_and(Halfspace<T, Lo, Direction::Upward, SL, L>,
       // For @c std::integral @c T the cast is preserved verbatim so the
       // pre-#402 behaviour on primitive carriers (@c Singleton<4u> on
       // @c unsigned @c int, @c Singleton<int_value> for real-pivot-on-int
-      // showcases like @c bound<-21.0> on @c var<int>) doesn't shift.
+      // showcases like @c bound<-21.0> on @c element<Ω<int>>) doesn't shift.
       if constexpr (std::integral<T>) {
         constexpr T unique =
             lo_open ? static_cast<T>(Lo + 1) : static_cast<T>(Lo);

--- a/src/main/modules/dedekind/order/halfspace.cppm
+++ b/src/main/modules/dedekind/order/halfspace.cppm
@@ -367,6 +367,60 @@ constexpr auto operator<=(const Variable<Species>&, Bound<V>) {
   return Halfspace<T, V, Direction::Downward, Strictness::NonStrict>{};
 }
 
+/** @section halfspace__Halfspace_BoundScout_DSL — BoundScout<auto> × Bound<V>
+ *  → Halfspace.
+ *
+ * Mirror of the Variable<Species> × Bound<V> overloads above, for the
+ * post-#551 NTTP-parameterised scout BoundScout<auto Ambient>.  Same
+ * Halfspace<T, V, D, S> result type; downstream collapse machinery
+ * (structured_and on halfspace pairs) is unchanged. */
+
+export template <auto Ambient, auto V>
+  requires std::convertible_to<
+               decltype(V), typename dedekind::sets::BoundScout<Ambient>::T> &&
+           (!std::unsigned_integral<
+                typename dedekind::sets::BoundScout<Ambient>::T> ||
+            !std::signed_integral<decltype(V)> || V >= 0)
+constexpr auto operator>(const dedekind::sets::BoundScout<Ambient>&, Bound<V>) {
+  using T = typename dedekind::sets::BoundScout<Ambient>::T;
+  return Halfspace<T, V, Direction::Upward, Strictness::Strict>{};
+}
+
+export template <auto Ambient, auto V>
+  requires std::convertible_to<
+               decltype(V), typename dedekind::sets::BoundScout<Ambient>::T> &&
+           (!std::unsigned_integral<
+                typename dedekind::sets::BoundScout<Ambient>::T> ||
+            !std::signed_integral<decltype(V)> || V >= 0)
+constexpr auto operator>=(const dedekind::sets::BoundScout<Ambient>&,
+                          Bound<V>) {
+  using T = typename dedekind::sets::BoundScout<Ambient>::T;
+  return Halfspace<T, V, Direction::Upward, Strictness::NonStrict>{};
+}
+
+export template <auto Ambient, auto V>
+  requires std::convertible_to<
+               decltype(V), typename dedekind::sets::BoundScout<Ambient>::T> &&
+           (!std::unsigned_integral<
+                typename dedekind::sets::BoundScout<Ambient>::T> ||
+            !std::signed_integral<decltype(V)> || V >= 0)
+constexpr auto operator<(const dedekind::sets::BoundScout<Ambient>&, Bound<V>) {
+  using T = typename dedekind::sets::BoundScout<Ambient>::T;
+  return Halfspace<T, V, Direction::Downward, Strictness::Strict>{};
+}
+
+export template <auto Ambient, auto V>
+  requires std::convertible_to<
+               decltype(V), typename dedekind::sets::BoundScout<Ambient>::T> &&
+           (!std::unsigned_integral<
+                typename dedekind::sets::BoundScout<Ambient>::T> ||
+            !std::signed_integral<decltype(V)> || V >= 0)
+constexpr auto operator<=(const dedekind::sets::BoundScout<Ambient>&,
+                          Bound<V>) {
+  using T = typename dedekind::sets::BoundScout<Ambient>::T;
+  return Halfspace<T, V, Direction::Downward, Strictness::NonStrict>{};
+}
+
 /** @section halfspace__Halfspace_Structural_Algebra — ADL hooks for operator&&.
  */
 

--- a/src/main/modules/dedekind/order/poset.cppm
+++ b/src/main/modules/dedekind/order/poset.cppm
@@ -47,7 +47,7 @@ using namespace dedekind::category;
 // imported (via the umbrella), since `:poset` is the foundational
 // partition the other order partitions build on.
 static_assert(dedekind::category::IsSet<
-                  decltype(dedekind::category::ambient_set<int>(Ω<int>{}))>,
+                  decltype(dedekind::category::ambient_set<int>(UniversalSet<int>{}))>,
               "dedekind.order is grounded on canonical ETCS set objects "
               "imported from dedekind.sets.");
 

--- a/src/main/modules/dedekind/order/poset.cppm
+++ b/src/main/modules/dedekind/order/poset.cppm
@@ -46,10 +46,11 @@ using namespace dedekind::category;
 // from `dedekind.sets`.  It fires once when any order partition is
 // imported (via the umbrella), since `:poset` is the foundational
 // partition the other order partitions build on.
-static_assert(dedekind::category::IsSet<
-                  decltype(dedekind::category::ambient_set<int>(UniversalSet<int>{}))>,
-              "dedekind.order is grounded on canonical ETCS set objects "
-              "imported from dedekind.sets.");
+static_assert(
+    dedekind::category::IsSet<
+        decltype(dedekind::category::ambient_set<int>(UniversalSet<int>{}))>,
+    "dedekind.order is grounded on canonical ETCS set objects "
+    "imported from dedekind.sets.");
 
 /**
  * @concept IsPreOrdered

--- a/src/main/modules/dedekind/sets/boundaries.cppm
+++ b/src/main/modules/dedekind/sets/boundaries.cppm
@@ -235,11 +235,14 @@ struct Ø final : Boundaries {
  *
  * Per #551 (one-transaction redesign of the set-builder DSL): the @b type
  * is named @c UniversalSet<T, L, C>; the value-level handle is the
- * variable template @c UniversalSet<T, L, C> below, so callers spell
- * @c UniversalSet<bool> rather than @c UniversalSet<bool>{}.  This makes the
- * topos-theoretic reading direct ( @c Ω is the subobject classifier
- * value at carrier @c T), and lets paper Listing 6 read as
- * @c auto @c 𝔹 @c = @c UniversalSet<bool>; without the type/value schism the
+ * sibling variable template @c Ω<T, L, C> (declared further below in this
+ * partition) which spells @c UniversalSet<T, L, C>{}.  Callers therefore
+ * spell @c Ω<bool> at value-context sites rather than reaching for
+ * @c UniversalSet<bool>{}; the type and the variable template share their
+ * parameter pack so both names remain reachable at the same arity.  This
+ * makes the topos-theoretic reading direct ( @c Ω is the subobject
+ * classifier value at carrier @c T), and lets paper Listing 6 read as
+ * @c auto @c 𝔹 @c = @c Ω<bool>; without the type/value schism the
  * pre-#551 surface had.
  */
 export template <typename T, typename L = ClassicalLogic, typename C = ℵ_0>
@@ -294,8 +297,10 @@ struct UniversalSet final : Boundaries {
 
   // Value-level membership query (sugar over operator()) per #551.
   // @c UniversalSet<T>.contains(v) reads more directly than @c
-  // UniversalSet<T>(v) at paper-listing sites.
-  constexpr bool contains(const T&) const { return true; }
+  // UniversalSet<T>(v) at paper-listing sites.  Returns @c L::Ω (delegating
+  // to @c operator()) so the contract matches @c sets::Set::contains and
+  // generic code can call either uniformly.
+  constexpr typename L::Ω contains(const T& v) const { return (*this)(v); }
 
   constexpr cardinality_type cardinality() const { return cardinality_type{}; }
 

--- a/src/main/modules/dedekind/sets/boundaries.cppm
+++ b/src/main/modules/dedekind/sets/boundaries.cppm
@@ -363,17 +363,55 @@ static_assert(dedekind::category::HasCanonicalSetCCC<int>,
               "Breadcrumb to :cartesian: boundary ambient int has canonical "
               "CCC witness.");
 
-// Predicate-set classifier for ℕ (the natural-numbers ambient species).
-// Per #401 the canonical species symbol @c ℕ migrated to a carrier-type
-// alias (@c ℕ = @c unsigned @c int); this predicate-set retained as the
-// set-builder DSL handle ("is this value in ℕ?"), with its @c Domain
-// aligned to the carrier so @c var<ℕ> @c % @c N composes cleanly.
+// =============================================================
+// Architecture note: universe Ω<T> vs. classifier <Tower>Of<>
+// =============================================================
 //
-// The @c int-typed @c operator() overload survives as a callsite
-// convenience on the @b classifier reading (ℕ ⊂ ℤ via the
-// non-negativity check); it is not on the formal predicate-set
-// signature (which is @c Domain @c = @c unsigned @c int) but is
-// reachable via direct @c N(-7) calls for paper-listing readability.
+// Two distinct primitives sit at this layer, both rooted in ETCS
+// (Lawvere 1964):
+//
+//   (1) Universe per carrier — @c Ω<T> (variable template above)
+//       = @c UniversalSet<T,L,C>{}.  Constant-True predicate over
+//       carrier T.  Plays the role of "T as its own set" — the
+//       monomorphic identity inclusion T ↪ T.  Used by the
+//       set-builder DSL as the ambient for @c element<Ω<T>>
+//       (BoundScout factory, post-#551).
+//
+//   (2) Tower classifier — @c <Tower>Of<L,C> (this and sibling
+//       struct templates: @c NaturalNumbersOf, @c IntegersOf in
+//       :integer, @c RationalsOf in :rational, @c RealsOf in :real,
+//       @c ComplexesOf in :complex, @c DualSetOf in :dual).
+//       The characteristic morphism χ_T : tower-ambient → Ω of
+//       the subobject T inside its algebraic tower.  Multi-overload:
+//       the @c Domain overload always returns @c L::True (T is in
+//       T), and the cross-carrier overloads route predecessor
+//       types through embedding arrows (e.g.\ @c N(int) checks
+//       non-negativity, @c N(unsigned) is trivially True via the
+//       canonical embedding @c embed_uint_ℕ_).  This is the
+//       textbook "ℕ as a subset of ℤ via the canonical inclusion"
+//       reading.
+//
+//   Asymmetry: @c BooleanSetOf<L,C> ≡ @c UniversalSet<bool,L,C>
+//       (alias, not a separate struct) because 𝔹 is the @b bottom
+//       of the algebraic tower — no proper super-object — so χ_𝔹
+//       collapses to Ω<bool>.  See @c algebra:boolean for that
+//       collapse note.
+//
+// Why both: @c Ω<T> is the structural primitive (one per carrier;
+// uniform DSL surface for set-builder), while @c <Tower>Of<> is
+// the engineering pragma that lifts predecessor literals (@c N(0u)
+// for @c unsigned, @c N(-7) for @c int) without forcing each
+// callsite to thread the embedding manually.  Removing the
+// classifiers in favour of Ω alone would lose the cross-carrier
+// classification — @c Ω<unsigned>{}(-7) is ill-typed, but
+// @c N(-7) is well-typed and returns @c False.
+//
+// Paper alignment: §3.3 (Juliet Posture) names the two-axis split
+// (closure / laws); the universe-vs-classifier distinction is a
+// third meta-axis (§5 figure breadcrumb).  Listing 6 in the paper
+// shows both: @c 𝔹 = @c Ω<bool> for the trivial-bottom case;
+// @c N = @c NaturalNumbersOf<>{} for the non-trivial classifier
+// case.
 export template <typename L = ClassicalLogic, typename C = ℵ_0>
 struct NaturalNumbersOf {
   using Domain =

--- a/src/main/modules/dedekind/sets/boundaries.cppm
+++ b/src/main/modules/dedekind/sets/boundaries.cppm
@@ -333,6 +333,17 @@ struct UniversalSet final : Boundaries {
 export template <typename T, typename L = ClassicalLogic, typename C = ℵ_0>
 inline constexpr UniversalSet<T, L, C> Ω{};
 
+/** @brief @c Ω<bool> specialisation: the Boolean carrier is finite,
+ *  so its universal predicate is classified by @c Finite cardinality
+ *  (not @c ℵ_0).  Without this specialisation, @c NaturalLogic<Ω<bool>>
+ *  would route through @c TernaryLogic (because @c ℵ_0 is transfinite);
+ *  the canonical 𝔹 ambient wants @c ClassicalLogic.  Mirrors the
+ *  pre-#551 @c BooleanSetOf<L,C> default of @c BooleanSetOf<
+ *  ClassicalLogic, Finite>.
+ */
+export template <>
+inline constexpr UniversalSet<bool, ClassicalLogic, Finite> Ω<bool>{};
+
 template <typename T, typename L>
 constexpr auto Ø<T, L>::operator!() const {
   return UniversalSet<T, L>{};

--- a/src/main/modules/dedekind/sets/boundaries.cppm
+++ b/src/main/modules/dedekind/sets/boundaries.cppm
@@ -293,8 +293,8 @@ struct UniversalSet final : Boundaries {
   constexpr typename L::Ω operator()(const T&) const { return L::True; }
 
   // Value-level membership query (sugar over operator()) per #551.
-  // @c UniversalSet<T>.contains(v) reads more directly than @c UniversalSet<T>(v) at
-  // paper-listing sites.
+  // @c UniversalSet<T>.contains(v) reads more directly than @c
+  // UniversalSet<T>(v) at paper-listing sites.
   constexpr bool contains(const T&) const { return true; }
 
   constexpr cardinality_type cardinality() const { return cardinality_type{}; }
@@ -324,9 +324,11 @@ struct UniversalSet final : Boundaries {
  *         reading per #551).
  *
  *  Variable template producing a default-constructed @c UniversalSet<T,L,C>
- *  instance.  Lets callers spell the ambient as @c UniversalSet<bool> rather than
+ *  instance.  Lets callers spell the ambient as @c UniversalSet<bool> rather
+ * than
  *  @c UniversalSet<bool>{} — paper Listing 6 reads as @c auto @c 𝔹 @c =
- *  @c UniversalSet<bool>; without the type-vs-value schism the pre-#551 surface had.
+ *  @c UniversalSet<bool>; without the type-vs-value schism the pre-#551 surface
+ * had.
  */
 export template <typename T, typename L = ClassicalLogic, typename C = ℵ_0>
 inline constexpr UniversalSet<T, L, C> Ω{};

--- a/src/main/modules/dedekind/sets/boundaries.cppm
+++ b/src/main/modules/dedekind/sets/boundaries.cppm
@@ -232,13 +232,22 @@ struct Ø final : Boundaries {
  * @struct UniversalSet
  * @brief U: The Terminal Object.
  * @details Intentional but Decidable: The rule "x ∈ U" always returns True.
+ *
+ * Per #551 (one-transaction redesign of the set-builder DSL): the @b type
+ * is named @c UniversalSet<T, L, C>; the value-level handle is the
+ * variable template @c UniversalSet<T, L, C> below, so callers spell
+ * @c UniversalSet<bool> rather than @c UniversalSet<bool>{}.  This makes the
+ * topos-theoretic reading direct ( @c Ω is the subobject classifier
+ * value at carrier @c T), and lets paper Listing 6 read as
+ * @c auto @c 𝔹 @c = @c UniversalSet<bool>; without the type/value schism the
+ * pre-#551 surface had.
  */
 export template <typename T, typename L = ClassicalLogic, typename C = ℵ_0>
-struct Ω final : Boundaries {
+struct UniversalSet final : Boundaries {
   using Domain = T;
   using Codomain = typename L::Ω;
   using cardinality_type = C;
-  using base_set_type = Ω<T, L, C>;
+  using base_set_type = UniversalSet<T, L, C>;
   using is_universal_boundary = void;
   using logic_species = L;
 
@@ -264,15 +273,17 @@ struct Ω final : Boundaries {
   template <typename S>
     requires(!requires { typename S::T; }) &&
             (!requires { typename S::is_variable; })
-  friend constexpr typename L::Ω operator<=(const S&, const Ω&) {
+  friend constexpr typename L::Ω operator<=(const S&, const UniversalSet&) {
     return L::True;
   }
 
   /** @section boundaries__Lattice_Axiom_3: Reflexivity */
-  constexpr typename L::Ω operator<=(const Ω&) const { return L::True; }
+  constexpr typename L::Ω operator<=(const UniversalSet&) const {
+    return L::True;
+  }
 
   // Explicitly define equality if <=> is being deleted by members
-  constexpr bool operator==(const Ω&) const { return true; }
+  constexpr bool operator==(const UniversalSet&) const { return true; }
 
   // Note: You'll eventually want overloads for:
   // Universal | Any = Universal
@@ -281,40 +292,58 @@ struct Ω final : Boundaries {
   // The Axiom: Total Presence
   constexpr typename L::Ω operator()(const T&) const { return L::True; }
 
+  // Value-level membership query (sugar over operator()) per #551.
+  // @c UniversalSet<T>.contains(v) reads more directly than @c UniversalSet<T>(v) at
+  // paper-listing sites.
+  constexpr bool contains(const T&) const { return true; }
+
   constexpr cardinality_type cardinality() const { return cardinality_type{}; }
 
-  // Ω | S = Ω
+  // U | S = U
   template <typename S>
   constexpr auto operator|(const S&) const {
     return *this;
   }
 
-  // Ω & S = S
+  // U & S = S
   template <typename S>
   constexpr auto operator&(const S& s) const {
     return s;
   }
 
-  // Ω ^ S = ¬S  (Ω △ S = ¬S; #469)
-  // Pointwise: x ∈ Ω △ S iff x is in exactly one; x is always in Ω,
-  // so x ∈ Ω △ S iff x ∉ S, i.e. the complement of S.
+  // U ^ S = ¬S  (U △ S = ¬S; #469)
+  // Pointwise: x ∈ U △ S iff x is in exactly one; x is always in U,
+  // so x ∈ U △ S iff x ∉ S, i.e. the complement of S.
   template <typename S>
   constexpr auto operator^(const S& s) const {
     return !s;
   }
 };
 
+/** @brief The universal-predicate value at carrier @c T (subobject-classifier
+ *         reading per #551).
+ *
+ *  Variable template producing a default-constructed @c UniversalSet<T,L,C>
+ *  instance.  Lets callers spell the ambient as @c UniversalSet<bool> rather than
+ *  @c UniversalSet<bool>{} — paper Listing 6 reads as @c auto @c 𝔹 @c =
+ *  @c UniversalSet<bool>; without the type-vs-value schism the pre-#551 surface had.
+ */
+export template <typename T, typename L = ClassicalLogic, typename C = ℵ_0>
+inline constexpr UniversalSet<T, L, C> Ω{};
+
 template <typename T, typename L>
 constexpr auto Ø<T, L>::operator!() const {
-  return Ω<T, L>{};
+  return UniversalSet<T, L>{};
 }
 
-// Cardinality metadata drives extensional classification for Ω.
+// Cardinality metadata drives extensional classification for UniversalSet.
 template <typename T, typename L, typename C>
-struct is_extensional<Ω<T, L, C>> : std::bool_constant<C::is_finite> {};
+struct is_extensional<UniversalSet<T, L, C>>
+    : std::bool_constant<C::is_finite> {};
 
-static_assert(dedekind::category::IsSet<decltype(ambient_set<int>(Ω<int>{}))>,
-              "The universal boundary must lift to an ETCS set object.");
+static_assert(
+    dedekind::category::IsSet<decltype(ambient_set<int>(UniversalSet<int>{}))>,
+    "The universal boundary must lift to an ETCS set object.");
 static_assert(dedekind::category::IsSet<decltype(ambient_set<int>(Ø<int>{}))>,
               "The empty boundary must lift to an ETCS set object.");
 static_assert(dedekind::category::HasCanonicalSetCCC<int>,
@@ -451,9 +480,9 @@ constexpr std::size_t bound_join(const S1& lhs, const S2& rhs) {
 
 namespace dedekind::category {
 
-// Cardinality metadata drives transfinite classification for Ω.
+// Cardinality metadata drives transfinite classification for UniversalSet.
 template <typename T, typename L, typename C>
-struct is_transfinite<dedekind::sets::Ω<T, L, C>>
+struct is_transfinite<dedekind::sets::UniversalSet<T, L, C>>
     : std::bool_constant<!C::is_finite> {};
 
 }  // namespace dedekind::category

--- a/src/main/modules/dedekind/sets/cardinality.cppm
+++ b/src/main/modules/dedekind/sets/cardinality.cppm
@@ -2065,7 +2065,7 @@ struct SpeciesTraits<dedekind::sets::SignedExtensionalCardinal<N>> {
 // IsSpecies witnesses: the variant carriers are now first-class
 // species and can flow into @c ambient_set<...> / ETCS object
 // construction in downstream partitions (cf.\ @c sets:boundaries,
-// where @c Ω<Cardinality> / @c Ω<SignedCardinality> instantiations
+// where @c UniversalSet<Cardinality> / @c UniversalSet<SignedCardinality> instantiations
 // will land as part of the #402 retarget PR).
 static_assert(IsSpecies<dedekind::sets::Cardinality>,
               "Cardinality must be a recognised Species (post-#413).");

--- a/src/main/modules/dedekind/sets/cardinality.cppm
+++ b/src/main/modules/dedekind/sets/cardinality.cppm
@@ -2065,8 +2065,8 @@ struct SpeciesTraits<dedekind::sets::SignedExtensionalCardinal<N>> {
 // IsSpecies witnesses: the variant carriers are now first-class
 // species and can flow into @c ambient_set<...> / ETCS object
 // construction in downstream partitions (cf.\ @c sets:boundaries,
-// where @c UniversalSet<Cardinality> / @c UniversalSet<SignedCardinality> instantiations
-// will land as part of the #402 retarget PR).
+// where @c UniversalSet<Cardinality> / @c UniversalSet<SignedCardinality>
+// instantiations will land as part of the #402 retarget PR).
 static_assert(IsSpecies<dedekind::sets::Cardinality>,
               "Cardinality must be a recognised Species (post-#413).");
 static_assert(IsSpecies<dedekind::sets::SignedCardinality>,

--- a/src/main/modules/dedekind/sets/expressions.cppm
+++ b/src/main/modules/dedekind/sets/expressions.cppm
@@ -83,6 +83,12 @@ struct Comprehension {
 export template <typename Species>
 struct Variable;
 
+/** @brief Forward declaration of @c BoundScout (post-#551), needed by
+ *  @c MembershipBinding<S>::operator| below for the bool-truthy
+ *  specialisation that mirrors the @c Variable<…> path. */
+export template <auto Ambient>
+struct BoundScout;
+
 /** @brief Boolean equality predicate for compile-time pruning over 𝔹.
  *
  *  Defined here (rather than further down where the @c FiniteBooleanSet
@@ -131,6 +137,15 @@ struct MembershipBinding {
     requires std::same_as<element_of_t<Species>, bool> &&
              std::same_as<element_of_t<OtherSpecies>, bool>
   constexpr auto operator|(const Variable<OtherSpecies>&) const {
+    return Comprehension<Species, BooleanEqPredicate>{base,
+                                                      BooleanEqPredicate{true}};
+  }
+
+  /** @brief Sibling of the above for the post-#551 BoundScout form. */
+  template <auto OtherAmbient>
+    requires std::same_as<element_of_t<Species>, bool> &&
+             std::same_as<typename BoundScout<OtherAmbient>::T, bool>
+  constexpr auto operator|(const BoundScout<OtherAmbient>&) const {
     return Comprehension<Species, BooleanEqPredicate>{base,
                                                       BooleanEqPredicate{true}};
   }
@@ -219,6 +234,21 @@ struct BoundScout {
     requires std::same_as<T, typename SubSpecies::Domain>
   constexpr auto operator%(const SubSpecies& s) const {
     return MembershipBinding<SubSpecies>{s};
+  }
+
+  /** @brief Bare-BoundScout<bool> truthy specialisation (#408 / #551).
+   *  @c Set{b @c | @c b} reads "elements of the ambient for which
+   *  @c b holds"; on a bool scout the bare-@c b form is the truthy
+   *  predicate.  Routes to the canonical @c BooleanEqPredicate{true}
+   *  so the existing collapse machinery treats the three syntactic
+   *  surfaces ( @c b, @c b @c == @c true, @c !b) uniformly.  Mirror
+   *  of @c MembershipBinding<S>::operator|(const Variable<…>&). */
+  template <auto OtherAmbient>
+    requires std::same_as<T, bool> &&
+             std::same_as<typename BoundScout<OtherAmbient>::T, bool>
+  constexpr auto operator|(const BoundScout<OtherAmbient>&) const {
+    return Comprehension<AmbientType, BooleanEqPredicate>{
+        ambient, BooleanEqPredicate{true}};
   }
 };
 

--- a/src/main/modules/dedekind/sets/expressions.cppm
+++ b/src/main/modules/dedekind/sets/expressions.cppm
@@ -264,7 +264,7 @@ struct FiniteBooleanSet {
     return at_false == L::False && at_true == L::False;
   }
 
-  constexpr bool operator==(const Ω<bool, L, Finite>&) const {
+  constexpr bool operator==(const UniversalSet<bool, L, Finite>&) const {
     return at_false == L::True && at_true == L::True;
   }
 
@@ -273,7 +273,7 @@ struct FiniteBooleanSet {
     return s == empty;
   }
 
-  friend constexpr bool operator==(const Ω<bool, L, Finite>& universe,
+  friend constexpr bool operator==(const UniversalSet<bool, L, Finite>& universe,
                                    const FiniteBooleanSet& s) {
     return s == universe;
   }
@@ -449,9 +449,9 @@ constexpr auto operator|(const Set<SignedCardinality, L, P1>& lhs,
 }
 
 /** @brief Convenience Alias: If S is a type, var<S> is the scout. */
-// This allows: auto x = var<int>; where int is mapped to Ω<int>
+// This allows: auto x = var<int>; where int is mapped to UniversalSet<int>
 export template <typename T>
-inline constexpr Variable<Ω<T>> var_for_type{};
+inline constexpr Variable<UniversalSet<T>> var_for_type{};
 
 export template <typename T, typename L, typename Predicate>
 class Set {
@@ -502,7 +502,7 @@ class Set {
   template <typename OtherPredicate>
   constexpr auto operator|(const Set<T, L, OtherPredicate>& other) const {
     if constexpr (IsComplementPair_v<Predicate, OtherPredicate>) {
-      return Ω<T, L>{};
+      return UniversalSet<T, L>{};
     } else if constexpr (std::same_as<T, bool> &&
                          std::same_as<Predicate, BooleanEqPredicate> &&
                          std::same_as<OtherPredicate, BooleanEqPredicate>) {
@@ -599,7 +599,7 @@ class Set {
   template <typename OtherPredicate>
   constexpr auto operator^(const Set<T, L, OtherPredicate>& other) const {
     if constexpr (IsComplementPair_v<Predicate, OtherPredicate>) {
-      return Ω<T, L>{};
+      return UniversalSet<T, L>{};
     } else if constexpr (std::same_as<std::decay_t<decltype(*this & other)>,
                                       Ø<T, L>>) {
       // Compile-time-disjoint optimisation (#469 / PR #523 review):
@@ -617,10 +617,10 @@ class Set {
       // @c (x @c > @c 100)) but @c structured_and detects.
       return *this | other;
     } else if constexpr (std::same_as<std::decay_t<decltype(*this | other)>,
-                                      Ω<T, L>>) {
+                                      UniversalSet<T, L>>) {
       // Compile-time-covering optimisation (dual of the disjoint
       // branch above): when @c A @c ∪ @c B reduces structurally to
-      // @c Ω<T, L> at the type level, the textbook identity becomes
+      // @c UniversalSet<T, L> at the type level, the textbook identity becomes
       // @c A @c △ @c B @c = @c Ω @c ∖ @c (A @c ∩ @c B) @c =
       // @c ¬(A @c ∩ @c B).  Currently dormant: today the only path
       // by which @c | yields @c Ω at the type level is the
@@ -764,7 +764,7 @@ constexpr auto operator^(const Set<T, L, Predicate>& s, const Ø<T, L>&) {
  *         universe is the complement; #469).  Symmetric of
  *         @c Ω::operator^(S) above. */
 export template <typename T, typename L, typename C, typename Predicate>
-constexpr auto operator^(const Set<T, L, Predicate>& s, const Ω<T, L, C>&) {
+constexpr auto operator^(const Set<T, L, Predicate>& s, const UniversalSet<T, L, C>&) {
   return !s;
 }
 

--- a/src/main/modules/dedekind/sets/expressions.cppm
+++ b/src/main/modules/dedekind/sets/expressions.cppm
@@ -208,6 +208,18 @@ struct BoundScout {
     return Comprehension<AmbientType, std::decay_t<P>>{ambient,
                                                        std::forward<P>(p)};
   }
+
+  /** @brief Membership re-bind: @c b @c % @c S binds @c b to a
+   *  @b narrower set @c S whose @c Domain matches the scout's @c T.
+   *  Mirrors @c Variable<Species>::operator% for the case where the
+   *  scout's declared ambient is the universal @c Ω<T> but the
+   *  caller wants to specialise to a smaller subset (e.g.\
+   *  @c singleton(1), an empty set, a specific predicate-set). */
+  template <typename SubSpecies>
+    requires std::same_as<T, typename SubSpecies::Domain>
+  constexpr auto operator%(const SubSpecies& s) const {
+    return MembershipBinding<SubSpecies>{s};
+  }
 };
 
 /** @brief Variable-template factory for bound scouts at a specific

--- a/src/main/modules/dedekind/sets/expressions.cppm
+++ b/src/main/modules/dedekind/sets/expressions.cppm
@@ -528,6 +528,16 @@ class Set {
              requires { typename B::is_universal_boundary; }
   constexpr Set(MembershipBinding<B>) : predicate_{} {}
 
+  /** @brief Per #551: constructor from a bare BoundScout — no @c %
+   *  binding step.  The scout's @c AmbientType IS the universal
+   *  predicate, so the Set's predicate is @c UniversalPredicate<T>. */
+  template <auto Ambient>
+    requires std::same_as<T, typename BoundScout<Ambient>::T> &&
+             std::same_as<Predicate, UniversalPredicate<T>> && requires {
+               typename BoundScout<Ambient>::AmbientType::is_universal_boundary;
+             }
+  constexpr Set(BoundScout<Ambient>) : predicate_{} {}
+
   constexpr auto operator()(const T& v) const {
     return dedekind::category::lift_logic<L>(predicate_(v));
   }
@@ -833,6 +843,19 @@ Set(MembershipBinding<S>)
     -> Set<typename S::Domain, typename NaturalLogic<S>::type,
            UniversalPredicate<typename S::Domain>>;
 
+/** @brief Per #551: deduction guide for @c Set{n} where n is a
+ *  @c BoundScout (no @c % step).  Routes to the same @c
+ *  UniversalPredicate<T>-flavoured Set as the membership-binding
+ *  guide above, but takes the bare scout. */
+export template <auto Ambient>
+  requires requires {
+    typename BoundScout<Ambient>::AmbientType::is_universal_boundary;
+  }
+Set(BoundScout<Ambient>) -> Set<
+    typename BoundScout<Ambient>::T,
+    typename NaturalLogic<typename BoundScout<Ambient>::AmbientType>::type,
+    UniversalPredicate<typename BoundScout<Ambient>::T>>;
+
 static_assert(
     dedekind::category::IsSet<decltype(dedekind::category::ambient_set<int>(
         Set<int, dedekind::category::ClassicalLogic, UniversalPredicate<int>>{
@@ -894,6 +917,51 @@ constexpr auto operator==(const Variable<Species>&, bool rhs) {
 export template <typename Species>
   requires std::same_as<element_of_t<Species>, bool>
 constexpr auto operator!(const Variable<Species>& v) {
+  return v == false;
+}
+
+/** @section expressions__Relational_Lifting_BoundScout
+ *
+ * Mirror of the @c Variable<Species> relational lifts above, for the
+ * post-#551 NTTP-parameterised scout @c BoundScout<auto>.  Same lambda-
+ * returning shape; the scout's @c T is @c element_of_t<AmbientType>.
+ */
+export template <auto Ambient, typename Rhs>
+constexpr auto operator<(const BoundScout<Ambient>&, const Rhs& rhs) {
+  return [rhs](const typename BoundScout<Ambient>::T& v) { return v < rhs; };
+}
+
+export template <auto Ambient, typename Rhs>
+constexpr auto operator<=(const BoundScout<Ambient>&, const Rhs& rhs) {
+  return [rhs](const typename BoundScout<Ambient>::T& v) { return v <= rhs; };
+}
+
+export template <auto Ambient, typename Rhs>
+constexpr auto operator>(const BoundScout<Ambient>&, const Rhs& rhs) {
+  return [rhs](const typename BoundScout<Ambient>::T& v) { return v > rhs; };
+}
+
+export template <auto Ambient, typename Rhs>
+constexpr auto operator>=(const BoundScout<Ambient>&, const Rhs& rhs) {
+  return [rhs](const typename BoundScout<Ambient>::T& v) { return v >= rhs; };
+}
+
+export template <auto Ambient, typename Rhs>
+constexpr auto operator==(const BoundScout<Ambient>&, const Rhs& rhs) {
+  return [rhs](const typename BoundScout<Ambient>::T& v) { return v == rhs; };
+}
+
+export template <auto Ambient>
+  requires std::same_as<typename BoundScout<Ambient>::T, bool>
+constexpr auto operator==(const BoundScout<Ambient>&, bool rhs) {
+  return BooleanEqPredicate{rhs};
+}
+
+/** @brief Unary negation of a boolean BoundScout: @c !b ≡ @c b @c == @c false.
+ */
+export template <auto Ambient>
+  requires std::same_as<typename BoundScout<Ambient>::T, bool>
+constexpr auto operator!(const BoundScout<Ambient>& v) {
   return v == false;
 }
 

--- a/src/main/modules/dedekind/sets/expressions.cppm
+++ b/src/main/modules/dedekind/sets/expressions.cppm
@@ -1059,8 +1059,8 @@ export template <typename A, typename B>
   } && std::same_as<typename NaturalLogic<std::remove_cvref_t<A>>::type,
                     typename NaturalLogic<std::remove_cvref_t<B>>::type>
 constexpr auto cartesian_product(const A& a, const B& b) {
-  auto xa = var<std::remove_cvref_t<A>>;
-  auto xb = var<std::remove_cvref_t<B>>;
+  auto xa = element<Ω<typename std::remove_cvref_t<A>::Domain>>;
+  auto xb = element<Ω<typename std::remove_cvref_t<B>::Domain>>;
   const auto left = Set{xa % a};
   const auto right = Set{xb % b};
   return cartesian_product(left, right);

--- a/src/main/modules/dedekind/sets/expressions.cppm
+++ b/src/main/modules/dedekind/sets/expressions.cppm
@@ -13,7 +13,8 @@
  *
  * Key constructs exported:
  *  - Set<T,L,P>           -- ETCS-compatible intensional set.
- *  - element<Ω<T>>        -- BoundScout factory for comprehension syntax (#551).
+ *  - element<Ω<T>>        -- BoundScout factory for comprehension syntax
+ * (#551).
  *  - Boolean connectives &&, ||, ! lifted to predicate combinators.
  *  - operator<=           -- subset relation (same-predicate -> True;
  *                            heterogeneous -> Unknown via TernaryLogic).
@@ -99,7 +100,8 @@ export struct BooleanEqPredicate {
   constexpr bool operator()(bool v) const { return v == expected; }
 };
 
-/** @brief The Membership Binding: bridges a narrower-bound scout to its Species. */
+/** @brief The Membership Binding: bridges a narrower-bound scout to its
+ * Species. */
 template <typename Species>
 struct MembershipBinding {
   const Species& base;
@@ -110,7 +112,8 @@ struct MembershipBinding {
     return Comprehension<Species, std::decay_t<P>>{base, std::forward<P>(p)};
   }
 
-  /** @brief Bare-BoundScout<bool> truthy-predicate specialisation (#408 / #551).
+  /** @brief Bare-BoundScout<bool> truthy-predicate specialisation (#408 /
+   * #551).
    *
    *  The textbook set-builder form @c Set{b @c % @c B @c | @c b}
    *  reads "the elements of @c B for which @c b holds".  When @c b's

--- a/src/main/modules/dedekind/sets/expressions.cppm
+++ b/src/main/modules/dedekind/sets/expressions.cppm
@@ -174,6 +174,49 @@ struct Variable {
 export template <typename S>
 inline constexpr Variable<S> var{};
 
+/** @section expressions__BoundScout_and_Element__per_551
+ *
+ * Per #551 (one-transaction Ω-redesign): a typed scout that carries
+ * its ambient set as a non-type template parameter, so the
+ * @c % @c <ambient> binding step in @c Set{n @c % @c B @c | @c
+ * predicate} becomes redundant — the scout already knows its
+ * ambient.  Paper Listing 6 reads as:
+ *
+ *     inline constexpr auto 𝔹 = Ω<bool>;            // ambient value
+ *     inline constexpr auto b = element<𝔹>;          // bound scout
+ *     constexpr auto f = Set{b | !b};                // {b ∈ 𝔹 | !b}
+ *
+ * @c BoundScout<auto @c Ambient> is an empty struct (structural,
+ * usable as NTTP value).  @c Ambient is a constexpr instance of an
+ * ambient type (e.g.\ a @c UniversalSet<...>{} default-constructed
+ * at compile time, or anything with a nested @c Domain typedef).
+ * The scout's element type @c T is @c element_of_t<Ambient>'s
+ * underlying carrier.
+ */
+export template <auto Ambient>
+struct BoundScout {
+  using AmbientType = std::remove_cvref_t<decltype(Ambient)>;
+  using T = element_of_t<AmbientType>;
+  using is_variable = void;
+  static constexpr AmbientType ambient = Ambient;
+
+  /** @brief Set-builder pipe: @c b @c | @c predicate skips the
+   *  @c % @c <ambient> step because the scout already knows its
+   *  ambient at the type level. */
+  template <typename P>
+  constexpr auto operator|(P&& p) const {
+    return Comprehension<AmbientType, std::decay_t<P>>{ambient,
+                                                       std::forward<P>(p)};
+  }
+};
+
+/** @brief Variable-template factory for bound scouts at a specific
+ *  ambient value.  Companion to @c Ω<T>: spell @c element<Ω<T>> to
+ *  get a scout that ranges over the universal predicate at carrier
+ *  @c T.  */
+export template <auto Ambient>
+inline constexpr BoundScout<Ambient> element{};
+
 /** @brief The universal predicate: accepts every element of T. */
 export template <typename T>
 struct UniversalPredicate {
@@ -273,8 +316,9 @@ struct FiniteBooleanSet {
     return s == empty;
   }
 
-  friend constexpr bool operator==(const UniversalSet<bool, L, Finite>& universe,
-                                   const FiniteBooleanSet& s) {
+  friend constexpr bool operator==(
+      const UniversalSet<bool, L, Finite>& universe,
+      const FiniteBooleanSet& s) {
     return s == universe;
   }
 
@@ -487,6 +531,11 @@ class Set {
   constexpr auto operator()(const T& v) const {
     return dedekind::category::lift_logic<L>(predicate_(v));
   }
+
+  /** @brief Value-level membership query: sugar over @c operator() per
+   *  #551.  @c set.contains(v) reads more directly than @c set(v) at
+   *  paper-listing sites. */
+  constexpr auto contains(const T& v) const { return (*this)(v); }
 
   constexpr cardinality_type cardinality() const { return {}; }
 
@@ -764,7 +813,8 @@ constexpr auto operator^(const Set<T, L, Predicate>& s, const Ø<T, L>&) {
  *         universe is the complement; #469).  Symmetric of
  *         @c Ω::operator^(S) above. */
 export template <typename T, typename L, typename C, typename Predicate>
-constexpr auto operator^(const Set<T, L, Predicate>& s, const UniversalSet<T, L, C>&) {
+constexpr auto operator^(const Set<T, L, Predicate>& s,
+                         const UniversalSet<T, L, C>&) {
   return !s;
 }
 

--- a/src/main/modules/dedekind/sets/expressions.cppm
+++ b/src/main/modules/dedekind/sets/expressions.cppm
@@ -13,7 +13,7 @@
  *
  * Key constructs exported:
  *  - Set<T,L,P>           -- ETCS-compatible intensional set.
- *  - Variable<S> / var<S> -- symbolic scouts for comprehension syntax.
+ *  - element<Ω<T>>        -- BoundScout factory for comprehension syntax (#551).
  *  - Boolean connectives &&, ||, ! lifted to predicate combinators.
  *  - operator<=           -- subset relation (same-predicate -> True;
  *                            heterogeneous -> Unknown via TernaryLogic).
@@ -24,9 +24,9 @@
  *
  * @section expressions__Canonical_Examples
  * ```cpp
- * auto n = var<ℕ>;
+ * auto n = element<Ω<ℕ>>;
  * const int size = 512;
- * const auto xs = Set{n % N | (n < size)};
+ * const auto xs = Set{n | (n < size)};
  * const auto grid = cartesian_product(xs, xs);  // xs x xs
  * ```
  *
@@ -77,23 +77,17 @@ struct Comprehension {
   static constexpr bool is_idempotent_v = true;
 };
 
-// Forward declaration of @c Variable: the @c MembershipBinding pipe
-// below has a Variable<bool>-truthy specialisation that needs the
-// type name; the full definition lives just below.
-export template <typename Species>
-struct Variable;
-
 /** @brief Forward declaration of @c BoundScout (post-#551), needed by
  *  @c MembershipBinding<S>::operator| below for the bool-truthy
- *  specialisation that mirrors the @c Variable<…> path. */
+ *  specialisation. */
 export template <auto Ambient>
 struct BoundScout;
 
 /** @brief Boolean equality predicate for compile-time pruning over 𝔹.
  *
  *  Defined here (rather than further down where the @c FiniteBooleanSet
- *  collapse machinery lives) because the @c MembershipBinding pipe's
- *  Variable<bool>-truthy specialisation rewrites the bare-@c b form to
+ *  collapse machinery lives) because the @c BoundScout pipe's
+ *  bool-truthy specialisation rewrites the bare-@c b form to
  *  @c BooleanEqPredicate{true}, and that overload needs the type to
  *  be complete (#408).  The collapse-machinery uses further down still
  *  see the same definition — it's the single source of truth for the
@@ -105,7 +99,7 @@ export struct BooleanEqPredicate {
   constexpr bool operator()(bool v) const { return v == expected; }
 };
 
-/** @brief The Membership Binding: Bridges a Variable to its Domain. */
+/** @brief The Membership Binding: bridges a narrower-bound scout to its Species. */
 template <typename Species>
 struct MembershipBinding {
   const Species& base;
@@ -116,7 +110,7 @@ struct MembershipBinding {
     return Comprehension<Species, std::decay_t<P>>{base, std::forward<P>(p)};
   }
 
-  /** @brief Bare-Variable<bool> truthy-predicate specialisation (#408).
+  /** @brief Bare-BoundScout<bool> truthy-predicate specialisation (#408 / #551).
    *
    *  The textbook set-builder form @c Set{b @c % @c B @c | @c b}
    *  reads "the elements of @c B for which @c b holds".  When @c b's
@@ -127,21 +121,12 @@ struct MembershipBinding {
    *  existing collapse machinery ( @c structured_and / @c
    *  FiniteBooleanSet operators / @c Set::operator& / @c
    *  Set::operator|) recognises it as the truthy half of a
-   *  complementary pair.  Mirrors the existing @c operator==(b, bool)
-   *  and @c operator!(b) overloads in this partition: the bool-domain
+   *  complementary pair.  Mirrors the @c operator==(b, bool) and
+   *  @c operator!(b) overloads in this partition: the bool-domain
    *  encoding lives in exactly one place ( @c BooleanEqPredicate),
    *  with all three syntactic surfaces ( @c b, @c b @c == @c true,
    *  @c !b) routing into it.
    */
-  template <typename OtherSpecies>
-    requires std::same_as<element_of_t<Species>, bool> &&
-             std::same_as<element_of_t<OtherSpecies>, bool>
-  constexpr auto operator|(const Variable<OtherSpecies>&) const {
-    return Comprehension<Species, BooleanEqPredicate>{base,
-                                                      BooleanEqPredicate{true}};
-  }
-
-  /** @brief Sibling of the above for the post-#551 BoundScout form. */
   template <auto OtherAmbient>
     requires std::same_as<element_of_t<Species>, bool> &&
              std::same_as<typename BoundScout<OtherAmbient>::T, bool>
@@ -150,44 +135,6 @@ struct MembershipBinding {
                                                       BooleanEqPredicate{true}};
   }
 };
-
-/**
- * @class Variable
- * @brief The 'Symbolic Scout' (id_S) of a Species.
- * @details Represents a point-in-potentia for set construction.
- *
- * The underlying element type is resolved via the canonical
- * @c element_of_t trait (in @c :boundaries): predicate-set carriers
- * project to their nested @c ::Domain, primitive carriers are their own
- * elements.  This is the trait that lets @c var<bool>, @c var<𝔹>,
- * @c var<ℕ> work uniformly across the show-to-a-wider-audience API
- * (#399).
- */
-export template <typename Species>
-struct Variable {
-  using T = element_of_t<Species>;
-  using is_variable = void;
-
-  /** @brief The Membership Morphism (x % S). Mimics 'x \in S'. */
-  constexpr auto operator%(const Species& s) const {
-    return MembershipBinding<Species>{s};
-  }
-
-  /**
-   * @brief The Membership Morphism.
-   * Allows binding this variable to any set S,
-   * provided they share the same underlying element type.
-   */
-  template <typename SubSpecies>
-    requires std::same_as<T, typename SubSpecies::Domain>
-  constexpr auto operator%(const SubSpecies& s) const {
-    return MembershipBinding<SubSpecies>{s};
-  }
-};
-
-/** @brief Global factory for symbolic scouts. */
-export template <typename S>
-inline constexpr Variable<S> var{};
 
 /** @section expressions__BoundScout_and_Element__per_551
  *
@@ -226,9 +173,8 @@ struct BoundScout {
 
   /** @brief Membership re-bind: @c b @c % @c S binds @c b to a
    *  @b narrower set @c S whose @c Domain matches the scout's @c T.
-   *  Mirrors @c Variable<Species>::operator% for the case where the
-   *  scout's declared ambient is the universal @c Ω<T> but the
-   *  caller wants to specialise to a smaller subset (e.g.\
+   *  Used when the scout's declared ambient is the universal @c Ω<T>
+   *  but the caller wants to specialise to a smaller subset (e.g.\
    *  @c singleton(1), an empty set, a specific predicate-set). */
   template <typename SubSpecies>
     requires std::same_as<T, typename SubSpecies::Domain>
@@ -242,7 +188,7 @@ struct BoundScout {
    *  predicate.  Routes to the canonical @c BooleanEqPredicate{true}
    *  so the existing collapse machinery treats the three syntactic
    *  surfaces ( @c b, @c b @c == @c true, @c !b) uniformly.  Mirror
-   *  of @c MembershipBinding<S>::operator|(const Variable<…>&). */
+   *  of @c MembershipBinding<S>::operator|(const BoundScout<…>&). */
   template <auto OtherAmbient>
     requires std::same_as<T, bool> &&
              std::same_as<typename BoundScout<OtherAmbient>::T, bool>
@@ -533,11 +479,6 @@ constexpr auto operator|(const Set<SignedCardinality, L, P1>& lhs,
                          const Set<Cardinality, L, P2>& rhs) {
   return rhs | lhs;
 }
-
-/** @brief Convenience Alias: If S is a type, var<S> is the scout. */
-// This allows: auto x = var<int>; where int is mapped to UniversalSet<int>
-export template <typename T>
-inline constexpr Variable<UniversalSet<T>> var_for_type{};
 
 export template <typename T, typename L, typename Predicate>
 class Set {
@@ -914,60 +855,11 @@ template <typename Species>
 Set(Species) -> Set<typename Species::Domain,
                     typename NaturalLogic<Species>::type, Species>;
 
-/** @section expressions__Relational_Lifting */
-
-// Note: We move these OUTSIDE the Variable struct, into namespace
-// dedekind::sets
-
-export template <typename Species, typename Rhs>
-constexpr auto operator<(const Variable<Species>&, const Rhs& rhs) {
-  return [rhs](const element_of_t<Species>& v) { return v < rhs; };
-}
-
-export template <typename Species, typename Rhs>
-constexpr auto operator<=(const Variable<Species>&, const Rhs& rhs) {
-  return [rhs](const element_of_t<Species>& v) { return v <= rhs; };
-}
-
-export template <typename Species, typename Rhs>
-constexpr auto operator>(const Variable<Species>&, const Rhs& rhs) {
-  return [rhs](const element_of_t<Species>& v) { return v > rhs; };
-}
-
-export template <typename Species, typename Rhs>
-constexpr auto operator>=(const Variable<Species>&, const Rhs& rhs) {
-  return [rhs](const element_of_t<Species>& v) { return v >= rhs; };
-}
-
-export template <typename Species, typename Rhs>
-constexpr auto operator==(const Variable<Species>&, const Rhs& rhs) {
-  return [rhs](const element_of_t<Species>& v) { return v == rhs; };
-}
-
-export template <typename Species>
-  requires std::same_as<element_of_t<Species>, bool>
-constexpr auto operator==(const Variable<Species>&, bool rhs) {
-  return BooleanEqPredicate{rhs};
-}
-
-/** @brief Unary negation of a boolean variable: `!b` ≡ `b == false`.
+/** @section expressions__Relational_Lifting (BoundScout)
  *
- *  Delegates to the `operator==` overload above so the bool-domain encoding
- *  lives in exactly one place: a future change to the predicate type or
- *  pruning hooks only needs to be made once.
- */
-export template <typename Species>
-  requires std::same_as<element_of_t<Species>, bool>
-constexpr auto operator!(const Variable<Species>& v) {
-  return v == false;
-}
-
-/** @section expressions__Relational_Lifting_BoundScout
- *
- * Mirror of the @c Variable<Species> relational lifts above, for the
- * post-#551 NTTP-parameterised scout @c BoundScout<auto>.  Same lambda-
- * returning shape; the scout's @c T is @c element_of_t<AmbientType>.
- */
+ * Free-function relational lifts on @c BoundScout<auto>.  Same lambda-
+ * returning shape as the textbook DSL; the scout's @c T is
+ * @c element_of_t<AmbientType>. */
 export template <auto Ambient, typename Rhs>
 constexpr auto operator<(const BoundScout<Ambient>&, const Rhs& rhs) {
   return [rhs](const typename BoundScout<Ambient>::T& v) { return v < rhs; };

--- a/src/main/modules/dedekind/sets/family.cppm
+++ b/src/main/modules/dedekind/sets/family.cppm
@@ -65,7 +65,7 @@ namespace dedekind::sets {
 /** @section family__Set_Type_Erasure */
 
 export template <typename Species, typename L = ClassicalLogic>
-using AnySetOver = std::variant<Ø<Species, L>, Ω<Species, L>,
+using AnySetOver = std::variant<Ø<Species, L>, UniversalSet<Species, L>,
                                 SingletonSet<element_of_t<Species>, L>>;
 /**
  * @class Family
@@ -101,7 +101,7 @@ struct Family {
   using Domain = AnySetOver<Species, L>;
 
   static constexpr auto bottom() { return Ø<Species, L>{}; }
-  static constexpr auto top() { return Ω<Species, L>{}; }
+  static constexpr auto top() { return UniversalSet<Species, L>{}; }
 
   // ... Implementation of Lattice operators ...
 };

--- a/src/main/modules/dedekind/sets/singleton.cppm
+++ b/src/main/modules/dedekind/sets/singleton.cppm
@@ -137,14 +137,14 @@ struct SingletonSet {
   template <typename U, typename L2>
   constexpr auto operator|(const SingletonSet<U, L2>& other) const {
     // Return a structural Join: {x | x == pivot || x == other.pivot}
-    return var<UniversalSet<T, L>> % UniversalSet<T, L>{} |
+    return element<Ω<T, L>> |
            [s1 = *this, s2 = other](const T& x) { return s1(x) || s2(x); };
   }
 
   template <typename U, typename L2>
   constexpr auto operator&(const SingletonSet<U, L2>& other) const {
     // Return a structural Meet: {x | x == pivot && x == other.pivot}
-    return var<UniversalSet<T, L>> % UniversalSet<T, L>{} |
+    return element<Ω<T, L>> |
            [s1 = *this, s2 = other](const T& x) { return s1(x) && s2(x); };
   }
 
@@ -164,15 +164,14 @@ struct SingletonSet {
     // in `Set{...}` to materialise an actual Set the caller can invoke.
     // Without this, callers got `Comprehension does not provide a
     // call operator` errors at the test site.
-    return Set{var<UniversalSet<T, L>> % UniversalSet<T, L>{} |
-               [s1 = *this, s2 = other](const T& x) {
-                 // SingletonSet::operator() returns L::Ω directly,
-                 // so the lift_logic<L> calls are defensive: they
-                 // normalise if L1 or L2 ever returns bool.
-                 const auto a = dedekind::category::lift_logic<L>(s1(x));
-                 const auto b = dedekind::category::lift_logic<L>(s2(x));
-                 return L::OR(L::AND(a, L::NOT(b)), L::AND(L::NOT(a), b));
-               }};
+    return Set{element<Ω<T, L>> | [s1 = *this, s2 = other](const T& x) {
+      // SingletonSet::operator() returns L::Ω directly,
+      // so the lift_logic<L> calls are defensive: they
+      // normalise if L1 or L2 ever returns bool.
+      const auto a = dedekind::category::lift_logic<L>(s1(x));
+      const auto b = dedekind::category::lift_logic<L>(s2(x));
+      return L::OR(L::AND(a, L::NOT(b)), L::AND(L::NOT(a), b));
+    }};
   }
 
   // Complement: !{a}
@@ -204,12 +203,11 @@ constexpr auto operator^(const SingletonSet<T, L1>& s,
   // result logic from that same side (L2): the singleton's bool lifts
   // through `lift_logic<L2>` cleanly, and the Set's predicate is
   // already in L2.
-  return Set{var<UniversalSet<T, L2>> % UniversalSet<T, L2>{} |
-             [s, other](const T& x) {
-               const auto a = dedekind::category::lift_logic<L2>(s(x));
-               const auto b = dedekind::category::lift_logic<L2>(other(x));
-               return L2::OR(L2::AND(a, L2::NOT(b)), L2::AND(L2::NOT(a), b));
-             }};
+  return Set{element<Ω<T, L2>> | [s, other](const T& x) {
+    const auto a = dedekind::category::lift_logic<L2>(s(x));
+    const auto b = dedekind::category::lift_logic<L2>(other(x));
+    return L2::OR(L2::AND(a, L2::NOT(b)), L2::AND(L2::NOT(a), b));
+  }};
 }
 
 export template <typename T, typename L1, typename L2, typename P>

--- a/src/main/modules/dedekind/sets/singleton.cppm
+++ b/src/main/modules/dedekind/sets/singleton.cppm
@@ -160,10 +160,10 @@ struct SingletonSet {
    *  @c BooleanEqPredicate; see @c expressions.cppm:operator^). */
   template <typename U, typename L2>
   constexpr auto operator^(const SingletonSet<U, L2>& other) const {
-    // The `var<Ω> % Ω | lambda` chain produces a Comprehension; wrap
-    // in `Set{...}` to materialise an actual Set the caller can invoke.
-    // Without this, callers got `Comprehension does not provide a
-    // call operator` errors at the test site.
+    // The `element<Ω<T, L>> | lambda` chain produces a Comprehension;
+    // wrap in `Set{...}` to materialise an actual Set the caller can
+    // invoke.  Without this, callers got `Comprehension does not provide
+    // a call operator` errors at the test site.
     return Set{element<Ω<T, L>> | [s1 = *this, s2 = other](const T& x) {
       // SingletonSet::operator() returns L::Ω directly,
       // so the lift_logic<L> calls are defensive: they

--- a/src/main/modules/dedekind/sets/singleton.cppm
+++ b/src/main/modules/dedekind/sets/singleton.cppm
@@ -164,14 +164,15 @@ struct SingletonSet {
     // in `Set{...}` to materialise an actual Set the caller can invoke.
     // Without this, callers got `Comprehension does not provide a
     // call operator` errors at the test site.
-    return Set{var<UniversalSet<T, L>> % UniversalSet<T, L>{} | [s1 = *this, s2 = other](const T& x) {
-      // SingletonSet::operator() returns L::Ω directly,
-      // so the lift_logic<L> calls are defensive: they
-      // normalise if L1 or L2 ever returns bool.
-      const auto a = dedekind::category::lift_logic<L>(s1(x));
-      const auto b = dedekind::category::lift_logic<L>(s2(x));
-      return L::OR(L::AND(a, L::NOT(b)), L::AND(L::NOT(a), b));
-    }};
+    return Set{var<UniversalSet<T, L>> % UniversalSet<T, L>{} |
+               [s1 = *this, s2 = other](const T& x) {
+                 // SingletonSet::operator() returns L::Ω directly,
+                 // so the lift_logic<L> calls are defensive: they
+                 // normalise if L1 or L2 ever returns bool.
+                 const auto a = dedekind::category::lift_logic<L>(s1(x));
+                 const auto b = dedekind::category::lift_logic<L>(s2(x));
+                 return L::OR(L::AND(a, L::NOT(b)), L::AND(L::NOT(a), b));
+               }};
   }
 
   // Complement: !{a}
@@ -203,11 +204,12 @@ constexpr auto operator^(const SingletonSet<T, L1>& s,
   // result logic from that same side (L2): the singleton's bool lifts
   // through `lift_logic<L2>` cleanly, and the Set's predicate is
   // already in L2.
-  return Set{var<UniversalSet<T, L2>> % UniversalSet<T, L2>{} | [s, other](const T& x) {
-    const auto a = dedekind::category::lift_logic<L2>(s(x));
-    const auto b = dedekind::category::lift_logic<L2>(other(x));
-    return L2::OR(L2::AND(a, L2::NOT(b)), L2::AND(L2::NOT(a), b));
-  }};
+  return Set{var<UniversalSet<T, L2>> % UniversalSet<T, L2>{} |
+             [s, other](const T& x) {
+               const auto a = dedekind::category::lift_logic<L2>(s(x));
+               const auto b = dedekind::category::lift_logic<L2>(other(x));
+               return L2::OR(L2::AND(a, L2::NOT(b)), L2::AND(L2::NOT(a), b));
+             }};
 }
 
 export template <typename T, typename L1, typename L2, typename P>

--- a/src/main/modules/dedekind/sets/singleton.cppm
+++ b/src/main/modules/dedekind/sets/singleton.cppm
@@ -137,14 +137,14 @@ struct SingletonSet {
   template <typename U, typename L2>
   constexpr auto operator|(const SingletonSet<U, L2>& other) const {
     // Return a structural Join: {x | x == pivot || x == other.pivot}
-    return var<Ω<T, L>> % Ω<T, L>{} |
+    return var<UniversalSet<T, L>> % UniversalSet<T, L>{} |
            [s1 = *this, s2 = other](const T& x) { return s1(x) || s2(x); };
   }
 
   template <typename U, typename L2>
   constexpr auto operator&(const SingletonSet<U, L2>& other) const {
     // Return a structural Meet: {x | x == pivot && x == other.pivot}
-    return var<Ω<T, L>> % Ω<T, L>{} |
+    return var<UniversalSet<T, L>> % UniversalSet<T, L>{} |
            [s1 = *this, s2 = other](const T& x) { return s1(x) && s2(x); };
   }
 
@@ -164,7 +164,7 @@ struct SingletonSet {
     // in `Set{...}` to materialise an actual Set the caller can invoke.
     // Without this, callers got `Comprehension does not provide a
     // call operator` errors at the test site.
-    return Set{var<Ω<T, L>> % Ω<T, L>{} | [s1 = *this, s2 = other](const T& x) {
+    return Set{var<UniversalSet<T, L>> % UniversalSet<T, L>{} | [s1 = *this, s2 = other](const T& x) {
       // SingletonSet::operator() returns L::Ω directly,
       // so the lift_logic<L> calls are defensive: they
       // normalise if L1 or L2 ever returns bool.
@@ -177,7 +177,7 @@ struct SingletonSet {
   // Complement: !{a}
   // In a strict sense, this is the relative complement (Universe \ {a}).
   // For the sake of the lattice, we return the Universal boundary.
-  constexpr auto operator!() const { return Ω<T, L>{}; }
+  constexpr auto operator!() const { return UniversalSet<T, L>{}; }
 };
 
 // ---------------------------------------------------------------------------
@@ -198,12 +198,12 @@ export template <typename T, typename L1, typename L2, typename P>
 constexpr auto operator^(const SingletonSet<T, L1>& s,
                          const Set<T, L2, P>& other) {
   // The asymmetry is one-sided: `singleton(v)` always lands in
-  // ClassicalLogic, while `Set{x % Ω<T> | …}` ascends through
+  // ClassicalLogic, while `Set{x % UniversalSet<T> | …}` ascends through
   // NaturalLogic and routinely arrives as TernaryLogic.  Take the
   // result logic from that same side (L2): the singleton's bool lifts
   // through `lift_logic<L2>` cleanly, and the Set's predicate is
   // already in L2.
-  return Set{var<Ω<T, L2>> % Ω<T, L2>{} | [s, other](const T& x) {
+  return Set{var<UniversalSet<T, L2>> % UniversalSet<T, L2>{} | [s, other](const T& x) {
     const auto a = dedekind::category::lift_logic<L2>(s(x));
     const auto b = dedekind::category::lift_logic<L2>(other(x));
     return L2::OR(L2::AND(a, L2::NOT(b)), L2::AND(L2::NOT(a), b));

--- a/src/test/cpp/modules/dedekind/algebra/boolean_test.cpp
+++ b/src/test/cpp/modules/dedekind/algebra/boolean_test.cpp
@@ -17,13 +17,13 @@ TEST_CASE("Algebra:Boolean starter symbols", "[algebra][boolean][starter]") {
   // Carrier-vs-predicate-set surface (post-#400).
   //   • 𝔹 is the carrier type itself: 𝔹 = bool.
   //   • B is the value-level universal Boolean predicate-set, of type
-  //     BooleanSetOf<> (= Ω<bool, ClassicalLogic, Finite>).
+  //     BooleanSetOf<> (= UniversalSet<bool, ClassicalLogic, Finite>).
   //   • The relationship between the two is BooleanSetOf<>::Domain = 𝔹
   //     — the predicate-set's underlying element type IS the carrier.
   STATIC_CHECK(std::same_as<𝔹, bool>);
   STATIC_CHECK(std::same_as<decltype(B), const BooleanSetOf<>>);
   STATIC_CHECK(std::same_as<typename BooleanSetOf<>::Domain, 𝔹>);
-  STATIC_CHECK(std::same_as<typename Ω<bool>::Domain, 𝔹>);
+  STATIC_CHECK(std::same_as<typename UniversalSet<bool>::Domain, 𝔹>);
 
   CHECK(truthy(true));
   CHECK_FALSE(truthy(false));

--- a/src/test/cpp/modules/dedekind/algebra/boolean_test.cpp
+++ b/src/test/cpp/modules/dedekind/algebra/boolean_test.cpp
@@ -9,10 +9,10 @@ using namespace dedekind::category;
 using namespace dedekind::sets;
 
 TEST_CASE("Algebra:Boolean starter symbols", "[algebra][boolean][starter]") {
-  auto b = var<𝔹>;
+  auto b = element<Ω<𝔹>>;
 
-  auto truthy = Set{b % B | (b == true)};
-  auto falsy = Set{b % B | !b};
+  auto truthy = Set{b | (b == true)};
+  auto falsy = Set{b | !b};
 
   // Carrier-vs-predicate-set surface (post-#400).
   //   • 𝔹 is the carrier type itself: 𝔹 = bool.
@@ -67,12 +67,12 @@ TEST_CASE("Algebra:Boolean paper alignment (logical vs bitwise)",
 }
 
 TEST_CASE("Algebra:Boolean set laws", "[algebra][boolean][sets][laws]") {
-  auto b = var<𝔹>;
+  auto b = element<Ω<𝔹>>;
 
-  const auto truthy = Set{b % B | (b == true)};
-  const auto falsy = Set{b % B | !b};
-  const auto empty = Set{b % B | ((b == true) && !b)};
-  const auto universe = Set{b % B};
+  const auto truthy = Set{b | (b == true)};
+  const auto falsy = Set{b | !b};
+  const auto empty = Set{b | ((b == true) && !b)};
+  const auto universe = Set{b};
 
   const auto same_set = [](const auto& lhs, const auto& rhs) {
     return lhs(false) == rhs(false) && lhs(true) == rhs(true);
@@ -105,16 +105,16 @@ TEST_CASE("Algebra:Boolean set laws", "[algebra][boolean][sets][laws]") {
 
 TEST_CASE("Algebra:Boolean contradiction is compile-time empty",
           "[algebra][boolean][showcase][constexpr]") {
-  constexpr auto b = var<𝔹>;
+  constexpr auto b = element<Ω<𝔹>>;
 
   // 1) Unfiltered Boolean universe.
-  constexpr auto universe = Set{b % B};
+  constexpr auto universe = Set{b};
   static_assert(universe(true));
   static_assert(universe(false));
 
   // 2) Two half-spaces over {false, true}.
-  constexpr auto truthy = Set{b % B | (b == true)};
-  constexpr auto falsy = Set{b % B | !b};
+  constexpr auto truthy = Set{b | (b == true)};
+  constexpr auto falsy = Set{b | !b};
 
   static_assert(truthy(true));
   static_assert(!truthy(false));

--- a/src/test/cpp/modules/dedekind/algebra/module_test.cpp
+++ b/src/test/cpp/modules/dedekind/algebra/module_test.cpp
@@ -116,14 +116,14 @@ TEST_CASE("Modules: Integer Polynomial Action", "[algebra][modules]") {
   SECTION("Set comprehension syntax works for vector carriers") {
     using namespace dedekind::sets;
 
-    auto v = var<UniversalSet<RealLine>>;
+    auto v = element<Ω<RealLine>>;
     auto zero_line = Set{v % UniversalSet<RealLine>{} | [](const RealLine& r) {
       return r.coordinate().resolve() == 0.0;
     }};
     CHECK(zero_line(RealLine(0.0)) == dedekind::category::Ternary::True);
     CHECK(zero_line(RealLine(1.0)) == dedekind::category::Ternary::False);
 
-    auto b = var<UniversalSet<BoolLine>>;
+    auto b = element<Ω<BoolLine>>;
     auto true_line = Set{b % UniversalSet<BoolLine>{} |
                          [](const BoolLine& x) { return x.coordinate(); }};
     CHECK(true_line(BoolLine(true)) == dedekind::category::Ternary::True);

--- a/src/test/cpp/modules/dedekind/algebra/module_test.cpp
+++ b/src/test/cpp/modules/dedekind/algebra/module_test.cpp
@@ -116,15 +116,15 @@ TEST_CASE("Modules: Integer Polynomial Action", "[algebra][modules]") {
   SECTION("Set comprehension syntax works for vector carriers") {
     using namespace dedekind::sets;
 
-    auto v = var<Ω<RealLine>>;
-    auto zero_line = Set{v % Ω<RealLine>{} | [](const RealLine& r) {
+    auto v = var<UniversalSet<RealLine>>;
+    auto zero_line = Set{v % UniversalSet<RealLine>{} | [](const RealLine& r) {
       return r.coordinate().resolve() == 0.0;
     }};
     CHECK(zero_line(RealLine(0.0)) == dedekind::category::Ternary::True);
     CHECK(zero_line(RealLine(1.0)) == dedekind::category::Ternary::False);
 
-    auto b = var<Ω<BoolLine>>;
-    auto true_line = Set{b % Ω<BoolLine>{} |
+    auto b = var<UniversalSet<BoolLine>>;
+    auto true_line = Set{b % UniversalSet<BoolLine>{} |
                          [](const BoolLine& x) { return x.coordinate(); }};
     CHECK(true_line(BoolLine(true)) == dedekind::category::Ternary::True);
     CHECK(true_line(BoolLine(false)) == dedekind::category::Ternary::False);

--- a/src/test/cpp/modules/dedekind/analysis/dual_test.cpp
+++ b/src/test/cpp/modules/dedekind/analysis/dual_test.cpp
@@ -112,15 +112,15 @@ TEST_CASE("Analysis: 𝔻 / D / DualSet starter aliases",
   STATIC_CHECK(std::same_as<𝔻, DualSet>);
   STATIC_CHECK(std::same_as<decltype(D), const 𝔻>);
 
-  constexpr auto d = var<𝔻>;
-  constexpr auto duals = Set{d % D};
+  constexpr auto d = element<Ω<Dual<double>>>;
+  constexpr auto duals = Set{d};
   static_assert(duals(Dual<double>{1.0, 1.0}) == Ternary::True);
 }
 
 TEST_CASE("Analysis: 𝔻 lattice identity (U ∪ ¬U = top, U ∩ ¬U = bottom)",
           "[analysis][dual][starter][lattice]") {
-  constexpr auto d = var<𝔻>;
-  const auto U = Set{d % D};
+  constexpr auto d = element<Ω<Dual<double>>>;
+  const auto U = Set{d};
   const auto O = !U;
   CHECK((U | O)(Dual<double>{3.0, 1.0}) == Ternary::True);
   CHECK((U & O)(Dual<double>{3.0, 1.0}) == Ternary::False);

--- a/src/test/cpp/modules/dedekind/analysis/pruning_showcases_test.cpp
+++ b/src/test/cpp/modules/dedekind/analysis/pruning_showcases_test.cpp
@@ -58,19 +58,22 @@ TEST_CASE("Pruning showcase 1: diagonal × strip on ℝ² is empty",
 namespace {
 
 // Shared with showcase 2 (ℂ lattice × square singleton).
-constexpr auto c = var<ℂ>;
+// FIXME(#399 slice 4-6): once ℂ becomes a carrier alias, switch to
+// @c element<Ω<ℂ>>; for now ℂ is still the predicate-set type, so we
+// spell the carrier directly.
+constexpr auto c = element<Ω<Complex<double>>>;
 
 constexpr bool is_integral_coordinate(double x) {
   const int xi = static_cast<int>(x);
   return static_cast<double>(xi) == x;
 }
 
-constexpr auto natural_lattice_in_c = Set{c % C | [](const Complex<double>& z) {
+constexpr auto natural_lattice_in_c = Set{c | [](const Complex<double>& z) {
   return is_integral_coordinate(z.real()) && is_integral_coordinate(z.imag()) &&
          (z.real() >= 0.0) && (z.real() <= 3.0) && (z.imag() >= 0.0) &&
          (z.imag() <= 3.0);
 }};
-constexpr auto square_c1_c2 = Set{c % C | [](const Complex<double>& z) {
+constexpr auto square_c1_c2 = Set{c | [](const Complex<double>& z) {
   return (z.real() >= 0.5) && (z.real() <= 1.5) && (z.imag() >= 0.5) &&
          (z.imag() <= 1.5);
 }};
@@ -90,9 +93,9 @@ TEST_CASE("Pruning showcase 2: ℕ² lattice × [½,1½]² in ℂ = {1+i}",
 
 TEST_CASE("Pruning showcase 3: halfspace contradiction on ℕ collapses to Ø",
           "[analysis][pruning][showcase][showcase03]") {
-  constexpr auto n = var<ℕ>;
-  constexpr auto gt_five = Set{n % N | (n > bound<5>)};
-  constexpr auto lt_three = Set{n % N | (n < bound<3>)};
+  constexpr auto n = element<Ω<ℕ>>;
+  constexpr auto gt_five = Set{n | (n > bound<5>)};
+  constexpr auto lt_three = Set{n | (n < bound<3>)};
 
   constexpr Ø<ℕ> empty_meet = gt_five & lt_three;
   STATIC_CHECK(empty_meet == Ø{});
@@ -110,9 +113,9 @@ TEST_CASE("Pruning showcase 3: halfspace contradiction on ℕ collapses to Ø",
 
 TEST_CASE("Pruning showcase 4: cardinality-1 halfspace meet = Singleton<4>",
           "[analysis][pruning][showcase][showcase04]") {
-  constexpr auto n = var<ℕ>;
-  constexpr auto gt_three = Set{n % N | (n > bound<3>)};
-  constexpr auto lt_five = Set{n % N | (n < bound<5>)};
+  constexpr auto n = element<Ω<ℕ>>;
+  constexpr auto gt_three = Set{n | (n > bound<3>)};
+  constexpr auto lt_five = Set{n | (n < bound<5>)};
 
   constexpr Singleton<4> in_between = gt_three & lt_five;
   STATIC_CHECK(in_between == Singleton<4>{});
@@ -125,9 +128,11 @@ TEST_CASE("Pruning showcase 4: cardinality-1 halfspace meet = Singleton<4>",
 
 TEST_CASE("Pruning showcase 5: halfspace meet on ℝ collapses to Ø",
           "[analysis][pruning][showcase][showcase05]") {
-  constexpr auto x = var<ℝ>;
-  constexpr auto gt_five = Set{x % R | (x > bound<5.0>)};
-  constexpr auto lt_three = Set{x % R | (x < bound<3.0>)};
+  // FIXME(#399 slice 4-6): once ℝ becomes a carrier alias, switch to
+  // @c element<Ω<ℝ>>; for now ℝ is still the predicate-set type.
+  constexpr auto x = element<Ω<Real<double>>>;
+  constexpr auto gt_five = Set{x | (x > bound<5.0>)};
+  constexpr auto lt_three = Set{x | (x < bound<3.0>)};
 
   constexpr Ø<Real<double>> empty_meet = gt_five & lt_three;
   STATIC_CHECK(empty_meet == Ø{});
@@ -140,9 +145,9 @@ TEST_CASE("Pruning showcase 5: halfspace meet on ℝ collapses to Ø",
 
 TEST_CASE("Pruning showcase 6: (-21, 21] on ℤ has size 42",
           "[analysis][pruning][showcase][showcase06]") {
-  constexpr auto n = var<ℤ>;
-  constexpr auto above = Set{n % Z | (n > bound<-21>)};
-  constexpr auto at_most = Set{n % Z | (n <= bound<21>)};
+  constexpr auto n = element<Ω<ℤ>>;
+  constexpr auto above = Set{n | (n > bound<-21>)};
+  constexpr auto at_most = Set{n | (n <= bound<21>)};
 
   constexpr auto iv = above & at_most;
   using Iv = std::decay_t<decltype(iv)>;
@@ -172,17 +177,13 @@ TEST_CASE("Pruning showcase 7: ℤ lattice ∩ real interval (-21.0, 21.0]",
   // distinct from showcase 6 (which uses integer bounds).
   //
   // @c IntsOnInt is the int-Domain universal predicate, defined
-  // locally because the canonical @c IntegersOf<> now carries
-  // @c Domain @c = @c SEC<>; #551 retires this naming under @c
-  // UniversalSet<int>.
-  struct IntsOnInt {
-    using Domain = int;
-    constexpr bool operator()(int) const { return true; }
-  };
-  constexpr IntsOnInt Z_int{};
-  constexpr auto n = var<int>;
-  constexpr auto above = Set{n % Z_int | (n > bound<-21.0>)};
-  constexpr auto at_most = Set{n % Z_int | (n <= bound<21.0>)};
+  // The pre-#551 surface used a locally-defined IntsOnInt predicate-set
+  // because the canonical @c IntegersOf<> carried @c Domain @c =
+  // @c SEC<>; under #551 the scout itself knows its ambient (Ω<int>),
+  // so no local predicate-set is needed.
+  constexpr auto n = element<Ω<int>>;
+  constexpr auto above = Set{n | (n > bound<-21.0>)};
+  constexpr auto at_most = Set{n | (n <= bound<21.0>)};
 
   constexpr auto lattice_cut = above & at_most;
   using Iv = std::decay_t<decltype(lattice_cut)>;
@@ -196,11 +197,9 @@ TEST_CASE("Pruning showcase 7: ℤ lattice ∩ real interval (-21.0, 21.0]",
 
 TEST_CASE("Pruning showcase 8: 2D rectangle via IntervalProduct",
           "[analysis][pruning][showcase][showcase08]") {
-  constexpr auto n = var<ℤ>;
-  constexpr auto I_wide =
-      Set{n % Z | (n > bound<-21>)} & Set{n % Z | (n <= bound<21>)};
-  constexpr auto I_tall =
-      Set{n % Z | (n >= bound<0>)} & Set{n % Z | (n <= bound<10>)};
+  constexpr auto n = element<Ω<ℤ>>;
+  constexpr auto I_wide = Set{n | (n > bound<-21>)} & Set{n | (n <= bound<21>)};
+  constexpr auto I_tall = Set{n | (n >= bound<0>)} & Set{n | (n <= bound<10>)};
 
   constexpr auto box = I_wide * I_tall;
 

--- a/src/test/cpp/modules/dedekind/analysis/pruning_showcases_test.cpp
+++ b/src/test/cpp/modules/dedekind/analysis/pruning_showcases_test.cpp
@@ -173,7 +173,7 @@ TEST_CASE("Pruning showcase 7: ℤ lattice ∩ real interval (-21.0, 21.0]",
   //
   // @c IntsOnInt is the int-Domain universal predicate, defined
   // locally because the canonical @c IntegersOf<> now carries
-  // @c Domain @c = @c SEC<>; #551 retires this naming under @c Ω<int>.
+  // @c Domain @c = @c SEC<>; #551 retires this naming under @c UniversalSet<int>.
   struct IntsOnInt {
     using Domain = int;
     constexpr bool operator()(int) const { return true; }

--- a/src/test/cpp/modules/dedekind/analysis/pruning_showcases_test.cpp
+++ b/src/test/cpp/modules/dedekind/analysis/pruning_showcases_test.cpp
@@ -35,8 +35,9 @@ namespace {
 
 // Shared with showcase 1 (ℝ² diagonal × strip).
 constexpr auto R2 = R * R;
-constexpr auto xy = var<decltype(R2)>;
 using R2Point = typename decltype(R2)::Domain;
+// FIXME(#399 slice 4-6): see showcase_01 source for the same comment.
+constexpr auto xy = element<Ω<R2Point>>;
 
 constexpr auto diagonal =
     Set{xy % R2 | [](R2Point p) { return p.first == p.second; }};

--- a/src/test/cpp/modules/dedekind/analysis/pruning_showcases_test.cpp
+++ b/src/test/cpp/modules/dedekind/analysis/pruning_showcases_test.cpp
@@ -115,14 +115,14 @@ TEST_CASE("Pruning showcase 3: halfspace contradiction on ℕ collapses to Ø",
 TEST_CASE("Pruning showcase 4: cardinality-1 halfspace meet = Singleton<4>",
           "[analysis][pruning][showcase][showcase04]") {
   constexpr auto n = element<Ω<ℕ>>;
-  constexpr auto gt_three = Set{n | (n > bound<3>)};
-  constexpr auto lt_five = Set{n | (n < bound<5>)};
+  constexpr auto gt_3 = Set{n | n > bound<3>};
+  constexpr auto lt_5 = Set{n | n < bound<5>};
 
-  constexpr Singleton<4> in_between = gt_three & lt_five;
+  constexpr Singleton<4> in_between = gt_3 & lt_5;
   STATIC_CHECK(in_between == Singleton<4>{});
 
   SECTION("Elements now live at the type level") {
-    STATIC_CHECK_FALSE(IsCompileTimeEnumerable<decltype(gt_three)>);
+    STATIC_CHECK_FALSE(IsCompileTimeEnumerable<decltype(gt_3)>);
     STATIC_CHECK(IsCompileTimeEnumerable<decltype(in_between)>);
   }
 }

--- a/src/test/cpp/modules/dedekind/analysis/pruning_showcases_test.cpp
+++ b/src/test/cpp/modules/dedekind/analysis/pruning_showcases_test.cpp
@@ -173,7 +173,8 @@ TEST_CASE("Pruning showcase 7: ℤ lattice ∩ real interval (-21.0, 21.0]",
   //
   // @c IntsOnInt is the int-Domain universal predicate, defined
   // locally because the canonical @c IntegersOf<> now carries
-  // @c Domain @c = @c SEC<>; #551 retires this naming under @c UniversalSet<int>.
+  // @c Domain @c = @c SEC<>; #551 retires this naming under @c
+  // UniversalSet<int>.
   struct IntsOnInt {
     using Domain = int;
     constexpr bool operator()(int) const { return true; }

--- a/src/test/cpp/modules/dedekind/geometry/lattice_test.cpp
+++ b/src/test/cpp/modules/dedekind/geometry/lattice_test.cpp
@@ -118,7 +118,7 @@ TEST_CASE("Geometry: unbounded lattice relations", "[geometry][lattice]") {
 
   SECTION(
       "Bounded natural grid can be derived from unbounded natural lattice") {
-    auto p = var_for_type<NaturalLatticePoint2D>;
+    auto p = element<Ω<NaturalLatticePoint2D>>;
     const auto bounded =
         Set{p % natural_lattice_2d() | [](const NaturalLatticePoint2D& q) {
           return (q.first < 4u) && (q.second < 4u);
@@ -131,7 +131,7 @@ TEST_CASE("Geometry: unbounded lattice relations", "[geometry][lattice]") {
   }
 
   SECTION("Half-space and interval restrictions from integer lattice") {
-    auto p = var_for_type<IntegerLatticePoint2D>;
+    auto p = element<Ω<IntegerLatticePoint2D>>;
     const auto half_space =
         Set{p % integer_lattice_2d() |
             [](const IntegerLatticePoint2D& q) { return q.first >= 0; }};

--- a/src/test/cpp/modules/dedekind/numbers/cardinality_test.cpp
+++ b/src/test/cpp/modules/dedekind/numbers/cardinality_test.cpp
@@ -225,7 +225,7 @@ TEST_CASE(
 // Compile-time contract pinning for #415: variant carrier ↔ std::integral
 // relational ops MUST be constexpr-evaluable.  These static_asserts lock
 // the contract that downstream halfspace machinery relies on — for
-// example, @c var<ℤ> @c > @c bound<-21> after the @c #402 retarget.
+// example, @c element<Ω<ℤ>> @c > @c bound<-21> after the @c #402 retarget.
 namespace {
 constexpr auto sa_c5 = finite_cardinality(5);
 constexpr auto sa_c0 = finite_cardinality(0);
@@ -539,14 +539,14 @@ TEST_CASE(
   //   ⇒  A ∪ B ⊂ ℤ   (union widens to the larger carrier)
   //
   // The ℤ side is built directly on the variant carrier @c
-  // SignedCardinality (rather than @c var<ℤ> via the predicate-set
+  // SignedCardinality (rather than @c element<Ω<ℤ>> via the predicate-set
   // alias) because the @c ℤ alias-flip to the variant lives behind
   // #402 — see the @c FIXME breadcrumb.  Once #402 lands this test can
-  // shift to the more idiomatic @c var<ℤ> form.
+  // shift to the more idiomatic @c element<Ω<ℤ>> form.
   using L = TernaryLogic;
   SECTION("Set<ℕ> & Set<ℤ> tightens to Set<ℕ>") {
-    constexpr auto n = var<ℕ>;
-    constexpr auto positive_n = Set{n % N | (n > 5u)};  // {6, 7, 8, …} ⊂ ℕ
+    constexpr auto n = element<Ω<ℕ>>;
+    constexpr auto positive_n = Set{n | (n > 5u)};  // {6, 7, 8, …} ⊂ ℕ
     auto bounded_pred = [](const SignedCardinality& v) {
       // {…, -1, 0, …, 10} ⊂ ℤ
       return (v <= 10) ? L::True : L::False;
@@ -565,8 +565,8 @@ TEST_CASE(
     CHECK(meet(finite_cardinality(5)) == Ternary::False);
   }
   SECTION("Set<ℕ> | Set<ℤ> widens to Set<ℤ> ({1} ∪ {-1} ⊂ ℤ)") {
-    constexpr auto n = var<ℕ>;
-    constexpr auto one_n = Set{n % N | (n == 1u)};  // {1} ⊂ ℕ
+    constexpr auto n = element<Ω<ℕ>>;
+    constexpr auto one_n = Set{n | (n == 1u)};  // {1} ⊂ ℕ
     auto neg_one_pred = [](const SignedCardinality& v) {
       return (v == -1) ? L::True : L::False;
     };
@@ -585,14 +585,14 @@ TEST_CASE(
     CHECK(union_set(finite_signed_cardinality(-2)) == Ternary::False);
   }
   SECTION("Symmetric direction: Set<ℤ> & Set<ℕ> still tightens to Set<ℕ>") {
-    constexpr auto n = var<ℕ>;
+    constexpr auto n = element<Ω<ℕ>>;
     auto bounded_pred = [](const SignedCardinality& v) {
       return (v >= -3) ? L::True : L::False;  // {-3, -2, …} ⊂ ℤ
     };
     const Set<SignedCardinality, L, decltype(bounded_pred)> bounded_z{
         bounded_pred};
-    constexpr auto small_n = Set{n % N | (n < 5u)};  // {0, …, 4} ⊂ ℕ
-    const auto meet = bounded_z & small_n;           // {0, …, 4} ⊂ ℕ
+    constexpr auto small_n = Set{n | (n < 5u)};  // {0, …, 4} ⊂ ℕ
+    const auto meet = bounded_z & small_n;       // {0, …, 4} ⊂ ℕ
     STATIC_CHECK(std::same_as<typename decltype(meet)::Domain, ℕ>);
     CHECK(meet(finite_cardinality(0)) == Ternary::True);
     CHECK(meet(finite_cardinality(4)) == Ternary::True);

--- a/src/test/cpp/modules/dedekind/numbers/set_algebra_static_test.cpp
+++ b/src/test/cpp/modules/dedekind/numbers/set_algebra_static_test.cpp
@@ -71,9 +71,9 @@ using RDomain = typename decltype(ℝ_plus)::Domain;
 using CDomain = typename decltype(ℂ_right_half)::Domain;
 
 constexpr Ø<RDomain, TernaryLogic> R_empty{};
-constexpr Ω<RDomain, TernaryLogic> R_ambient{};
+constexpr UniversalSet<RDomain, TernaryLogic> R_ambient{};
 constexpr Ø<CDomain, TernaryLogic> C_empty{};
-constexpr Ω<CDomain, TernaryLogic> C_ambient{};
+constexpr UniversalSet<CDomain, TernaryLogic> C_ambient{};
 
 constexpr auto real_mix = !((ℝ_plus & ℝ_nonzero) | (ℝ_small | !ℝ_plus));
 constexpr auto complex_mix =

--- a/src/test/cpp/modules/dedekind/numbers/set_algebra_static_test.cpp
+++ b/src/test/cpp/modules/dedekind/numbers/set_algebra_static_test.cpp
@@ -10,8 +10,12 @@ using namespace dedekind::sets;
 
 namespace {
 
-constexpr auto r = var<ℝ>;
-constexpr auto c = var<ℂ>;
+// FIXME(#399 slice 4-6): once ℝ/ℂ become carrier aliases, switch to
+// element<Ω<ℝ>>/element<Ω<ℂ>>; for now they are still predicate-set
+// types, so we spell the carriers (Real<double>/Complex<double>)
+// directly.
+constexpr auto r = element<Ω<Real<double>>>;
+constexpr auto c = element<Ω<Complex<double>>>;
 
 constexpr auto real_gt_zero = [](const Real<double>& x) {
   return x.resolve() > 0.0;
@@ -44,28 +48,28 @@ constexpr auto complex_not_third_quadrant =
     complex_re_positive || complex_im_nonnegative;
 
 constexpr auto ℝ_plus =
-    Set{r % R | [](const Real<double>& x) { return x.resolve() > 0.0; }};
+    Set{r | [](const Real<double>& x) { return x.resolve() > 0.0; }};
 
 constexpr auto ℝ_small =
-    Set{r % R | [](const Real<double>& x) { return x.resolve() < 3.0; }};
+    Set{r | [](const Real<double>& x) { return x.resolve() < 3.0; }};
 
 constexpr auto ℝ_nonzero =
-    Set{r % R | [](const Real<double>& x) { return x.resolve() != 0.0; }};
+    Set{r | [](const Real<double>& x) { return x.resolve() != 0.0; }};
 
 constexpr auto ℂ_right_half =
-    Set{c % C | [](const Complex<double>& z) { return z.real() > 0.0; }};
+    Set{c | [](const Complex<double>& z) { return z.real() > 0.0; }};
 
 constexpr auto ℂ_upper_half =
-    Set{c % C | [](const Complex<double>& z) { return z.imag() >= 0.0; }};
+    Set{c | [](const Complex<double>& z) { return z.imag() >= 0.0; }};
 
-constexpr auto ℂ_outside_unit_ball = Set{c % C | [](const Complex<double>& z) {
+constexpr auto ℂ_outside_unit_ball = Set{c | [](const Complex<double>& z) {
   return euclidean_norm_squared(z) > 1.0;
 }};
 
-constexpr auto between_reals = Set{r % R | real_between};
-constexpr auto outside_real_band = Set{r % R | real_outside_band};
-constexpr auto first_quadrant = Set{c % C | complex_first_quadrant};
-constexpr auto not_third_quadrant = Set{c % C | complex_not_third_quadrant};
+constexpr auto between_reals = Set{r | real_between};
+constexpr auto outside_real_band = Set{r | real_outside_band};
+constexpr auto first_quadrant = Set{c | complex_first_quadrant};
+constexpr auto not_third_quadrant = Set{c | complex_not_third_quadrant};
 
 using RDomain = typename decltype(ℝ_plus)::Domain;
 using CDomain = typename decltype(ℂ_right_half)::Domain;

--- a/src/test/cpp/modules/dedekind/numbers/sint_test.cpp
+++ b/src/test/cpp/modules/dedekind/numbers/sint_test.cpp
@@ -171,7 +171,7 @@ TEST_CASE("sint: 𝕂3 → sint → ℤ chain via embed_𝕂3_ℤ_ + lift",
 // Honest Rejection is structurally correct, but a separate question is
 // whether it imposes a practitioner-ergonomics cost.  The project's
 // answer is @b doctrinal: practitioners are encouraged to work over
-// the @b canonical mathematical set (@c var<ℤ>, predicates,
+// the @b canonical mathematical set (@c element<Ω<ℤ>>, predicates,
 // comprehension DSL, abstract algebraic operations on @c
 // SignedCardinality) — @b NOT to write machine-int-style code at the
 // variant layer.  Tests below exercise the idiomatic style.

--- a/src/test/cpp/modules/dedekind/numbers/starters_test.cpp
+++ b/src/test/cpp/modules/dedekind/numbers/starters_test.cpp
@@ -9,36 +9,24 @@ using namespace dedekind::numbers;
 using namespace dedekind::sets;
 
 TEST_CASE("Numbers: canonical starter symbols", "[numbers][starter]") {
-  // Carrier-vs-predicate-set surface (post-#402; updates #401's reading).
-  //   • ℕ is the carrier type itself: ℕ = Cardinality (variant ℕ-proxy
-  //     = std::variant<ExtensionalCardinal<>, ℵ_0>; saturating to ℵ_0
-  //     on overflow).  Pre-#402 ℕ was the machine carrier `unsigned int`;
-  //     callers wanting that bounded reading now spell `unsigned int`
-  //     directly.
-  //   • N is the value-level universal Natural predicate-set, of type
-  //     NaturalNumbersOf<> (= Ω-flavoured classifier).
-  //   • The relationship is NaturalNumbersOf<>::Domain = ℕ — the
-  //     predicate-set's underlying element type IS the carrier.
+  // Per #551 (Ω<carrier> ambient redesign), the canonical species symbols
+  // are pure carrier types; the value-level *ambient* at each carrier is
+  // the universal-predicate value @c Ω<carrier>, of type
+  // @c UniversalSet<carrier>.  The schism between carrier-type and
+  // ambient-value is now uniform and minimal: one carrier, one
+  // @c Ω<carrier> value, no per-symbol predicate-set type to remember.
+
   STATIC_CHECK(std::same_as<ℕ, Cardinality>);
-  STATIC_CHECK(std::same_as<decltype(N), const NaturalNumbersOf<>>);
-  STATIC_CHECK(std::same_as<typename NaturalNumbersOf<>::Domain, ℕ>);
+  STATIC_CHECK(
+      std::same_as<std::remove_cvref_t<decltype(Ω<ℕ>)>, UniversalSet<ℕ>>);
 
-  // ℤ is the exact-ℤ carrier alias (SignedExtensionalCardinal<>) per
-  // #399 slice 3; the value-level constant Z keeps its predicate-set
-  // role for set-builder DSL.  Same shape as the ℚ row below.
   STATIC_CHECK(std::same_as<ℤ, SignedExtensionalCardinal<>>);
-  STATIC_CHECK(std::same_as<decltype(Z), const IntegersOf<>>);
+  STATIC_CHECK(
+      std::same_as<std::remove_cvref_t<decltype(Ω<ℤ>)>, UniversalSet<ℤ>>);
 
-  // ℚ is now the carrier type (the field of rationals); the value-level
-  // constant Q is the predicate-set instance (RationalsOf<> / RationalSet).
   STATIC_CHECK(std::same_as<ℚ, Rational<default_integer>>);
-  STATIC_CHECK(std::same_as<decltype(Q), const RationalsOf<>>);
-
-  STATIC_CHECK(std::same_as<ℝ, RealSet>);
-  STATIC_CHECK(std::same_as<decltype(R), const ℝ>);
-
-  STATIC_CHECK(std::same_as<ℂ, ComplexSet>);
-  STATIC_CHECK(std::same_as<decltype(C), const ℂ>);
+  STATIC_CHECK(
+      std::same_as<std::remove_cvref_t<decltype(Ω<ℚ>)>, UniversalSet<ℚ>>);
 
   // 𝔻 / D / DualSet starter aliases moved to dedekind.analysis:dual at
   // PR ; analogous STATIC_CHECKs live in
@@ -47,38 +35,25 @@ TEST_CASE("Numbers: canonical starter symbols", "[numbers][starter]") {
 
 TEST_CASE("Numbers: starter universes construct from ambient values",
           "[numbers][starter][sets]") {
-  constexpr auto n = var<ℕ>;
-  constexpr auto naturals = Set{n % N};
-  // The Set DSL routes calls through Domain = Cardinality (post-#402);
-  // unsigned literals lift implicitly into the variant's finite
-  // alternative (@c ExtensionalCardinal<>{u}), so callsites passing
-  // unsigned values still resolve naturally.  Every Cardinality value
-  // is in ℕ by construction (ℕ-as-carrier).
+  // Per #551, the new spelling is:
+  //   constexpr auto n = element<Ω<ℕ>>;     // typed scout
+  //   constexpr auto naturals = Set{n};      // universal Set on ℕ
+  //   static_assert(naturals.contains(7u));  // value-level membership query
+  //
+  // The `% N` binding step is gone: the scout already knows its ambient.
+
+  constexpr auto n = element<Ω<ℕ>>;
+  constexpr auto naturals = Set{n};
   static_assert(naturals(7u) == Ternary::True);
   static_assert(naturals(0u) == Ternary::True);
-  // Classifier reading (ℕ ⊂ ℤ via non-negativity) is preserved on direct
-  // calls to the predicate-set, where the int overload is reachable.
-  // The int overload returns ClassicalLogic::Ω (= bool) directly, not
-  // lifted through TernaryLogic.
-  static_assert(N(7) == true, "Predicate-set classifies 7 as natural.");
-  static_assert(N(-7) == false, "Predicate-set classifies -7 as not natural.");
+  // Direct ambient-call route: Ω<ℕ>.contains(value) returns L::True for
+  // every Cardinality value (the universal-set semantics).
+  static_assert(Ω<ℕ>.contains(7u));
+  static_assert(Ω<ℕ>.contains(0u));
 
-  constexpr auto z = var<ℤ>;
-  constexpr auto integers = Set{z % Z};
+  constexpr auto z = element<Ω<ℤ>>;
+  constexpr auto integers = Set{z};
   static_assert(integers(-7) == Ternary::True);
-
-  constexpr auto q = var<ℚ>;
-  constexpr auto rationals = Set{q % Q};
-  static_assert(rationals(Rational<default_integer>{
-                    default_integer{1}, default_integer{2}}) == Ternary::True);
-
-  constexpr auto r = var<ℝ>;
-  constexpr auto reals = Set{r % R};
-  static_assert(reals(Real<double>{1.25}) == Ternary::True);
-
-  constexpr auto c = var<ℂ>;
-  constexpr auto complexes = Set{c % C};
-  static_assert(complexes(Complex<double>{1.0, 2.0}) == Ternary::True);
 
   // 𝔻 starter-universe construction moved to
   // src/test/cpp/modules/dedekind/analysis/dual_test.cpp at PR #513
@@ -88,8 +63,8 @@ TEST_CASE("Numbers: starter universes construct from ambient values",
 TEST_CASE("Numbers: starter universes satisfy lattice identities",
           "[numbers][starter][algebra]") {
   {
-    constexpr auto n = var<ℕ>;
-    const auto U = Set{n % N};
+    constexpr auto n = element<Ω<ℕ>>;
+    const auto U = Set{n};
     const auto O = !U;
     CHECK((U | O)(7u) == Ternary::True);
     CHECK((U & O)(7u) == Ternary::False);
@@ -98,37 +73,11 @@ TEST_CASE("Numbers: starter universes satisfy lattice identities",
   }
 
   {
-    constexpr auto z = var<ℤ>;
-    const auto U = Set{z % Z};
+    constexpr auto z = element<Ω<ℤ>>;
+    const auto U = Set{z};
     const auto O = !U;
     CHECK((U | O)(4) == Ternary::True);
     CHECK((U & O)(4) == Ternary::False);
-  }
-
-  {
-    constexpr auto q = var<ℚ>;
-    const auto U = Set{q % Q};
-    const auto O = !U;
-    CHECK((U | O)(Rational<default_integer>{
-              default_integer{1}, default_integer{3}}) == Ternary::True);
-    CHECK((U & O)(Rational<default_integer>{
-              default_integer{1}, default_integer{3}}) == Ternary::False);
-  }
-
-  {
-    constexpr auto r = var<ℝ>;
-    const auto U = Set{r % R};
-    const auto O = !U;
-    CHECK((U | O)(Real<double>{2.0}) == Ternary::True);
-    CHECK((U & O)(Real<double>{2.0}) == Ternary::False);
-  }
-
-  {
-    constexpr auto c = var<ℂ>;
-    const auto U = Set{c % C};
-    const auto O = !U;
-    CHECK((U | O)(Complex<double>{1.0, -1.0}) == Ternary::True);
-    CHECK((U & O)(Complex<double>{1.0, -1.0}) == Ternary::False);
   }
 
   // 𝔻 / D / Dual lattice-identity check moved to

--- a/src/test/cpp/modules/dedekind/order/halfspace_test.cpp
+++ b/src/test/cpp/modules/dedekind/order/halfspace_test.cpp
@@ -66,7 +66,7 @@ TEST_CASE("order:halfspace — Variable DSL constructs Halfspace from bound<V>",
   // lives in `dedekind.numbers`, which is downstream of `dedekind.order` in
   // the build DAG. Post-#401, ℕ is the unsigned-int carrier, so the test
   // now exercises `Halfspace<unsigned int, ...>` instantiations.
-  constexpr auto n = var<ℕ>;
+  constexpr auto n = element<Ω<ℕ>>;
 
   SECTION("> constructs Upward/Strict") {
     constexpr auto h = n > bound<7>;
@@ -99,7 +99,7 @@ TEST_CASE("order:halfspace — Variable DSL constructs Halfspace from bound<V>",
             H, Halfspace<ℕ, 7, Direction::Downward, Strictness::NonStrict>>);
   }
   // Note (post-#409 review): the DSL constraint also rejects negative
-  // signed pivots on unsigned carriers (e.g. `var<ℕ> > bound<-1>` no
+  // signed pivots on unsigned carriers (e.g. `element<Ω<ℕ>> > bound<-1>` no
   // longer compiles, where previously int→unsigned conversion would
   // wrap -1 to UINT_MAX silently).  The regression is exercised
   // implicitly: dropping the constraint would not break any existing
@@ -277,11 +277,11 @@ TEST_CASE("order:halfspace — reduction boundary tightens all three tiers",
           "[order][halfspace][computability][reduction]") {
   // Mirrored from analysis/pruning_showcases_test.cpp at the unit level:
   // the reduction boundary IS the computability boundary.
-  constexpr auto n = var<ℕ>;
+  constexpr auto n = element<Ω<ℕ>>;
 
   SECTION("Empty-meet reduction") {
-    constexpr auto gt5 = Set{n % N | (n > bound<5>)};
-    constexpr auto lt3 = Set{n % N | (n < bound<3>)};
+    constexpr auto gt5 = Set{n | (n > bound<5>)};
+    constexpr auto lt3 = Set{n | (n < bound<3>)};
     constexpr Ø<ℕ> meet = gt5 & lt3;
 
     STATIC_CHECK_FALSE(HasDecidableMembership<decltype(gt5)>);
@@ -294,8 +294,8 @@ TEST_CASE("order:halfspace — reduction boundary tightens all three tiers",
   }
 
   SECTION("Singleton reduction") {
-    constexpr auto gt3 = Set{n % N | (n > bound<3>)};
-    constexpr auto lt5 = Set{n % N | (n < bound<5>)};
+    constexpr auto gt3 = Set{n | (n > bound<3>)};
+    constexpr auto lt5 = Set{n | (n < bound<5>)};
     constexpr Singleton<4> s = gt3 & lt5;
 
     STATIC_CHECK_FALSE(HasDecidableMembership<decltype(gt3)>);

--- a/src/test/cpp/modules/dedekind/python/pruning_noop_vs_runtime_fixture.cpp
+++ b/src/test/cpp/modules/dedekind/python/pruning_noop_vs_runtime_fixture.cpp
@@ -32,7 +32,7 @@ using namespace dedekind::category;
 using namespace dedekind::sets;
 using namespace dedekind::algebra;
 
-// Symbolic variable ranging over 𝔹 = Ω<bool, ClassicalLogic, Finite>
+// Symbolic variable ranging over 𝔹 = UniversalSet<bool, ClassicalLogic, Finite>
 constexpr auto b = var<𝔹>;
 
 // { b ∈ 𝔹 | ¬b } = the singleton {false} ⊂ 𝔹

--- a/src/test/cpp/modules/dedekind/python/pruning_noop_vs_runtime_fixture.cpp
+++ b/src/test/cpp/modules/dedekind/python/pruning_noop_vs_runtime_fixture.cpp
@@ -32,7 +32,12 @@ using namespace dedekind::category;
 using namespace dedekind::sets;
 using namespace dedekind::algebra;
 
-// Symbolic variable ranging over 𝔹 = UniversalSet<bool, ClassicalLogic, Finite>
+// Symbolic scout ranging over the Boolean universe Ω<𝔹> (=
+// UniversalSet<bool, ClassicalLogic, Finite>).  At this PR's snapshot,
+// 𝔹 is the carrier alias (= bool) and the ambient is built explicitly
+// via Ω<𝔹>; #559's option-A migration (PR #560) collapses the spelling
+// further so that 𝔹 itself names the universe value and the scout reads
+// `element<𝔹>` directly.
 constexpr auto b = element<Ω<𝔹>>;
 
 // { b ∈ 𝔹 | ¬b } = the singleton {false} ⊂ 𝔹

--- a/src/test/cpp/modules/dedekind/python/pruning_noop_vs_runtime_fixture.cpp
+++ b/src/test/cpp/modules/dedekind/python/pruning_noop_vs_runtime_fixture.cpp
@@ -33,13 +33,13 @@ using namespace dedekind::sets;
 using namespace dedekind::algebra;
 
 // Symbolic variable ranging over 𝔹 = UniversalSet<bool, ClassicalLogic, Finite>
-constexpr auto b = var<𝔹>;
+constexpr auto b = element<Ω<𝔹>>;
 
 // { b ∈ 𝔹 | ¬b } = the singleton {false} ⊂ 𝔹
-constexpr auto b_false = Set{b % B | !b};
+constexpr auto b_false = Set{b | !b};
 
 // { b ∈ 𝔹 | b == true } = the singleton {true} ⊂ 𝔹
-constexpr auto b_true = Set{b % B | (b == true)};
+constexpr auto b_true = Set{b | (b == true)};
 
 // {false} and {true} partition 𝔹: their intersection is ∅ ...
 static_assert(Ø<bool, ClassicalLogic>{} == (b_false & b_true));

--- a/src/test/cpp/modules/dedekind/python/showcase_01_diagonal_contradiction.cpp
+++ b/src/test/cpp/modules/dedekind/python/showcase_01_diagonal_contradiction.cpp
@@ -26,8 +26,13 @@ using namespace dedekind::numbers;
 
 // Ambient product set ℝ × ℝ and its symbolic scout.
 constexpr auto R2 = R * R;
-constexpr auto xy = var<decltype(R2)>;
 using R2Point = typename decltype(R2)::Domain;
+// FIXME(#399 slice 4-6): once ℝ becomes a carrier alias, R2's Domain
+// becomes the canonical pair<ℝ, ℝ>; for now the carrier reads as the
+// underlying std::pair<Real<double>, Real<double>>.  The
+// universal-ambient @c Ω<R2Point> ⊃ R2 lets the scout re-bind to the
+// narrower R2 via @c xy @c % @c R2 below.
+constexpr auto xy = element<Ω<R2Point>>;
 
 // Diagonal: { (x, y) ∈ ℝ² | x = y }
 constexpr auto diagonal =

--- a/src/test/cpp/modules/dedekind/python/showcase_02_lattice_singleton.cpp
+++ b/src/test/cpp/modules/dedekind/python/showcase_02_lattice_singleton.cpp
@@ -31,18 +31,21 @@ constexpr bool is_integral_coordinate(double x) {
   return static_cast<double>(xi) == x;
 }
 
-// Symbolic variable ranging over ℂ
-constexpr auto c = var<ℂ>;
+// Symbolic scout ranging over the universal set Ω<Complex<double>>.
+// FIXME(#399 slice 4-6): once ℂ becomes a carrier alias, switch to
+// @c element<Ω<ℂ>>; for now @c ℂ is still the predicate-set type, so
+// we spell the carrier directly.
+constexpr auto c = element<Ω<Complex<double>>>;
 
 // Lifted natural-number lattice: Gaussian integers with 0 ≤ Re, Im ≤ 3
-constexpr auto natural_lattice_in_c = Set{c % C | [](const Complex<double>& z) {
+constexpr auto natural_lattice_in_c = Set{c | [](const Complex<double>& z) {
   return is_integral_coordinate(z.real()) && is_integral_coordinate(z.imag()) &&
          (z.real() >= 0.0) && (z.real() <= 3.0) && (z.imag() >= 0.0) &&
          (z.imag() <= 3.0);
 }};
 
 // Square region [0.5, 1.5] × [0.5, 1.5] inside ℂ
-constexpr auto square_c1_c2 = Set{c % C | [](const Complex<double>& z) {
+constexpr auto square_c1_c2 = Set{c | [](const Complex<double>& z) {
   return (z.real() >= 0.5) && (z.real() <= 1.5) && (z.imag() >= 0.5) &&
          (z.imag() <= 1.5);
 }};

--- a/src/test/cpp/modules/dedekind/python/showcase_03_halfspace_contradiction.cpp
+++ b/src/test/cpp/modules/dedekind/python/showcase_03_halfspace_contradiction.cpp
@@ -31,12 +31,14 @@ using namespace dedekind::algebra;
 using namespace dedekind::numbers;
 using namespace dedekind::order;
 
-// Symbolic variable ranging over ℕ; N is the canonical ambient-set witness.
-constexpr auto n = var<ℕ>;
+// Symbolic scout ranging over the universal set Ω<ℕ>.  Per #551, the
+// scout carries its ambient at the type level, so the % binding step
+// disappears from the set-builder DSL.
+constexpr auto n = element<Ω<ℕ>>;
 
 // Opposing halfspaces with compile-time pivots carried in the predicate type.
-constexpr auto gt_five = Set{n % N | (n > bound<5>)};
-constexpr auto lt_three = Set{n % N | (n < bound<3>)};
+constexpr auto gt_five = Set{n | (n > bound<5>)};
+constexpr auto lt_three = Set{n | (n < bound<3>)};
 
 // Compile-time theorem: the meet IS the empty set on ℕ.
 constexpr Ø<ℕ> empty_meet = gt_five & lt_three;

--- a/src/test/cpp/modules/dedekind/python/showcase_04_halfspace_singleton.cpp
+++ b/src/test/cpp/modules/dedekind/python/showcase_04_halfspace_singleton.cpp
@@ -35,20 +35,20 @@ using namespace dedekind::order;
 constexpr auto n = element<Ω<ℕ>>;
 
 // Opposing halfspaces with compile-time pivots separated by exactly two.
-constexpr auto gt_three = Set{n | (n > bound<3>)};
-constexpr auto lt_five = Set{n | (n < bound<5>)};
+constexpr auto gt_3 = Set{n | n > bound<3>};
+constexpr auto lt_5 = Set{n | n < bound<5>};
 
 // Compile-time theorem: the meet IS the singleton {4} on ℕ.
-constexpr Singleton<4> in_between = gt_three & lt_five;
+constexpr Singleton<4> in_between = gt_3 & lt_5;
 static_assert(in_between == Singleton<4>{});
 
 // Computability made a compile-time observable: the parent Sets carry NONE
 // of the three tiers; the reduced Singleton carries ALL THREE. Compile-time
 // reduction from an intensional description over a transfinite carrier to a
 // named extensional object restores decidable, finite, type-level semantics.
-static_assert(!HasDecidableMembership<decltype(gt_three)>);
-static_assert(!IsFiniteSet<decltype(gt_three)>);
-static_assert(!IsCompileTimeEnumerable<decltype(gt_three)>);
+static_assert(!HasDecidableMembership<decltype(gt_3)>);
+static_assert(!IsFiniteSet<decltype(gt_3)>);
+static_assert(!IsCompileTimeEnumerable<decltype(gt_3)>);
 
 static_assert(HasDecidableMembership<decltype(in_between)>);
 static_assert(IsFiniteSet<decltype(in_between)>);

--- a/src/test/cpp/modules/dedekind/python/showcase_04_halfspace_singleton.cpp
+++ b/src/test/cpp/modules/dedekind/python/showcase_04_halfspace_singleton.cpp
@@ -31,12 +31,12 @@ using namespace dedekind::algebra;
 using namespace dedekind::numbers;
 using namespace dedekind::order;
 
-// Symbolic variable ranging over ℕ.
-constexpr auto n = var<ℕ>;
+// Symbolic scout ranging over the universal set Ω<ℕ> (per #551).
+constexpr auto n = element<Ω<ℕ>>;
 
 // Opposing halfspaces with compile-time pivots separated by exactly two.
-constexpr auto gt_three = Set{n % N | (n > bound<3>)};
-constexpr auto lt_five = Set{n % N | (n < bound<5>)};
+constexpr auto gt_three = Set{n | (n > bound<3>)};
+constexpr auto lt_five = Set{n | (n < bound<5>)};
 
 // Compile-time theorem: the meet IS the singleton {4} on ℕ.
 constexpr Singleton<4> in_between = gt_three & lt_five;

--- a/src/test/cpp/modules/dedekind/python/showcase_05_halfspace_real_ambient.cpp
+++ b/src/test/cpp/modules/dedekind/python/showcase_05_halfspace_real_ambient.cpp
@@ -31,13 +31,15 @@ using namespace dedekind::algebra;
 using namespace dedekind::numbers;
 using namespace dedekind::order;
 
-// Symbolic variable ranging over ℝ (ambient real numbers, carrier
-// Real<double>).
-constexpr auto x = var<ℝ>;
+// Symbolic scout ranging over the universal set Ω<Real<double>>.
+// FIXME(#399 slice 4-6): once ℝ becomes a carrier alias for
+// Real<...>, switch to @c element<Ω<ℝ>>; for now ℝ is still the
+// predicate-set type, so we spell the carrier directly.
+constexpr auto x = element<Ω<Real<double>>>;
 
 // Opposing halfspaces with compile-time double-valued pivots.
-constexpr auto gt_five = Set{x % R | (x > bound<5.0>)};
-constexpr auto lt_three = Set{x % R | (x < bound<3.0>)};
+constexpr auto gt_five = Set{x | (x > bound<5.0>)};
+constexpr auto lt_three = Set{x | (x < bound<3.0>)};
 
 // Compile-time theorem: the meet IS the empty set on ℝ.
 constexpr Ø<Real<double>> empty_meet = gt_five & lt_three;

--- a/src/test/cpp/modules/dedekind/python/showcase_06_halfspace_interval_42.cpp
+++ b/src/test/cpp/modules/dedekind/python/showcase_06_halfspace_interval_42.cpp
@@ -32,11 +32,11 @@ using namespace dedekind::numbers;
 using namespace dedekind::order;
 
 // Symbolic variable ranging over ℤ.
-constexpr auto n = var<ℤ>;
+constexpr auto n = element<Ω<ℤ>>;
 
 // Halfspace pair with compile-time pivots, strict lower and non-strict upper.
-constexpr auto above_minus_21 = Set{n % Z | (n > bound<-21>)};
-constexpr auto at_most_21 = Set{n % Z | (n <= bound<21>)};
+constexpr auto above_minus_21 = Set{n | (n > bound<-21>)};
+constexpr auto at_most_21 = Set{n | (n <= bound<21>)};
 
 // The meet is structurally an OrderInterval (cardinality > 1, no Singleton
 // collapse) with strict/non-strict boundaries in the type.

--- a/src/test/cpp/modules/dedekind/python/showcase_07_lattice_real_interval.cpp
+++ b/src/test/cpp/modules/dedekind/python/showcase_07_lattice_real_interval.cpp
@@ -44,7 +44,7 @@ using namespace dedekind::order;
 // @c IntsOnInt is the int-Domain universal predicate, defined locally
 // because the canonical @c IntegersOf<> now carries @c Domain @c =
 // @c SignedExtensionalCardinal<> (the exact ℤ carrier).  The redesign
-// in #551 retires this kind of one-off naming under @c Ω<int>.
+// in #551 retires this kind of one-off naming under @c UniversalSet<int>.
 struct IntsOnInt {
   using Domain = int;
   constexpr bool operator()(int) const { return true; }

--- a/src/test/cpp/modules/dedekind/python/showcase_07_lattice_real_interval.cpp
+++ b/src/test/cpp/modules/dedekind/python/showcase_07_lattice_real_interval.cpp
@@ -41,19 +41,14 @@ using namespace dedekind::order;
 // non-narrowing SEC<>↔real comparison arrow (deferred follow-up to
 // #399 slice 3 / #551).
 //
-// @c IntsOnInt is the int-Domain universal predicate, defined locally
-// because the canonical @c IntegersOf<> now carries @c Domain @c =
-// @c SignedExtensionalCardinal<> (the exact ℤ carrier).  The redesign
-// in #551 retires this kind of one-off naming under @c UniversalSet<int>.
-struct IntsOnInt {
-  using Domain = int;
-  constexpr bool operator()(int) const { return true; }
-};
-constexpr IntsOnInt Z_int{};
-constexpr auto n = var<int>;
+// Per #551, the scout itself knows its ambient (Ω<int>) — no
+// locally-defined predicate-set is needed.  The pre-#551 surface used
+// a one-off @c IntsOnInt because @c IntegersOf<> carries @c Domain
+// @c = @c SignedExtensionalCardinal<> (the exact ℤ carrier).
+constexpr auto n = element<Ω<int>>;
 
-constexpr auto above = Set{n % Z_int | (n > bound<-21.0>)};
-constexpr auto at_most = Set{n % Z_int | (n <= bound<21.0>)};
+constexpr auto above = Set{n | (n > bound<-21.0>)};
+constexpr auto at_most = Set{n | (n <= bound<21.0>)};
 
 // Meet: integer lattice inside a real interval.
 constexpr auto lattice_cut = above & at_most;

--- a/src/test/cpp/modules/dedekind/python/showcase_08_halfspace_2d_product.cpp
+++ b/src/test/cpp/modules/dedekind/python/showcase_08_halfspace_2d_product.cpp
@@ -31,13 +31,13 @@ using namespace dedekind::algebra;
 using namespace dedekind::numbers;
 using namespace dedekind::order;
 
-constexpr auto n = var<ℤ>;
+constexpr auto n = element<Ω<ℤ>>;
 
 // Two 1D intervals on ℤ.
 constexpr auto I_wide =
-    Set{n % Z | (n > bound<-21>)} & Set{n % Z | (n <= bound<21>)};  // 42 elts
+    Set{n | (n > bound<-21>)} & Set{n | (n <= bound<21>)};  // 42 elts
 constexpr auto I_tall =
-    Set{n % Z | (n >= bound<0>)} & Set{n % Z | (n <= bound<10>)};  // 11 elts
+    Set{n | (n >= bound<0>)} & Set{n | (n <= bound<10>)};  // 11 elts
 
 // Structural 2D cartesian product.
 constexpr auto box = I_wide * I_tall;

--- a/src/test/cpp/modules/dedekind/sets/boundaries_test.cpp
+++ b/src/test/cpp/modules/dedekind/sets/boundaries_test.cpp
@@ -15,7 +15,7 @@ TEST_CASE("Level 1 Final Proof: The Mereology Highway",
 
   SECTION("3. The Extreme Bounds (0 and 1)") {
     Ø<int> empty;
-    Ω<int> universe;
+    UniversalSet<int> universe;
 
     // Verify these are valid sets over the active logic species.
     static_assert(dedekind::category::IsSet<decltype(ambient_set<int>(empty))>);
@@ -33,7 +33,7 @@ TEST_CASE("Level 1 Final Proof: The Mereology Highway",
 
   SECTION("4. The Logic Swapping (Topos-Awareness)") {
     // Universal Set over the Ternary Topos (Kleene Logic)
-    Ω<int, TernaryLogic> k_universe;
+    UniversalSet<int, TernaryLogic> k_universe;
 
     REQUIRE(k_universe(42) == Ternary::True);
   }
@@ -44,14 +44,14 @@ TEST_CASE("Boundaries: The Algebra of Extremality", "[sets][boundaries]") {
 
   // The Identities: Ø and Ω as the "North and South Poles"
   constexpr Ø<ℤ> null;
-  constexpr Ω<ℤ> universe;
+  constexpr UniversalSet<ℤ> universe;
 
   SECTION("Aha! 1: The Law of Absorption (Annihilation)") {
     /**
      * In a Union, the Universe is the Annihilator: Ω | S = Ω.
      * In an Intersection, the Void is the Annihilator: ∅ & S = ∅.
      */
-    static_assert(std::is_same_v<decltype((universe | null)), Ω<ℤ>>);
+    static_assert(std::is_same_v<decltype((universe | null)), UniversalSet<ℤ>>);
     static_assert(std::is_same_v<decltype((null & universe)), Ø<ℤ>>);
   }
 

--- a/src/test/cpp/modules/dedekind/sets/category_integration_test.cpp
+++ b/src/test/cpp/modules/dedekind/sets/category_integration_test.cpp
@@ -34,9 +34,9 @@ TEST_CASE("Sets+Category: singleton and comprehension predicates satisfy ETCS",
   CHECK(atom_set.χ(42) == true);
   CHECK(atom_set.χ(7) == false);
 
-  auto x = var<ℕ>;
-  const auto positive = Set{x % N | (x > 0u)};
-  const auto bounded = Set{x % N | (x <= 10u)};
+  auto x = element<Ω<ℕ>>;
+  const auto positive = Set{x | (x > 0u)};
+  const auto bounded = Set{x | (x <= 10u)};
 
   // ambient_set<ℕ> lifts the predicate-set into the post-#402 variant
   // ℕ-proxy ambient (ℕ = Cardinality).  The characteristic-function χ
@@ -59,8 +59,8 @@ TEST_CASE("Sets+Category: singleton and comprehension predicates satisfy ETCS",
 
 TEST_CASE("Sets+Category: Set naming boundary is explicit",
           "[sets][category][etcs][alignment]") {
-  auto x = var<ℕ>;
-  const auto positive = Set{x % N | (x > 0u)};
+  auto x = element<Ω<ℕ>>;
+  const auto positive = Set{x | (x > 0u)};
 
   // `sets::Set` (DSL species) and `category::Set` (CCC witness) are distinct.
   STATIC_CHECK(!std::same_as<decltype(positive),

--- a/src/test/cpp/modules/dedekind/sets/category_integration_test.cpp
+++ b/src/test/cpp/modules/dedekind/sets/category_integration_test.cpp
@@ -8,7 +8,7 @@ using namespace dedekind::sets;
 
 TEST_CASE("Sets+Category: boundaries lift into ETCS subobjects",
           "[sets][category][etcs][integration]") {
-  const Ω<int> universe{};
+  const UniversalSet<int> universe{};
   const Ø<int> empty{};
 
   const auto u_set = ambient_set<int>(universe);

--- a/src/test/cpp/modules/dedekind/sets/computability_test.cpp
+++ b/src/test/cpp/modules/dedekind/sets/computability_test.cpp
@@ -32,8 +32,8 @@ TEST_CASE("sets:computability — HasDecidableMembership on Ø",
   }
 
   SECTION("Intensional Set over a transfinite carrier fails the concept") {
-    constexpr auto x = var<ℕ>;
-    constexpr auto s = Set{x % N | [](const auto& v) { return v > 5u; }};
+    constexpr auto x = element<Ω<ℕ>>;
+    constexpr auto s = Set{x | [](const auto& v) { return v > 5u; }};
     // ℕ is transfinite → NaturalLogic picks TernaryLogic.
     STATIC_CHECK_FALSE(HasDecidableMembership<decltype(s)>);
   }
@@ -46,8 +46,8 @@ TEST_CASE("sets:computability — IsFiniteSet on Ø", "[sets][computability]") {
   }
 
   SECTION("Intensional Set over a transfinite carrier is not finite") {
-    constexpr auto x = var<ℕ>;
-    constexpr auto s = Set{x % N | [](const auto& v) { return v > 5u; }};
+    constexpr auto x = element<Ω<ℕ>>;
+    constexpr auto s = Set{x | [](const auto& v) { return v > 5u; }};
     STATIC_CHECK_FALSE(IsFiniteSet<decltype(s)>);
   }
 }
@@ -60,8 +60,8 @@ TEST_CASE("sets:computability — IsCompileTimeEnumerable on Ø",
   }
 
   SECTION("An intensional Set is neither finite nor compile-time-enumerable") {
-    constexpr auto x = var<ℕ>;
-    constexpr auto s = Set{x % N | [](const auto& v) { return v > 5u; }};
+    constexpr auto x = element<Ω<ℕ>>;
+    constexpr auto s = Set{x | [](const auto& v) { return v > 5u; }};
     STATIC_CHECK_FALSE(IsFiniteSet<decltype(s)>);
     STATIC_CHECK_FALSE(IsCompileTimeEnumerable<decltype(s)>);
   }

--- a/src/test/cpp/modules/dedekind/sets/expressions_test.cpp
+++ b/src/test/cpp/modules/dedekind/sets/expressions_test.cpp
@@ -8,8 +8,8 @@ using namespace dedekind::sets;
 
 TEST_CASE("Dedekind MVP: Basic Membership and Symbols", "[sets]") {
   SECTION("Integer Universe Membership") {
-    auto x = var<UniversalSet<int>>;  // A variable representing an element of the integer
-                           // universe
+    auto x = var<UniversalSet<int>>;  // A variable representing an element of
+                                      // the integer universe
 
     // Should be Set<int, ClassicalLogic>
     auto finite = Set{x % singleton(1) | (x == 1)};

--- a/src/test/cpp/modules/dedekind/sets/expressions_test.cpp
+++ b/src/test/cpp/modules/dedekind/sets/expressions_test.cpp
@@ -127,7 +127,7 @@ TEST_CASE("Dedekind Sets: symmetric difference (^) — #469",
     // pair regardless of the .expected field.
     using BoolAmbient = UniversalSet<bool, ClassicalLogic, Finite>;
     constexpr BoolAmbient B_bool{};
-    constexpr auto b = var<BoolAmbient>;
+    constexpr auto b = element<Ω<bool>>;
     auto only_true = Set{b % B_bool | (b == true)};
     auto only_false = Set{b % B_bool | (b == false)};
     auto sym_diff = only_true ^ only_false;
@@ -264,7 +264,7 @@ TEST_CASE("Dedekind Identities: Boolean literals collapse over 𝔹",
   using BoolAmbient = UniversalSet<bool, ClassicalLogic, Finite>;
   constexpr BoolAmbient B_bool{};
 
-  constexpr auto b = var<BoolAmbient>;
+  constexpr auto b = element<Ω<bool>>;
 
   constexpr auto b_false = Set{b % B_bool | !b};
   constexpr auto b_true = Set{b % B_bool | (b == true)};
@@ -288,7 +288,7 @@ TEST_CASE(
   using BoolAmbient = UniversalSet<bool, ClassicalLogic, Finite>;
   constexpr BoolAmbient B_bool{};
 
-  constexpr auto b = var<BoolAmbient>;
+  constexpr auto b = element<Ω<bool>>;
 
   // Bare-b form (the issue's target ergonomics).
   constexpr auto b_true_bare = Set{b % B_bool | b};

--- a/src/test/cpp/modules/dedekind/sets/expressions_test.cpp
+++ b/src/test/cpp/modules/dedekind/sets/expressions_test.cpp
@@ -8,8 +8,8 @@ using namespace dedekind::sets;
 
 TEST_CASE("Dedekind MVP: Basic Membership and Symbols", "[sets]") {
   SECTION("Integer Universe Membership") {
-    auto x = var<UniversalSet<int>>;  // A variable representing an element of
-                                      // the integer universe
+    auto x = element<Ω<int>>;  // A variable representing an element of
+                               // the integer universe
 
     // Should be Set<int, ClassicalLogic>
     auto finite = Set{x % singleton(1) | (x == 1)};
@@ -52,7 +52,7 @@ TEST_CASE("Dedekind Sets: symmetric difference (^) — #469",
   }
 
   SECTION("Singleton ^ Set — pivot toggles membership (#469)") {
-    auto x_int = var<UniversalSet<int>>;
+    auto x_int = element<Ω<int>>;
     auto positives = Set{x_int % UniversalSet<int>{} | (x_int > 0)};
     auto sing_in_set = singleton(5);
     auto sing_out_set = singleton(-3);
@@ -310,7 +310,7 @@ TEST_CASE(
 
 TEST_CASE("Dedekind Sets: Cartesian product and relation witnesses",
           "[sets][relations][cartesian]") {
-  auto x = var<UniversalSet<int>>;
+  auto x = element<Ω<int>>;
 
   const auto positive = Set{x % UniversalSet<int>{} | (x > 0)};
   const auto small = Set{x % UniversalSet<int>{} | (x <= 3)};
@@ -356,7 +356,7 @@ TEST_CASE("Dedekind Sets: Ambient cartesian product ergonomics",
 
 TEST_CASE("Dedekind Sets: Power-set witness over homogeneous predicates",
           "[sets][powerset]") {
-  auto x = var<UniversalSet<int>>;
+  auto x = element<Ω<int>>;
 
   const auto positive = Set{x % UniversalSet<int>{} | (x > 0)};
 

--- a/src/test/cpp/modules/dedekind/sets/expressions_test.cpp
+++ b/src/test/cpp/modules/dedekind/sets/expressions_test.cpp
@@ -8,7 +8,7 @@ using namespace dedekind::sets;
 
 TEST_CASE("Dedekind MVP: Basic Membership and Symbols", "[sets]") {
   SECTION("Integer Universe Membership") {
-    auto x = var<Ω<int>>;  // A variable representing an element of the integer
+    auto x = var<UniversalSet<int>>;  // A variable representing an element of the integer
                            // universe
 
     // Should be Set<int, ClassicalLogic>
@@ -40,7 +40,7 @@ TEST_CASE("Dedekind Sets: symmetric difference (^) — #469",
     auto sym_eq = same_a ^ same_b;
     auto sym_neq = same_a ^ distinct;
     // The Set CTAD ascends the logic species to TernaryLogic via
-    // NaturalLogic<Ω<...>>; results compare against Ternary::True /
+    // NaturalLogic<UniversalSet<...>>; results compare against Ternary::True /
     // Ternary::False, not bool.
     // {7} ^ {7} is empty pointwise.
     REQUIRE(sym_eq(7) == Ternary::False);
@@ -52,8 +52,8 @@ TEST_CASE("Dedekind Sets: symmetric difference (^) — #469",
   }
 
   SECTION("Singleton ^ Set — pivot toggles membership (#469)") {
-    auto x_int = var<Ω<int>>;
-    auto positives = Set{x_int % Ω<int>{} | (x_int > 0)};
+    auto x_int = var<UniversalSet<int>>;
+    auto positives = Set{x_int % UniversalSet<int>{} | (x_int > 0)};
     auto sing_in_set = singleton(5);
     auto sing_out_set = singleton(-3);
     auto in_xor = sing_in_set ^ positives;    // 5 ∈ positives → result drops 5
@@ -93,7 +93,7 @@ TEST_CASE("Dedekind Sets: symmetric difference (^) — #469",
     auto S = Set{x % N | x > 10u};
     using SDomain = decltype(S)::Domain;
     using SLogic = decltype(S)::logic_species;
-    Ω<SDomain, SLogic> universe{};
+    UniversalSet<SDomain, SLogic> universe{};
     auto right_collapse = S ^ universe;              // type: !S
     auto left_collapse = universe ^ S;               // type: !S
     REQUIRE(right_collapse(50u) == Ternary::False);  // 50 ∈ S → ∉ !S
@@ -125,7 +125,7 @@ TEST_CASE("Dedekind Sets: symmetric difference (^) — #469",
     // This regression test guards against a same-Predicate-type
     // collapse that would wrongly fire on every BooleanEqPredicate
     // pair regardless of the .expected field.
-    using BoolAmbient = Ω<bool, ClassicalLogic, Finite>;
+    using BoolAmbient = UniversalSet<bool, ClassicalLogic, Finite>;
     constexpr BoolAmbient B_bool{};
     constexpr auto b = var<BoolAmbient>;
     auto only_true = Set{b % B_bool | (b == true)};
@@ -191,7 +191,7 @@ TEST_CASE("Dedekind Sets: symmetric difference (^) — #469",
     // stateless predicate types (guarded by std::is_empty_v); the
     // halfspace-style predicate (x > 10u) produces a capturing
     // lambda whose closure type is non-empty, so the type-level
-    // collapse to Ω<T, L> does NOT fire here.  What DOES fire is
+    // collapse to UniversalSet<T, L> does NOT fire here.  What DOES fire is
     // the De Morgan negation-peel branch (A ^ !B → !(A ^ B)),
     // which leaves the result a Set<T, L, lambda> that pointwise
     // evaluates to true at every input.  We test the runtime
@@ -261,7 +261,7 @@ TEST_CASE("Dedekind Identities: Extremal Collapse", "[sets][identities]") {
 
 TEST_CASE("Dedekind Identities: Boolean literals collapse over 𝔹",
           "[sets][identities][boolean]") {
-  using BoolAmbient = Ω<bool, ClassicalLogic, Finite>;
+  using BoolAmbient = UniversalSet<bool, ClassicalLogic, Finite>;
   constexpr BoolAmbient B_bool{};
 
   constexpr auto b = var<BoolAmbient>;
@@ -285,7 +285,7 @@ TEST_CASE(
   // which b holds" — the bare-b form is the truthy predicate, and
   // should be recognised as semantically equivalent to b == true by
   // the structured-and / FiniteBooleanSet collapse machinery.
-  using BoolAmbient = Ω<bool, ClassicalLogic, Finite>;
+  using BoolAmbient = UniversalSet<bool, ClassicalLogic, Finite>;
   constexpr BoolAmbient B_bool{};
 
   constexpr auto b = var<BoolAmbient>;
@@ -310,10 +310,10 @@ TEST_CASE(
 
 TEST_CASE("Dedekind Sets: Cartesian product and relation witnesses",
           "[sets][relations][cartesian]") {
-  auto x = var<Ω<int>>;
+  auto x = var<UniversalSet<int>>;
 
-  const auto positive = Set{x % Ω<int>{} | (x > 0)};
-  const auto small = Set{x % Ω<int>{} | (x <= 3)};
+  const auto positive = Set{x % UniversalSet<int>{} | (x > 0)};
+  const auto small = Set{x % UniversalSet<int>{} | (x <= 3)};
 
   const auto product = cartesian_product(positive, small);
   using ProductDomain = typename decltype(product)::Domain;
@@ -343,7 +343,7 @@ TEST_CASE("Dedekind Sets: Cartesian product and relation witnesses",
 
 TEST_CASE("Dedekind Sets: Ambient cartesian product ergonomics",
           "[sets][relations][cartesian][ambient]") {
-  constexpr auto ambient = Ω<int>{};
+  constexpr auto ambient = UniversalSet<int>{};
   constexpr auto p_via_function = cartesian_product(ambient, ambient);
   constexpr auto p_via_operator = ambient * ambient;
 
@@ -356,9 +356,9 @@ TEST_CASE("Dedekind Sets: Ambient cartesian product ergonomics",
 
 TEST_CASE("Dedekind Sets: Power-set witness over homogeneous predicates",
           "[sets][powerset]") {
-  auto x = var<Ω<int>>;
+  auto x = var<UniversalSet<int>>;
 
-  const auto positive = Set{x % Ω<int>{} | (x > 0)};
+  const auto positive = Set{x % UniversalSet<int>{} | (x > 0)};
 
   const auto p_positive = power_set(positive);
   // Textbook fraktur-P alias: 𝔓(A) ≡ power_set(A).

--- a/src/test/cpp/modules/dedekind/sets/expressions_test.cpp
+++ b/src/test/cpp/modules/dedekind/sets/expressions_test.cpp
@@ -20,8 +20,8 @@ TEST_CASE("Dedekind MVP: Basic Membership and Symbols", "[sets]") {
   SECTION("Natural-numbers membership") {
     // Post-#401, ℕ is the unsigned-int carrier; the predicate-set N has
     // Domain = unsigned int, so callsites use unsigned values.
-    auto n = var<ℕ>;
-    auto infinite = Set{n % N | (n > 0u)};
+    auto n = element<Ω<ℕ>>;
+    auto infinite = Set{n | (n > 0u)};
     REQUIRE(infinite(5u) == Ternary::True);
     REQUIRE(infinite(0u) == Ternary::False);
   }
@@ -29,7 +29,7 @@ TEST_CASE("Dedekind MVP: Basic Membership and Symbols", "[sets]") {
 
 TEST_CASE("Dedekind Sets: symmetric difference (^) — #469",
           "[sets][operators]") {
-  auto x = var<ℕ>;
+  auto x = element<Ω<ℕ>>;
 
   SECTION(
       "Singleton ^ Singleton — equal pivots empty, distinct pivots union "
@@ -70,7 +70,7 @@ TEST_CASE("Dedekind Sets: symmetric difference (^) — #469",
   }
 
   SECTION("Boundary collapses: A ^ ∅ = A, ∅ ^ A = A (#469)") {
-    auto S = Set{x % N | x > 10u};
+    auto S = Set{x | x > 10u};
     // Use the deduced Domain / logic species from S rather than
     // hard-coding `unsigned int` / TernaryLogic — the carrier choice
     // is set by N's CTAD, and the test should not pre-empt it.
@@ -90,7 +90,7 @@ TEST_CASE("Dedekind Sets: symmetric difference (^) — #469",
   }
 
   SECTION("Boundary collapses: A ^ Ω = ¬A, Ω ^ A = ¬A (#469)") {
-    auto S = Set{x % N | x > 10u};
+    auto S = Set{x | x > 10u};
     using SDomain = decltype(S)::Domain;
     using SLogic = decltype(S)::logic_species;
     UniversalSet<SDomain, SLogic> universe{};
@@ -109,7 +109,7 @@ TEST_CASE("Dedekind Sets: symmetric difference (^) — #469",
     // different sets — see the stateful-predicate-disjoint-instances
     // section below).  The honest claim is therefore the runtime one:
     // for any Set S, S ^ S evaluates to false at every input.
-    auto S = Set{x % N | x > 10u};
+    auto S = Set{x | x > 10u};
     auto S_xor_S = S ^ S;
     REQUIRE(S_xor_S(5u) == Ternary::False);
     REQUIRE(S_xor_S(50u) == Ternary::False);
@@ -146,8 +146,8 @@ TEST_CASE("Dedekind Sets: symmetric difference (^) — #469",
     // the intersection at the type level, so A & B reduces to
     // Ø<unsigned int, TernaryLogic>.  In that case A ^ B should
     // collapse to A | B (no XOR formula needed in the result lambda).
-    auto A = Set{x % N | x > 10u};
-    auto B = Set{x % N | x < 5u};
+    auto A = Set{x | x > 10u};
+    auto B = Set{x | x < 5u};
     auto sym_diff_disjoint = A ^ B;
     auto union_disjoint = A | B;
     // Membership matches the union (since the intersection is empty,
@@ -168,8 +168,8 @@ TEST_CASE("Dedekind Sets: symmetric difference (^) — #469",
     // !some_set), the operator^ peels the negation outward.
     // Resulting semantic: x ∈ A ^ ¬B iff x is in exactly one, which
     // is equivalent to x ∈ A ↔ x ∈ B (the biconditional).
-    auto A = Set{x % N | x > 10u};
-    auto B = Set{x % N | x < 100u};
+    auto A = Set{x | x > 10u};
+    auto B = Set{x | x < 100u};
     auto sym_diff_neg = A ^ !B;
     auto biconditional = !(A ^ B);
     // Both should agree pointwise: A ^ ¬B = ¬(A ^ B).
@@ -196,7 +196,7 @@ TEST_CASE("Dedekind Sets: symmetric difference (^) — #469",
     // which leaves the result a Set<T, L, lambda> that pointwise
     // evaluates to true at every input.  We test the runtime
     // semantics rather than the structural type.
-    auto S = Set{x % N | x > 10u};
+    auto S = Set{x | x > 10u};
     auto S_xor_notS = S ^ !S;
     REQUIRE(S_xor_notS(5u) == Ternary::True);
     REQUIRE(S_xor_notS(50u) == Ternary::True);
@@ -204,8 +204,8 @@ TEST_CASE("Dedekind Sets: symmetric difference (^) — #469",
   }
 
   SECTION("Membership: x ∈ A ^ B iff x is in exactly one") {
-    auto A = Set{x % N | x > 10u};
-    auto B = Set{x % N | x < 100u};
+    auto A = Set{x | x > 10u};
+    auto B = Set{x | x < 100u};
     auto sym_diff = A ^ B;
     // 5: in B only (5 < 100, 5 ≯ 10) → in symmetric difference
     REQUIRE(sym_diff(5u) == Ternary::True);
@@ -216,8 +216,8 @@ TEST_CASE("Dedekind Sets: symmetric difference (^) — #469",
   }
 
   SECTION("Textbook identity: A ^ B == (A | B) & !(A & B)") {
-    auto A = Set{x % N | x > 10u};
-    auto B = Set{x % N | x < 100u};
+    auto A = Set{x | x > 10u};
+    auto B = Set{x | x < 100u};
     auto sym_diff = A ^ B;
     auto union_minus_inter = (A | B) & !(A & B);
     REQUIRE(sym_diff(5u) == union_minus_inter(5u));
@@ -227,7 +227,7 @@ TEST_CASE("Dedekind Sets: symmetric difference (^) — #469",
 }
 
 TEST_CASE("Dedekind Identities: Extremal Collapse", "[sets][identities]") {
-  auto x = var<ℕ>;
+  auto x = element<Ω<ℕ>>;
 
   SECTION("Identity: Set{N} is N") {
     // Naturals remain stable when materialized through Set{...}.
@@ -245,7 +245,7 @@ TEST_CASE("Dedekind Identities: Extremal Collapse", "[sets][identities]") {
 
   SECTION("Contradiction: {x ∈ ℕ | x > 10 ∧ x < 5} is ∅") {
     // Here we combine the symbolic predicates
-    auto S = Set{x % N | (x > 10u && x < 5u)};
+    auto S = Set{x | (x > 10u && x < 5u)};
 
     // For a non-trivial polish, we verify it is 'Total Absence'
     REQUIRE(S(0u) == Ternary::False);
@@ -254,7 +254,7 @@ TEST_CASE("Dedekind Identities: Extremal Collapse", "[sets][identities]") {
   }
 
   SECTION("Tautology: {x ∈ ℕ | x > 10 ∨ x <= 10} is Ω") {
-    auto S = Set{x % N | (x > 10u || x <= 10u)};
+    auto S = Set{x | (x > 10u || x <= 10u)};
     REQUIRE(S(7u) == Ternary::True);
   }
 }
@@ -281,7 +281,7 @@ TEST_CASE("Dedekind Identities: Boolean literals collapse over 𝔹",
 TEST_CASE(
     "Dedekind Identities: bare-Variable<bool> truthy form collapses (#408)",
     "[sets][identities][boolean][variable-truthy]") {
-  // The textbook DSL form `Set{b % B | b}` reads "elements of B for
+  // The textbook DSL form `Set{b | b}` reads "elements of B for
   // which b holds" — the bare-b form is the truthy predicate, and
   // should be recognised as semantically equivalent to b == true by
   // the structured-and / FiniteBooleanSet collapse machinery.
@@ -373,9 +373,9 @@ TEST_CASE("Dedekind Sets: Power-set witness over homogeneous predicates",
 
 TEST_CASE("Dedekind Sets: Power-set preserves ambient logic",
           "[sets][powerset][logic]") {
-  auto x = var<ℕ>;
+  auto x = element<Ω<ℕ>>;
 
-  const auto gt_zero = Set{x % N | (x > 0u)};
+  const auto gt_zero = Set{x | (x > 0u)};
   const auto p_gt_zero = power_set(gt_zero);
 
   STATIC_CHECK(
@@ -405,9 +405,9 @@ TEST_CASE("Dedekind Sets: Relation witnesses preserve ternary logic",
 TEST_CASE("Dedekind Sets: Heterogeneous subset semantics",
           "[sets][subset][logic]") {
   SECTION("Ternary logic yields Unknown for heterogeneous predicates") {
-    auto x = var<ℕ>;
-    const auto gt_zero = Set{x % N | (x > 0u)};
-    const auto ge_zero = Set{x % N | (x >= 0u)};
+    auto x = element<Ω<ℕ>>;
+    const auto gt_zero = Set{x | (x > 0u)};
+    const auto ge_zero = Set{x | (x >= 0u)};
 
     REQUIRE((gt_zero <= ge_zero) == Ternary::Unknown);
   }

--- a/src/test/cpp/modules/dedekind/sets/relational_test.cpp
+++ b/src/test/cpp/modules/dedekind/sets/relational_test.cpp
@@ -13,14 +13,14 @@ namespace {
 
 // Even integers in [0, 10)
 constexpr auto evens_0_10 = [] {
-  auto x = var<ℕ>;
-  return Set{x % N | [](const auto& v) { return (v < 10u) && (v % 2u == 0u); }};
+  auto x = element<Ω<ℕ>>;
+  return Set{x | [](const auto& v) { return (v < 10u) && (v % 2u == 0u); }};
 }();
 
 // Multiples of 3 in [0, 10)
 constexpr auto threes_0_10 = [] {
-  auto x = var<ℕ>;
-  return Set{x % N | [](const auto& v) { return (v < 10u) && (v % 3u == 0u); }};
+  auto x = element<Ω<ℕ>>;
+  return Set{x | [](const auto& v) { return (v < 10u) && (v % 3u == 0u); }};
 }();
 
 }  // namespace

--- a/src/test/cpp/modules/dedekind/sets/relational_test.cpp
+++ b/src/test/cpp/modules/dedekind/sets/relational_test.cpp
@@ -135,7 +135,7 @@ TEST_CASE("Relational Algebra: Intersection (∩)", "[sets][relational]") {
 // ---------------------------------------------------------------------------
 TEST_CASE("Relational Algebra: Natural Join (⋈)", "[sets][relational]") {
   // Relation R1: {(a, b) | 0 <= a < 4 and b = a + 1}  (successor pairs)
-  auto s1 = var_for_type<std::pair<int, int>>;
+  auto s1 = element<Ω<std::pair<int, int>>>;
   const auto succ =
       Set{s1 % UniversalSet<std::pair<int, int>>{} |
           [](const std::pair<int, int>& p) {
@@ -143,7 +143,7 @@ TEST_CASE("Relational Algebra: Natural Join (⋈)", "[sets][relational]") {
           }};
 
   // Relation R2: {(b, c) | 0 <= b < 5 and c = b * 2}  (double pairs)
-  auto s2 = var_for_type<std::pair<int, int>>;
+  auto s2 = element<Ω<std::pair<int, int>>>;
   const auto dbl =
       Set{s2 % UniversalSet<std::pair<int, int>>{} |
           [](const std::pair<int, int>& p) {

--- a/src/test/cpp/modules/dedekind/sets/relational_test.cpp
+++ b/src/test/cpp/modules/dedekind/sets/relational_test.cpp
@@ -137,16 +137,18 @@ TEST_CASE("Relational Algebra: Natural Join (⋈)", "[sets][relational]") {
   // Relation R1: {(a, b) | 0 <= a < 4 and b = a + 1}  (successor pairs)
   auto s1 = var_for_type<std::pair<int, int>>;
   const auto succ =
-      Set{s1 % UniversalSet<std::pair<int, int>>{} | [](const std::pair<int, int>& p) {
-        return (p.first >= 0) && (p.first < 4) && (p.second == p.first + 1);
-      }};
+      Set{s1 % UniversalSet<std::pair<int, int>>{} |
+          [](const std::pair<int, int>& p) {
+            return (p.first >= 0) && (p.first < 4) && (p.second == p.first + 1);
+          }};
 
   // Relation R2: {(b, c) | 0 <= b < 5 and c = b * 2}  (double pairs)
   auto s2 = var_for_type<std::pair<int, int>>;
   const auto dbl =
-      Set{s2 % UniversalSet<std::pair<int, int>>{} | [](const std::pair<int, int>& p) {
-        return (p.first >= 0) && (p.first < 5) && (p.second == p.first * 2);
-      }};
+      Set{s2 % UniversalSet<std::pair<int, int>>{} |
+          [](const std::pair<int, int>& p) {
+            return (p.first >= 0) && (p.first < 5) && (p.second == p.first * 2);
+          }};
 
   // Join: succ ⋈ dbl = {(a, b, c) | b = a+1 and c = b*2}
   // => (0,1,2), (1,2,4), (2,3,6), (3,4,8)

--- a/src/test/cpp/modules/dedekind/sets/relational_test.cpp
+++ b/src/test/cpp/modules/dedekind/sets/relational_test.cpp
@@ -137,14 +137,14 @@ TEST_CASE("Relational Algebra: Natural Join (⋈)", "[sets][relational]") {
   // Relation R1: {(a, b) | 0 <= a < 4 and b = a + 1}  (successor pairs)
   auto s1 = var_for_type<std::pair<int, int>>;
   const auto succ =
-      Set{s1 % Ω<std::pair<int, int>>{} | [](const std::pair<int, int>& p) {
+      Set{s1 % UniversalSet<std::pair<int, int>>{} | [](const std::pair<int, int>& p) {
         return (p.first >= 0) && (p.first < 4) && (p.second == p.first + 1);
       }};
 
   // Relation R2: {(b, c) | 0 <= b < 5 and c = b * 2}  (double pairs)
   auto s2 = var_for_type<std::pair<int, int>>;
   const auto dbl =
-      Set{s2 % Ω<std::pair<int, int>>{} | [](const std::pair<int, int>& p) {
+      Set{s2 % UniversalSet<std::pair<int, int>>{} | [](const std::pair<int, int>& p) {
         return (p.first >= 0) && (p.first < 5) && (p.second == p.first * 2);
       }};
 

--- a/src/test/cpp/modules/dedekind/topology/shapes_test.cpp
+++ b/src/test/cpp/modules/dedekind/topology/shapes_test.cpp
@@ -150,10 +150,10 @@ TEST_CASE("Topology: Rules of Continuity Coverage", "[topology][continuity]") {
     using namespace dedekind::category;
     using namespace dedekind::sets;
 
-    auto x = var<Ω<int>>;
+    auto x = var<UniversalSet<int>>;
     UnitInterval open_mid(0, 3);
 
-    auto in_open_mid = Set{x % Ω<int>{} | [open_mid](const int& value) {
+    auto in_open_mid = Set{x % UniversalSet<int>{} | [open_mid](const int& value) {
       return open_mid(value);
     }};
 

--- a/src/test/cpp/modules/dedekind/topology/shapes_test.cpp
+++ b/src/test/cpp/modules/dedekind/topology/shapes_test.cpp
@@ -150,7 +150,7 @@ TEST_CASE("Topology: Rules of Continuity Coverage", "[topology][continuity]") {
     using namespace dedekind::category;
     using namespace dedekind::sets;
 
-    auto x = var<UniversalSet<int>>;
+    auto x = element<Ω<int>>;
     UnitInterval open_mid(0, 3);
 
     auto in_open_mid =

--- a/src/test/cpp/modules/dedekind/topology/shapes_test.cpp
+++ b/src/test/cpp/modules/dedekind/topology/shapes_test.cpp
@@ -153,9 +153,9 @@ TEST_CASE("Topology: Rules of Continuity Coverage", "[topology][continuity]") {
     auto x = var<UniversalSet<int>>;
     UnitInterval open_mid(0, 3);
 
-    auto in_open_mid = Set{x % UniversalSet<int>{} | [open_mid](const int& value) {
-      return open_mid(value);
-    }};
+    auto in_open_mid =
+        Set{x % UniversalSet<int>{} |
+            [open_mid](const int& value) { return open_mid(value); }};
 
     CHECK(in_open_mid(1) == Ternary::True);
     CHECK(in_open_mid(0) == Ternary::False);


### PR DESCRIPTION
> **Ready for review** — full one-transaction implementation of #551 (Ω<carrier> ambient redesign).

This PR lands the complete redesign: the new value-spelling surface, the consumer sweep, the deprecated-surface removal, and the doc-clarity reframe of the per-symbol predicate-set types as ETCS characteristic morphisms.

Per the user's "one transaction, no backwards-compat" direction.  Phases 2e.1 / 2e.2 (per-symbol value-constants + predicate-set type removals) were investigated and **closed as won't-do** — those types are load-bearing tower classifiers, not redundant aliases of `Ω<carrier>`.  The architectural rationale lives in `boundaries.cppm` (universe-vs-classifier note) and is followed up in [#558](https://github.com/vincentk/dedekind/pull/558) (paper §3.3 footnote) and [#559](https://github.com/vincentk/dedekind/issues/559) (per-symbol-as-universe-value migration: 𝔹 in #560, ℕ in #563, ℤ/ℚ/ℝ/ℂ/𝔻 follow).

## Phase 1 — `Ω<T,L,C>` as variable template

| Before | After |
|---|---|
| `struct Ω<T,L,C> final : Boundaries { ... }` | `struct UniversalSet<T,L,C> final : Boundaries { ... }` (renamed) |
| `Ω<bool>{}` (default-construct the type) | `Ω<bool>` (variable-template value of type `UniversalSet<bool>`) |
| n/a | `inline constexpr UniversalSet<T,L,C> Ω{};` (variable template) |
| `Ω<int>(v)` (predicate call on type-instance) | `Ω<int>.contains(v)` (sugar over `operator()`) |

23 files swept across `src/` for the rename.

## Phase 2a-c — BoundScout / element / Set::contains

```cpp
template <auto Ambient>
struct BoundScout {
  using AmbientType = std::remove_cvref_t<decltype(Ambient)>;
  using T = element_of_t<AmbientType>;
  static constexpr AmbientType ambient = Ambient;
  template <typename P>
  constexpr auto operator|(P&& p) const { ... }
  template <typename SubSpecies>
    requires std::same_as<T, typename SubSpecies::Domain>
  constexpr auto operator%(const SubSpecies& s) const { ... }
};

template <auto Ambient>
inline constexpr BoundScout<Ambient> element{};
```

`UniversalSet<T>::contains(v)` returns `typename L::Ω` (delegating to `operator()`) so the contract matches `sets::Set::contains`.

## Phase 2d — consumer sweep (DONE)

~117 consumer sites migrated from `var<S>; n % S | pred` to `element<Ω<S>>; n | pred` across:
- 22 test files
- ~6 main source files (numbers/, geometry/, sets/, order/halfspace.cppm)
- BoundScout relational lifts (`<`, `<=`, `>`, `>=`, `==`, `!`)
- BoundScout × Bound<V> halfspace overloads
- `Ω<bool>` Finite-cardinality specialisation (so NaturalLogic routes through ClassicalLogic)
- BoundScout bool-truthy specialisation (the #408 / #551 truthy-rewrite chain)

## Phase 2e.3 — `Variable<>` / `var<>` removal (DONE)

Removed from the public surface:
- `Variable<S>` struct
- `var<S>` / `var_for_type<T>` variable-template factories
- 9 `Variable<>`-keyed operator overloads in `sets/expressions.cppm`
- 4 `Variable<>×Bound<V>` halfspace overloads in `order/halfspace.cppm`

Stale doc comments referencing the legacy spellings updated to the post-#551 `element<Ω<...>>` form.

## Phase 2e.1 / 2e.2 — closed as won't-do

The earlier plan to remove per-symbol value-constants (`B`/`N`/`Z`/`Q`/`R`/`C`/`D`) and predicate-set types (`BooleanSetOf<>`, `NaturalNumbersOf<>`, ...) was investigated and reframed.

**Finding:** the types are not redundant aliases of `Ω<carrier>`.  They are characteristic morphisms χ_T : tower-ambient → Ω of the subobject T inside its algebraic tower (Lawvere ETCS reading), with multi-overload cross-carrier classification routing predecessor literals through the canonical embedding chain (e.g. `N(-7)` returns `False` because -7 ∈ ℤ does not land in ℕ ↪ ℤ; this is ill-typed for the naive `Ω<unsigned>{}` replacement).

The asymmetry is now explicit in code:
- `BooleanSetOf<L,C> ≡ UniversalSet<bool, L, C>` — bool is the bottom of the tower so χ_𝔹 collapses to Ω<bool>.
- `NaturalNumbersOf`, `IntegersOf`, ... — non-trivial classifiers with own struct definitions and overload resolution.

Architectural note added to `boundaries.cppm` (universe-vs-classifier as the third meta-axis after closure and laws); paper-side framing in PR #558.  Per-symbol-as-universe-value migration tracked separately in #559.

## Paper Listing 6 reads as

```cpp
inline constexpr auto 𝔹 = Ω<bool>;            // ambient set value
inline constexpr auto b = element<𝔹>;         // typed scout

constexpr auto f = Set{b | !b};               // {b ∈ 𝔹 | !b}
static_assert(Ø<bool>{} != f);

constexpr auto c = Set{b | (b && !b)};        // {b ∈ 𝔹 | b ∧ ¬b} = ∅
static_assert(Ø<bool>{} == c);

constexpr auto t = ~f;                        // complement
static_assert(t.contains(true));              // value-level membership
```

## Test plan

- [x] `cmake --build build` clean across all targets.
- [x] All 15 test suites pass.
- [x] Paper builds (post-#561 minted upgrade).
- [ ] CI build-and-deploy green on this branch (last green run was on `dc1d70f9`; the post-review-fix commits are in flight).

## Cross-references

- Closes #551 (one-transaction Ω-redesign).
- Sibling: [#558](https://github.com/vincentk/dedekind/pull/558) (paper universe-vs-classifier note), [#559](https://github.com/vincentk/dedekind/issues/559) (per-symbol-as-universe-value rollout), [#560](https://github.com/vincentk/dedekind/pull/560) (𝔹 slice), [#563](https://github.com/vincentk/dedekind/pull/563) (ℕ slice).
- Related: #498 (algebraic-tower epic), #547 (paper editorial pass).