### PR TITLE
feat(numbers, sets, tests): #559 ℤ slice — redefine ℤ as universe value Ω<SignedExtensionalCardinal<>> (option A)

### DIFF
--- a/src/main/modules/dedekind/algebra/algebra.cppm
+++ b/src/main/modules/dedekind/algebra/algebra.cppm
@@ -42,9 +42,9 @@ export import :division;
 export import :field;
 export import :galois;
 export import :group;
-export import :initial_ring;  // SignedExtensionalCardinal<> as Initial Ring + Grothendieck Group
-                              // of ℕ (closes part of #446)
-export import :free;          // IsFreeAlgebra<F> + structural-trait propagation
+export import :initial_ring;  // SignedExtensionalCardinal<> as Initial Ring +
+                              // Grothendieck Group of ℕ (closes part of #446)
+export import :free;  // IsFreeAlgebra<F> + structural-trait propagation
                       // (textbook companion to HSP; R[x] etc.; #498/#499)
 export import :modules;
 export import :polynomial;

--- a/src/main/modules/dedekind/algebra/algebra.cppm
+++ b/src/main/modules/dedekind/algebra/algebra.cppm
@@ -42,7 +42,7 @@ export import :division;
 export import :field;
 export import :galois;
 export import :group;
-export import :initial_ring;  // ℤ as Initial Ring + Grothendieck Group
+export import :initial_ring;  // SignedExtensionalCardinal<> as Initial Ring + Grothendieck Group
                               // of ℕ (closes part of #446)
 export import :free;          // IsFreeAlgebra<F> + structural-trait propagation
                       // (textbook companion to HSP; R[x] etc.; #498/#499)

--- a/src/main/modules/dedekind/algebra/algebra.cppm
+++ b/src/main/modules/dedekind/algebra/algebra.cppm
@@ -44,7 +44,7 @@ export import :galois;
 export import :group;
 export import :initial_ring;  // SignedExtensionalCardinal<> as Initial Ring +
                               // Grothendieck Group of ℕ (closes part of #446)
-export import :free;  // IsFreeAlgebra<F> + structural-trait propagation
+export import :free;          // IsFreeAlgebra<F> + structural-trait propagation
                       // (textbook companion to HSP; R[x] etc.; #498/#499)
 export import :modules;
 export import :polynomial;

--- a/src/main/modules/dedekind/category/species.cppm
+++ b/src/main/modules/dedekind/category/species.cppm
@@ -777,7 +777,7 @@ struct is_total
     : std::bool_constant<
           is_periodic_v<T, Op> ||    // Path A: It wraps (Groups/Rings)
           is_idempotent_v<T, Op> ||  // Path B: It's stable (Lattices/Extrema)
-          is_saturating_v<T, Op>     // Path C: It escalates (extended ℤ, ±ℵ_0)
+          is_saturating_v<T, Op>     // Path C: It escalates (extended SignedExtensionalCardinal<>, ±ℵ_0)
           > {};
 
 export template <typename T, typename Op>

--- a/src/main/modules/dedekind/category/species.cppm
+++ b/src/main/modules/dedekind/category/species.cppm
@@ -777,7 +777,8 @@ struct is_total
     : std::bool_constant<
           is_periodic_v<T, Op> ||    // Path A: It wraps (Groups/Rings)
           is_idempotent_v<T, Op> ||  // Path B: It's stable (Lattices/Extrema)
-          is_saturating_v<T, Op>     // Path C: It escalates (extended SignedExtensionalCardinal<>, ±ℵ_0)
+          is_saturating_v<T, Op>     // Path C: It escalates (extended
+                                     // SignedExtensionalCardinal<>, ±ℵ_0)
           > {};
 
 export template <typename T, typename Op>

--- a/src/main/modules/dedekind/numbers/integer.cppm
+++ b/src/main/modules/dedekind/numbers/integer.cppm
@@ -436,8 +436,9 @@ using IntegerSet = IntegersOf<>;
 
 /** @brief The canonical Boolean-tower successor: the exact ℤ universe.
  *
- *  Post-#559, @c ℤ names the @b universe value @c Ω<SignedExtensionalCardinal<>>
- *  (a constexpr @c UniversalSet<...>{}).  The carrier is
+ *  Post-#559, @c ℤ names the @b universe value @c
+ * Ω<SignedExtensionalCardinal<>> (a constexpr @c UniversalSet<...>{}).  The
+ * carrier is
  *  @c dedekind::sets::SignedExtensionalCardinal<>, addressed directly in
  *  template-type-parameter positions; the math symbol denotes the set.
  *

--- a/src/main/modules/dedekind/numbers/integer.cppm
+++ b/src/main/modules/dedekind/numbers/integer.cppm
@@ -434,14 +434,20 @@ struct IntegersOf {
 // @c BooleanSetOf<> / @c B handling on the @c 𝔹 side (#400 / #407).
 using IntegerSet = IntegersOf<>;
 
-/** @brief The canonical Boolean-tower successor: the exact ℤ @b carrier.
+/** @brief The canonical Boolean-tower successor: the exact ℤ universe.
  *
- *  Aliased to @c dedekind::sets::SignedExtensionalCardinal<> per #399's
- *  show-to-a-wider-audience API: the species symbol names the carrier
- *  type itself, so @c static_assert(IsRing<ℤ, ...>) and @c var<ℤ>
- *  read directly against the carrier.  The value-level constant
- *  @c Z below keeps its predicate-set role for the set-builder DSL
- *  (e.g.\ @c Set{n @c % @c Z @c | @c (n @c > @c bound<-21>)}).
+ *  Post-#559, @c ℤ names the @b universe value @c Ω<SignedExtensionalCardinal<>>
+ *  (a constexpr @c UniversalSet<...>{}).  The carrier is
+ *  @c dedekind::sets::SignedExtensionalCardinal<>, addressed directly in
+ *  template-type-parameter positions; the math symbol denotes the set.
+ *
+ *  This makes @c element<ℤ> the canonical scout spelling — closer to
+ *  textbook math notation than the pre-#559 @c element<Ω<ℤ>> form
+ *  (which required @c ℤ to be a carrier-type alias).  Pre-#559 the
+ *  spelling was @c using @c ℤ @c = @c SignedExtensionalCardinal<>; the
+ *  ~73 type-context sites in concept gates / static_asserts were
+ *  migrated to @c SignedExtensionalCardinal<> directly in step 1 of
+ *  this slice.
  *
  *  Strict semantic witnesses on the carrier (@c IsRing,
  *  @c IsArithmeticAdditiveGroup, @c Group_ℤ, etc.) live in @c :rational
@@ -449,12 +455,18 @@ using IntegerSet = IntegersOf<>;
  *  there); the partition-local witnesses below cover what is reachable
  *  in @c :integer's import scope.
  */
-export using ℤ = dedekind::sets::SignedExtensionalCardinal<>;
+export inline constexpr auto ℤ =
+    dedekind::sets::Ω<dedekind::sets::SignedExtensionalCardinal<>>;
 
-static_assert(std::same_as<SignedExtensionalCardinal<>, dedekind::sets::SignedExtensionalCardinal<>>,
-              "ℤ is the exact-ℤ carrier alias (#399 slice 3); the "
-              "predicate-set form spells as @c IntegersOf<> or "
-              "@c decltype(Z).");
+static_assert(
+    std::same_as<std::remove_cvref_t<decltype(ℤ)>,
+                 dedekind::sets::UniversalSet<SignedExtensionalCardinal<>,
+                                              ClassicalLogic, ℵ_0>>,
+    "ℤ is the universe Ω<SignedExtensionalCardinal<>> (post-#559).");
+static_assert(std::same_as<typename std::remove_cvref_t<decltype(ℤ)>::Domain,
+                           SignedExtensionalCardinal<>>,
+              "ℤ's underlying carrier IS SignedExtensionalCardinal<> — the "
+              "exact-ℤ carrier from #399 slice 3.");
 
 export inline constexpr IntegerSet Z{};
 

--- a/src/main/modules/dedekind/numbers/integer.cppm
+++ b/src/main/modules/dedekind/numbers/integer.cppm
@@ -426,12 +426,13 @@ struct IntegersOf {
 };
 
 // Non-exported convenience alias used by the value-level @c Z constant
-// below.  Per #399 (canonical species symbols as carrier types), the
-// public name @c ℤ now denotes the exact ℤ @b carrier
-// (@c SignedExtensionalCardinal<>) rather than the predicate-set form;
-// callers who specifically need the predicate-set type should spell
+// below.  Post-#559 (option-A migration), the public name @c ℤ denotes
+// the @b universe @b value @c Ω<SignedExtensionalCardinal<>>; the
+// carrier @c SignedExtensionalCardinal<> is named directly in
+// template-type-parameter positions (per #399 slice 3).  Callers who
+// specifically need the predicate-set @b classifier should spell
 // @c IntegersOf<> or @c decltype(Z) — symmetric with the
-// @c BooleanSetOf<> / @c B handling on the @c 𝔹 side (#400 / #407).
+// @c BooleanSetOf<> / @c B handling on the @c 𝔹 side.
 using IntegerSet = IntegersOf<>;
 
 /** @brief The canonical Boolean-tower successor: the exact ℤ universe.

--- a/src/main/modules/dedekind/numbers/integer.cppm
+++ b/src/main/modules/dedekind/numbers/integer.cppm
@@ -451,7 +451,7 @@ using IntegerSet = IntegersOf<>;
  */
 export using ℤ = dedekind::sets::SignedExtensionalCardinal<>;
 
-static_assert(std::same_as<ℤ, dedekind::sets::SignedExtensionalCardinal<>>,
+static_assert(std::same_as<SignedExtensionalCardinal<>, dedekind::sets::SignedExtensionalCardinal<>>,
               "ℤ is the exact-ℤ carrier alias (#399 slice 3); the "
               "predicate-set form spells as @c IntegersOf<> or "
               "@c decltype(Z).");

--- a/src/main/modules/dedekind/numbers/numbers.cppm
+++ b/src/main/modules/dedekind/numbers/numbers.cppm
@@ -32,18 +32,19 @@ export import dedekind.order;  // Ordered predicate concepts for numeric species
 export import dedekind.topology;  // Rays, half-spaces, intervals, convex shapes
 
 /** @section numbers__Discrete_Foundations */
-export import :boolean;         // Truth<L> and Ω
-export import :uint;            // std::unsigned_integral as ℤ/2^wℤ
-                                // (machine layer below ℕ; closes part of #417)
-export import :natural;         // Cardinality partition (carrier:
-                                // dedekind::sets::Cardinality)
-export import :integer;         // SignedExtensionalCardinal<> partition (variant ℤ-proxy / IntegersOf<>)
-export import :sint;            // std::signed_integral: operator surface ✓,
-                                // axiomatic ring ✗ (Honest Rejection;
-                                // closes part of #418)
-export import :integral;        // std::integral umbrella note over the three
-                                // siblings (unsigned_integral / signed_integral
-                                // / bool); closes #419
+export import :boolean;   // Truth<L> and Ω
+export import :uint;      // std::unsigned_integral as ℤ/2^wℤ
+                          // (machine layer below ℕ; closes part of #417)
+export import :natural;   // Cardinality partition (carrier:
+                          // dedekind::sets::Cardinality)
+export import :integer;   // SignedExtensionalCardinal<> partition (variant
+                          // ℤ-proxy / IntegersOf<>)
+export import :sint;      // std::signed_integral: operator surface ✓,
+                          // axiomatic ring ✗ (Honest Rejection;
+                          // closes part of #418)
+export import :integral;  // std::integral umbrella note over the three
+                          // siblings (unsigned_integral / signed_integral
+                          // / bool); closes #419
 export import :floating_point;  // std::floating_point: operator surface +
                                 // operational ordered-field ✓; axiomatic ring /
                                 // field / total order ✗ (IEEE 754 Honest

--- a/src/main/modules/dedekind/numbers/numbers.cppm
+++ b/src/main/modules/dedekind/numbers/numbers.cppm
@@ -37,7 +37,7 @@ export import :uint;            // std::unsigned_integral as ℤ/2^wℤ
                                 // (machine layer below ℕ; closes part of #417)
 export import :natural;         // Cardinality partition (carrier:
                                 // dedekind::sets::Cardinality)
-export import :integer;         // ℤ partition (variant ℤ-proxy / IntegersOf<>)
+export import :integer;         // SignedExtensionalCardinal<> partition (variant ℤ-proxy / IntegersOf<>)
 export import :sint;            // std::signed_integral: operator surface ✓,
                                 // axiomatic ring ✗ (Honest Rejection;
                                 // closes part of #418)

--- a/src/test/cpp/modules/dedekind/analysis/pruning_showcases_test.cpp
+++ b/src/test/cpp/modules/dedekind/analysis/pruning_showcases_test.cpp
@@ -146,7 +146,7 @@ TEST_CASE("Pruning showcase 5: halfspace meet on ℝ collapses to Ø",
 
 TEST_CASE("Pruning showcase 6: (-21, 21] on ℤ has size 42",
           "[analysis][pruning][showcase][showcase06]") {
-  constexpr auto n = element<Ω<SignedExtensionalCardinal<>>>;
+  constexpr auto n = element<ℤ>;
   constexpr auto above = Set{n | (n > bound<-21>)};
   constexpr auto at_most = Set{n | (n <= bound<21>)};
 
@@ -198,7 +198,7 @@ TEST_CASE("Pruning showcase 7: ℤ lattice ∩ real interval (-21.0, 21.0]",
 
 TEST_CASE("Pruning showcase 8: 2D rectangle via IntervalProduct",
           "[analysis][pruning][showcase][showcase08]") {
-  constexpr auto n = element<Ω<SignedExtensionalCardinal<>>>;
+  constexpr auto n = element<ℤ>;
   constexpr auto I_wide = Set{n | (n > bound<-21>)} & Set{n | (n <= bound<21>)};
   constexpr auto I_tall = Set{n | (n >= bound<0>)} & Set{n | (n <= bound<10>)};
 

--- a/src/test/cpp/modules/dedekind/analysis/pruning_showcases_test.cpp
+++ b/src/test/cpp/modules/dedekind/analysis/pruning_showcases_test.cpp
@@ -146,7 +146,7 @@ TEST_CASE("Pruning showcase 5: halfspace meet on ℝ collapses to Ø",
 
 TEST_CASE("Pruning showcase 6: (-21, 21] on ℤ has size 42",
           "[analysis][pruning][showcase][showcase06]") {
-  constexpr auto n = element<Ω<ℤ>>;
+  constexpr auto n = element<Ω<SignedExtensionalCardinal<>>>;
   constexpr auto above = Set{n | (n > bound<-21>)};
   constexpr auto at_most = Set{n | (n <= bound<21>)};
 
@@ -198,7 +198,7 @@ TEST_CASE("Pruning showcase 7: ℤ lattice ∩ real interval (-21.0, 21.0]",
 
 TEST_CASE("Pruning showcase 8: 2D rectangle via IntervalProduct",
           "[analysis][pruning][showcase][showcase08]") {
-  constexpr auto n = element<Ω<ℤ>>;
+  constexpr auto n = element<Ω<SignedExtensionalCardinal<>>>;
   constexpr auto I_wide = Set{n | (n > bound<-21>)} & Set{n | (n <= bound<21>)};
   constexpr auto I_tall = Set{n | (n >= bound<0>)} & Set{n | (n <= bound<10>)};
 

--- a/src/test/cpp/modules/dedekind/numbers/cardinality_test.cpp
+++ b/src/test/cpp/modules/dedekind/numbers/cardinality_test.cpp
@@ -572,8 +572,8 @@ TEST_CASE(
       return (v == -1) ? L::True : L::False;
     };
     const Set<SignedCardinality, L, decltype(neg_one_pred)> neg_one_z{
-        neg_one_pred};                         // {-1} ⊂ ℤ
-    const auto union_set = one_n | neg_one_z;  // {1, -1} ⊂ ℤ
+        neg_one_pred};                         // {-1} ⊂ SignedExtensionalCardinal<>
+    const auto union_set = one_n | neg_one_z;  // {1, -1} ⊂ SignedExtensionalCardinal<>
     // Type-level proof: result carrier widens to ℤ (SignedCardinality).
     STATIC_CHECK(
         std::same_as<typename decltype(union_set)::Domain, SignedCardinality>);
@@ -588,7 +588,7 @@ TEST_CASE(
   SECTION("Symmetric direction: Set<ℤ> & Set<ℕ> still tightens to Set<ℕ>") {
     constexpr auto n = element<ℕ>;
     auto bounded_pred = [](const SignedCardinality& v) {
-      return (v >= -3) ? L::True : L::False;  // {-3, -2, …} ⊂ ℤ
+      return (v >= -3) ? L::True : L::False;  // {-3, -2, …} ⊂ SignedExtensionalCardinal<>
     };
     const Set<SignedCardinality, L, decltype(bounded_pred)> bounded_z{
         bounded_pred};

--- a/src/test/cpp/modules/dedekind/numbers/cardinality_test.cpp
+++ b/src/test/cpp/modules/dedekind/numbers/cardinality_test.cpp
@@ -572,8 +572,9 @@ TEST_CASE(
       return (v == -1) ? L::True : L::False;
     };
     const Set<SignedCardinality, L, decltype(neg_one_pred)> neg_one_z{
-        neg_one_pred};                         // {-1} ⊂ SignedExtensionalCardinal<>
-    const auto union_set = one_n | neg_one_z;  // {1, -1} ⊂ SignedExtensionalCardinal<>
+        neg_one_pred};  // {-1} ⊂ SignedExtensionalCardinal<>
+    const auto union_set =
+        one_n | neg_one_z;  // {1, -1} ⊂ SignedExtensionalCardinal<>
     // Type-level proof: result carrier widens to ℤ (SignedCardinality).
     STATIC_CHECK(
         std::same_as<typename decltype(union_set)::Domain, SignedCardinality>);
@@ -588,7 +589,8 @@ TEST_CASE(
   SECTION("Symmetric direction: Set<ℤ> & Set<ℕ> still tightens to Set<ℕ>") {
     constexpr auto n = element<ℕ>;
     auto bounded_pred = [](const SignedCardinality& v) {
-      return (v >= -3) ? L::True : L::False;  // {-3, -2, …} ⊂ SignedExtensionalCardinal<>
+      return (v >= -3) ? L::True
+                       : L::False;  // {-3, -2, …} ⊂ SignedExtensionalCardinal<>
     };
     const Set<SignedCardinality, L, decltype(bounded_pred)> bounded_z{
         bounded_pred};

--- a/src/test/cpp/modules/dedekind/numbers/integer_test.cpp
+++ b/src/test/cpp/modules/dedekind/numbers/integer_test.cpp
@@ -37,15 +37,15 @@ using namespace dedekind::sets;
 TEST_CASE("Integer: ℕ → ℤ → ℕ via unary − then abs (closes #436 round-trip)",
           "[numbers][integer][carrier-lattice][round-trip]") {
   const auto n = finite_cardinality(7);
-  const auto neg = -n;         // Cardinality → ℤ (closure-forcing negation)
-  const auto back = abs(neg);  // ℤ → Cardinality (retraction)
+  const auto neg = -n;         // Cardinality → SignedExtensionalCardinal<> (closure-forcing negation)
+  const auto back = abs(neg);  // SignedExtensionalCardinal<> → Cardinality (retraction)
   CHECK(back == n);
 }
 
 TEST_CASE("Integer: ℕ → ℤ → ℕ via binary − then abs",
           "[numbers][integer][carrier-lattice][round-trip]") {
   const auto n = finite_cardinality(7);
-  const auto z = finite_cardinality(0) - n;  // → -7 in ℤ
+  const auto z = finite_cardinality(0) - n;  // → -7 in SignedExtensionalCardinal<>
   const auto back = abs(z);                  // → 7 in Cardinality
   CHECK(back == n);
 }
@@ -54,7 +54,7 @@ TEST_CASE("Integer: ℤ → ℕ → ℤ folds sign — abs is not a bijection",
           "[numbers][integer][carrier-lattice][round-trip]") {
   const auto z_neg = finite_signed_cardinality(-5);
   const auto folded = abs(z_neg);  // → 5 in Cardinality
-  const auto re_embedded = folded - finite_cardinality(0);  // → +5 in ℤ
+  const auto re_embedded = folded - finite_cardinality(0);  // → +5 in SignedExtensionalCardinal<>
   CHECK(re_embedded == finite_signed_cardinality(5));
   CHECK_FALSE(re_embedded == z_neg);  // sign was lost on the round-trip
 }

--- a/src/test/cpp/modules/dedekind/numbers/integer_test.cpp
+++ b/src/test/cpp/modules/dedekind/numbers/integer_test.cpp
@@ -37,16 +37,19 @@ using namespace dedekind::sets;
 TEST_CASE("Integer: ℕ → ℤ → ℕ via unary − then abs (closes #436 round-trip)",
           "[numbers][integer][carrier-lattice][round-trip]") {
   const auto n = finite_cardinality(7);
-  const auto neg = -n;         // Cardinality → SignedExtensionalCardinal<> (closure-forcing negation)
-  const auto back = abs(neg);  // SignedExtensionalCardinal<> → Cardinality (retraction)
+  const auto neg = -n;  // Cardinality → SignedExtensionalCardinal<>
+                        // (closure-forcing negation)
+  const auto back =
+      abs(neg);  // SignedExtensionalCardinal<> → Cardinality (retraction)
   CHECK(back == n);
 }
 
 TEST_CASE("Integer: ℕ → ℤ → ℕ via binary − then abs",
           "[numbers][integer][carrier-lattice][round-trip]") {
   const auto n = finite_cardinality(7);
-  const auto z = finite_cardinality(0) - n;  // → -7 in SignedExtensionalCardinal<>
-  const auto back = abs(z);                  // → 7 in Cardinality
+  const auto z =
+      finite_cardinality(0) - n;  // → -7 in SignedExtensionalCardinal<>
+  const auto back = abs(z);       // → 7 in Cardinality
   CHECK(back == n);
 }
 
@@ -54,7 +57,8 @@ TEST_CASE("Integer: ℤ → ℕ → ℤ folds sign — abs is not a bijection",
           "[numbers][integer][carrier-lattice][round-trip]") {
   const auto z_neg = finite_signed_cardinality(-5);
   const auto folded = abs(z_neg);  // → 5 in Cardinality
-  const auto re_embedded = folded - finite_cardinality(0);  // → +5 in SignedExtensionalCardinal<>
+  const auto re_embedded =
+      folded - finite_cardinality(0);  // → +5 in SignedExtensionalCardinal<>
   CHECK(re_embedded == finite_signed_cardinality(5));
   CHECK_FALSE(re_embedded == z_neg);  // sign was lost on the round-trip
 }

--- a/src/test/cpp/modules/dedekind/numbers/starters_test.cpp
+++ b/src/test/cpp/modules/dedekind/numbers/starters_test.cpp
@@ -23,9 +23,11 @@ TEST_CASE("Numbers: canonical starter symbols", "[numbers][starter]") {
   STATIC_CHECK(std::same_as<std::remove_cvref_t<decltype(Ω<Cardinality>)>,
                             UniversalSet<Cardinality>>);
 
-  STATIC_CHECK(std::same_as<SignedExtensionalCardinal<>, SignedExtensionalCardinal<>>);
   STATIC_CHECK(
-      std::same_as<std::remove_cvref_t<decltype(Ω<SignedExtensionalCardinal<>>)>, UniversalSet<SignedExtensionalCardinal<>>>);
+      std::same_as<SignedExtensionalCardinal<>, SignedExtensionalCardinal<>>);
+  STATIC_CHECK(std::same_as<
+               std::remove_cvref_t<decltype(Ω<SignedExtensionalCardinal<>>)>,
+               UniversalSet<SignedExtensionalCardinal<>>>);
 
   STATIC_CHECK(std::same_as<ℚ, Rational<default_integer>>);
   STATIC_CHECK(

--- a/src/test/cpp/modules/dedekind/numbers/starters_test.cpp
+++ b/src/test/cpp/modules/dedekind/numbers/starters_test.cpp
@@ -23,9 +23,9 @@ TEST_CASE("Numbers: canonical starter symbols", "[numbers][starter]") {
   STATIC_CHECK(std::same_as<std::remove_cvref_t<decltype(Ω<Cardinality>)>,
                             UniversalSet<Cardinality>>);
 
-  STATIC_CHECK(std::same_as<ℤ, SignedExtensionalCardinal<>>);
+  STATIC_CHECK(std::same_as<SignedExtensionalCardinal<>, SignedExtensionalCardinal<>>);
   STATIC_CHECK(
-      std::same_as<std::remove_cvref_t<decltype(Ω<ℤ>)>, UniversalSet<ℤ>>);
+      std::same_as<std::remove_cvref_t<decltype(Ω<SignedExtensionalCardinal<>>)>, UniversalSet<SignedExtensionalCardinal<>>>);
 
   STATIC_CHECK(std::same_as<ℚ, Rational<default_integer>>);
   STATIC_CHECK(
@@ -56,7 +56,7 @@ TEST_CASE("Numbers: starter universes construct from ambient values",
   static_assert(Ω<Cardinality>.contains(7u));
   static_assert(Ω<Cardinality>.contains(0u));
 
-  constexpr auto z = element<Ω<ℤ>>;
+  constexpr auto z = element<Ω<SignedExtensionalCardinal<>>>;
   constexpr auto integers = Set{z};
   static_assert(integers(-7) == Ternary::True);
 
@@ -78,7 +78,7 @@ TEST_CASE("Numbers: starter universes satisfy lattice identities",
   }
 
   {
-    constexpr auto z = element<Ω<ℤ>>;
+    constexpr auto z = element<Ω<SignedExtensionalCardinal<>>>;
     const auto U = Set{z};
     const auto O = !U;
     CHECK((U | O)(4) == Ternary::True);

--- a/src/test/cpp/modules/dedekind/numbers/starters_test.cpp
+++ b/src/test/cpp/modules/dedekind/numbers/starters_test.cpp
@@ -56,7 +56,7 @@ TEST_CASE("Numbers: starter universes construct from ambient values",
   static_assert(Ω<Cardinality>.contains(7u));
   static_assert(Ω<Cardinality>.contains(0u));
 
-  constexpr auto z = element<Ω<SignedExtensionalCardinal<>>>;
+  constexpr auto z = element<ℤ>;
   constexpr auto integers = Set{z};
   static_assert(integers(-7) == Ternary::True);
 
@@ -78,7 +78,7 @@ TEST_CASE("Numbers: starter universes satisfy lattice identities",
   }
 
   {
-    constexpr auto z = element<Ω<SignedExtensionalCardinal<>>>;
+    constexpr auto z = element<ℤ>;
     const auto U = Set{z};
     const auto O = !U;
     CHECK((U | O)(4) == Ternary::True);

--- a/src/test/cpp/modules/dedekind/numbers/starters_test.cpp
+++ b/src/test/cpp/modules/dedekind/numbers/starters_test.cpp
@@ -23,8 +23,10 @@ TEST_CASE("Numbers: canonical starter symbols", "[numbers][starter]") {
   STATIC_CHECK(std::same_as<std::remove_cvref_t<decltype(Ω<Cardinality>)>,
                             UniversalSet<Cardinality>>);
 
-  STATIC_CHECK(
-      std::same_as<SignedExtensionalCardinal<>, SignedExtensionalCardinal<>>);
+  STATIC_CHECK(std::same_as<std::remove_cvref_t<decltype(ℤ)>,
+                            UniversalSet<SignedExtensionalCardinal<>>>);
+  STATIC_CHECK(std::same_as<typename std::remove_cvref_t<decltype(ℤ)>::Domain,
+                            SignedExtensionalCardinal<>>);
   STATIC_CHECK(std::same_as<
                std::remove_cvref_t<decltype(Ω<SignedExtensionalCardinal<>>)>,
                UniversalSet<SignedExtensionalCardinal<>>>);

--- a/src/test/cpp/modules/dedekind/python/showcase_06_halfspace_interval_42.cpp
+++ b/src/test/cpp/modules/dedekind/python/showcase_06_halfspace_interval_42.cpp
@@ -32,7 +32,7 @@ using namespace dedekind::numbers;
 using namespace dedekind::order;
 
 // Symbolic variable ranging over ℤ.
-constexpr auto n = element<Ω<SignedExtensionalCardinal<>>>;
+constexpr auto n = element<ℤ>;
 
 // Halfspace pair with compile-time pivots, strict lower and non-strict upper.
 constexpr auto above_minus_21 = Set{n | (n > bound<-21>)};

--- a/src/test/cpp/modules/dedekind/python/showcase_06_halfspace_interval_42.cpp
+++ b/src/test/cpp/modules/dedekind/python/showcase_06_halfspace_interval_42.cpp
@@ -32,7 +32,7 @@ using namespace dedekind::numbers;
 using namespace dedekind::order;
 
 // Symbolic variable ranging over ℤ.
-constexpr auto n = element<Ω<ℤ>>;
+constexpr auto n = element<Ω<SignedExtensionalCardinal<>>>;
 
 // Halfspace pair with compile-time pivots, strict lower and non-strict upper.
 constexpr auto above_minus_21 = Set{n | (n > bound<-21>)};

--- a/src/test/cpp/modules/dedekind/python/showcase_08_halfspace_2d_product.cpp
+++ b/src/test/cpp/modules/dedekind/python/showcase_08_halfspace_2d_product.cpp
@@ -31,7 +31,7 @@ using namespace dedekind::algebra;
 using namespace dedekind::numbers;
 using namespace dedekind::order;
 
-constexpr auto n = element<Ω<SignedExtensionalCardinal<>>>;
+constexpr auto n = element<ℤ>;
 
 // Two 1D intervals on ℤ.
 constexpr auto I_wide =

--- a/src/test/cpp/modules/dedekind/python/showcase_08_halfspace_2d_product.cpp
+++ b/src/test/cpp/modules/dedekind/python/showcase_08_halfspace_2d_product.cpp
@@ -31,7 +31,7 @@ using namespace dedekind::algebra;
 using namespace dedekind::numbers;
 using namespace dedekind::order;
 
-constexpr auto n = element<Ω<ℤ>>;
+constexpr auto n = element<Ω<SignedExtensionalCardinal<>>>;
 
 // Two 1D intervals on ℤ.
 constexpr auto I_wide =

--- a/src/test/cpp/modules/dedekind/sets/boundaries_test.cpp
+++ b/src/test/cpp/modules/dedekind/sets/boundaries_test.cpp
@@ -40,19 +40,22 @@ TEST_CASE("Level 1 Final Proof: The Mereology Highway",
 }
 
 TEST_CASE("Boundaries: The Algebra of Extremality", "[sets][boundaries]") {
-  using ℤ = int;  // Using a raw type as a Species proxy
+  // Use SignedExtensionalCardinal<> directly as the carrier for the
+  // boundary identities (post-#559 ℤ slice migration; the prior local
+  // alias `using ℤ = int` is no longer referenced after the type-site
+  // sweep replaced ℤ with the carrier name in the body).
 
   // The Identities: Ø and Ω as the "North and South Poles"
-  constexpr Ø<ℤ> null;
-  constexpr UniversalSet<ℤ> universe;
+  constexpr Ø<SignedExtensionalCardinal<>> null;
+  constexpr UniversalSet<SignedExtensionalCardinal<>> universe;
 
   SECTION("Aha! 1: The Law of Absorption (Annihilation)") {
     /**
      * In a Union, the Universe is the Annihilator: Ω | S = Ω.
      * In an Intersection, the Void is the Annihilator: ∅ & S = ∅.
      */
-    static_assert(std::is_same_v<decltype((universe | null)), UniversalSet<ℤ>>);
-    static_assert(std::is_same_v<decltype((null & universe)), Ø<ℤ>>);
+    static_assert(std::is_same_v<decltype((universe | null)), UniversalSet<SignedExtensionalCardinal<>>>);
+    static_assert(std::is_same_v<decltype((null & universe)), Ø<SignedExtensionalCardinal<>>>);
   }
 
   // SECTION("Aha! 2: The Law of Identity") {
@@ -80,9 +83,9 @@ TEST_CASE("Boundaries: The Algebra of Extremality", "[sets][boundaries]") {
   }
 
   SECTION("Cardinality bounds for extensional sets are computed explicitly") {
-    constexpr SingletonSet<ℤ> s1{1};
-    constexpr SingletonSet<ℤ> s2{2};
-    constexpr Ø<ℤ> empty;
+    constexpr SingletonSet<SignedExtensionalCardinal<>> s1{1};
+    constexpr SingletonSet<SignedExtensionalCardinal<>> s2{2};
+    constexpr Ø<SignedExtensionalCardinal<>> empty;
 
     CHECK(bound_meet(s1, s2) == 1);
     CHECK(bound_join(s1, s2) == 2);
@@ -95,8 +98,8 @@ TEST_CASE("Boundaries: The Algebra of Extremality", "[sets][boundaries]") {
     // ℕ is now the carrier (unsigned int) post-#401; the predicate-set
     // value is the namespace-level constant @c N (NaturalNumbersOf<>).
     constexpr auto naturals = N;
-    constexpr Ø<ℤ> empty;
-    constexpr SingletonSet<ℤ> singleton{7};
+    constexpr Ø<SignedExtensionalCardinal<>> empty;
+    constexpr SingletonSet<SignedExtensionalCardinal<>> singleton{7};
     const auto max_v = std::numeric_limits<std::size_t>::max();
 
     CHECK(bound_meet(universe, naturals) == max_v);
@@ -107,10 +110,10 @@ TEST_CASE("Boundaries: The Algebra of Extremality", "[sets][boundaries]") {
   }
 
   SECTION("Identity optimizations remain structurally valid") {
-    constexpr SingletonSet<ℤ> s{42};
-    constexpr Ø<ℤ> empty;
+    constexpr SingletonSet<SignedExtensionalCardinal<>> s{42};
+    constexpr Ø<SignedExtensionalCardinal<>> empty;
 
-    CHECK(std::is_same_v<decltype(empty | s), SingletonSet<ℤ>>);
-    CHECK(std::is_same_v<decltype(universe & s), SingletonSet<ℤ>>);
+    CHECK(std::is_same_v<decltype(empty | s), SingletonSet<SignedExtensionalCardinal<>>>);
+    CHECK(std::is_same_v<decltype(universe & s), SingletonSet<SignedExtensionalCardinal<>>>);
   }
 }

--- a/src/test/cpp/modules/dedekind/sets/boundaries_test.cpp
+++ b/src/test/cpp/modules/dedekind/sets/boundaries_test.cpp
@@ -54,8 +54,10 @@ TEST_CASE("Boundaries: The Algebra of Extremality", "[sets][boundaries]") {
      * In a Union, the Universe is the Annihilator: Ω | S = Ω.
      * In an Intersection, the Void is the Annihilator: ∅ & S = ∅.
      */
-    static_assert(std::is_same_v<decltype((universe | null)), UniversalSet<SignedExtensionalCardinal<>>>);
-    static_assert(std::is_same_v<decltype((null & universe)), Ø<SignedExtensionalCardinal<>>>);
+    static_assert(std::is_same_v<decltype((universe | null)),
+                                 UniversalSet<SignedExtensionalCardinal<>>>);
+    static_assert(std::is_same_v<decltype((null & universe)),
+                                 Ø<SignedExtensionalCardinal<>>>);
   }
 
   // SECTION("Aha! 2: The Law of Identity") {
@@ -113,7 +115,9 @@ TEST_CASE("Boundaries: The Algebra of Extremality", "[sets][boundaries]") {
     constexpr SingletonSet<SignedExtensionalCardinal<>> s{42};
     constexpr Ø<SignedExtensionalCardinal<>> empty;
 
-    CHECK(std::is_same_v<decltype(empty | s), SingletonSet<SignedExtensionalCardinal<>>>);
-    CHECK(std::is_same_v<decltype(universe & s), SingletonSet<SignedExtensionalCardinal<>>>);
+    CHECK(std::is_same_v<decltype(empty | s),
+                         SingletonSet<SignedExtensionalCardinal<>>>);
+    CHECK(std::is_same_v<decltype(universe & s),
+                         SingletonSet<SignedExtensionalCardinal<>>>);
   }
 }


### PR DESCRIPTION
## Summary

Third slice of [#559](https://github.com/vincentk/dedekind/issues/559)'s option-A migration: redefine `ℤ` from a carrier-type alias (`using ℤ = SignedExtensionalCardinal<>`) to the universe value (`inline constexpr auto ℤ = Ω<SignedExtensionalCardinal<>>`).

Sibling of [#560](https://github.com/vincentk/dedekind/pull/560) (𝔹 slice) and [#563](https://github.com/vincentk/dedekind/pull/563) (ℕ slice).  Continues the per-tower-position rollout: 𝔹 ✓ → ℕ ✓ → **ℤ** → ℚ → ℝ → ℂ → 𝔻.

## Changes

### Step 1: rename type-context `ℤ` → `SignedExtensionalCardinal<>` (semantics-preserving prep)

73 lines across 13 files migrated.  Same recipe as the 𝔹 / ℕ slices.

Two test-local proxy aliases (`using ℤ = int` in `path_test.cpp` and `polynomials_test.cpp` — stand-ins for ℤ that avoid pulling in heavy imports for tests upstream of numbers in the build DAG) had their bodies wrongly rewritten by the migration script's STANDALONE regex (which doesn't distinguish global from test-local symbols).  Reverted those bodies to use the local alias.  Removed the now-unused local alias in `boundaries_test.cpp` where the body genuinely migrated to the global carrier.

### Step 2: redefine `ℤ` as universe value `Ω<SignedExtensionalCardinal<>>`

`numbers/integer.cppm`: `using ℤ = SignedExtensionalCardinal<>` → `inline constexpr auto ℤ = Ω<SignedExtensionalCardinal<>>`.

Step 1's now-vacuous `static_assert(std::same_as<SignedExtensionalCardinal<>, dedekind::sets::SignedExtensionalCardinal<>>)` reframed as the universe-witness pair:
1. `decltype(ℤ) == UniversalSet<SignedExtensionalCardinal<>, ClassicalLogic, ℵ_0>` — pinning ℤ as the universe value.
2. `decltype(ℤ)::Domain == SignedExtensionalCardinal<>` — the underlying carrier (the exact-ℤ from #399 slice 3).

Test files (4 sites): bulk `element<Ω<SignedExtensionalCardinal<>>>` → `element<ℤ>` across `starters_test`, `pruning_showcases_test`, `showcase_06_halfspace_interval_42`, `showcase_08_halfspace_2d_product`.

## Test plan

- [x] `test_algebra` / `test_numbers` / `test_sets` / `test_linear_algebra` / `test_python` / `test_analysis` / `test_geometry` / `test_order` / `test_sequences` build green (323/324 targets, captured with redirect-to-file + grep).
- [ ] CI build-and-deploy green.

## Out of scope

- ℚ / ℝ / ℂ / 𝔻 slices — separate PRs per #559's slice plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)