### PR TITLE
feat(numbers, tests): #559 ℝ slice — redefine ℝ as universe value Ω<Real<machine_real_scalar>, ClassicalLogic, ℶ_1> (option A)

### DIFF
--- a/src/main/modules/dedekind/numbers/lattice.cppm
+++ b/src/main/modules/dedekind/numbers/lattice.cppm
@@ -138,10 +138,10 @@ struct LatticeFactory<C, N> {
  */
 template <>
 struct LatticeFactory<R, 1> {
-  using Domain = typename ℝ::Domain;
-  using Codomain = typename ℝ::Codomain;
-  using logic_species = typename ℝ::logic_species;
-  using cardinality_type = typename ℝ::cardinality_type;
+  using Domain = typename RealsOf<>::Domain;
+  using Codomain = typename RealsOf<>::Codomain;
+  using logic_species = typename RealsOf<>::logic_species;
+  using cardinality_type = typename RealsOf<>::cardinality_type;
 
   constexpr Codomain operator()(const Domain& x) const {
     return detail::is_integral_coordinate(x.resolve()) ? logic_species::True
@@ -169,7 +169,7 @@ struct LatticeFactory<R, N> {
   using Domain = std::array<Real<double>, N>;
   using Codomain = bool;
   using logic_species = ClassicalLogic;
-  using cardinality_type = typename ℝ::cardinality_type;
+  using cardinality_type = typename RealsOf<>::cardinality_type;
 
   constexpr Codomain operator()(const Domain& xs) const {
     for (const auto& x : xs) {

--- a/src/main/modules/dedekind/numbers/lattice.cppm
+++ b/src/main/modules/dedekind/numbers/lattice.cppm
@@ -149,9 +149,11 @@ struct LatticeFactory<R, 1> {
   }
 
   constexpr auto bounded(int n) const {
-    // FIXME(#399 slice 4-6): once ℝ becomes a carrier alias, switch
-    // to @c element<Ω<ℝ>>; for now ℝ is still the predicate-set type.
-    auto r = element<Ω<Real<double>>>;
+    // Post-#559 ℝ is the universe value Ω<Real<machine_real_scalar>>;
+    // element<ℝ> is the canonical scout spelling.  Spelt directly with
+    // @c Real<double> here because this lattice specialisation is keyed
+    // on the @c R (classifier) value rather than the universe symbol.
+    auto r = element<ℝ>;
     return Set{r | [n](const Real<double>& x) {
       const double v = x.resolve();
       if (!detail::is_integral_coordinate(v)) return false;

--- a/src/main/modules/dedekind/numbers/numbers.cppm
+++ b/src/main/modules/dedekind/numbers/numbers.cppm
@@ -55,7 +55,7 @@ export import :rational;    // ℚ (The Quotient Field)
 export import :complex;     // ℂ (The Cayley-Dickson construction)
 export import :quaternion;  // ℍ (Hamilton's division ring)
 export import :scalars;     // Floating-point anchors
-export import :lattice;     // Lattices over ℝ and ℂ
+export import :lattice;     // Lattices over RealsOf<> and ℂ
 export import :mandelbrot;  // Mandelbrot recurrence/orbit helpers
 
 /** @section numbers__Non_Standard_Analysis */
@@ -65,7 +65,7 @@ export import :mandelbrot;  // Mandelbrot recurrence/orbit helpers
 // `import dedekind.analysis;` (downstream of :numbers in the build graph)
 // to reach Dual<F> and the 𝔻 alias.
 export import :symbolic;     // Formal symbols / Indeterminates
-export import :real;         // ℝ (The Dedekind Cut / Cauchy continuum)
+export import :real;         // RealsOf<> (The Dedekind Cut / Cauchy continuum)
 export import :cardinality;  // Draft finite/aleph0 carrier and policies
 
 /** @section numbers__Metadata */

--- a/src/main/modules/dedekind/numbers/numbers.cppm
+++ b/src/main/modules/dedekind/numbers/numbers.cppm
@@ -67,8 +67,8 @@ export import :mandelbrot;  // Mandelbrot recurrence/orbit helpers
 export import :symbolic;  // Formal symbols / Indeterminates
 export import :real;      // ℝ (universe value Ω<Real<machine_real_scalar>,
                           // ClassicalLogic, ℶ_1>); RealsOf<> / RealSet (the
-                      // cross-carrier classifier); R (classifier instance) —
-                      // Dedekind Cut / Cauchy continuum
+// cross-carrier classifier); R (classifier instance) —
+// Dedekind Cut / Cauchy continuum
 export import :cardinality;  // Draft finite/aleph0 carrier and policies
 
 /** @section numbers__Metadata */

--- a/src/main/modules/dedekind/numbers/numbers.cppm
+++ b/src/main/modules/dedekind/numbers/numbers.cppm
@@ -64,8 +64,11 @@ export import :mandelbrot;  // Mandelbrot recurrence/orbit helpers
 // (:ftc, :forms, :hamilton) live in :analysis.  Consumers should
 // `import dedekind.analysis;` (downstream of :numbers in the build graph)
 // to reach Dual<F> and the 𝔻 alias.
-export import :symbolic;     // Formal symbols / Indeterminates
-export import :real;         // RealsOf<> (The Dedekind Cut / Cauchy continuum)
+export import :symbolic;  // Formal symbols / Indeterminates
+export import :real;      // ℝ (universe value Ω<Real<machine_real_scalar>,
+                          // ClassicalLogic, ℶ_1>); RealsOf<> / RealSet (the
+                      // cross-carrier classifier); R (classifier instance) —
+                      // Dedekind Cut / Cauchy continuum
 export import :cardinality;  // Draft finite/aleph0 carrier and policies
 
 /** @section numbers__Metadata */

--- a/src/main/modules/dedekind/numbers/real.cppm
+++ b/src/main/modules/dedekind/numbers/real.cppm
@@ -374,7 +374,45 @@ struct RealsOf {
 };
 
 export using RealSet = RealsOf<>;
-export using ℝ = RealSet;
+
+/** @brief The canonical real-number universe ℝ = Ω<Real<machine_real_scalar>,
+ *         ClassicalLogic, ℶ_1> (post-#559).
+ *
+ *  @details Per #559's chosen direction (option A): the named species
+ *  symbols (@c 𝔹 / @c ℕ / @c ℤ / @c ℚ / @c ℝ / @c ℂ / @c 𝔻) denote the
+ *  @b universe values (constexpr instances of @c UniversalSet over the
+ *  carrier), not classifier-alias types.  The carrier is
+ *  @c Real<machine_real_scalar> directly; the classifier (multi-overload
+ *  cross-carrier @c operator() that delegates to @c RationalsOf<I>{}
+ *  for non-real arguments) is reachable via @c RealSet @c = @c
+ *  RealsOf<>.
+ *
+ *  Cardinality is set explicitly to @c ℶ_1 (continuum) — the textbook
+ *  cardinality of ℝ — overriding the @c Ω<...> variable template's
+ *  @c ℵ_0 default.  Without this override, @c NaturalLogic<decltype(ℝ)>
+ *  would still route through @c TernaryLogic (since both ℵ_0 and ℶ_1
+ *  are transfinite), so the cardinality choice is honesty-only at this
+ *  layer; downstream consumers that key on the precise cardinality
+ *  distinction (e.g.\ Cantor's diagonal arguments, future
+ *  cardinality-aware optimisations) get the correct value.
+ *
+ *  Pre-#559 the spelling was @c using @c ℝ @c = @c RealSet (the
+ *  classifier alias); type-context sites in concept gates and member
+ *  extractions (@c typename @c ℝ::Domain etc.) were migrated to
+ *  @c RealsOf<> directly in step 1 of this slice.
+ */
+export inline constexpr auto ℝ =
+    dedekind::sets::Ω<Real<machine_real_scalar>, ClassicalLogic, ℶ_1>;
+
+static_assert(
+    std::same_as<std::remove_cvref_t<decltype(ℝ)>,
+                 dedekind::sets::UniversalSet<Real<machine_real_scalar>,
+                                              ClassicalLogic, ℶ_1>>,
+    "ℝ is the universe Ω<Real<machine_real_scalar>, ClassicalLogic, ℶ_1> "
+    "(post-#559).");
+static_assert(std::same_as<typename std::remove_cvref_t<decltype(ℝ)>::Domain,
+                           Real<machine_real_scalar>>,
+              "ℝ's underlying carrier IS Real<machine_real_scalar>.");
 
 export inline constexpr RealsOf<> R{};
 

--- a/src/main/modules/dedekind/numbers/real.cppm
+++ b/src/main/modules/dedekind/numbers/real.cppm
@@ -379,13 +379,18 @@ export using RealSet = RealsOf<>;
  *         ClassicalLogic, ℶ_1> (post-#559).
  *
  *  @details Per #559's chosen direction (option A): the named species
- *  symbols (@c 𝔹 / @c ℕ / @c ℤ / @c ℚ / @c ℝ / @c ℂ / @c 𝔻) denote the
- *  @b universe values (constexpr instances of @c UniversalSet over the
- *  carrier), not classifier-alias types.  The carrier is
- *  @c Real<machine_real_scalar> directly; the classifier (multi-overload
- *  cross-carrier @c operator() that delegates to @c RationalsOf<I>{}
- *  for non-real arguments) is reachable via @c RealSet @c = @c
- *  RealsOf<>.
+ *  symbols denote @b universe values (constexpr instances of
+ *  @c UniversalSet over the carrier), not classifier-alias types.  At
+ *  this slice's snapshot, @c 𝔹, @c ℕ, @c ℤ, @c ℚ, and (with this
+ *  commit) @c ℝ have completed the migration; @c ℂ and @c 𝔻 are still
+ *  exported as classifier aliases and are tracked under #559 for
+ *  follow-up via the @c quotient operator (#567), since both are
+ *  textbook quotient constructions (ℂ = ℝ[i]/(i²+1), 𝔻 = ℝ[ε]/(ε²)).
+ *
+ *  The carrier of @c ℝ is @c Real<machine_real_scalar> directly; the
+ *  classifier (multi-overload cross-carrier @c operator() that
+ *  delegates to @c RationalsOf<I>{} for non-real arguments) is
+ *  reachable via @c RealSet @c = @c RealsOf<>.
  *
  *  Cardinality is set explicitly to @c ℶ_1 (continuum) — the textbook
  *  cardinality of ℝ — overriding the @c Ω<...> variable template's

--- a/src/main/modules/dedekind/numbers/real.cppm
+++ b/src/main/modules/dedekind/numbers/real.cppm
@@ -376,7 +376,7 @@ struct RealsOf {
 export using RealSet = RealsOf<>;
 export using ℝ = RealSet;
 
-export inline constexpr ℝ R{};
+export inline constexpr RealsOf<> R{};
 
 }  // namespace dedekind::numbers
 


### PR DESCRIPTION
## Summary

Fifth slice of [#559](https://github.com/vincentk/dedekind/issues/559)'s option-A migration: redefine `ℝ` from a *classifier* alias (`using ℝ = RealSet = RealsOf<>`) to the universe value (`inline constexpr auto ℝ = Ω<Real<machine_real_scalar>, ClassicalLogic, ℶ_1>`).

Sibling of [#560](https://github.com/vincentk/dedekind/pull/560) (𝔹), [#563](https://github.com/vincentk/dedekind/pull/563) (ℕ), [#565](https://github.com/vincentk/dedekind/pull/565) (ℤ), [#566](https://github.com/vincentk/dedekind/pull/566) (ℚ).  Continues the per-tower-position rollout: 𝔹 ✓ → ℕ ✓ → ℤ ✓ → ℚ ✓ → **ℝ** → ℂ → 𝔻.

## Different shape from earlier slices

Pre-#559 ℝ was a **classifier** alias, not a carrier alias.  Type-context sites accessing `ℝ::Domain` etc. were extracting classifier members; the migration script's mechanical replacement is therefore `RealsOf<>` (the classifier struct) rather than the carrier `Real<machine_real_scalar>`.  After step 2:
- `RealsOf<>` / `RealSet` stay as the multi-overload cross-carrier classifier (delegating to `RationalsOf<I>{}` for non-real arguments).
- `ℝ` is the universe value over the carrier — what `element<ℝ>` ranges over.

Cardinality is set explicitly to **ℶ_1** (continuum) — the textbook cardinality of ℝ — overriding `Ω<...>`'s default ℵ_0.  Without the override `decltype(ℝ)::cardinality_type` would be ℵ_0, mathematically wrong (continuum is strictly larger than countable).

## Changes

### Step 1: rename type-context `ℝ` → `RealsOf<>` (semantics-preserving prep)

61 lines across 7 files (3 main: `numbers/numbers`, `numbers/lattice`, `numbers/real`; 4 test: `topology/shapes`, `analysis/hamilton`, `geometry/hilbert`, `sequences/cauchy`).

Same overreach pattern as the ℤ slice: 4 test files had local `using ℝ = int/double` proxy aliases (avoiding heavy `dedekind.numbers` imports for tests upstream of numbers in some build-DAG paths); the migration script's STANDALONE regex wrongly rewrote the bodies.  Reverted those bodies to use the local alias.

### Step 2: redefine `ℝ` as universe value `Ω<Real<machine_real_scalar>, ClassicalLogic, ℶ_1>`

`numbers/real.cppm`: classifier-alias removed, universe-value definition added with explicit ℶ_1 cardinality.  `inline constexpr ℝ R{}` rewritten to `inline constexpr RealsOf<> R{}` (R was always intended as the classifier value).

Universe-witness static_assert pair: `decltype(ℝ) == UniversalSet<Real<machine_real_scalar>, ClassicalLogic, ℶ_1>` + `decltype(ℝ)::Domain == Real<machine_real_scalar>`.

## Test plan

- [x] `test_algebra` / `test_numbers` / `test_sets` / `test_linear_algebra` / `test_python` / `test_analysis` / `test_geometry` / `test_order` / `test_sequences` / `test_topology` build green (321/322 targets)
- [ ] CI build-and-deploy green

## Out of scope

- ℂ / 𝔻 slices — same classifier-alias-shape as ℝ.  Sequencing options:
  - **Continue routine recipe** (~30 min each, same scaffolding); OR
  - **Pivot to #567** (`quotient` operator) and have ℂ = ℝ[i]/(i²+1) and 𝔻 = ℝ[ε]/(ε²) ride on the textbook quotient construction — paying back the operator's cost across two slices instead of one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)