### PR TITLE
fix(ci): install JuliaMono from upstream releases (PR #561 follow-up; no fonts-juliamono apt package)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -203,10 +203,12 @@ ci-install-paper-deps:
 		exit 2; \
 	fi
 	sudo apt-get update
-	sudo apt-get install -y biber texlive-latex-base texlive-latex-extra texlive-bibtex-extra texlive-pictures texlive-plain-generic texlive-fonts-recommended texlive-fonts-extra texlive-luatex python3-pygments unzip
+	sudo apt-get install -y biber texlive-latex-base texlive-latex-extra texlive-bibtex-extra texlive-pictures texlive-plain-generic texlive-fonts-recommended texlive-fonts-extra texlive-luatex python3-pygments curl unzip fontconfig
 	# JuliaMono — downloaded from GitHub releases, installed system-wide,
-	# fontconfig cache refreshed so lualatex/luaotfload finds it.
-	cd /tmp && curl -sSL -o JuliaMono.zip "https://github.com/cormullion/juliamono/releases/download/v$(JULIAMONO_VERSION)/JuliaMono-ttf.zip" \
+	# fontconfig cache refreshed so lualatex/luaotfload finds it.  `curl -fsSL`
+	# fails fast on HTTP errors (e.g. a missing release asset) rather than
+	# producing a confusing unzip failure later in the && chain.
+	cd /tmp && curl -fsSL -o JuliaMono.zip "https://github.com/cormullion/juliamono/releases/download/v$(JULIAMONO_VERSION)/JuliaMono-ttf.zip" \
 		&& sudo mkdir -p /usr/local/share/fonts/juliamono \
 		&& sudo unzip -o JuliaMono.zip -d /usr/local/share/fonts/juliamono \
 		&& sudo fc-cache -f /usr/local/share/fonts/juliamono \

--- a/Makefile
+++ b/Makefile
@@ -192,13 +192,25 @@ ci-install-doxygen-deps:
 # native UTF-8 support, and python3-pygments for the `minted` package
 # (per #557 — minted shells out to Pygments for native UTF-8 in code
 # listings; see lualatex -shell-escape in docs/paper/Makefile).
+#
+# JuliaMono is downloaded from upstream releases since Ubuntu doesn't ship
+# it as an apt package (`fonts-juliamono` does not exist).  Pinned version
+# for reproducibility; bump as needed.
+JULIAMONO_VERSION := 0.062
 ci-install-paper-deps:
 	@if ! command -v apt-get >/dev/null 2>&1; then \
 		echo "ERROR: ci-install-paper-deps requires apt-get (intended for Ubuntu CI runners)."; \
 		exit 2; \
 	fi
 	sudo apt-get update
-	sudo apt-get install -y biber texlive-latex-base texlive-latex-extra texlive-bibtex-extra texlive-pictures texlive-plain-generic texlive-fonts-recommended texlive-fonts-extra texlive-luatex python3-pygments fonts-juliamono
+	sudo apt-get install -y biber texlive-latex-base texlive-latex-extra texlive-bibtex-extra texlive-pictures texlive-plain-generic texlive-fonts-recommended texlive-fonts-extra texlive-luatex python3-pygments unzip
+	# JuliaMono — downloaded from GitHub releases, installed system-wide,
+	# fontconfig cache refreshed so lualatex/luaotfload finds it.
+	cd /tmp && curl -sSL -o JuliaMono.zip "https://github.com/cormullion/juliamono/releases/download/v$(JULIAMONO_VERSION)/JuliaMono-ttf.zip" \
+		&& sudo mkdir -p /usr/local/share/fonts/juliamono \
+		&& sudo unzip -o JuliaMono.zip -d /usr/local/share/fonts/juliamono \
+		&& sudo fc-cache -f /usr/local/share/fonts/juliamono \
+		&& rm -f JuliaMono.zip
 
 # CI/PR workflow helpers (optimistic concurrency loop)
 


### PR DESCRIPTION
## Summary

Hotfix for the paper-build CI step that broke after PR #561 landed:

```
sudo apt-get install -y ... fonts-juliamono
E: Unable to locate package fonts-juliamono
make: *** [Makefile:198: ci-install-paper-deps] Error 100
```

JuliaMono is **not packaged** for Debian/Ubuntu — it is distributed via GitHub releases and the AUR (Arch).  Per the upstream ["Linux - on the command line"](https://cormullion.github.io/pages/2020-07-26-JuliaMono/#linux_-_on_the_command_line) recipe: download the `.ttf` zip, extract to a system font folder, run `fc-cache`.

## Changes

- `Makefile` (`ci-install-paper-deps`): replace `fonts-juliamono` apt line with a download + unzip + fc-cache pattern off the GitHub release artefact.
- Adds `unzip` to the apt list (required to extract the JuliaMono archive).
- Pinned to JuliaMono **v0.062** (the version installed locally during the #557 upgrade) via a `JULIAMONO_VERSION` make variable; bump as the upstream releases new versions.

## Local install (alternative)

For developers running CI deps locally on macOS:
```
brew install --cask font-juliamono
```

For Linux desktops: `sudo apt install font-manager` followed by manual download + drag-and-drop, or just run the curl pipeline above.

## Test plan

- [ ] CI `build-and-deploy` paper step passes (this PR's CI run will exercise the new install path).
- [ ] `fc-list | grep JuliaMono` returns matches in the runner after install.

🤖 Generated with [Claude Code](https://claude.com/claude-code)