### PR TITLE
feat(sets, numbers, tests): #559 ℕ slice — redefine ℕ as universe value Ω<Cardinality> (option A)

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ It defines an embedded domain-specific language (eDSL) for mathematics with the 
 // Cardinality-1 reduction: an intensional set over a transfinite
 // carrier collapses to a named extensional Singleton — at compile
 // time, with no lambdas, no predicate erasure.
-constexpr auto n    = element<Ω<ℕ>>;
+constexpr auto n    = element<ℕ>;
 constexpr auto gt_3 = Set{n | n > bound<3>};
 constexpr auto lt_5 = Set{n | n < bound<5>};
 

--- a/src/main/modules/dedekind/geometry/lattice.cppm
+++ b/src/main/modules/dedekind/geometry/lattice.cppm
@@ -85,7 +85,10 @@ export using IntegerLatticeSet = UniversalSet<int>;
 export using IntegerLatticeScalar = typename IntegerLatticeSet::Domain;
 export using IntegerLatticePoint2D =
     std::pair<IntegerLatticeScalar, IntegerLatticeScalar>;
-// Natural-lattice scalar matches the post-#401 ℕ carrier (= unsigned int).
+// Natural-lattice scalar is the Cardinality carrier — the variant ℕ-proxy
+// (post-#402; supersedes the post-#401 unsigned-int reading).  Post-#559,
+// ℕ is the universe value Ω<Cardinality>; the carrier in concept gates
+// and template-type-parameter positions is Cardinality directly.
 export using NaturalLatticeScalar = Cardinality;
 export using NaturalLatticePoint2D =
     std::pair<NaturalLatticeScalar, NaturalLatticeScalar>;
@@ -122,8 +125,9 @@ template <>
 struct LatticeFactory<NaturalLatticeSet> {
   constexpr auto line() const {
     auto k = element<ℕ>;
-    // Every Cardinality value is in ℕ by construction post-#401;
-    // the universal-set @c Ω<ℕ> is the canonical classifier here.
+    // Every Cardinality value is in ℕ by construction (post-#402);
+    // the universe value @c ℕ (= @c Ω<Cardinality>, post-#559) is the
+    // canonical ambient here.
     return Set{k};
   }
 

--- a/src/main/modules/dedekind/geometry/lattice.cppm
+++ b/src/main/modules/dedekind/geometry/lattice.cppm
@@ -121,7 +121,7 @@ struct LatticeFactory;
 template <>
 struct LatticeFactory<NaturalLatticeSet> {
   constexpr auto line() const {
-    auto k = element<Ω<Cardinality>>;
+    auto k = element<ℕ>;
     // Every Cardinality value is in ℕ by construction post-#401;
     // the universal-set @c Ω<ℕ> is the canonical classifier here.
     return Set{k};

--- a/src/main/modules/dedekind/geometry/lattice.cppm
+++ b/src/main/modules/dedekind/geometry/lattice.cppm
@@ -66,7 +66,7 @@ export module dedekind.geometry:lattice;
 
 import :affine;  // for Vector<F, N>
 import dedekind.category;
-import dedekind.sets; // for Set, var, Ω, ℕ, N, cartesian_product
+import dedekind.sets; // for Set, var, Ω, Cardinality, N, cartesian_product
 
 namespace dedekind::geometry {
 
@@ -86,7 +86,7 @@ export using IntegerLatticeScalar = typename IntegerLatticeSet::Domain;
 export using IntegerLatticePoint2D =
     std::pair<IntegerLatticeScalar, IntegerLatticeScalar>;
 // Natural-lattice scalar matches the post-#401 ℕ carrier (= unsigned int).
-export using NaturalLatticeScalar = ℕ;
+export using NaturalLatticeScalar = Cardinality;
 export using NaturalLatticePoint2D =
     std::pair<NaturalLatticeScalar, NaturalLatticeScalar>;
 
@@ -121,7 +121,7 @@ struct LatticeFactory;
 template <>
 struct LatticeFactory<NaturalLatticeSet> {
   constexpr auto line() const {
-    auto k = element<Ω<ℕ>>;
+    auto k = element<Ω<Cardinality>>;
     // Every Cardinality value is in ℕ by construction post-#401;
     // the universal-set @c Ω<ℕ> is the canonical classifier here.
     return Set{k};

--- a/src/main/modules/dedekind/numbers/natural.cppm
+++ b/src/main/modules/dedekind/numbers/natural.cppm
@@ -300,13 +300,15 @@ static_assert(dedekind::order::IsDirectedPoset<Cardinality>,
 // sub-sequence of natural numbers presents as IsFiniteSequence.
 static_assert(dedekind::sequences::IsFiniteSequence<
                   dedekind::sequences::FinitePath<Cardinality>>,
-              "FinitePath<ℕ> is a bona-fide finite sequence; ℕ is a valid "
-              "sequence codomain.");
+              "FinitePath<Cardinality> is a bona-fide finite sequence; the "
+              "Cardinality carrier (carrier of the ℕ universe post-#559) is a "
+              "valid sequence codomain.");
 
-// (4) Primitive-type arrows.  ℕ *is* @c unsigned @c int (post-#401), so
-// the predicate-set membership question reduces to direct calls on the
-// classifier @c N (the namespace-level @c NaturalNumbersOf<> constant
-// from sets:boundaries):
+// (4) Primitive-type arrows.  ℕ is the universe @c Ω<Cardinality> (post-#559;
+// underlying carrier @c Cardinality from #402, replacing the earlier
+// post-#401 unsigned-int reading).  Predicate-set membership reduces to
+// direct calls on the classifier @c N (the namespace-level
+// @c NaturalNumbersOf<> constant from sets:boundaries):
 //   - Forward (unsigned → ℕ): trivially total (every unsigned is a
 //     natural).
 //   - Forward into a certified IsNatural domain (e.g.\ ExtensionalCardinal<>):

--- a/src/main/modules/dedekind/numbers/natural.cppm
+++ b/src/main/modules/dedekind/numbers/natural.cppm
@@ -185,14 +185,15 @@ using ::dedekind::sets::ℕ;
 //     ℵ_0>) — saturating to ℵ_0 on overflow; honestly models ℕ (no
 //     additive inverses; rig-not-ring).  Callers wanting the bounded
 //     machine carrier explicitly spell @c unsigned @c int directly.
+static_assert(std::same_as<std::remove_cvref_t<decltype(dedekind::sets::ℕ)>,
+                           UniversalSet<Cardinality, ClassicalLogic, ℵ_0>>,
+              "ℕ is the universe Ω<Cardinality> (post-#559).");
 static_assert(
-    std::same_as<std::remove_cvref_t<decltype(dedekind::sets::ℕ)>,
-                 UniversalSet<Cardinality, ClassicalLogic, ℵ_0>>,
-    "ℕ is the universe Ω<Cardinality> (post-#559).");
-static_assert(
-    std::same_as<typename std::remove_cvref_t<decltype(dedekind::sets::ℕ)>::Domain,
-                 Cardinality>,
-    "ℕ's underlying carrier IS Cardinality — the textbook universe-over-carrier reading.");
+    std::same_as<
+        typename std::remove_cvref_t<decltype(dedekind::sets::ℕ)>::Domain,
+        Cardinality>,
+    "ℕ's underlying carrier IS Cardinality — the textbook "
+    "universe-over-carrier reading.");
 
 // (0a) Relationship between ℕ (the carrier) and NaturalNumbersOf<>
 //      (the predicate-set / classifier).  The predicate-set's @c Domain
@@ -209,8 +210,8 @@ static_assert(std::same_as<typename NaturalNumbersOf<>::Domain, Cardinality>,
 //     set.  Witnesses the set-builder DSL entry point that survives the
 //     carrier migration.
 static_assert(
-    dedekind::category::IsSet<
-        decltype(dedekind::category::ambient_set<Cardinality>(NaturalNumbersOf<>{}))>,
+    dedekind::category::IsSet<decltype(dedekind::category::ambient_set<
+                                       Cardinality>(NaturalNumbersOf<>{}))>,
     "NaturalNumbersOf<> is the canonical IsSet anchor for ℕ.");
 
 // (2) Syntax (the C++ operator surface that maps to ℕ's algebra).
@@ -297,10 +298,10 @@ static_assert(dedekind::order::IsDirectedPoset<Cardinality>,
 // Sequence witness: FinitePath<ℕ> is a finite sequence enumerating
 // a ℕ-prefix.  Pins ℕ as a valid @b sequence codomain: any finite
 // sub-sequence of natural numbers presents as IsFiniteSequence.
-static_assert(
-    dedekind::sequences::IsFiniteSequence<dedekind::sequences::FinitePath<Cardinality>>,
-    "FinitePath<ℕ> is a bona-fide finite sequence; ℕ is a valid "
-    "sequence codomain.");
+static_assert(dedekind::sequences::IsFiniteSequence<
+                  dedekind::sequences::FinitePath<Cardinality>>,
+              "FinitePath<ℕ> is a bona-fide finite sequence; ℕ is a valid "
+              "sequence codomain.");
 
 // (4) Primitive-type arrows.  ℕ *is* @c unsigned @c int (post-#401), so
 // the predicate-set membership question reduces to direct calls on the
@@ -361,7 +362,9 @@ static_assert(N(-7) == ClassicalLogic::False,
  *         witness on @c Cardinality.  Nullary callable, returns
  *         @c finite_cardinality(0). */
 export struct cardinality_zero {
-  constexpr Cardinality operator()() const noexcept { return finite_cardinality(0); }
+  constexpr Cardinality operator()() const noexcept {
+    return finite_cardinality(0);
+  }
 };
 
 /** @brief The successor map @c ℕ → @c ℕ for the NNO universal property
@@ -373,12 +376,13 @@ export struct cardinality_succ {
   }
 };
 
-static_assert(dedekind::category::IsNNO<Cardinality, cardinality_zero, cardinality_succ>,
-              "Cardinality is the canonical NNO witness: "
-              "z = cardinality_zero, s = cardinality_succ.  ℵ_0 "
-              "saturation is the carrier's extra behaviour beyond "
-              "the textbook NNO — an honest sentinel for values "
-              "that exceed the machine implementation's range.");
+static_assert(
+    dedekind::category::IsNNO<Cardinality, cardinality_zero, cardinality_succ>,
+    "Cardinality is the canonical NNO witness: "
+    "z = cardinality_zero, s = cardinality_succ.  ℵ_0 "
+    "saturation is the carrier's extra behaviour beyond "
+    "the textbook NNO — an honest sentinel for values "
+    "that exceed the machine implementation's range.");
 
 }  // namespace dedekind::numbers
 

--- a/src/main/modules/dedekind/numbers/natural.cppm
+++ b/src/main/modules/dedekind/numbers/natural.cppm
@@ -177,16 +177,22 @@ using ::dedekind::sets::ℕ;
 
 /** @section natural__Formal_Verification */
 
-// (0) Carrier-type witness: ℕ names the carrier itself (post-#402; the
-//     variant ℕ-proxy from sets:cardinality, replacing the unsigned-int
-//     reading shipped under #401).
-static_assert(std::same_as<Cardinality, dedekind::sets::Cardinality>,
-              "ℕ is the variant ℕ-proxy carrier @c Cardinality "
-              "(= @c std::variant<ExtensionalCardinal<>, ℵ_0>) — "
-              "saturating to ℵ_0 on overflow; honestly models ℕ "
-              "(no additive inverses; rig-not-ring).  Callers wanting "
-              "the bounded machine carrier explicitly spell @c unsigned "
-              "@c int directly.");
+// (0) Universe witness: ℕ names the universe over the Cardinality
+//     carrier (post-#559).  Pre-#559, ℕ was a carrier-type alias for
+//     Cardinality; post-#559 it is the value Ω<Cardinality> (a constexpr
+//     UniversalSet<Cardinality, ClassicalLogic, ℵ_0>{}).  Cardinality is
+//     the variant ℕ-proxy carrier (= @c std::variant<ExtensionalCardinal<>,
+//     ℵ_0>) — saturating to ℵ_0 on overflow; honestly models ℕ (no
+//     additive inverses; rig-not-ring).  Callers wanting the bounded
+//     machine carrier explicitly spell @c unsigned @c int directly.
+static_assert(
+    std::same_as<std::remove_cvref_t<decltype(dedekind::sets::ℕ)>,
+                 UniversalSet<Cardinality, ClassicalLogic, ℵ_0>>,
+    "ℕ is the universe Ω<Cardinality> (post-#559).");
+static_assert(
+    std::same_as<typename std::remove_cvref_t<decltype(dedekind::sets::ℕ)>::Domain,
+                 Cardinality>,
+    "ℕ's underlying carrier IS Cardinality — the textbook universe-over-carrier reading.");
 
 // (0a) Relationship between ℕ (the carrier) and NaturalNumbersOf<>
 //      (the predicate-set / classifier).  The predicate-set's @c Domain

--- a/src/main/modules/dedekind/numbers/natural.cppm
+++ b/src/main/modules/dedekind/numbers/natural.cppm
@@ -58,7 +58,7 @@ export module dedekind.numbers:natural;
 import dedekind.algebra; // HasRingOperators / HasSemiringOperators / IsArithmeticRing (canonical-spine witnesses)
 import dedekind.category;
 import dedekind.order; // HasLatticeOperators (canonical-spine witnesses)
-import dedekind.sequences; // IsFiniteSequence (canonical-spine witnesses on FinitePath<ℕ>)
+import dedekind.sequences; // IsFiniteSequence (canonical-spine witnesses on FinitePath<Cardinality>)
 import dedekind.sets;
 import :scalars;
 import :boolean;
@@ -180,7 +180,7 @@ using ::dedekind::sets::ℕ;
 // (0) Carrier-type witness: ℕ names the carrier itself (post-#402; the
 //     variant ℕ-proxy from sets:cardinality, replacing the unsigned-int
 //     reading shipped under #401).
-static_assert(std::same_as<ℕ, dedekind::sets::Cardinality>,
+static_assert(std::same_as<Cardinality, dedekind::sets::Cardinality>,
               "ℕ is the variant ℕ-proxy carrier @c Cardinality "
               "(= @c std::variant<ExtensionalCardinal<>, ℵ_0>) — "
               "saturating to ℵ_0 on overflow; honestly models ℕ "
@@ -194,7 +194,7 @@ static_assert(std::same_as<ℕ, dedekind::sets::Cardinality>,
 //      relationship from #400.  IsSet<ℕ> itself does @b not fire (carrier types
 //      carry no predicate-set surface); to participate as a set, lift
 //      through the predicate-set.
-static_assert(std::same_as<typename NaturalNumbersOf<>::Domain, ℕ>,
+static_assert(std::same_as<typename NaturalNumbersOf<>::Domain, Cardinality>,
               "NaturalNumbersOf<>::Domain is the variant ℕ-proxy carrier "
               "ℕ — predicate-set's underlying element type IS the "
               "carrier.");
@@ -204,7 +204,7 @@ static_assert(std::same_as<typename NaturalNumbersOf<>::Domain, ℕ>,
 //     carrier migration.
 static_assert(
     dedekind::category::IsSet<
-        decltype(dedekind::category::ambient_set<ℕ>(NaturalNumbersOf<>{}))>,
+        decltype(dedekind::category::ambient_set<Cardinality>(NaturalNumbersOf<>{}))>,
     "NaturalNumbersOf<> is the canonical IsSet anchor for ℕ.");
 
 // (2) Syntax (the C++ operator surface that maps to ℕ's algebra).
@@ -270,13 +270,13 @@ static_assert(dedekind::algebra::IsRig<unsigned int, std::plus<unsigned int>,
 // level; the spaceship and the four partial-order operators all
 // fire on the carrier.  Mirrors the @b shape vs.\ @b axiom split of
 // HasRingOperators / IsRing from PR #394.
-static_assert(dedekind::order::HasPartialOrderOperators<ℕ>,
+static_assert(dedekind::order::HasPartialOrderOperators<Cardinality>,
               "ℕ carries the partial-order operator surface "
               "(<, <=, >, >=).");
-static_assert(dedekind::order::HasTotalOrderOperators<ℕ>,
+static_assert(dedekind::order::HasTotalOrderOperators<Cardinality>,
               "ℕ carries the total-order operator surface "
               "(spaceship + the four partial-order operators).");
-static_assert(dedekind::order::IsTotallyOrdered<ℕ>,
+static_assert(dedekind::order::IsTotallyOrdered<Cardinality>,
               "ℕ is axiomatically totally ordered (the chain "
               "0 ≤ 1 ≤ 2 ≤ ...).");
 // Order-domain witnesses: ℕ is a directed set (every finite subset has
@@ -284,15 +284,15 @@ static_assert(dedekind::order::IsTotallyOrdered<ℕ>,
 // These pin ℕ as a valid @b net-domain in the Munkres / Kelley sense:
 // a net is a function from a directed set, and ℕ is the prototypical
 // directed set (sequences are nets indexed by ℕ).
-static_assert(dedekind::order::IsDirectedSet<ℕ>,
+static_assert(dedekind::order::IsDirectedSet<Cardinality>,
               "ℕ is a directed set — the prototypical net domain.");
-static_assert(dedekind::order::IsDirectedPoset<ℕ>,
+static_assert(dedekind::order::IsDirectedPoset<Cardinality>,
               "ℕ is a directed poset (directed + antisymmetric).");
 // Sequence witness: FinitePath<ℕ> is a finite sequence enumerating
 // a ℕ-prefix.  Pins ℕ as a valid @b sequence codomain: any finite
 // sub-sequence of natural numbers presents as IsFiniteSequence.
 static_assert(
-    dedekind::sequences::IsFiniteSequence<dedekind::sequences::FinitePath<ℕ>>,
+    dedekind::sequences::IsFiniteSequence<dedekind::sequences::FinitePath<Cardinality>>,
     "FinitePath<ℕ> is a bona-fide finite sequence; ℕ is a valid "
     "sequence codomain.");
 
@@ -355,19 +355,19 @@ static_assert(N(-7) == ClassicalLogic::False,
  *         witness on @c Cardinality.  Nullary callable, returns
  *         @c finite_cardinality(0). */
 export struct cardinality_zero {
-  constexpr ℕ operator()() const noexcept { return finite_cardinality(0); }
+  constexpr Cardinality operator()() const noexcept { return finite_cardinality(0); }
 };
 
 /** @brief The successor map @c ℕ → @c ℕ for the NNO universal property
  *         witness on @c Cardinality.  On the finite fragment, returns
  *         @c n + 1; on @c ℵ_0, returns @c ℵ_0 (saturation). */
 export struct cardinality_succ {
-  constexpr ℕ operator()(const ℕ& n) const noexcept {
+  constexpr Cardinality operator()(const Cardinality& n) const noexcept {
     return n + finite_cardinality(1);
   }
 };
 
-static_assert(dedekind::category::IsNNO<ℕ, cardinality_zero, cardinality_succ>,
+static_assert(dedekind::category::IsNNO<Cardinality, cardinality_zero, cardinality_succ>,
               "Cardinality is the canonical NNO witness: "
               "z = cardinality_zero, s = cardinality_succ.  ℵ_0 "
               "saturation is the carrier's extra behaviour beyond "

--- a/src/main/modules/dedekind/numbers/numbers.cppm
+++ b/src/main/modules/dedekind/numbers/numbers.cppm
@@ -35,7 +35,7 @@ export import dedekind.topology;  // Rays, half-spaces, intervals, convex shapes
 export import :boolean;   // Truth<L> and Ω
 export import :uint;      // std::unsigned_integral as ℤ/2^wℤ
                           // (machine layer below ℕ; closes part of #417)
-export import :natural;   // ℕ partition (carrier: dedekind::sets::Cardinality)
+export import :natural;   // Cardinality partition (carrier: dedekind::sets::Cardinality)
 export import :integer;   // ℤ partition (variant ℤ-proxy / IntegersOf<>)
 export import :sint;      // std::signed_integral: operator surface ✓,
                           // axiomatic ring ✗ (Honest Rejection;

--- a/src/main/modules/dedekind/numbers/numbers.cppm
+++ b/src/main/modules/dedekind/numbers/numbers.cppm
@@ -32,17 +32,18 @@ export import dedekind.order;  // Ordered predicate concepts for numeric species
 export import dedekind.topology;  // Rays, half-spaces, intervals, convex shapes
 
 /** @section numbers__Discrete_Foundations */
-export import :boolean;   // Truth<L> and Ω
-export import :uint;      // std::unsigned_integral as ℤ/2^wℤ
-                          // (machine layer below ℕ; closes part of #417)
-export import :natural;   // Cardinality partition (carrier: dedekind::sets::Cardinality)
-export import :integer;   // ℤ partition (variant ℤ-proxy / IntegersOf<>)
-export import :sint;      // std::signed_integral: operator surface ✓,
-                          // axiomatic ring ✗ (Honest Rejection;
-                          // closes part of #418)
-export import :integral;  // std::integral umbrella note over the three
-                          // siblings (unsigned_integral / signed_integral
-                          // / bool); closes #419
+export import :boolean;         // Truth<L> and Ω
+export import :uint;            // std::unsigned_integral as ℤ/2^wℤ
+                                // (machine layer below ℕ; closes part of #417)
+export import :natural;         // Cardinality partition (carrier:
+                                // dedekind::sets::Cardinality)
+export import :integer;         // ℤ partition (variant ℤ-proxy / IntegersOf<>)
+export import :sint;            // std::signed_integral: operator surface ✓,
+                                // axiomatic ring ✗ (Honest Rejection;
+                                // closes part of #418)
+export import :integral;        // std::integral umbrella note over the three
+                                // siblings (unsigned_integral / signed_integral
+                                // / bool); closes #419
 export import :floating_point;  // std::floating_point: operator surface +
                                 // operational ordered-field ✓; axiomatic ring /
                                 // field / total order ✗ (IEEE 754 Honest

--- a/src/main/modules/dedekind/sets/boundaries.cppm
+++ b/src/main/modules/dedekind/sets/boundaries.cppm
@@ -420,7 +420,7 @@ static_assert(dedekind::category::HasCanonicalSetCCC<int>,
 export template <typename L = ClassicalLogic, typename C = ℵ_0>
 struct NaturalNumbersOf {
   using Domain =
-      dedekind::sets::Cardinality;  // Aligned to the @c ℕ carrier post-#402.
+      dedekind::sets::Cardinality;  // Aligned to the @c Cardinality carrier post-#402.
   using Codomain = typename L::Ω;
   using logic_species = L;
   using cardinality_type = C;

--- a/src/main/modules/dedekind/sets/boundaries.cppm
+++ b/src/main/modules/dedekind/sets/boundaries.cppm
@@ -455,28 +455,37 @@ struct NaturalNumbersOf {
 // @c BooleanSet de-export pattern from #407.
 using NaturalNumbers = NaturalNumbersOf<>;
 
-/** @brief The canonical Natural-numbers carrier symbol @c ℕ = @c Cardinality.
+/** @brief The canonical Natural-numbers universe @c ℕ = @c Ω<Cardinality>
+ *  (post-#559).
  *
- *  @details Per #402 (math-wins-over-C++ retarget).  @c ℕ is now the
- *  variant ℕ-proxy carrier @c Cardinality (= @c
- *  std::variant<ExtensionalCardinal<>, ℵ_0>) — saturating to @c ℵ_0
- *  on overflow rather than wrapping the way @c unsigned @c int (the
- *  earlier post-#401 reading) did.  The structural advantage: the
- *  variant honestly models ℕ (no additive inverses; rig-not-ring),
- *  whereas @c unsigned @c int is structurally @b more than ℕ (modular
- *  ring with additive inverses, since @c 0 @c - @c 1 wraps to
- *  @c UINT_MAX).  Callers wanting the bounded machine carrier
- *  explicitly spell @c unsigned @c int directly.
+ *  @details Per #559's chosen direction (option A): the named species
+ *  symbols (@c 𝔹 / @c ℕ / @c ℤ / @c ℚ / @c ℝ / @c ℂ / @c 𝔻) denote the
+ *  @b universe values (constexpr instances of @c UniversalSet over the
+ *  carrier), not carrier @b types.  Carrier types are spelled directly
+ *  (@c bool, @c Cardinality, @c SignedExtensionalCardinal<>, ...) in
+ *  template-type-parameter positions; the math symbols denote the sets.
  *
- *  Witness layer: @c Cardinality carries the homogeneous operator +
- *  trait + concept surface shipped in PR #425 (#424) — @c +, @c *,
- *  @c /, @c %, @c <=>, @c ==; @c IsRig, @c IsCommutativeMonoid under
- *  each op, @c HasPartialOrderOperators / @c HasTotalOrderOperators,
- *  @c IsTotallyOrdered, @c IsDirectedSet / @c IsDirectedPoset,
- *  @c IsDividableChain.  Subtraction is intentionally absent: ℕ × ℕ →
- *  ℤ is the @c SignedCardinality job.
+ *  This makes @c element<ℕ> the canonical scout spelling for the
+ *  natural-numbers universe — closer to textbook math notation than the
+ *  pre-#559 @c element<Ω<ℕ>> form (which required @c ℕ to be a type
+ *  alias for @c Cardinality).
+ *
+ *  Pre-#559 the spelling was @c using @c ℕ @c = @c
+ *  dedekind::sets::Cardinality (carrier-type alias, post-#402); the
+ *  ~110 type-context sites of @c ℕ in concept gates and static_asserts
+ *  were migrated to @c Cardinality directly in step 1 of the ℕ slice.
+ *
+ *  Carrier reading retained: @c Cardinality is the variant ℕ-proxy
+ *  (= @c std::variant<ExtensionalCardinal<>, ℵ_0>) — saturating to
+ *  @c ℵ_0 on overflow rather than wrapping the way @c unsigned @c int
+ *  would.  The structural advantage: the variant honestly models ℕ
+ *  (no additive inverses; rig-not-ring), whereas @c unsigned @c int
+ *  is structurally @b more than ℕ (modular ring with additive
+ *  inverses).  Witnesses (@c IsRig, @c IsCommutativeMonoid,
+ *  @c IsTotallyOrdered, @c IsDirectedSet, @c IsDirectedPoset, ...)
+ *  are now expressed against @c Cardinality directly.
  */
-export using ℕ = dedekind::sets::Cardinality;
+export inline constexpr auto ℕ = Ω<Cardinality>;
 
 // Canonical ambient-set value used by the sets DSL tests.
 export inline constexpr NaturalNumbersOf<> N{};

--- a/src/main/modules/dedekind/sets/boundaries.cppm
+++ b/src/main/modules/dedekind/sets/boundaries.cppm
@@ -419,8 +419,8 @@ static_assert(dedekind::category::HasCanonicalSetCCC<int>,
 // case.
 export template <typename L = ClassicalLogic, typename C = ℵ_0>
 struct NaturalNumbersOf {
-  using Domain =
-      dedekind::sets::Cardinality;  // Aligned to the @c Cardinality carrier post-#402.
+  using Domain = dedekind::sets::Cardinality;  // Aligned to the @c Cardinality
+                                               // carrier post-#402.
   using Codomain = typename L::Ω;
   using logic_species = L;
   using cardinality_type = C;

--- a/src/test/cpp/modules/dedekind/analysis/pruning_showcases_test.cpp
+++ b/src/test/cpp/modules/dedekind/analysis/pruning_showcases_test.cpp
@@ -94,7 +94,7 @@ TEST_CASE("Pruning showcase 2: ℕ² lattice × [½,1½]² in ℂ = {1+i}",
 
 TEST_CASE("Pruning showcase 3: halfspace contradiction on ℕ collapses to Ø",
           "[analysis][pruning][showcase][showcase03]") {
-  constexpr auto n = element<Ω<Cardinality>>;
+  constexpr auto n = element<ℕ>;
   constexpr auto gt_five = Set{n | (n > bound<5>)};
   constexpr auto lt_three = Set{n | (n < bound<3>)};
 
@@ -114,7 +114,7 @@ TEST_CASE("Pruning showcase 3: halfspace contradiction on ℕ collapses to Ø",
 
 TEST_CASE("Pruning showcase 4: cardinality-1 halfspace meet = Singleton<4>",
           "[analysis][pruning][showcase][showcase04]") {
-  constexpr auto n = element<Ω<Cardinality>>;
+  constexpr auto n = element<ℕ>;
   constexpr auto gt_3 = Set{n | n > bound<3>};
   constexpr auto lt_5 = Set{n | n < bound<5>};
 

--- a/src/test/cpp/modules/dedekind/analysis/pruning_showcases_test.cpp
+++ b/src/test/cpp/modules/dedekind/analysis/pruning_showcases_test.cpp
@@ -94,11 +94,11 @@ TEST_CASE("Pruning showcase 2: ℕ² lattice × [½,1½]² in ℂ = {1+i}",
 
 TEST_CASE("Pruning showcase 3: halfspace contradiction on ℕ collapses to Ø",
           "[analysis][pruning][showcase][showcase03]") {
-  constexpr auto n = element<Ω<ℕ>>;
+  constexpr auto n = element<Ω<Cardinality>>;
   constexpr auto gt_five = Set{n | (n > bound<5>)};
   constexpr auto lt_three = Set{n | (n < bound<3>)};
 
-  constexpr Ø<ℕ> empty_meet = gt_five & lt_three;
+  constexpr Ø<Cardinality> empty_meet = gt_five & lt_three;
   STATIC_CHECK(empty_meet == Ø{});
 
   SECTION("Computability tiers tighten at the reduction boundary") {
@@ -114,7 +114,7 @@ TEST_CASE("Pruning showcase 3: halfspace contradiction on ℕ collapses to Ø",
 
 TEST_CASE("Pruning showcase 4: cardinality-1 halfspace meet = Singleton<4>",
           "[analysis][pruning][showcase][showcase04]") {
-  constexpr auto n = element<Ω<ℕ>>;
+  constexpr auto n = element<Ω<Cardinality>>;
   constexpr auto gt_3 = Set{n | n > bound<3>};
   constexpr auto lt_5 = Set{n | n < bound<5>};
 

--- a/src/test/cpp/modules/dedekind/numbers/cardinality_test.cpp
+++ b/src/test/cpp/modules/dedekind/numbers/cardinality_test.cpp
@@ -506,7 +506,7 @@ TEST_CASE("Numbers: variant carriers ↔ std::floating_point comparison (#428)",
     const auto naz = SignedCardinality{NaZ{}};
     // Finite ℕ vs ℤ — the lift settles equality and ordering.
     CHECK(five_n == five_z);
-    CHECK(five_n > neg_three_z);  // ℕ ≥ 0 > -3
+    CHECK(five_n > neg_three_z);  // Cardinality ≥ 0 > -3
     CHECK(five_n < finite_signed_cardinality(7));
     // ℵ_0 ↦ +ℵ_0 under the lift; equivalent to PositiveInfinity.
     CHECK(inf_n == pos_inf_z);
@@ -545,17 +545,17 @@ TEST_CASE(
   // shift to the more idiomatic @c element<Ω<ℤ>> form.
   using L = TernaryLogic;
   SECTION("Set<ℕ> & Set<ℤ> tightens to Set<ℕ>") {
-    constexpr auto n = element<Ω<ℕ>>;
-    constexpr auto positive_n = Set{n | (n > 5u)};  // {6, 7, 8, …} ⊂ ℕ
+    constexpr auto n = element<Ω<Cardinality>>;
+    constexpr auto positive_n = Set{n | (n > 5u)};  // {6, 7, 8, …} ⊂ Cardinality
     auto bounded_pred = [](const SignedCardinality& v) {
       // {…, -1, 0, …, 10} ⊂ ℤ
       return (v <= 10) ? L::True : L::False;
     };
     const Set<SignedCardinality, L, decltype(bounded_pred)> bounded_z{
         bounded_pred};
-    const auto meet = positive_n & bounded_z;  // {6, 7, …, 10} ⊂ ℕ
+    const auto meet = positive_n & bounded_z;  // {6, 7, …, 10} ⊂ Cardinality
     // Type-level proof: result carrier is ℕ (Cardinality), not ℤ.
-    STATIC_CHECK(std::same_as<typename decltype(meet)::Domain, ℕ>);
+    STATIC_CHECK(std::same_as<typename decltype(meet)::Domain, Cardinality>);
     // Members in the natural-side window are in the meet.
     CHECK(meet(finite_cardinality(6)) == Ternary::True);
     CHECK(meet(finite_cardinality(10)) == Ternary::True);
@@ -565,8 +565,8 @@ TEST_CASE(
     CHECK(meet(finite_cardinality(5)) == Ternary::False);
   }
   SECTION("Set<ℕ> | Set<ℤ> widens to Set<ℤ> ({1} ∪ {-1} ⊂ ℤ)") {
-    constexpr auto n = element<Ω<ℕ>>;
-    constexpr auto one_n = Set{n | (n == 1u)};  // {1} ⊂ ℕ
+    constexpr auto n = element<Ω<Cardinality>>;
+    constexpr auto one_n = Set{n | (n == 1u)};  // {1} ⊂ Cardinality
     auto neg_one_pred = [](const SignedCardinality& v) {
       return (v == -1) ? L::True : L::False;
     };
@@ -585,15 +585,15 @@ TEST_CASE(
     CHECK(union_set(finite_signed_cardinality(-2)) == Ternary::False);
   }
   SECTION("Symmetric direction: Set<ℤ> & Set<ℕ> still tightens to Set<ℕ>") {
-    constexpr auto n = element<Ω<ℕ>>;
+    constexpr auto n = element<Ω<Cardinality>>;
     auto bounded_pred = [](const SignedCardinality& v) {
       return (v >= -3) ? L::True : L::False;  // {-3, -2, …} ⊂ ℤ
     };
     const Set<SignedCardinality, L, decltype(bounded_pred)> bounded_z{
         bounded_pred};
-    constexpr auto small_n = Set{n | (n < 5u)};  // {0, …, 4} ⊂ ℕ
-    const auto meet = bounded_z & small_n;       // {0, …, 4} ⊂ ℕ
-    STATIC_CHECK(std::same_as<typename decltype(meet)::Domain, ℕ>);
+    constexpr auto small_n = Set{n | (n < 5u)};  // {0, …, 4} ⊂ Cardinality
+    const auto meet = bounded_z & small_n;       // {0, …, 4} ⊂ Cardinality
+    STATIC_CHECK(std::same_as<typename decltype(meet)::Domain, Cardinality>);
     CHECK(meet(finite_cardinality(0)) == Ternary::True);
     CHECK(meet(finite_cardinality(4)) == Ternary::True);
     CHECK(meet(finite_cardinality(5)) == Ternary::False);

--- a/src/test/cpp/modules/dedekind/numbers/cardinality_test.cpp
+++ b/src/test/cpp/modules/dedekind/numbers/cardinality_test.cpp
@@ -545,7 +545,7 @@ TEST_CASE(
   // shift to the more idiomatic @c element<Ω<ℤ>> form.
   using L = TernaryLogic;
   SECTION("Set<ℕ> & Set<ℤ> tightens to Set<ℕ>") {
-    constexpr auto n = element<Ω<Cardinality>>;
+    constexpr auto n = element<ℕ>;
     constexpr auto positive_n = Set{n | (n > 5u)};  // {6, 7, 8, …} ⊂ Cardinality
     auto bounded_pred = [](const SignedCardinality& v) {
       // {…, -1, 0, …, 10} ⊂ ℤ
@@ -565,7 +565,7 @@ TEST_CASE(
     CHECK(meet(finite_cardinality(5)) == Ternary::False);
   }
   SECTION("Set<ℕ> | Set<ℤ> widens to Set<ℤ> ({1} ∪ {-1} ⊂ ℤ)") {
-    constexpr auto n = element<Ω<Cardinality>>;
+    constexpr auto n = element<ℕ>;
     constexpr auto one_n = Set{n | (n == 1u)};  // {1} ⊂ Cardinality
     auto neg_one_pred = [](const SignedCardinality& v) {
       return (v == -1) ? L::True : L::False;
@@ -585,7 +585,7 @@ TEST_CASE(
     CHECK(union_set(finite_signed_cardinality(-2)) == Ternary::False);
   }
   SECTION("Symmetric direction: Set<ℤ> & Set<ℕ> still tightens to Set<ℕ>") {
-    constexpr auto n = element<Ω<Cardinality>>;
+    constexpr auto n = element<ℕ>;
     auto bounded_pred = [](const SignedCardinality& v) {
       return (v >= -3) ? L::True : L::False;  // {-3, -2, …} ⊂ ℤ
     };

--- a/src/test/cpp/modules/dedekind/numbers/cardinality_test.cpp
+++ b/src/test/cpp/modules/dedekind/numbers/cardinality_test.cpp
@@ -546,7 +546,8 @@ TEST_CASE(
   using L = TernaryLogic;
   SECTION("Set<ℕ> & Set<ℤ> tightens to Set<ℕ>") {
     constexpr auto n = element<ℕ>;
-    constexpr auto positive_n = Set{n | (n > 5u)};  // {6, 7, 8, …} ⊂ Cardinality
+    constexpr auto positive_n =
+        Set{n | (n > 5u)};  // {6, 7, 8, …} ⊂ Cardinality
     auto bounded_pred = [](const SignedCardinality& v) {
       // {…, -1, 0, …, 10} ⊂ ℤ
       return (v <= 10) ? L::True : L::False;

--- a/src/test/cpp/modules/dedekind/numbers/integer_test.cpp
+++ b/src/test/cpp/modules/dedekind/numbers/integer_test.cpp
@@ -37,8 +37,8 @@ using namespace dedekind::sets;
 TEST_CASE("Integer: ℕ → ℤ → ℕ via unary − then abs (closes #436 round-trip)",
           "[numbers][integer][carrier-lattice][round-trip]") {
   const auto n = finite_cardinality(7);
-  const auto neg = -n;         // ℕ → ℤ (closure-forcing negation)
-  const auto back = abs(neg);  // ℤ → ℕ (retraction)
+  const auto neg = -n;         // Cardinality → ℤ (closure-forcing negation)
+  const auto back = abs(neg);  // ℤ → Cardinality (retraction)
   CHECK(back == n);
 }
 
@@ -46,14 +46,14 @@ TEST_CASE("Integer: ℕ → ℤ → ℕ via binary − then abs",
           "[numbers][integer][carrier-lattice][round-trip]") {
   const auto n = finite_cardinality(7);
   const auto z = finite_cardinality(0) - n;  // → -7 in ℤ
-  const auto back = abs(z);                  // → 7 in ℕ
+  const auto back = abs(z);                  // → 7 in Cardinality
   CHECK(back == n);
 }
 
 TEST_CASE("Integer: ℤ → ℕ → ℤ folds sign — abs is not a bijection",
           "[numbers][integer][carrier-lattice][round-trip]") {
   const auto z_neg = finite_signed_cardinality(-5);
-  const auto folded = abs(z_neg);                           // → 5 in ℕ
+  const auto folded = abs(z_neg);                           // → 5 in Cardinality
   const auto re_embedded = folded - finite_cardinality(0);  // → +5 in ℤ
   CHECK(re_embedded == finite_signed_cardinality(5));
   CHECK_FALSE(re_embedded == z_neg);  // sign was lost on the round-trip

--- a/src/test/cpp/modules/dedekind/numbers/integer_test.cpp
+++ b/src/test/cpp/modules/dedekind/numbers/integer_test.cpp
@@ -53,7 +53,7 @@ TEST_CASE("Integer: ℕ → ℤ → ℕ via binary − then abs",
 TEST_CASE("Integer: ℤ → ℕ → ℤ folds sign — abs is not a bijection",
           "[numbers][integer][carrier-lattice][round-trip]") {
   const auto z_neg = finite_signed_cardinality(-5);
-  const auto folded = abs(z_neg);                           // → 5 in Cardinality
+  const auto folded = abs(z_neg);  // → 5 in Cardinality
   const auto re_embedded = folded - finite_cardinality(0);  // → +5 in ℤ
   CHECK(re_embedded == finite_signed_cardinality(5));
   CHECK_FALSE(re_embedded == z_neg);  // sign was lost on the round-trip

--- a/src/test/cpp/modules/dedekind/numbers/nno_test.cpp
+++ b/src/test/cpp/modules/dedekind/numbers/nno_test.cpp
@@ -139,8 +139,9 @@ TEST_CASE(
   STATIC_CHECK(
       std::same_as<decltype(cardinality_succ{}(Cardinality{})), Cardinality>);
 
-  // Layer 3: ℕ is the alias pointing to Cardinality.  The textbook
+  // Layer 3: ℕ is the universe Ω<Cardinality> (post-#559).  The textbook
   // symbol practitioners use; the NNO universal property is what it
   // _means_ via the chain.
-  STATIC_CHECK(std::same_as<Cardinality, Cardinality>);
+  STATIC_CHECK(std::same_as<typename std::remove_cvref_t<decltype(ℕ)>::Domain,
+                            Cardinality>);
 }

--- a/src/test/cpp/modules/dedekind/numbers/nno_test.cpp
+++ b/src/test/cpp/modules/dedekind/numbers/nno_test.cpp
@@ -36,7 +36,7 @@ TEST_CASE(
     "category:nno — IsNNO<Cardinality, cardinality_zero, "
     "cardinality_succ> fires",
     "[category][nno][cardinality][witness]") {
-  STATIC_CHECK(IsNNO<ℕ, cardinality_zero, cardinality_succ>);
+  STATIC_CHECK(IsNNO<Cardinality, cardinality_zero, cardinality_succ>);
   STATIC_CHECK(IsNNO<Cardinality, cardinality_zero, cardinality_succ>);
 }
 
@@ -107,7 +107,7 @@ TEST_CASE(
   // The unique morphism f : ℕ → A produced by the NNO universal
   // property over this coalgebra is the Fibonacci sequence;
   // nno_iterate materialises f(n) for finite n.
-  using State = std::pair<ℕ, ℕ>;
+  using State = std::pair<Cardinality, Cardinality>;
   // Initial state (F_1, F_0) = (1, 0); we step n times to get
   // (F_{n+1}, F_n), then read off the second component for F_n.
   const State a0 = {finite_cardinality(1), finite_cardinality(0)};
@@ -142,5 +142,5 @@ TEST_CASE(
   // Layer 3: ℕ is the alias pointing to Cardinality.  The textbook
   // symbol practitioners use; the NNO universal property is what it
   // _means_ via the chain.
-  STATIC_CHECK(std::same_as<ℕ, Cardinality>);
+  STATIC_CHECK(std::same_as<Cardinality, Cardinality>);
 }

--- a/src/test/cpp/modules/dedekind/numbers/starters_test.cpp
+++ b/src/test/cpp/modules/dedekind/numbers/starters_test.cpp
@@ -16,9 +16,10 @@ TEST_CASE("Numbers: canonical starter symbols", "[numbers][starter]") {
   // ambient-value is now uniform and minimal: one carrier, one
   // @c Ω<carrier> value, no per-symbol predicate-set type to remember.
 
-  STATIC_CHECK(std::same_as<std::remove_cvref_t<decltype(ℕ)>, UniversalSet<Cardinality>>);
-  STATIC_CHECK(
-      std::same_as<std::remove_cvref_t<decltype(Ω<Cardinality>)>, UniversalSet<Cardinality>>);
+  STATIC_CHECK(std::same_as<std::remove_cvref_t<decltype(ℕ)>,
+                            UniversalSet<Cardinality>>);
+  STATIC_CHECK(std::same_as<std::remove_cvref_t<decltype(Ω<Cardinality>)>,
+                            UniversalSet<Cardinality>>);
 
   STATIC_CHECK(std::same_as<ℤ, SignedExtensionalCardinal<>>);
   STATIC_CHECK(

--- a/src/test/cpp/modules/dedekind/numbers/starters_test.cpp
+++ b/src/test/cpp/modules/dedekind/numbers/starters_test.cpp
@@ -9,12 +9,14 @@ using namespace dedekind::numbers;
 using namespace dedekind::sets;
 
 TEST_CASE("Numbers: canonical starter symbols", "[numbers][starter]") {
-  // Per #551 (Ω<carrier> ambient redesign), the canonical species symbols
-  // are pure carrier types; the value-level *ambient* at each carrier is
-  // the universal-predicate value @c Ω<carrier>, of type
-  // @c UniversalSet<carrier>.  The schism between carrier-type and
-  // ambient-value is now uniform and minimal: one carrier, one
-  // @c Ω<carrier> value, no per-symbol predicate-set type to remember.
+  // Per #559 (option-A migration, sibling to #551's Ω<carrier> ambient
+  // redesign), the canonical species symbols are universe @b values:
+  // @c ℕ = @c Ω<Cardinality>, @c ℤ = @c Ω<SignedExtensionalCardinal<>>,
+  // and so on.  Carriers are spelled directly (Cardinality, ℤ-as-alias,
+  // ℚ-as-alias, ...) in template-type-parameter positions.  Each symbol's
+  // STATIC_CHECK below witnesses the universe-over-carrier reading by
+  // asserting (a) decltype(symbol) == UniversalSet<carrier> and (b)
+  // decltype(symbol)::Domain == carrier.
 
   STATIC_CHECK(std::same_as<std::remove_cvref_t<decltype(ℕ)>,
                             UniversalSet<Cardinality>>);
@@ -36,19 +38,21 @@ TEST_CASE("Numbers: canonical starter symbols", "[numbers][starter]") {
 
 TEST_CASE("Numbers: starter universes construct from ambient values",
           "[numbers][starter][sets]") {
-  // Per #551, the new spelling is:
-  //   constexpr auto n = element<Ω<ℕ>>;     // typed scout
-  //   constexpr auto naturals = Set{n};      // universal Set on ℕ
+  // Per #559 option-A, the canonical scout spelling is:
+  //   constexpr auto n = element<ℕ>;         // ℕ is itself the universe value
+  //   constexpr auto naturals = Set{n};      // universal Set over ℕ-carrier
   //   static_assert(naturals.contains(7u));  // value-level membership query
   //
-  // The `% N` binding step is gone: the scout already knows its ambient.
+  // (Pre-#559 the spelling was @c element<Ω<ℕ>> with ℕ a carrier alias;
+  //  the @c % @c N binding step had already gone in #551.)
 
   constexpr auto n = element<ℕ>;
   constexpr auto naturals = Set{n};
   static_assert(naturals(7u) == Ternary::True);
   static_assert(naturals(0u) == Ternary::True);
-  // Direct ambient-call route: Ω<ℕ>.contains(value) returns L::True for
-  // every Cardinality value (the universal-set semantics).
+  // Direct ambient-call route: ℕ.contains(value) (or equivalently
+  // Ω<Cardinality>.contains(value), since ℕ = Ω<Cardinality>) returns
+  // L::True for every Cardinality value (the universal-set semantics).
   static_assert(Ω<Cardinality>.contains(7u));
   static_assert(Ω<Cardinality>.contains(0u));
 

--- a/src/test/cpp/modules/dedekind/numbers/starters_test.cpp
+++ b/src/test/cpp/modules/dedekind/numbers/starters_test.cpp
@@ -16,7 +16,7 @@ TEST_CASE("Numbers: canonical starter symbols", "[numbers][starter]") {
   // ambient-value is now uniform and minimal: one carrier, one
   // @c Ω<carrier> value, no per-symbol predicate-set type to remember.
 
-  STATIC_CHECK(std::same_as<Cardinality, Cardinality>);
+  STATIC_CHECK(std::same_as<std::remove_cvref_t<decltype(ℕ)>, UniversalSet<Cardinality>>);
   STATIC_CHECK(
       std::same_as<std::remove_cvref_t<decltype(Ω<Cardinality>)>, UniversalSet<Cardinality>>);
 
@@ -42,7 +42,7 @@ TEST_CASE("Numbers: starter universes construct from ambient values",
   //
   // The `% N` binding step is gone: the scout already knows its ambient.
 
-  constexpr auto n = element<Ω<Cardinality>>;
+  constexpr auto n = element<ℕ>;
   constexpr auto naturals = Set{n};
   static_assert(naturals(7u) == Ternary::True);
   static_assert(naturals(0u) == Ternary::True);
@@ -63,7 +63,7 @@ TEST_CASE("Numbers: starter universes construct from ambient values",
 TEST_CASE("Numbers: starter universes satisfy lattice identities",
           "[numbers][starter][algebra]") {
   {
-    constexpr auto n = element<Ω<Cardinality>>;
+    constexpr auto n = element<ℕ>;
     const auto U = Set{n};
     const auto O = !U;
     CHECK((U | O)(7u) == Ternary::True);

--- a/src/test/cpp/modules/dedekind/numbers/starters_test.cpp
+++ b/src/test/cpp/modules/dedekind/numbers/starters_test.cpp
@@ -16,9 +16,9 @@ TEST_CASE("Numbers: canonical starter symbols", "[numbers][starter]") {
   // ambient-value is now uniform and minimal: one carrier, one
   // @c Ω<carrier> value, no per-symbol predicate-set type to remember.
 
-  STATIC_CHECK(std::same_as<ℕ, Cardinality>);
+  STATIC_CHECK(std::same_as<Cardinality, Cardinality>);
   STATIC_CHECK(
-      std::same_as<std::remove_cvref_t<decltype(Ω<ℕ>)>, UniversalSet<ℕ>>);
+      std::same_as<std::remove_cvref_t<decltype(Ω<Cardinality>)>, UniversalSet<Cardinality>>);
 
   STATIC_CHECK(std::same_as<ℤ, SignedExtensionalCardinal<>>);
   STATIC_CHECK(
@@ -42,14 +42,14 @@ TEST_CASE("Numbers: starter universes construct from ambient values",
   //
   // The `% N` binding step is gone: the scout already knows its ambient.
 
-  constexpr auto n = element<Ω<ℕ>>;
+  constexpr auto n = element<Ω<Cardinality>>;
   constexpr auto naturals = Set{n};
   static_assert(naturals(7u) == Ternary::True);
   static_assert(naturals(0u) == Ternary::True);
   // Direct ambient-call route: Ω<ℕ>.contains(value) returns L::True for
   // every Cardinality value (the universal-set semantics).
-  static_assert(Ω<ℕ>.contains(7u));
-  static_assert(Ω<ℕ>.contains(0u));
+  static_assert(Ω<Cardinality>.contains(7u));
+  static_assert(Ω<Cardinality>.contains(0u));
 
   constexpr auto z = element<Ω<ℤ>>;
   constexpr auto integers = Set{z};
@@ -63,7 +63,7 @@ TEST_CASE("Numbers: starter universes construct from ambient values",
 TEST_CASE("Numbers: starter universes satisfy lattice identities",
           "[numbers][starter][algebra]") {
   {
-    constexpr auto n = element<Ω<ℕ>>;
+    constexpr auto n = element<Ω<Cardinality>>;
     const auto U = Set{n};
     const auto O = !U;
     CHECK((U | O)(7u) == Ternary::True);

--- a/src/test/cpp/modules/dedekind/order/halfspace_test.cpp
+++ b/src/test/cpp/modules/dedekind/order/halfspace_test.cpp
@@ -63,9 +63,11 @@ TEST_CASE("order:halfspace — Halfspace operator() on integral carrier",
 TEST_CASE("order:halfspace — Variable DSL constructs Halfspace from bound<V>",
           "[order][halfspace][dsl]") {
   // ℕ rather than ℤ so the order-test target stays upstream of numbers: ℤ
-  // lives in `dedekind.numbers`, which is downstream of `dedekind.order` in
-  // the build DAG. Post-#401, ℕ is the unsigned-int carrier, so the test
-  // now exercises `Halfspace<unsigned int, ...>` instantiations.
+  // lives in `dedekind.numbers`, which is downstream of `dedekind.order`
+  // in the build DAG.  Post-#559 ℕ is the universe value Ω<Cardinality>;
+  // the underlying carrier is Cardinality (the variant ℕ-proxy from
+  // #402), so the test exercises `Halfspace<Cardinality, ...>`
+  // instantiations.
   constexpr auto n = element<ℕ>;
 
   SECTION("> constructs Upward/Strict") {

--- a/src/test/cpp/modules/dedekind/order/halfspace_test.cpp
+++ b/src/test/cpp/modules/dedekind/order/halfspace_test.cpp
@@ -71,32 +71,29 @@ TEST_CASE("order:halfspace — Variable DSL constructs Halfspace from bound<V>",
   SECTION("> constructs Upward/Strict") {
     constexpr auto h = n > bound<7>;
     using H = std::decay_t<decltype(h)>;
-    STATIC_CHECK(
-        std::same_as<H,
-                     Halfspace<Cardinality, 7, Direction::Upward, Strictness::Strict>>);
+    STATIC_CHECK(std::same_as<H, Halfspace<Cardinality, 7, Direction::Upward,
+                                           Strictness::Strict>>);
   }
 
   SECTION(">= constructs Upward/NonStrict") {
     constexpr auto h = n >= bound<7>;
     using H = std::decay_t<decltype(h)>;
-    STATIC_CHECK(std::same_as<
-                 H, Halfspace<Cardinality, 7, Direction::Upward, Strictness::NonStrict>>);
+    STATIC_CHECK(std::same_as<H, Halfspace<Cardinality, 7, Direction::Upward,
+                                           Strictness::NonStrict>>);
   }
 
   SECTION("< constructs Downward/Strict") {
     constexpr auto h = n < bound<7>;
     using H = std::decay_t<decltype(h)>;
-    STATIC_CHECK(
-        std::same_as<H,
-                     Halfspace<Cardinality, 7, Direction::Downward, Strictness::Strict>>);
+    STATIC_CHECK(std::same_as<H, Halfspace<Cardinality, 7, Direction::Downward,
+                                           Strictness::Strict>>);
   }
 
   SECTION("<= constructs Downward/NonStrict") {
     constexpr auto h = n <= bound<7>;
     using H = std::decay_t<decltype(h)>;
-    STATIC_CHECK(
-        std::same_as<
-            H, Halfspace<Cardinality, 7, Direction::Downward, Strictness::NonStrict>>);
+    STATIC_CHECK(std::same_as<H, Halfspace<Cardinality, 7, Direction::Downward,
+                                           Strictness::NonStrict>>);
   }
   // Note (post-#409 review): the DSL constraint also rejects negative
   // signed pivots on unsigned carriers (e.g. `element<Ω<ℕ>> > bound<-1>` no

--- a/src/test/cpp/modules/dedekind/order/halfspace_test.cpp
+++ b/src/test/cpp/modules/dedekind/order/halfspace_test.cpp
@@ -66,21 +66,21 @@ TEST_CASE("order:halfspace — Variable DSL constructs Halfspace from bound<V>",
   // lives in `dedekind.numbers`, which is downstream of `dedekind.order` in
   // the build DAG. Post-#401, ℕ is the unsigned-int carrier, so the test
   // now exercises `Halfspace<unsigned int, ...>` instantiations.
-  constexpr auto n = element<Ω<ℕ>>;
+  constexpr auto n = element<Ω<Cardinality>>;
 
   SECTION("> constructs Upward/Strict") {
     constexpr auto h = n > bound<7>;
     using H = std::decay_t<decltype(h)>;
     STATIC_CHECK(
         std::same_as<H,
-                     Halfspace<ℕ, 7, Direction::Upward, Strictness::Strict>>);
+                     Halfspace<Cardinality, 7, Direction::Upward, Strictness::Strict>>);
   }
 
   SECTION(">= constructs Upward/NonStrict") {
     constexpr auto h = n >= bound<7>;
     using H = std::decay_t<decltype(h)>;
     STATIC_CHECK(std::same_as<
-                 H, Halfspace<ℕ, 7, Direction::Upward, Strictness::NonStrict>>);
+                 H, Halfspace<Cardinality, 7, Direction::Upward, Strictness::NonStrict>>);
   }
 
   SECTION("< constructs Downward/Strict") {
@@ -88,7 +88,7 @@ TEST_CASE("order:halfspace — Variable DSL constructs Halfspace from bound<V>",
     using H = std::decay_t<decltype(h)>;
     STATIC_CHECK(
         std::same_as<H,
-                     Halfspace<ℕ, 7, Direction::Downward, Strictness::Strict>>);
+                     Halfspace<Cardinality, 7, Direction::Downward, Strictness::Strict>>);
   }
 
   SECTION("<= constructs Downward/NonStrict") {
@@ -96,7 +96,7 @@ TEST_CASE("order:halfspace — Variable DSL constructs Halfspace from bound<V>",
     using H = std::decay_t<decltype(h)>;
     STATIC_CHECK(
         std::same_as<
-            H, Halfspace<ℕ, 7, Direction::Downward, Strictness::NonStrict>>);
+            H, Halfspace<Cardinality, 7, Direction::Downward, Strictness::NonStrict>>);
   }
   // Note (post-#409 review): the DSL constraint also rejects negative
   // signed pivots on unsigned carriers (e.g. `element<Ω<ℕ>> > bound<-1>` no
@@ -277,12 +277,12 @@ TEST_CASE("order:halfspace — reduction boundary tightens all three tiers",
           "[order][halfspace][computability][reduction]") {
   // Mirrored from analysis/pruning_showcases_test.cpp at the unit level:
   // the reduction boundary IS the computability boundary.
-  constexpr auto n = element<Ω<ℕ>>;
+  constexpr auto n = element<Ω<Cardinality>>;
 
   SECTION("Empty-meet reduction") {
     constexpr auto gt5 = Set{n | (n > bound<5>)};
     constexpr auto lt3 = Set{n | (n < bound<3>)};
-    constexpr Ø<ℕ> meet = gt5 & lt3;
+    constexpr Ø<Cardinality> meet = gt5 & lt3;
 
     STATIC_CHECK_FALSE(HasDecidableMembership<decltype(gt5)>);
     STATIC_CHECK_FALSE(IsFiniteSet<decltype(gt5)>);

--- a/src/test/cpp/modules/dedekind/order/halfspace_test.cpp
+++ b/src/test/cpp/modules/dedekind/order/halfspace_test.cpp
@@ -66,7 +66,7 @@ TEST_CASE("order:halfspace — Variable DSL constructs Halfspace from bound<V>",
   // lives in `dedekind.numbers`, which is downstream of `dedekind.order` in
   // the build DAG. Post-#401, ℕ is the unsigned-int carrier, so the test
   // now exercises `Halfspace<unsigned int, ...>` instantiations.
-  constexpr auto n = element<Ω<Cardinality>>;
+  constexpr auto n = element<ℕ>;
 
   SECTION("> constructs Upward/Strict") {
     constexpr auto h = n > bound<7>;
@@ -277,7 +277,7 @@ TEST_CASE("order:halfspace — reduction boundary tightens all three tiers",
           "[order][halfspace][computability][reduction]") {
   // Mirrored from analysis/pruning_showcases_test.cpp at the unit level:
   // the reduction boundary IS the computability boundary.
-  constexpr auto n = element<Ω<Cardinality>>;
+  constexpr auto n = element<ℕ>;
 
   SECTION("Empty-meet reduction") {
     constexpr auto gt5 = Set{n | (n > bound<5>)};

--- a/src/test/cpp/modules/dedekind/python/showcase_03_halfspace_contradiction.cpp
+++ b/src/test/cpp/modules/dedekind/python/showcase_03_halfspace_contradiction.cpp
@@ -34,7 +34,7 @@ using namespace dedekind::order;
 // Symbolic scout ranging over the universal set Ω<ℕ>.  Per #551, the
 // scout carries its ambient at the type level, so the % binding step
 // disappears from the set-builder DSL.
-constexpr auto n = element<Ω<Cardinality>>;
+constexpr auto n = element<ℕ>;
 
 // Opposing halfspaces with compile-time pivots carried in the predicate type.
 constexpr auto gt_five = Set{n | (n > bound<5>)};

--- a/src/test/cpp/modules/dedekind/python/showcase_03_halfspace_contradiction.cpp
+++ b/src/test/cpp/modules/dedekind/python/showcase_03_halfspace_contradiction.cpp
@@ -34,14 +34,14 @@ using namespace dedekind::order;
 // Symbolic scout ranging over the universal set Ω<ℕ>.  Per #551, the
 // scout carries its ambient at the type level, so the % binding step
 // disappears from the set-builder DSL.
-constexpr auto n = element<Ω<ℕ>>;
+constexpr auto n = element<Ω<Cardinality>>;
 
 // Opposing halfspaces with compile-time pivots carried in the predicate type.
 constexpr auto gt_five = Set{n | (n > bound<5>)};
 constexpr auto lt_three = Set{n | (n < bound<3>)};
 
 // Compile-time theorem: the meet IS the empty set on ℕ.
-constexpr Ø<ℕ> empty_meet = gt_five & lt_three;
+constexpr Ø<Cardinality> empty_meet = gt_five & lt_three;
 static_assert(empty_meet == Ø{});
 
 // Computability made a compile-time observable: the parent Sets carry NONE

--- a/src/test/cpp/modules/dedekind/python/showcase_03_halfspace_contradiction.cpp
+++ b/src/test/cpp/modules/dedekind/python/showcase_03_halfspace_contradiction.cpp
@@ -31,9 +31,10 @@ using namespace dedekind::algebra;
 using namespace dedekind::numbers;
 using namespace dedekind::order;
 
-// Symbolic scout ranging over the universal set Ω<ℕ>.  Per #551, the
-// scout carries its ambient at the type level, so the % binding step
-// disappears from the set-builder DSL.
+// Symbolic scout ranging over the natural-numbers universe ℕ.  Per
+// #551 the scout carries its ambient at the type level (the % binding
+// step disappears); per #559 the canonical spelling is element<ℕ> with
+// ℕ itself the universe value (= Ω<Cardinality>).
 constexpr auto n = element<ℕ>;
 
 // Opposing halfspaces with compile-time pivots carried in the predicate type.

--- a/src/test/cpp/modules/dedekind/python/showcase_04_halfspace_singleton.cpp
+++ b/src/test/cpp/modules/dedekind/python/showcase_04_halfspace_singleton.cpp
@@ -32,7 +32,7 @@ using namespace dedekind::numbers;
 using namespace dedekind::order;
 
 // Symbolic scout ranging over the universal set Ω<ℕ> (per #551).
-constexpr auto n = element<Ω<Cardinality>>;
+constexpr auto n = element<ℕ>;
 
 // Opposing halfspaces with compile-time pivots separated by exactly two.
 constexpr auto gt_3 = Set{n | n > bound<3>};

--- a/src/test/cpp/modules/dedekind/python/showcase_04_halfspace_singleton.cpp
+++ b/src/test/cpp/modules/dedekind/python/showcase_04_halfspace_singleton.cpp
@@ -32,7 +32,7 @@ using namespace dedekind::numbers;
 using namespace dedekind::order;
 
 // Symbolic scout ranging over the universal set Ω<ℕ> (per #551).
-constexpr auto n = element<Ω<ℕ>>;
+constexpr auto n = element<Ω<Cardinality>>;
 
 // Opposing halfspaces with compile-time pivots separated by exactly two.
 constexpr auto gt_3 = Set{n | n > bound<3>};

--- a/src/test/cpp/modules/dedekind/python/showcase_04_halfspace_singleton.cpp
+++ b/src/test/cpp/modules/dedekind/python/showcase_04_halfspace_singleton.cpp
@@ -31,7 +31,8 @@ using namespace dedekind::algebra;
 using namespace dedekind::numbers;
 using namespace dedekind::order;
 
-// Symbolic scout ranging over the universal set Ω<ℕ> (per #551).
+// Symbolic scout ranging over the natural-numbers universe ℕ (= Ω<Cardinality>
+// post-#559; per #551 the scout carries its ambient at the type level).
 constexpr auto n = element<ℕ>;
 
 // Opposing halfspaces with compile-time pivots separated by exactly two.

--- a/src/test/cpp/modules/dedekind/sets/category_integration_test.cpp
+++ b/src/test/cpp/modules/dedekind/sets/category_integration_test.cpp
@@ -38,11 +38,11 @@ TEST_CASE("Sets+Category: singleton and comprehension predicates satisfy ETCS",
   const auto positive = Set{x | (x > 0u)};
   const auto bounded = Set{x | (x <= 10u)};
 
-  // ambient_set<ℕ> lifts the predicate-set into the post-#402 variant
-  // ℕ-proxy ambient (ℕ = Cardinality).  The characteristic-function χ
-  // then reads on Cardinality values; unsigned literals like @c 5u /
-  // @c 0u lift implicitly into the variant's finite alternative on the
-  // call site.
+  // ambient_set<Cardinality> lifts the predicate-set into the variant
+  // ℕ-proxy ambient (the carrier of the ℕ universe; post-#402 / #559
+  // ℕ = Ω<Cardinality>).  The characteristic-function χ then reads on
+  // Cardinality values; unsigned literals like @c 5u / @c 0u lift
+  // implicitly into the variant's finite alternative on the call site.
   const auto positive_set = ambient_set<Cardinality>(positive);
   const auto bounded_set = ambient_set<Cardinality>(bounded);
   const auto support = set_intersection(positive_set, bounded_set);

--- a/src/test/cpp/modules/dedekind/sets/category_integration_test.cpp
+++ b/src/test/cpp/modules/dedekind/sets/category_integration_test.cpp
@@ -34,7 +34,7 @@ TEST_CASE("Sets+Category: singleton and comprehension predicates satisfy ETCS",
   CHECK(atom_set.χ(42) == true);
   CHECK(atom_set.χ(7) == false);
 
-  auto x = element<Ω<Cardinality>>;
+  auto x = element<ℕ>;
   const auto positive = Set{x | (x > 0u)};
   const auto bounded = Set{x | (x <= 10u)};
 
@@ -59,7 +59,7 @@ TEST_CASE("Sets+Category: singleton and comprehension predicates satisfy ETCS",
 
 TEST_CASE("Sets+Category: Set naming boundary is explicit",
           "[sets][category][etcs][alignment]") {
-  auto x = element<Ω<Cardinality>>;
+  auto x = element<ℕ>;
   const auto positive = Set{x | (x > 0u)};
 
   // `sets::Set` (DSL species) and `category::Set` (CCC witness) are distinct.

--- a/src/test/cpp/modules/dedekind/sets/category_integration_test.cpp
+++ b/src/test/cpp/modules/dedekind/sets/category_integration_test.cpp
@@ -34,7 +34,7 @@ TEST_CASE("Sets+Category: singleton and comprehension predicates satisfy ETCS",
   CHECK(atom_set.χ(42) == true);
   CHECK(atom_set.χ(7) == false);
 
-  auto x = element<Ω<ℕ>>;
+  auto x = element<Ω<Cardinality>>;
   const auto positive = Set{x | (x > 0u)};
   const auto bounded = Set{x | (x <= 10u)};
 
@@ -43,8 +43,8 @@ TEST_CASE("Sets+Category: singleton and comprehension predicates satisfy ETCS",
   // then reads on Cardinality values; unsigned literals like @c 5u /
   // @c 0u lift implicitly into the variant's finite alternative on the
   // call site.
-  const auto positive_set = ambient_set<ℕ>(positive);
-  const auto bounded_set = ambient_set<ℕ>(bounded);
+  const auto positive_set = ambient_set<Cardinality>(positive);
+  const auto bounded_set = ambient_set<Cardinality>(bounded);
   const auto support = set_intersection(positive_set, bounded_set);
 
   STATIC_CHECK(dedekind::category::IsSet<decltype(positive_set)>);
@@ -59,17 +59,17 @@ TEST_CASE("Sets+Category: singleton and comprehension predicates satisfy ETCS",
 
 TEST_CASE("Sets+Category: Set naming boundary is explicit",
           "[sets][category][etcs][alignment]") {
-  auto x = element<Ω<ℕ>>;
+  auto x = element<Ω<Cardinality>>;
   const auto positive = Set{x | (x > 0u)};
 
   // `sets::Set` (DSL species) and `category::Set` (CCC witness) are distinct.
   STATIC_CHECK(!std::same_as<decltype(positive),
-                             dedekind::category::CanonicalSetCCC<ℕ>>);
-  STATIC_CHECK(dedekind::category::HasCanonicalSetCCC<ℕ>);
+                             dedekind::category::CanonicalSetCCC<Cardinality>>);
+  STATIC_CHECK(dedekind::category::HasCanonicalSetCCC<Cardinality>);
 
   // Bridge through ETCS object construction over the post-#402 ℕ carrier
   // (ℕ = Cardinality, the variant ℕ-proxy).
-  const auto positive_set = ambient_set<ℕ>(positive);
+  const auto positive_set = ambient_set<Cardinality>(positive);
   STATIC_CHECK(dedekind::category::IsSetInCanonicalCCC<decltype(positive_set)>);
 
   CHECK(positive_set.χ(3u) == Ternary::True);

--- a/src/test/cpp/modules/dedekind/sets/computability_test.cpp
+++ b/src/test/cpp/modules/dedekind/sets/computability_test.cpp
@@ -32,7 +32,7 @@ TEST_CASE("sets:computability — HasDecidableMembership on Ø",
   }
 
   SECTION("Intensional Set over a transfinite carrier fails the concept") {
-    constexpr auto x = element<Ω<Cardinality>>;
+    constexpr auto x = element<ℕ>;
     constexpr auto s = Set{x | [](const auto& v) { return v > 5u; }};
     // ℕ is transfinite → NaturalLogic picks TernaryLogic.
     STATIC_CHECK_FALSE(HasDecidableMembership<decltype(s)>);
@@ -46,7 +46,7 @@ TEST_CASE("sets:computability — IsFiniteSet on Ø", "[sets][computability]") {
   }
 
   SECTION("Intensional Set over a transfinite carrier is not finite") {
-    constexpr auto x = element<Ω<Cardinality>>;
+    constexpr auto x = element<ℕ>;
     constexpr auto s = Set{x | [](const auto& v) { return v > 5u; }};
     STATIC_CHECK_FALSE(IsFiniteSet<decltype(s)>);
   }
@@ -60,7 +60,7 @@ TEST_CASE("sets:computability — IsCompileTimeEnumerable on Ø",
   }
 
   SECTION("An intensional Set is neither finite nor compile-time-enumerable") {
-    constexpr auto x = element<Ω<Cardinality>>;
+    constexpr auto x = element<ℕ>;
     constexpr auto s = Set{x | [](const auto& v) { return v > 5u; }};
     STATIC_CHECK_FALSE(IsFiniteSet<decltype(s)>);
     STATIC_CHECK_FALSE(IsCompileTimeEnumerable<decltype(s)>);

--- a/src/test/cpp/modules/dedekind/sets/computability_test.cpp
+++ b/src/test/cpp/modules/dedekind/sets/computability_test.cpp
@@ -32,7 +32,7 @@ TEST_CASE("sets:computability — HasDecidableMembership on Ø",
   }
 
   SECTION("Intensional Set over a transfinite carrier fails the concept") {
-    constexpr auto x = element<Ω<ℕ>>;
+    constexpr auto x = element<Ω<Cardinality>>;
     constexpr auto s = Set{x | [](const auto& v) { return v > 5u; }};
     // ℕ is transfinite → NaturalLogic picks TernaryLogic.
     STATIC_CHECK_FALSE(HasDecidableMembership<decltype(s)>);
@@ -46,7 +46,7 @@ TEST_CASE("sets:computability — IsFiniteSet on Ø", "[sets][computability]") {
   }
 
   SECTION("Intensional Set over a transfinite carrier is not finite") {
-    constexpr auto x = element<Ω<ℕ>>;
+    constexpr auto x = element<Ω<Cardinality>>;
     constexpr auto s = Set{x | [](const auto& v) { return v > 5u; }};
     STATIC_CHECK_FALSE(IsFiniteSet<decltype(s)>);
   }
@@ -60,7 +60,7 @@ TEST_CASE("sets:computability — IsCompileTimeEnumerable on Ø",
   }
 
   SECTION("An intensional Set is neither finite nor compile-time-enumerable") {
-    constexpr auto x = element<Ω<ℕ>>;
+    constexpr auto x = element<Ω<Cardinality>>;
     constexpr auto s = Set{x | [](const auto& v) { return v > 5u; }};
     STATIC_CHECK_FALSE(IsFiniteSet<decltype(s)>);
     STATIC_CHECK_FALSE(IsCompileTimeEnumerable<decltype(s)>);

--- a/src/test/cpp/modules/dedekind/sets/expressions_test.cpp
+++ b/src/test/cpp/modules/dedekind/sets/expressions_test.cpp
@@ -18,8 +18,10 @@ TEST_CASE("Dedekind MVP: Basic Membership and Symbols", "[sets]") {
   }
 
   SECTION("Natural-numbers membership") {
-    // Post-#401, ℕ is the unsigned-int carrier; the predicate-set N has
-    // Domain = unsigned int, so callsites use unsigned values.
+    // Post-#559, ℕ is the universe value Ω<Cardinality>; the underlying
+    // carrier is Cardinality (the variant ℕ-proxy from #402, which
+    // accepts unsigned literals via implicit construction).  Callsites
+    // here use unsigned values that lift into Cardinality.
     auto n = element<ℕ>;
     auto infinite = Set{n | (n > 0u)};
     REQUIRE(infinite(5u) == Ternary::True);

--- a/src/test/cpp/modules/dedekind/sets/expressions_test.cpp
+++ b/src/test/cpp/modules/dedekind/sets/expressions_test.cpp
@@ -20,7 +20,7 @@ TEST_CASE("Dedekind MVP: Basic Membership and Symbols", "[sets]") {
   SECTION("Natural-numbers membership") {
     // Post-#401, ℕ is the unsigned-int carrier; the predicate-set N has
     // Domain = unsigned int, so callsites use unsigned values.
-    auto n = element<Ω<ℕ>>;
+    auto n = element<Ω<Cardinality>>;
     auto infinite = Set{n | (n > 0u)};
     REQUIRE(infinite(5u) == Ternary::True);
     REQUIRE(infinite(0u) == Ternary::False);
@@ -29,7 +29,7 @@ TEST_CASE("Dedekind MVP: Basic Membership and Symbols", "[sets]") {
 
 TEST_CASE("Dedekind Sets: symmetric difference (^) — #469",
           "[sets][operators]") {
-  auto x = element<Ω<ℕ>>;
+  auto x = element<Ω<Cardinality>>;
 
   SECTION(
       "Singleton ^ Singleton — equal pivots empty, distinct pivots union "
@@ -227,7 +227,7 @@ TEST_CASE("Dedekind Sets: symmetric difference (^) — #469",
 }
 
 TEST_CASE("Dedekind Identities: Extremal Collapse", "[sets][identities]") {
-  auto x = element<Ω<ℕ>>;
+  auto x = element<Ω<Cardinality>>;
 
   SECTION("Identity: Set{N} is N") {
     // Naturals remain stable when materialized through Set{...}.
@@ -373,7 +373,7 @@ TEST_CASE("Dedekind Sets: Power-set witness over homogeneous predicates",
 
 TEST_CASE("Dedekind Sets: Power-set preserves ambient logic",
           "[sets][powerset][logic]") {
-  auto x = element<Ω<ℕ>>;
+  auto x = element<Ω<Cardinality>>;
 
   const auto gt_zero = Set{x | (x > 0u)};
   const auto p_gt_zero = power_set(gt_zero);
@@ -405,7 +405,7 @@ TEST_CASE("Dedekind Sets: Relation witnesses preserve ternary logic",
 TEST_CASE("Dedekind Sets: Heterogeneous subset semantics",
           "[sets][subset][logic]") {
   SECTION("Ternary logic yields Unknown for heterogeneous predicates") {
-    auto x = element<Ω<ℕ>>;
+    auto x = element<Ω<Cardinality>>;
     const auto gt_zero = Set{x | (x > 0u)};
     const auto ge_zero = Set{x | (x >= 0u)};
 

--- a/src/test/cpp/modules/dedekind/sets/expressions_test.cpp
+++ b/src/test/cpp/modules/dedekind/sets/expressions_test.cpp
@@ -20,7 +20,7 @@ TEST_CASE("Dedekind MVP: Basic Membership and Symbols", "[sets]") {
   SECTION("Natural-numbers membership") {
     // Post-#401, ℕ is the unsigned-int carrier; the predicate-set N has
     // Domain = unsigned int, so callsites use unsigned values.
-    auto n = element<Ω<Cardinality>>;
+    auto n = element<ℕ>;
     auto infinite = Set{n | (n > 0u)};
     REQUIRE(infinite(5u) == Ternary::True);
     REQUIRE(infinite(0u) == Ternary::False);
@@ -29,7 +29,7 @@ TEST_CASE("Dedekind MVP: Basic Membership and Symbols", "[sets]") {
 
 TEST_CASE("Dedekind Sets: symmetric difference (^) — #469",
           "[sets][operators]") {
-  auto x = element<Ω<Cardinality>>;
+  auto x = element<ℕ>;
 
   SECTION(
       "Singleton ^ Singleton — equal pivots empty, distinct pivots union "
@@ -227,7 +227,7 @@ TEST_CASE("Dedekind Sets: symmetric difference (^) — #469",
 }
 
 TEST_CASE("Dedekind Identities: Extremal Collapse", "[sets][identities]") {
-  auto x = element<Ω<Cardinality>>;
+  auto x = element<ℕ>;
 
   SECTION("Identity: Set{N} is N") {
     // Naturals remain stable when materialized through Set{...}.
@@ -373,7 +373,7 @@ TEST_CASE("Dedekind Sets: Power-set witness over homogeneous predicates",
 
 TEST_CASE("Dedekind Sets: Power-set preserves ambient logic",
           "[sets][powerset][logic]") {
-  auto x = element<Ω<Cardinality>>;
+  auto x = element<ℕ>;
 
   const auto gt_zero = Set{x | (x > 0u)};
   const auto p_gt_zero = power_set(gt_zero);
@@ -405,7 +405,7 @@ TEST_CASE("Dedekind Sets: Relation witnesses preserve ternary logic",
 TEST_CASE("Dedekind Sets: Heterogeneous subset semantics",
           "[sets][subset][logic]") {
   SECTION("Ternary logic yields Unknown for heterogeneous predicates") {
-    auto x = element<Ω<Cardinality>>;
+    auto x = element<ℕ>;
     const auto gt_zero = Set{x | (x > 0u)};
     const auto ge_zero = Set{x | (x >= 0u)};
 

--- a/src/test/cpp/modules/dedekind/sets/relational_test.cpp
+++ b/src/test/cpp/modules/dedekind/sets/relational_test.cpp
@@ -13,13 +13,13 @@ namespace {
 
 // Even integers in [0, 10)
 constexpr auto evens_0_10 = [] {
-  auto x = element<Ω<Cardinality>>;
+  auto x = element<ℕ>;
   return Set{x | [](const auto& v) { return (v < 10u) && (v % 2u == 0u); }};
 }();
 
 // Multiples of 3 in [0, 10)
 constexpr auto threes_0_10 = [] {
-  auto x = element<Ω<Cardinality>>;
+  auto x = element<ℕ>;
   return Set{x | [](const auto& v) { return (v < 10u) && (v % 3u == 0u); }};
 }();
 

--- a/src/test/cpp/modules/dedekind/sets/relational_test.cpp
+++ b/src/test/cpp/modules/dedekind/sets/relational_test.cpp
@@ -13,13 +13,13 @@ namespace {
 
 // Even integers in [0, 10)
 constexpr auto evens_0_10 = [] {
-  auto x = element<Ω<ℕ>>;
+  auto x = element<Ω<Cardinality>>;
   return Set{x | [](const auto& v) { return (v < 10u) && (v % 2u == 0u); }};
 }();
 
 // Multiples of 3 in [0, 10)
 constexpr auto threes_0_10 = [] {
-  auto x = element<Ω<ℕ>>;
+  auto x = element<Ω<Cardinality>>;
   return Set{x | [](const auto& v) { return (v < 10u) && (v % 3u == 0u); }};
 }();
 


### PR DESCRIPTION
## Summary

Second slice of [#559](https://github.com/vincentk/dedekind/issues/559)'s option-A migration: redefine the named species symbol `ℕ` from a carrier-type alias (`using ℕ = dedekind::sets::Cardinality`) to the universe value (`inline constexpr auto ℕ = Ω<Cardinality>`).  Makes `element<ℕ>` the canonical scout spelling — closer to textbook math notation.

Sibling of [#560](https://github.com/vincentk/dedekind/pull/560) (the 𝔹 slice).  Continues the per-tower-position rollout: 𝔹 → **ℕ** → ℤ → ℚ → ℝ → ℂ → 𝔻.

**Stacked on PR #555** — depends on the post-#551 `element<>` / `BoundScout` / `Ω<>` machinery.

## Changes

### Step 1: rename type-context `ℕ` → `Cardinality` (semantics-preserving prep)

Mechanical migration of `ℕ` in template-type-parameter / static_assert / concept-gate type-context positions across **16 files (72 lines)**:

- `src/main/modules/dedekind/numbers/natural.cppm` (13)
- `src/main/modules/dedekind/numbers/numbers.cppm` (1)
- `src/main/modules/dedekind/sets/boundaries.cppm` (1)
- `src/main/modules/dedekind/geometry/lattice.cppm` (3)
- 12 test files in `numbers/`, `sets/`, `analysis/`, `order/`, `python/` (54)

**Preserved** (per the migration script's skip rules): comments, prose, string literals; identifiers containing ℕ (`embed_uint_ℕ_`, `lift_ℕ_ℤ_`, `χ_ℕ`); the symbol-re-export `using ::dedekind::sets::ℕ;`; the definition line itself.

Step 1 is semantics-preserving because `ℕ` was `using ℕ = dedekind::sets::Cardinality` — the rename just substitutes the alias for its underlying type.

### Step 2: redefine `ℕ` as universe value `Ω<Cardinality>`

`sets/boundaries.cppm`: `using ℕ = dedekind::sets::Cardinality` → `inline constexpr auto ℕ = Ω<Cardinality>`.

`numbers/natural.cppm`: vacuous post-step-1 `static_assert(std::same_as<Cardinality, dedekind::sets::Cardinality>)` reframed as the universe-witness pair:
1. `decltype(ℕ) == UniversalSet<Cardinality, ClassicalLogic, ℵ_0>` — pinning `ℕ` as the universe value.
2. `decltype(ℕ)::Domain == Cardinality` — the universe's underlying carrier IS Cardinality.

Test files: bulk migration of value-context `element<Ω<Cardinality>>` → `element<ℕ>` (~10 sites across `halfspace_test`, `cardinality_test`, `starters_test`, `pruning_showcases_test`, `showcase_03`, `showcase_04`, `category_integration_test`, `computability_test`, `relational_test`, `expressions_test`).

`README.md`: `element<Ω<ℕ>>` → `element<ℕ>` in the showcase 4 example.  The README spelling now reads `constexpr auto n = element<ℕ>;` — exactly the textbook math reading.

## Test plan

- [x] `test_algebra` / `test_numbers` / `test_sets` / `test_linear_algebra` / `test_python` / `test_analysis` / `test_geometry` / `test_order` build green (312/313 targets, captured with redirect-to-file + grep)
- [ ] CI `build-and-deploy` green (depends on #562 landing first to fix the JuliaMono apt issue)

## Out of scope

- ℤ / ℚ / ℝ / ℂ / 𝔻 slices — separate PRs per #559's slice plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)