### PR TITLE
docs(algebra): #498 NEW-A pilot — is_module_v inventory + identified gaps for follow-up

### DIFF
--- a/src/main/modules/dedekind/algebra/modules.cppm
+++ b/src/main/modules/dedekind/algebra/modules.cppm
@@ -361,6 +361,57 @@ namespace dedekind::algebra {
  * identity) — @c is_free_module_v and @c is_endomorphism_ring_v —
  * live in @c dedekind.linear_algebra:basis where the metadata is at
  * home.
+ *
+ * @section modules__Trait_Registry_Status (NEW-A pilot inventory)
+ *
+ * The carriers that currently fire @c is_module_v across the
+ * codebase, with the static_assert witness site for each:
+ *
+ *   @c is_module_v<Rational<default_integer>, default_integer>
+ *     — @c numbers/rational.cppm: ℚ is a ℤ-module via the Frac
+ *     construction (the localisation @c S^{-1}ℤ at @c S=ℤ_≠0).
+ *
+ *   @c is_module_v<Complex<Rational<default_integer>>,
+ *                  Rational<default_integer>>
+ *     — @c numbers/complex.cppm: ℂ over ℚ is a ℚ-module via the
+ *     quotient ring @c ℚ[i]/(i²+1) carrying the canonical
+ *     componentwise ℚ-action on the (real, imag) pair.
+ *
+ *   @c is_module_v<Vec2V<unsigned int>, unsigned int>
+ *     — @c linear_algebra/vec2.cppm: the rank-2 free module over
+ *     the unsigned-integer modular ring.
+ *
+ *   @c is_module_v<Vec2V<Rational<default_integer>>,
+ *                  Rational<default_integer>>
+ *     — @c linear_algebra/mat2x2.cppm: Vec2 over ℚ as a ℚ-module
+ *     (the rank-2 vector space over the field ℚ, witnessed at the
+ *     module tier; the strengthening to @c is_vector_space_v needs
+ *     @c IsField<Rational> to bind, tracked as the next NEW-A
+ *     deliverable).
+ *
+ * Gaps the NEW-A pilot has identified for follow-up slices:
+ *
+ *   @c is_vector_space_v<V, F> recursive upgrade — the trait fires
+ *   automatically once @c IsField<F> holds in addition to
+ *   @c IsModule<V, F>; the @c IsField specialisation surface for
+ *   @c Rational<I> is the load-bearing gap.
+ *
+ *   @c is_module_v<Dual<F>, F> for the Dual numbers — the
+ *   quotient-algebra propagation in @c algebra:quotient lifts
+ *   @c F-action to @c Dual<F>; a static_assert exhibit at
+ *   @c analysis/dual.cppm would pin the recursive enrichment for
+ *   the AD carrier.
+ *
+ *   @c is_endomorphism_ring_v<Matrix2x2V<F>, Vec2V<F>> — the
+ *   internal-hom witness for the rank-2 free module; opt-in trait
+ *   in @c linear_algebra:basis, populated for specific (F, n)
+ *   pairs.
+ *
+ * The recursive enrichment Figure~1 of the paper depicts (ℚ as
+ * ℤ-module, 𝔻 as ℝ-module, ℂ as ℝ-module, …) lands one carrier at
+ * a time as the corresponding scalar action and trait
+ * specialisation are wired.  This inventory is the running
+ * snapshot.
  */
 
 /** @brief @c is_module_v<M, R>: @c M is an @c R-module.  Concept-based

--- a/src/main/modules/dedekind/algebra/modules.cppm
+++ b/src/main/modules/dedekind/algebra/modules.cppm
@@ -364,8 +364,10 @@ namespace dedekind::algebra {
  *
  * @section modules__Trait_Registry_Status (NEW-A pilot inventory)
  *
- * The carriers that currently fire @c is_module_v across the
+ * The carriers that currently fire the trait registry across the
  * codebase, with the static_assert witness site for each:
+ *
+ *   @b is_module_v witnesses:
  *
  *   @c is_module_v<Rational<default_integer>, default_integer>
  *     — @c numbers/rational.cppm: ℚ is a ℤ-module via the Frac
@@ -377,6 +379,12 @@ namespace dedekind::algebra {
  *     quotient ring @c ℚ[i]/(i²+1) carrying the canonical
  *     componentwise ℚ-action on the (real, imag) pair.
  *
+ *   @c is_module_v<Dual<Rational<default_integer>>,
+ *                  Rational<default_integer>>
+ *     — @c analysis/dual.cppm: Dual<ℚ> is a ℚ-module via the
+ *     quotient-algebra propagation in @c algebra:quotient (the
+ *     exact-arithmetic AD instance).
+ *
  *   @c is_module_v<Vec2V<unsigned int>, unsigned int>
  *     — @c linear_algebra/vec2.cppm: the rank-2 free module over
  *     the unsigned-integer modular ring.
@@ -386,31 +394,47 @@ namespace dedekind::algebra {
  *     — @c linear_algebra/mat2x2.cppm: Vec2 over ℚ as a ℚ-module
  *     (the rank-2 vector space over the field ℚ, witnessed at the
  *     module tier; the strengthening to @c is_vector_space_v needs
- *     @c IsField<Rational> to bind, tracked as the next NEW-A
- *     deliverable).
+ *     @c IsField<Rational> to bind, see "remaining gap" below).
  *
- * Gaps the NEW-A pilot has identified for follow-up slices:
+ *   @b is_free_module_v specialisations (rank-bearing):
+ *
+ *   @c is_free_module_v<Vec2V<unsigned int>, unsigned int, 2>
+ *     and @c is_free_module_v<Covec2V<unsigned int>, unsigned int, 2>
+ *     — @c linear_algebra/vec2.cppm: the rank-2 free modules and
+ *     their dual rank-2 free modules over the unsigned-integer
+ *     modular ring.
+ *
+ *   @c is_free_module_v<Vec2V<Rational<default_integer>>,
+ *                       Rational<default_integer>, 2>
+ *     — @c linear_algebra/mat2x2.cppm: Vec2 over ℚ as a rank-2
+ *     free ℚ-module.
+ *
+ *   @b is_endomorphism_ring_v specialisations (internal-hom):
+ *
+ *   @c is_endomorphism_ring_v<Matrix2x2V<unsigned int>,
+ *                             Vec2V<unsigned int>>
+ *     and @c is_endomorphism_ring_v<Matrix2x2V<Rational<default_integer>>,
+ *                                   Vec2V<Rational<default_integer>>>
+ *     — @c linear_algebra/mat2x2.cppm: 2×2 matrices as the
+ *     endomorphism ring of the rank-2 free module, on both the
+ *     unsigned-integer and ℚ scalar carriers.
+ *
+ * Remaining gap (one architectural lift to unblock):
  *
  *   @c is_vector_space_v<V, F> recursive upgrade — the trait fires
  *   automatically once @c IsField<F> holds in addition to
- *   @c IsModule<V, F>; the @c IsField specialisation surface for
- *   @c Rational<I> is the load-bearing gap.
- *
- *   @c is_module_v<Dual<F>, F> for the Dual numbers — the
- *   quotient-algebra propagation in @c algebra:quotient lifts
- *   @c F-action to @c Dual<F>; a static_assert exhibit at
- *   @c analysis/dual.cppm would pin the recursive enrichment for
- *   the AD carrier.
- *
- *   @c is_endomorphism_ring_v<Matrix2x2V<F>, Vec2V<F>> — the
- *   internal-hom witness for the rank-2 free module; opt-in trait
- *   in @c linear_algebra:basis, populated for specific (F, n)
- *   pairs.
+ *   @c IsModule<V, F>.  The strict @c category::IsField on
+ *   @c Rational<I> is currently parked behind the @c IsTotal
+ *   architectural gate (none of the periodic / idempotent /
+ *   saturating paths apply to exact carriers).  Lifting that gate
+ *   with an exact-carrier path is the load-bearing follow-up; once
+ *   it lands, every @c is_module_v witness above whose scalar is a
+ *   field carrier auto-upgrades to @c is_vector_space_v.
  *
  * The recursive enrichment Figure~1 of the paper depicts (ℚ as
- * ℤ-module, 𝔻 as ℝ-module, ℂ as ℝ-module, …) lands one carrier at
- * a time as the corresponding scalar action and trait
- * specialisation are wired.  This inventory is the running
+ * ℤ-module, 𝔻 as ℝ-module, ℂ as ℝ-module, …) is structurally in
+ * place at the @c is_module_v / @c is_free_module_v /
+ * @c is_endomorphism_ring_v tier.  This inventory is the running
  * snapshot.
  */
 


### PR DESCRIPTION
## Summary

**Draft** PR — first slice on NEW-A (trait-registry pilot per #498's epic).  Documentation-only deliverable that records the running inventory of `is_module_v` specialisations across the codebase and flags the gaps identified during the pilot investigation.

The intent is to give §4 (Algebraic Lattice) a stable scaffold to build on when developing the trait-registry compare-and-contrast.

## What's in scope here

A new `@section modules__Trait_Registry_Status` block in `algebra:modules` with:

### Carriers already firing `is_module_v` (with file:line witnesses)
- `is_module_v<Rational<default_integer>, default_integer>` — `numbers/rational.cppm`: ℚ is a ℤ-module via the Frac construction (the localisation $S^{-1}\mathbb{Z}$ at $S = \mathbb{Z}_{\neq 0}$).
- `is_module_v<Complex<Rational<default_integer>>, Rational<default_integer>>` — `numbers/complex.cppm`: ℂ over ℚ via the quotient ring $\mathbb{Q}[i]/(i^2 + 1)$ carrying the canonical componentwise ℚ-action.
- `is_module_v<Vec2V<unsigned int>, unsigned int>` — `linear_algebra/vec2.cppm`: rank-2 free module over the unsigned-integer modular ring.
- `is_module_v<Vec2V<Rational>, Rational>` — `linear_algebra/mat2x2.cppm`: rank-2 vector-space-at-the-module-tier over ℚ.

### Gaps identified for follow-up slices
- **`is_vector_space_v` recursive upgrade**: the trait fires automatically when `IsField<F>` holds in addition to `IsModule<V, F>`.  The `IsField<Rational>` specialisation surface is the load-bearing gap; the recursive enrichment Figure 1 depicts (Complex<T> → vector-space when T is a field) lands once that's wired.
- **`is_module_v<Dual<F>, F>` exhibit**: the quotient-algebra propagation in `algebra:quotient` lifts F-action to `Dual<F>`; a `static_assert` in `analysis/dual.cppm` would pin the recursive enrichment for the AD carrier.
- **`is_endomorphism_ring_v<Matrix2x2V<F>, Vec2V<F>>`**: opt-in trait in `linear_algebra:basis`, populated per `(F, n)` pair.

## Why doc-only

The pilot investigation revealed two issues that require more wiring than the pilot scope permits:

1. **Namespace-ordering bug**: adding a new `is_module_v<Rational, Z>` `static_assert` *before* the species-trait specialisations in `rational.cppm` caches a `false` result for the trait template instantiation.  The existing post-specialisation `static_assert` at line 493 then also fails (presumably because the compiler's instantiation cache reuses the false result).  Working around this requires either reorganising the namespace blocks or moving the witness to a downstream consumer.
2. **`is_vector_space_v<Complex<Rational>, Rational>` upgrade**: doesn't auto-fire because `IsField<Rational>` requires more wiring (the strict categorical field witness for `Rational` hasn't been registered).  This is the recursive upgrade NEW-A specifically asks for; a focused next-slice PR would land both the `IsField<Rational>` registration and the `is_vector_space_v` exhibit.

Both are substantive follow-ups, not pilot-scope.  Filing this PR as draft so the inventory is visible while the gaps get addressed in subsequent slices.

## Test plan
- [ ] CI green: `dedekind_algebra` compiles clean (doc-comment only)
- [ ] Existing `is_module_v` `static_assert`s at the four witness sites continue to fire
- [ ] No new bib citations or label references introduced

## Sequencing
- This PR: pilot inventory (doc-only).
- Next slice: `IsField<Rational>` + `is_vector_space_v<Complex<ℚ>, ℚ>` exhibit.
- Subsequent: `is_module_v<Dual<F>, F>` exhibit; `is_endomorphism_ring_v` per-(F, n) populations.

References #498.

🤖 Generated with [Claude Code](https://claude.com/claude-code)