### PR TITLE
feat(analysis, tests): #559 𝔻 slice — redefine 𝔻 as universe value Ω<Dual<machine_real_scalar>, ClassicalLogic, ℶ_1> (option A) — closes #559

### DIFF
--- a/src/main/modules/dedekind/analysis/dual.cppm
+++ b/src/main/modules/dedekind/analysis/dual.cppm
@@ -258,8 +258,8 @@ static_assert(
     "Dual<int> is the discrete-side tangent-bundle (finite-difference) "
     "carrier over the machine integers.");
 
-export template <typename F = double, typename L = ClassicalLogic,
-                 typename C = ℶ_1>
+export template <typename F = dedekind::numbers::machine_real_scalar,
+                 typename L = ClassicalLogic, typename C = ℶ_1>
 using DualSetOf = UniversalSet<Dual<F>, L, C>;
 
 export using DualSet = DualSetOf<>;

--- a/src/main/modules/dedekind/analysis/dual.cppm
+++ b/src/main/modules/dedekind/analysis/dual.cppm
@@ -299,10 +299,10 @@ export inline constexpr auto 𝔻 =
                       ClassicalLogic, ℶ_1>;
 
 static_assert(
-    std::same_as<std::remove_cvref_t<decltype(𝔻)>,
-                 dedekind::sets::UniversalSet<
-                     Dual<dedekind::numbers::machine_real_scalar>,
-                     ClassicalLogic, ℶ_1>>,
+    std::same_as<
+        std::remove_cvref_t<decltype(𝔻)>,
+        dedekind::sets::UniversalSet<
+            Dual<dedekind::numbers::machine_real_scalar>, ClassicalLogic, ℶ_1>>,
     "𝔻 is the universe Ω<Dual<machine_real_scalar>, ClassicalLogic, ℶ_1> "
     "(post-#559).");
 static_assert(std::same_as<typename std::remove_cvref_t<decltype(𝔻)>::Domain,

--- a/src/main/modules/dedekind/analysis/dual.cppm
+++ b/src/main/modules/dedekind/analysis/dual.cppm
@@ -263,9 +263,53 @@ export template <typename F = double, typename L = ClassicalLogic,
 using DualSetOf = UniversalSet<Dual<F>, L, C>;
 
 export using DualSet = DualSetOf<>;
-export using 𝔻 = DualSet;
 
-export inline constexpr 𝔻 D{};
+/** @brief The canonical dual-number universe 𝔻 = Ω<Dual<machine_real_scalar>,
+ *         ClassicalLogic, ℶ_1> (post-#559).
+ *
+ *  @details Per #559's chosen direction (option A): the named species
+ *  symbols denote @b universe values (constexpr instances of
+ *  @c UniversalSet over the carrier), not classifier-alias types.
+ *  This slice closes #559 — with @c 𝔻 migrated, all seven species
+ *  symbols (𝔹, ℕ, ℤ, ℚ, ℝ, ℂ, 𝔻) carry the canonical
+ *  @c element<𝔻> scout spelling.
+ *
+ *  The carrier of @c 𝔻 is @c Dual<machine_real_scalar> directly; the
+ *  classifier is reachable via @c DualSet @c = @c DualSetOf<>.
+ *
+ *  Cardinality is set explicitly to @c ℶ_1 (continuum) — @c 𝔻 is in
+ *  bijection with ℝ × ℝ via the @c (a, @c b) coefficient pair (the
+ *  same shape that gives @c ℂ its @c ℶ_1) — overriding the
+ *  @c Ω<...> variable template's @c ℵ_0 default.
+ *
+ *  Pre-#559 the spelling was @c using @c 𝔻 @c = @c DualSet (the
+ *  classifier alias); type-context sites in concept gates and member
+ *  extractions (@c typename @c 𝔻::Domain etc.) were migrated to
+ *  @c DualSet directly in step 1 of this slice.
+ *
+ *  Textbook construction: @c 𝔻 @c = @c ℝ[ε]/(ε²) — a polynomial
+ *  quotient observable via the @c quotient operator from
+ *  @c sets:quotient (the same DSL primitive ℚ rides on under #567's
+ *  textbook quotient exhibit).  The structural-trait propagation
+ *  through @c quotient_algebra_base<Dual<F>>::type @c = @c F (below)
+ *  is the universal-algebra side of that same construction.
+ */
+export inline constexpr auto 𝔻 =
+    dedekind::sets::Ω<Dual<dedekind::numbers::machine_real_scalar>,
+                      ClassicalLogic, ℶ_1>;
+
+static_assert(
+    std::same_as<std::remove_cvref_t<decltype(𝔻)>,
+                 dedekind::sets::UniversalSet<
+                     Dual<dedekind::numbers::machine_real_scalar>,
+                     ClassicalLogic, ℶ_1>>,
+    "𝔻 is the universe Ω<Dual<machine_real_scalar>, ClassicalLogic, ℶ_1> "
+    "(post-#559).");
+static_assert(std::same_as<typename std::remove_cvref_t<decltype(𝔻)>::Domain,
+                           Dual<dedekind::numbers::machine_real_scalar>>,
+              "𝔻's underlying carrier IS Dual<machine_real_scalar>.");
+
+export inline constexpr DualSet D{};
 
 }  // namespace dedekind::analysis
 

--- a/src/test/cpp/modules/dedekind/analysis/dual_test.cpp
+++ b/src/test/cpp/modules/dedekind/analysis/dual_test.cpp
@@ -111,7 +111,7 @@ TEST_CASE("Analysis: 𝔻 / D / DualSet starter aliases",
           "[analysis][dual][starter]") {
   // Post-#559: 𝔻 is the universe value Ω<Dual<machine_real_scalar>,
   // ClassicalLogic, ℶ_1>, and D is the classifier instance DualSet{}
-  // (= DualSetOf<>{}).  The pair is the same shape ℝ/ℂ carry.
+  // (= DualSetOf<>{}).  The pair has the same shape as ℝ/ℂ.
   STATIC_CHECK(std::same_as<
                std::remove_cvref_t<decltype(𝔻)>,
                UniversalSet<Dual<machine_real_scalar>, ClassicalLogic, ℶ_1>>);

--- a/src/test/cpp/modules/dedekind/analysis/dual_test.cpp
+++ b/src/test/cpp/modules/dedekind/analysis/dual_test.cpp
@@ -112,10 +112,9 @@ TEST_CASE("Analysis: 𝔻 / D / DualSet starter aliases",
   // Post-#559: 𝔻 is the universe value Ω<Dual<machine_real_scalar>,
   // ClassicalLogic, ℶ_1>, and D is the classifier instance DualSet{}
   // (= DualSetOf<>{}).  The pair is the same shape ℝ/ℂ carry.
-  STATIC_CHECK(
-      std::same_as<std::remove_cvref_t<decltype(𝔻)>,
-                   UniversalSet<Dual<machine_real_scalar>, ClassicalLogic,
-                                ℶ_1>>);
+  STATIC_CHECK(std::same_as<
+               std::remove_cvref_t<decltype(𝔻)>,
+               UniversalSet<Dual<machine_real_scalar>, ClassicalLogic, ℶ_1>>);
   STATIC_CHECK(std::same_as<typename std::remove_cvref_t<decltype(𝔻)>::Domain,
                             Dual<machine_real_scalar>>);
   STATIC_CHECK(std::same_as<decltype(D), const DualSet>);

--- a/src/test/cpp/modules/dedekind/analysis/dual_test.cpp
+++ b/src/test/cpp/modules/dedekind/analysis/dual_test.cpp
@@ -109,17 +109,25 @@ TEST_CASE(
 
 TEST_CASE("Analysis: 𝔻 / D / DualSet starter aliases",
           "[analysis][dual][starter]") {
-  STATIC_CHECK(std::same_as<𝔻, DualSet>);
-  STATIC_CHECK(std::same_as<decltype(D), const 𝔻>);
+  // Post-#559: 𝔻 is the universe value Ω<Dual<machine_real_scalar>,
+  // ClassicalLogic, ℶ_1>, and D is the classifier instance DualSet{}
+  // (= DualSetOf<>{}).  The pair is the same shape ℝ/ℂ carry.
+  STATIC_CHECK(
+      std::same_as<std::remove_cvref_t<decltype(𝔻)>,
+                   UniversalSet<Dual<machine_real_scalar>, ClassicalLogic,
+                                ℶ_1>>);
+  STATIC_CHECK(std::same_as<typename std::remove_cvref_t<decltype(𝔻)>::Domain,
+                            Dual<machine_real_scalar>>);
+  STATIC_CHECK(std::same_as<decltype(D), const DualSet>);
 
-  constexpr auto d = element<Ω<Dual<double>>>;
+  constexpr auto d = element<𝔻>;
   constexpr auto duals = Set{d};
   static_assert(duals(Dual<double>{1.0, 1.0}) == Ternary::True);
 }
 
 TEST_CASE("Analysis: 𝔻 lattice identity (U ∪ ¬U = top, U ∩ ¬U = bottom)",
           "[analysis][dual][starter][lattice]") {
-  constexpr auto d = element<Ω<Dual<double>>>;
+  constexpr auto d = element<𝔻>;
   const auto U = Set{d};
   const auto O = !U;
   CHECK((U | O)(Dual<double>{3.0, 1.0}) == Ternary::True);


### PR DESCRIPTION
## Summary

Final slice of #559 (universe-value migration).  With this commit, all seven named species symbols (`𝔹`, `ℕ`, `ℤ`, `ℚ`, `ℝ`, `ℂ`, `𝔻`) carry the canonical `element<𝔻>` scout spelling — no double-Ω, no carrier-alias type remnants.

- `analysis/dual.cppm` — redefine `𝔻` as `Ω<Dual<machine_real_scalar>, ClassicalLogic, ℶ_1>` (continuum-cardinality universe value; 𝔻 is in bijection with ℝ × ℝ via the `(a, b)` coefficient pair).  Keeps `DualSet = DualSetOf<>` as the classifier alias for member-extraction sites.  `inline constexpr DualSet D{}` for the classifier value.  Doc-comment block names the textbook construction `𝔻 = ℝ[ε]/(ε²)` — the same polynomial-quotient construction the structural-trait propagation in `dedekind.algebra:quotient` already uses (via `quotient_algebra_base<Dual<F>>::type = F`).
- `test/.../analysis/dual_test.cpp` — type-context migration:
  - The pre-migration `STATIC_CHECK`s at lines 112–113 (`std::same_as<𝔻, DualSet>` and `std::same_as<decltype(D), const 𝔻>`) reframed for the post-migration shape: first checks `decltype(𝔻)` is `UniversalSet<Dual<machine_real_scalar>, ClassicalLogic, ℶ_1>` and `decltype(𝔻)::Domain` is `Dual<machine_real_scalar>`; second checks `D` against `DualSet` (the classifier alias) rather than the now-value `𝔻`.
  - Two scout sites switched from `element<Ω<Dual<double>>>` to `element<𝔻>` (the canonical post-#559 spelling — `𝔻` already includes the `Ω<>`).

## Test plan
- [ ] CI green (compile + all 14 test suites + paper build)
- [ ] `static_assert`s in `dual.cppm` witness the universe shape: `decltype(𝔻)` is `UniversalSet<Dual<machine_real_scalar>, ClassicalLogic, ℶ_1>`; `decltype(𝔻)::Domain` is `Dual<machine_real_scalar>`
- [ ] No remaining `typename 𝔻::X` callsites in `src/`
- [ ] `test_analysis` passes (the two scout-site migrations + the reframed starter-aliases test)

## Sequencing
- 7/7 of the per-symbol migration done.  **Closes #559.**
- Out of scope here: the textbook quotient-operator exhibits (`ℂ = ℝ[i]/(i²+1)` and `𝔻 = ℝ[ε]/(ε²)`) — those are operational discharges under #567 alongside the universe-value migration this issue tracks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)