### PR TITLE
feat(numbers, tests): #559 ℂ slice — redefine ℂ as universe value Ω<Complex<machine_real_scalar>, ClassicalLogic, ℶ_1> (option A)

### DIFF
--- a/docs/paper/paper.tex
+++ b/docs/paper/paper.tex
@@ -2138,13 +2138,13 @@ exported function to a single \cppinline{ret i1 true}.
 constexpr auto c = element<ℂ>;
 
 constexpr auto natural_lattice_in_c =
-    Set{c % C | [](const Complex<double>& z) {
+    Set{c |[](const Complex<double>& z) {
       return is_integral_coordinate(z.real()) &&
              is_integral_coordinate(z.imag()) &&
              (z.real() >= 0.0) && (z.real() <= 3.0) &&
              (z.imag() >= 0.0) && (z.imag() <= 3.0);
     }};
-constexpr auto square_c1_c2 = Set{c % C | [](const Complex<double>& z) {
+constexpr auto square_c1_c2 = Set{c |[](const Complex<double>& z) {
   return (z.real() >= 0.5) && (z.real() <= 1.5) &&
          (z.imag() >= 0.5) && (z.imag() <= 1.5);
 }};

--- a/docs/paper/paper.tex
+++ b/docs/paper/paper.tex
@@ -2135,7 +2135,7 @@ exported function to a single \cppinline{ret i1 true}.
 \label{lst:showcase02_src}
 \begin{cpp}
 
-constexpr auto c = var<ℂ>;
+constexpr auto c = element<ℂ>;
 
 constexpr auto natural_lattice_in_c =
     Set{c % C | [](const Complex<double>& z) {

--- a/src/main/modules/dedekind/numbers/complex.cppm
+++ b/src/main/modules/dedekind/numbers/complex.cppm
@@ -304,9 +304,54 @@ struct ComplexesOf {
 };
 
 export using ComplexSet = ComplexesOf<>;
-export using ℂ = ComplexSet;
 
-export inline constexpr ℂ C{};
+/** @brief The canonical complex-number universe ℂ = Ω<Complex<machine_real_scalar>,
+ *         ClassicalLogic, ℶ_1> (post-#559).
+ *
+ *  @details Per #559's chosen direction (option A): the named species
+ *  symbols denote @b universe values (constexpr instances of
+ *  @c UniversalSet over the carrier), not classifier-alias types.  At
+ *  this slice's snapshot, @c 𝔹, @c ℕ, @c ℤ, @c ℚ, @c ℝ, and (with this
+ *  commit) @c ℂ have completed the migration; @c 𝔻 is still exported
+ *  as a classifier alias and is tracked under #559 for follow-up via
+ *  the @c quotient operator (#567), since 𝔻 is the textbook quotient
+ *  construction 𝔻 = ℝ[ε]/(ε²).
+ *
+ *  The carrier of @c ℂ is @c Complex<machine_real_scalar> directly;
+ *  the classifier (multi-overload cross-carrier @c operator() that
+ *  delegates ℝ-side arguments through @c embed_ℝ_ℂ and lands non-
+ *  parent ancestors via @c RealsOf<>) is reachable via @c ComplexSet
+ *  @c = @c ComplexesOf<>.
+ *
+ *  Cardinality is set explicitly to @c ℶ_1 (continuum) — the textbook
+ *  cardinality of ℂ, matching ℝ — overriding the @c Ω<...> variable
+ *  template's @c ℵ_0 default.  ℂ is in bijection with ℝ × ℝ and
+ *  therefore shares ℝ's continuum cardinality.
+ *
+ *  Pre-#559 the spelling was @c using @c ℂ @c = @c ComplexSet (the
+ *  classifier alias); type-context sites in concept gates and member
+ *  extractions (@c typename @c ℂ::Domain etc.) were migrated to
+ *  @c ComplexesOf<> directly in step 1 of this slice.
+ *
+ *  Textbook construction: ℂ = ℝ[i]/(i²+1) — observable via the
+ *  @c quotient operator from @c sets:quotient (the same DSL primitive
+ *  ℚ rides on under #567).  The 𝔻 follow-up (𝔻 = ℝ[ε]/(ε²)) lands
+ *  next under the same operator surface.
+ */
+export inline constexpr auto ℂ =
+    dedekind::sets::Ω<Complex<machine_real_scalar>, ClassicalLogic, ℶ_1>;
+
+static_assert(
+    std::same_as<std::remove_cvref_t<decltype(ℂ)>,
+                 dedekind::sets::UniversalSet<Complex<machine_real_scalar>,
+                                              ClassicalLogic, ℶ_1>>,
+    "ℂ is the universe Ω<Complex<machine_real_scalar>, ClassicalLogic, ℶ_1> "
+    "(post-#559).");
+static_assert(std::same_as<typename std::remove_cvref_t<decltype(ℂ)>::Domain,
+                           Complex<machine_real_scalar>>,
+              "ℂ's underlying carrier IS Complex<machine_real_scalar>.");
+
+export inline constexpr ComplexSet C{};
 
 }  // namespace dedekind::numbers
 

--- a/src/main/modules/dedekind/numbers/complex.cppm
+++ b/src/main/modules/dedekind/numbers/complex.cppm
@@ -305,8 +305,8 @@ struct ComplexesOf {
 
 export using ComplexSet = ComplexesOf<>;
 
-/** @brief The canonical complex-number universe ℂ = Ω<Complex<machine_real_scalar>,
- *         ClassicalLogic, ℶ_1> (post-#559).
+/** @brief The canonical complex-number universe ℂ =
+ * Ω<Complex<machine_real_scalar>, ClassicalLogic, ℶ_1> (post-#559).
  *
  *  @details Per #559's chosen direction (option A): the named species
  *  symbols denote @b universe values (constexpr instances of

--- a/src/main/modules/dedekind/numbers/lattice.cppm
+++ b/src/main/modules/dedekind/numbers/lattice.cppm
@@ -76,10 +76,10 @@ struct LatticeFactory;
  */
 template <>
 struct LatticeFactory<C, 1> {
-  using Domain = typename ℂ::Domain;
-  using Codomain = typename ℂ::Codomain;
-  using logic_species = typename ℂ::logic_species;
-  using cardinality_type = typename ℂ::cardinality_type;
+  using Domain = typename ComplexesOf<>::Domain;
+  using Codomain = typename ComplexesOf<>::Codomain;
+  using logic_species = typename ComplexesOf<>::logic_species;
+  using cardinality_type = typename ComplexesOf<>::cardinality_type;
 
   constexpr Codomain operator()(const Domain& z) const {
     return detail::is_integral_coordinate(z.real()) &&
@@ -100,7 +100,7 @@ struct LatticeFactory<C, N> {
   using Domain = std::array<Complex<double>, N>;
   using Codomain = bool;
   using logic_species = ClassicalLogic;
-  using cardinality_type = typename ℂ::cardinality_type;
+  using cardinality_type = typename ComplexesOf<>::cardinality_type;
 
   constexpr Codomain operator()(const Domain& xs) const {
     for (const auto& z : xs) {

--- a/src/test/cpp/modules/dedekind/analysis/pruning_showcases_test.cpp
+++ b/src/test/cpp/modules/dedekind/analysis/pruning_showcases_test.cpp
@@ -59,10 +59,9 @@ TEST_CASE("Pruning showcase 1: diagonal × strip on ℝ² is empty",
 namespace {
 
 // Shared with showcase 2 (ℂ lattice × square singleton).
-// FIXME(#399 slice 4-6): once ℂ becomes a carrier alias, switch to
-// @c element<Ω<ℂ>>; for now ℂ is still the predicate-set type, so we
-// spell the carrier directly.
-constexpr auto c = element<Ω<Complex<double>>>;
+// Post-#559: ℂ is the universe value Ω<Complex<machine_real_scalar>,
+// ClassicalLogic, ℶ_1>, so the canonical scout spelling is element<ℂ>.
+constexpr auto c = element<ℂ>;
 
 constexpr bool is_integral_coordinate(double x) {
   const int xi = static_cast<int>(x);

--- a/src/test/cpp/modules/dedekind/numbers/set_algebra_static_test.cpp
+++ b/src/test/cpp/modules/dedekind/numbers/set_algebra_static_test.cpp
@@ -10,12 +10,13 @@ using namespace dedekind::sets;
 
 namespace {
 
-// FIXME(#399 slice 4-6): once ℝ/ℂ become carrier aliases, switch to
-// element<Ω<ℝ>>/element<Ω<ℂ>>; for now they are still predicate-set
-// types, so we spell the carriers (Real<double>/Complex<double>)
-// directly.
+// Post-#559: ℂ is the universe value Ω<Complex<machine_real_scalar>,
+// ClassicalLogic, ℶ_1>, so the canonical scout spelling is element<ℂ>
+// (no double-Ω).  ℝ migration to element<ℝ> is tracked separately
+// (FIXME(#559): ℝ scout still spells Ω<Real<double>> with default ℵ_0
+// rather than ℝ's actual ℶ_1; sweep alongside the post-ℂ tidy-up).
 constexpr auto r = element<Ω<Real<double>>>;
-constexpr auto c = element<Ω<Complex<double>>>;
+constexpr auto c = element<ℂ>;
 
 constexpr auto real_gt_zero = [](const Real<double>& x) {
   return x.resolve() > 0.0;

--- a/src/test/cpp/modules/dedekind/python/showcase_02_lattice_singleton.cpp
+++ b/src/test/cpp/modules/dedekind/python/showcase_02_lattice_singleton.cpp
@@ -31,11 +31,9 @@ constexpr bool is_integral_coordinate(double x) {
   return static_cast<double>(xi) == x;
 }
 
-// Symbolic scout ranging over the universal set Ω<Complex<double>>.
-// FIXME(#399 slice 4-6): once ℂ becomes a carrier alias, switch to
-// @c element<Ω<ℂ>>; for now @c ℂ is still the predicate-set type, so
-// we spell the carrier directly.
-constexpr auto c = element<Ω<Complex<double>>>;
+// Post-#559: ℂ is the universe value Ω<Complex<machine_real_scalar>,
+// ClassicalLogic, ℶ_1>, so the canonical scout spelling is element<ℂ>.
+constexpr auto c = element<ℂ>;
 
 // Lifted natural-number lattice: Gaussian integers with 0 ≤ Re, Im ≤ 3
 constexpr auto natural_lattice_in_c = Set{c | [](const Complex<double>& z) {


### PR DESCRIPTION
## Summary

Sixth slice of #559 (universe-value migration for the named species symbols).  Bumps `ℂ` from a classifier-alias type (`using ℂ = ComplexSet`) to a constexpr universe value, parallel to the ℝ slice (#569).

- `numbers/complex.cppm` — redefine `ℂ` as `Ω<Complex<machine_real_scalar>, ClassicalLogic, ℶ_1>`.  Keeps `ComplexSet = ComplexesOf<>` as the classifier alias for type-context callsites.  `inline constexpr ComplexSet C{}` for the lattice-key value.  Cardinality set to `ℶ_1` (continuum) — ℂ is in bijection with ℝ × ℝ.
- `numbers/lattice.cppm` — type-context migration: 5 sites of `typename ℂ::X` (lines 79–82, 103) → `typename ComplexesOf<>::X`, parallel to ℝ's `typename RealsOf<>::X`.
- Tests: resolve the ℂ half of the pre-existing `FIXME(#399 slice 4-6)`s — switch ℂ scouts from `element<Ω<Complex<double>>>` to `element<ℂ>` (the canonical post-#559 spelling — ℂ already includes the `Ω<>`).  Affected: `set_algebra_static_test.cpp`, `pruning_showcases_test.cpp`, `showcase_02_lattice_singleton.cpp`.  ℝ scout left as-is and re-tagged with `FIXME(#559)` — the post-ℝ tidy-up across the whole test surface is a separate sweep.
- `docs/paper/paper.tex` — Showcase 2 listing: `var<ℂ>` (pre-#551 style) → `element<ℂ>` (canonical post-#551 / post-#559 spelling).

Doc-comment block on the new `ℂ` definition names the textbook construction `ℂ = ℝ[i]/(i²+1)` as the next exhibit (the same DSL primitive ℚ rides on under #567's quotient operator); 𝔻 (final slice, `𝔻 = ℝ[ε]/(ε²)`) lands next under the same operator surface.

## Test plan
- [ ] CI green (compile + test_numbers + test_analysis + test_python + paper build)
- [ ] `static_assert`s in `complex.cppm` witness the universe shape: `decltype(ℂ)` is `UniversalSet<Complex<machine_real_scalar>, ClassicalLogic, ℶ_1>`; `decltype(ℂ)::Domain` is `Complex<machine_real_scalar>`
- [ ] No remaining `typename ℂ::X` callsites in `src/main`
- [ ] Showcase 2 tests pass under the new `element<ℂ>` scout (cardinality jumps from default `ℵ_0` to `ℶ_1`, but the lattice-singleton results are unchanged)
- [ ] Paper Showcase 2 listing still renders coherently with `element<ℂ>` (49pp single-pass lualatex local; CI confirms with `-halt-on-error`)

## Sequencing
- 6/7 of the per-symbol migration done (𝔹/ℕ/ℤ/ℚ/ℝ/ℂ).
- 𝔻 (Dual numbers) is the final slice under #559.
- The textbook quotient-operator exhibits (ℂ = ℝ[i]/(i²+1), 𝔻 = ℝ[ε]/(ε²)) are deferred to follow-up slices alongside the universe-value migrations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)