### PR TITLE
feat(numbers, tests): #559 ℚ slice — redefine ℚ as universe value Ω<Rational<default_integer>> (option A)

### DIFF
--- a/src/main/modules/dedekind/linear_algebra/mat2x2.cppm
+++ b/src/main/modules/dedekind/linear_algebra/mat2x2.cppm
@@ -73,7 +73,7 @@ export module dedekind.linear_algebra:mat2x2;
 
 import dedekind.algebra; // HasRingOperators, HasFieldOperators, HasVectorSpaceOperators
 import dedekind.category; // IsFunctor / Set / arrow (for matrix2x2_functor witness)
-import dedekind.numbers; // Rational<Z> for the Rational<default_integer> carrier
+import dedekind.numbers; // Rational<default_integer> — the rational carrier (post-#559 ℚ is the universe value Ω<Rational<default_integer>>)
 import dedekind.order; // IsDirectedSet — algebraic gate on operator[] index domain (any net domain)
 import dedekind.sets; // Finite cardinality tag (for dimension_type)
 import :basis;        // is_endomorphism_ring_v trait declaration

--- a/src/main/modules/dedekind/linear_algebra/mat2x2.cppm
+++ b/src/main/modules/dedekind/linear_algebra/mat2x2.cppm
@@ -73,7 +73,7 @@ export module dedekind.linear_algebra:mat2x2;
 
 import dedekind.algebra; // HasRingOperators, HasFieldOperators, HasVectorSpaceOperators
 import dedekind.category; // IsFunctor / Set / arrow (for matrix2x2_functor witness)
-import dedekind.numbers; // Rational<Z> for the ℚ carrier
+import dedekind.numbers; // Rational<Z> for the Rational<default_integer> carrier
 import dedekind.order; // IsDirectedSet — algebraic gate on operator[] index domain (any net domain)
 import dedekind.sets; // Finite cardinality tag (for dimension_type)
 import :basis;        // is_endomorphism_ring_v trait declaration

--- a/src/main/modules/dedekind/numbers/numbers.cppm
+++ b/src/main/modules/dedekind/numbers/numbers.cppm
@@ -51,7 +51,7 @@ export import :floating_point;  // std::floating_point: operator surface +
                                 // Rejection); closes #420
 
 /** @section numbers__Algebraic_Extensions */
-export import :rational;    // ℚ (The Quotient Field)
+export import :rational;    // Rational<default_integer> (The Quotient Field)
 export import :complex;     // ℂ (The Cayley-Dickson construction)
 export import :quaternion;  // ℍ (Hamilton's division ring)
 export import :scalars;     // Floating-point anchors

--- a/src/main/modules/dedekind/numbers/rational.cppm
+++ b/src/main/modules/dedekind/numbers/rational.cppm
@@ -497,8 +497,8 @@ using RationalSet = RationalsOf<>;
 export template <IsInteger I = default_integer>
 using ℚ_t = Rational<I>;
 
-/** @brief The canonical rational-number universe ℚ = Ω<Rational<default_integer>>
- *         (post-#559).
+/** @brief The canonical rational-number universe ℚ =
+ * Ω<Rational<default_integer>> (post-#559).
  *
  *  @details Per #559's chosen direction (option A): the named species
  *  symbols (@c 𝔹 / @c ℕ / @c ℤ / @c ℚ / @c ℝ / @c ℂ / @c 𝔻) denote the
@@ -539,11 +539,10 @@ using ℚ_t = Rational<I>;
  */
 export inline constexpr auto ℚ = dedekind::sets::Ω<Rational<default_integer>>;
 
-static_assert(
-    std::same_as<std::remove_cvref_t<decltype(ℚ)>,
-                 dedekind::sets::UniversalSet<Rational<default_integer>,
-                                              ClassicalLogic, ℵ_0>>,
-    "ℚ is the universe Ω<Rational<default_integer>> (post-#559).");
+static_assert(std::same_as<std::remove_cvref_t<decltype(ℚ)>,
+                           dedekind::sets::UniversalSet<
+                               Rational<default_integer>, ClassicalLogic, ℵ_0>>,
+              "ℚ is the universe Ω<Rational<default_integer>> (post-#559).");
 static_assert(
     std::same_as<typename std::remove_cvref_t<decltype(ℚ)>::Domain,
                  Rational<default_integer>>,
@@ -810,13 +809,15 @@ static_assert(dedekind::algebra::HasRingOperators<Rational<default_integer>>,
               "unary -, *).");
 static_assert(dedekind::algebra::HasFieldOperators<Rational<default_integer>>,
               "ℚ closes the literal field operator surface (+, -, *, /).");
-static_assert(dedekind::algebra::HasGroupOperatorsAdd<Rational<default_integer>>,
-              "ℚ closes the additive-group operator surface (+, binary -, "
-              "unary -).");
-static_assert(dedekind::algebra::HasGroupOperatorsMul<Rational<default_integer>>,
-              "ℚ closes the multiplicative-group operator surface "
-              "(*, /), modulo division-by-zero (the field carrier "
-              "of ℚ is total only off the multiplicative-zero set).");
+static_assert(
+    dedekind::algebra::HasGroupOperatorsAdd<Rational<default_integer>>,
+    "ℚ closes the additive-group operator surface (+, binary -, "
+    "unary -).");
+static_assert(
+    dedekind::algebra::HasGroupOperatorsMul<Rational<default_integer>>,
+    "ℚ closes the multiplicative-group operator surface "
+    "(*, /), modulo division-by-zero (the field carrier "
+    "of ℚ is total only off the multiplicative-zero set).");
 
 // (3) Semantics (the algebraic structures Rational<default_integer> actually
 //     carries).  The strict @c category::IsField<ℚ, std::plus, std::multiplies>

--- a/src/main/modules/dedekind/numbers/rational.cppm
+++ b/src/main/modules/dedekind/numbers/rational.cppm
@@ -485,18 +485,39 @@ struct RationalsOf {
  */
 using RationalSet = RationalsOf<>;
 
-/** @brief The canonical rational-number field ℚ, as the carrier type
- *         (default-instantiated @c Rational<default_integer>).
+/** @brief Pluggable rational-field type alias parameterised on the
+ *         integer carrier.
  *
- *  @details Pluggable via @c ℚ_t<MyInteger> for non-default integer
- *  carriers; the bare @c ℚ defaults to @c Rational<default_integer>
- *  so the show-to-a-wider-audience API reads as plain mathematics:
- *  @c static_assert(algebra::HasFieldOperators<ℚ>), @c auto @c q @c
- *  = @c var<ℚ>, etc.
+ *  @details @c ℚ_t<MyInteger> instantiates @c Rational<MyInteger>; the
+ *  bare @c ℚ_t<> defaults to @c Rational<default_integer>.  Used in
+ *  template-type-parameter positions where the rational carrier needs
+ *  to be named directly (e.g.\ @c std::plus<ℚ_t<>>,
+ *  @c HasFieldOperators<ℚ_t<>>).
+ */
+export template <IsInteger I = default_integer>
+using ℚ_t = Rational<I>;
+
+/** @brief The canonical rational-number universe ℚ = Ω<Rational<default_integer>>
+ *         (post-#559).
  *
- *  @note  The strict @c category::IsField<ℚ, std::plus<ℚ>,
- *  std::multiplies<ℚ>> is @b not currently certified.  Two distinct
- *  blocks compose:
+ *  @details Per #559's chosen direction (option A): the named species
+ *  symbols (@c 𝔹 / @c ℕ / @c ℤ / @c ℚ / @c ℝ / @c ℂ / @c 𝔻) denote the
+ *  @b universe values (constexpr instances of @c UniversalSet over the
+ *  carrier), not carrier @b types.  Carrier types are spelled directly
+ *  (@c Rational<default_integer>, or @c ℚ_t<I> for the parameterised
+ *  form) in template-type-parameter positions; @c ℚ alone is the
+ *  universe value the set-builder DSL takes as ambient.
+ *
+ *  This makes @c element<ℚ> the canonical scout spelling — closer to
+ *  textbook math notation than the pre-#559 @c element<Ω<ℚ>> form.
+ *  Pre-#559 the spelling was @c using @c ℚ @c = @c ℚ_t<> (a carrier-
+ *  type alias); the type-context sites in concept gates and
+ *  static_asserts were migrated to @c Rational<default_integer> /
+ *  @c ℚ_t<> directly in step 1 of this slice.
+ *
+ *  @note  The strict @c category::IsField<Rational<default_integer>,
+ *  std::plus<...>, std::multiplies<...>> is @b not currently certified.
+ *  Two distinct blocks compose:
  *
  *  1. @b IsTotal @b gate (architectural).  The strict ring/field
  *     ladder requires @c IsMagma, which requires @c IsTotal<T, Op>
@@ -513,13 +534,21 @@ using RationalSet = RationalsOf<>;
  *
  *  See the @c FIXME(\#379) breadcrumb at the Field_ℚ definition in
  *  @c :integer.  Until both blocks lift, the operational
- *  @c algebra::HasFieldOperators<ℚ> is the load-bearing field-
- *  arithmetic guarantee.
+ *  @c algebra::HasFieldOperators<Rational<default_integer>> is the
+ *  load-bearing field-arithmetic guarantee.
  */
-export template <IsInteger I = default_integer>
-using ℚ_t = Rational<I>;
+export inline constexpr auto ℚ = dedekind::sets::Ω<Rational<default_integer>>;
 
-export using ℚ = ℚ_t<>;
+static_assert(
+    std::same_as<std::remove_cvref_t<decltype(ℚ)>,
+                 dedekind::sets::UniversalSet<Rational<default_integer>,
+                                              ClassicalLogic, ℵ_0>>,
+    "ℚ is the universe Ω<Rational<default_integer>> (post-#559).");
+static_assert(
+    std::same_as<typename std::remove_cvref_t<decltype(ℚ)>::Domain,
+                 Rational<default_integer>>,
+    "ℚ's underlying carrier IS Rational<default_integer> — the textbook "
+    "universe-over-carrier reading.");
 
 /** @brief The predicate-set value (instance of @c RationalSet),
  *         retained for set-builder DSL usage like @c Set{q @c % @c Q}

--- a/src/main/modules/dedekind/numbers/rational.cppm
+++ b/src/main/modules/dedekind/numbers/rational.cppm
@@ -23,6 +23,7 @@ module;
 #include <limits>
 #include <numeric>
 #include <stdexcept>
+#include <type_traits>  // std::remove_cvref_t for the post-#559 universe-witness static_asserts
 #include <utility>
 
 export module dedekind.numbers:rational;
@@ -798,12 +799,18 @@ static_assert(
     "RationalsOf must be the canonical IsSet anchor for "
     "dedekind.numbers:rational.");
 
-// (2) Syntax (the C++ operator surface that maps to ℚ's algebra).
-//   - HasRingOperators<ℚ>: literal +, binary -, unary -, * close on ℚ.
-//   - HasFieldOperators<ℚ>: literal +, -, *, / close on ℚ
-//     (HasRingOperators + closure under /).
-//   - HasGroupOperatorsAdd<ℚ>: literal +, binary -, unary - close on ℚ.
-//   - HasGroupOperatorsMul<ℚ>: literal *, / close on ℚ \ {0}.
+// (2) Syntax (the C++ operator surface that maps to ℚ's algebra).  Post-
+// #559, ℚ is the universe value Ω<Rational<default_integer>>; the carrier
+// in concept-gate type-parameter slots is Rational<default_integer>
+// (a.k.a.\ ℚ_t<>) directly.
+//   - HasRingOperators<Rational<default_integer>>: literal +, binary -,
+//     unary -, * close on the carrier.
+//   - HasFieldOperators<Rational<default_integer>>: literal +, -, *, /
+//     close on the carrier (HasRingOperators + closure under /).
+//   - HasGroupOperatorsAdd<Rational<default_integer>>: literal +, binary -,
+//     unary - close on the carrier.
+//   - HasGroupOperatorsMul<Rational<default_integer>>: literal *, / close
+//     on the carrier \ {0}.
 static_assert(dedekind::algebra::HasRingOperators<Rational<default_integer>>,
               "ℚ closes the literal ring operator surface (+, binary -, "
               "unary -, *).");

--- a/src/main/modules/dedekind/numbers/rational.cppm
+++ b/src/main/modules/dedekind/numbers/rational.cppm
@@ -776,15 +776,15 @@ static_assert(
 //     (HasRingOperators + closure under /).
 //   - HasGroupOperatorsAdd<ℚ>: literal +, binary -, unary - close on ℚ.
 //   - HasGroupOperatorsMul<ℚ>: literal *, / close on ℚ \ {0}.
-static_assert(dedekind::algebra::HasRingOperators<ℚ>,
+static_assert(dedekind::algebra::HasRingOperators<Rational<default_integer>>,
               "ℚ closes the literal ring operator surface (+, binary -, "
               "unary -, *).");
-static_assert(dedekind::algebra::HasFieldOperators<ℚ>,
+static_assert(dedekind::algebra::HasFieldOperators<Rational<default_integer>>,
               "ℚ closes the literal field operator surface (+, -, *, /).");
-static_assert(dedekind::algebra::HasGroupOperatorsAdd<ℚ>,
+static_assert(dedekind::algebra::HasGroupOperatorsAdd<Rational<default_integer>>,
               "ℚ closes the additive-group operator surface (+, binary -, "
               "unary -).");
-static_assert(dedekind::algebra::HasGroupOperatorsMul<ℚ>,
+static_assert(dedekind::algebra::HasGroupOperatorsMul<Rational<default_integer>>,
               "ℚ closes the multiplicative-group operator surface "
               "(*, /), modulo division-by-zero (the field carrier "
               "of ℚ is total only off the multiplicative-zero set).");

--- a/src/test/cpp/modules/dedekind/linear_algebra/matrix_test.cpp
+++ b/src/test/cpp/modules/dedekind/linear_algebra/matrix_test.cpp
@@ -19,7 +19,7 @@ import dedekind.category;
 import dedekind.numbers;
 import dedekind.linear_algebra;
 import dedekind.order; // dedekind::order::HasLatticeOperators on bool (bool lattice corner)
-import dedekind.sets; // SignedExtensionalCardinal (the canonical Rational<default_integer> carrier for the lattice corners)
+import dedekind.sets; // SignedExtensionalCardinal (the canonical default_integer carrier; Rational<default_integer> sits over it for the rational lattice corner)
 
 using namespace dedekind::analysis;
 using namespace dedekind::numbers;

--- a/src/test/cpp/modules/dedekind/linear_algebra/matrix_test.cpp
+++ b/src/test/cpp/modules/dedekind/linear_algebra/matrix_test.cpp
@@ -19,7 +19,7 @@ import dedekind.category;
 import dedekind.numbers;
 import dedekind.linear_algebra;
 import dedekind.order; // dedekind::order::HasLatticeOperators on bool (bool lattice corner)
-import dedekind.sets; // SignedExtensionalCardinal (the canonical ℚ carrier for the lattice corners)
+import dedekind.sets; // SignedExtensionalCardinal (the canonical Rational<default_integer> carrier for the lattice corners)
 
 using namespace dedekind::analysis;
 using namespace dedekind::numbers;

--- a/src/test/cpp/modules/dedekind/numbers/starters_test.cpp
+++ b/src/test/cpp/modules/dedekind/numbers/starters_test.cpp
@@ -1,4 +1,5 @@
 #include <catch2/catch_test_macros.hpp>
+#include <type_traits>
 
 import dedekind.category;
 import dedekind.numbers;

--- a/src/test/cpp/modules/dedekind/numbers/starters_test.cpp
+++ b/src/test/cpp/modules/dedekind/numbers/starters_test.cpp
@@ -31,9 +31,9 @@ TEST_CASE("Numbers: canonical starter symbols", "[numbers][starter]") {
                std::remove_cvref_t<decltype(Ω<SignedExtensionalCardinal<>>)>,
                UniversalSet<SignedExtensionalCardinal<>>>);
 
-  STATIC_CHECK(std::same_as<ℚ, Rational<default_integer>>);
+  STATIC_CHECK(std::same_as<Rational<default_integer>, Rational<default_integer>>);
   STATIC_CHECK(
-      std::same_as<std::remove_cvref_t<decltype(Ω<ℚ>)>, UniversalSet<ℚ>>);
+      std::same_as<std::remove_cvref_t<decltype(Ω<Rational<default_integer>>)>, UniversalSet<Rational<default_integer>>>);
 
   // 𝔻 / D / DualSet starter aliases moved to dedekind.analysis:dual at
   // PR ; analogous STATIC_CHECKs live in

--- a/src/test/cpp/modules/dedekind/numbers/starters_test.cpp
+++ b/src/test/cpp/modules/dedekind/numbers/starters_test.cpp
@@ -31,9 +31,13 @@ TEST_CASE("Numbers: canonical starter symbols", "[numbers][starter]") {
                std::remove_cvref_t<decltype(Ω<SignedExtensionalCardinal<>>)>,
                UniversalSet<SignedExtensionalCardinal<>>>);
 
-  STATIC_CHECK(std::same_as<Rational<default_integer>, Rational<default_integer>>);
+  STATIC_CHECK(std::same_as<std::remove_cvref_t<decltype(ℚ)>,
+                            UniversalSet<Rational<default_integer>>>);
+  STATIC_CHECK(std::same_as<typename std::remove_cvref_t<decltype(ℚ)>::Domain,
+                            Rational<default_integer>>);
   STATIC_CHECK(
-      std::same_as<std::remove_cvref_t<decltype(Ω<Rational<default_integer>>)>, UniversalSet<Rational<default_integer>>>);
+      std::same_as<std::remove_cvref_t<decltype(Ω<Rational<default_integer>>)>,
+                   UniversalSet<Rational<default_integer>>>);
 
   // 𝔻 / D / DualSet starter aliases moved to dedekind.analysis:dual at
   // PR ; analogous STATIC_CHECKs live in


### PR DESCRIPTION
## Summary

Fourth slice of [#559](https://github.com/vincentk/dedekind/issues/559)'s option-A migration: redefine `ℚ` from a carrier-type alias (`using ℚ = ℚ_t<>`) to the universe value (`inline constexpr auto ℚ = Ω<Rational<default_integer>>`).

Sibling of [#560](https://github.com/vincentk/dedekind/pull/560) (𝔹), [#563](https://github.com/vincentk/dedekind/pull/563) (ℕ), [#565](https://github.com/vincentk/dedekind/pull/565) (ℤ).  Continues the per-tower-position rollout: 𝔹 ✓ → ℕ ✓ → ℤ ✓ → **ℚ** → ℝ → ℂ → 𝔻.

## Changes

### Step 1: rename type-context `ℚ` → `Rational<default_integer>` (semantics-preserving prep)

9 lines across 5 files (`numbers/numbers`, `numbers/rational`, `linear_algebra/mat2x2`; tests in `numbers/starters` and `linear_algebra/matrix`).  Smaller surface than the integer-tower slices (ℚ has fewer concept-gate occurrences than ℤ / ℕ).

The parameterised alias `ℚ_t<I>` is preserved unchanged — it's a template alias on `I`, distinct from the bare `ℚ` token; the migration script's STANDALONE regex correctly leaves it alone.  Callsites that need the rational carrier in a template-type-parameter slot can spell `ℚ_t<>` (default integer) or `ℚ_t<MyInt>` (custom integer).

### Step 2: redefine `ℚ` as universe value `Ω<Rational<default_integer>>`

`numbers/rational.cppm`: `using ℚ = ℚ_t<>` → `inline constexpr auto ℚ = Ω<Rational<default_integer>>`.

Step 1's now-vacuous `static_assert(std::same_as<Rational<default_integer>, Rational<default_integer>>)` reframed as the universe-witness pair:
1. `decltype(ℚ) == UniversalSet<Rational<default_integer>, ClassicalLogic, ℵ_0>`
2. `decltype(ℚ)::Domain == Rational<default_integer>`

Doc comment on the new ℚ definition explicitly contrasts the universe (`ℚ`) with the carrier (`Rational<default_integer>` / `ℚ_t<>`).  The §3.3 universe-vs-classifier framing (#558 / `boundaries.cppm` arch-note) carries over verbatim.

## Test plan

- [x] `test_algebra` / `test_numbers` / `test_sets` / `test_linear_algebra` / `test_python` / `test_analysis` / `test_geometry` / `test_order` / `test_sequences` build green (321/322 targets)
- [ ] CI build-and-deploy green

## Out of scope

- ℝ / ℂ / 𝔻 slices — separate PRs per #559's slice plan.
- Forthcoming follow-up: a `quotient(Set, EquivRel)` DSL operator that constructs `ℚ = (ℤ × ℤ_≠0) / ~` as a textbook-style worked exhibit (issue to be filed; the payoff cascades to ℂ = ℝ[i]/(i²+1) and 𝔻 = ℝ[ε]/(ε²) which are also quotient constructions).  This PR delivers the routine-recipe ℚ slice; the textbook-construction exhibit is a separate structural claim.

🤖 Generated with [Claude Code](https://claude.com/claude-code)