### PR TITLE
cleanup(numbers): #379 retire the *Like cluster from numbers:integer

### DIFF
--- a/src/main/modules/dedekind/algebra/field.cppm
+++ b/src/main/modules/dedekind/algebra/field.cppm
@@ -233,7 +233,7 @@ static_assert(
 export template <typename T, typename Add = std::plus<T>,
                  typename Mult = std::multiplies<T>>
 concept IsAlgebraicallyClosed =
-    IsField<T, Add, Mult> && true;  // Refined by its use in Algebra_ℂ
+    IsField<T, Add, Mult> && true;
 
 static_assert(!IsField<int>, "Structural Integrity: Integers are not a Field.");
 

--- a/src/main/modules/dedekind/algebra/field.cppm
+++ b/src/main/modules/dedekind/algebra/field.cppm
@@ -232,8 +232,7 @@ static_assert(
  */
 export template <typename T, typename Add = std::plus<T>,
                  typename Mult = std::multiplies<T>>
-concept IsAlgebraicallyClosed =
-    IsField<T, Add, Mult> && true;
+concept IsAlgebraicallyClosed = IsField<T, Add, Mult> && true;
 
 static_assert(!IsField<int>, "Structural Integrity: Integers are not a Field.");
 

--- a/src/main/modules/dedekind/numbers/integer.cppm
+++ b/src/main/modules/dedekind/numbers/integer.cppm
@@ -164,57 +164,6 @@ export using extensional_integer = int;
  */
 export using default_integer = SignedExtensionalCardinal<>;
 
-// FIXME(#379): the *Like cluster below is a candidate for the
-// retire-Like surgery phase that follows the alignment sweep.
-//   - `IsRationalLike` checks only operator closure (+, -, *, /); it is
-//     structurally identical to `algebra::HasFieldOperators` (shipped in
-//     #394) modulo the absence of the `T{1}` clause.  Retarget call
-//     sites to `HasFieldOperators` and remove this concept.
-//   - `IsFieldLike = IsRationalLike` is a tautological alias with no
-//     additional content; remove and retarget to the same replacement.
-//   - `IsReal = IsRealLike || IsRationalLike` is a disjunction whose
-//     two arms are semantically distinct (floating-point arithmetic vs
-//     exact-rational arithmetic).  The union "is approximately real"
-//     reading is loose; tighten to a single explicit concept or split
-//     into two.
-//   - `IsContinuous` and `IsDiscrete` partition `std::regular` types by
-//     `std::integral` --- a syntactic split that says nothing about
-//     mathematical density / discreteness.  Reconsider as part of the
-//     retire-Like sweep.
-export template <typename T>
-concept IsRationalLike = std::regular<T> && requires(T a, T b) {
-  { a + b } -> std::same_as<T>;
-  { a * b } -> std::same_as<T>;
-  { a / b } -> std::same_as<T>;
-  { a - b } -> std::same_as<T>;
-};
-
-export template <typename T>
-concept IsFieldLike = IsRationalLike<T>;
-
-export template <typename Q, typename Z>
-concept IsRational = IsFieldLike<Q> && IsInteger<Z> && requires(Q q) {
-  { q } -> std::same_as<Q>;
-};
-
-export template <typename T>
-concept IsRealLike = std::floating_point<T> && IsReflectiveSpecies<T>;
-
-export template <typename T>
-concept IsReal = IsRealLike<T> || IsRationalLike<T>;
-
-export template <typename S>
-concept IsContinuous = std::regular<S> && !std::integral<S>;
-
-export template <typename S>
-concept IsDiscrete = std::regular<S> && std::integral<S>;
-
-export template <typename C, typename R>
-concept IsComplex = requires(C z) {
-  { z.real() } -> std::same_as<R>;
-  { z.imag() } -> std::same_as<R>;
-};
-
 /**
  * @concept Group_ℤ
  * @brief ℤ as the abelian group of integers under addition.
@@ -236,73 +185,6 @@ concept IsComplex = requires(C z) {
 export template <typename T>
 concept Group_ℤ =
     IsInteger<T> && dedekind::category::IsAbelianGroup<T, std::plus<T>>;
-
-/**
- * @concept Field_ℚ
- * @brief ℚ as the field of rationals.
- *
- * @details A carrier @c Q satisfies @c Field_ℚ iff it is @c IsRational over
- * some integer domain @c Z *and* @c (Q, +, *) carries the operational
- * field-like witness. Writing `template <Field_ℚ Q>` in a generic function
- * asserts both the rational-structure shape and the field arithmetic
- * without naming a concrete @c Rational<Z>.
- *
- * @note FIXME(#379): the field-side requirement is expressed via
- * @c dedekind::algebra::HasFieldOperators (an operational shape), not
- * via the strict @c dedekind::category::IsField that shipped in #375
- * (closed 2026-04-24).  Two distinct blocks compose into the actual
- * current blocker:
- *
- * 1. @b IsTotal @b gate.  The strict ring/field ladder requires
- *    @c IsMagma, which requires @c IsTotal<T, Op> @c = @c IsPeriodic
- *    @c || @c IsIdempotent @c || @c IsSaturating (per
- *    @c category:species).  Exact carriers like @c Rational<...> /
- *    @c ExactReal<> are none of those (no wrap, no idempotence, no
- *    saturation), so the strict ladder is architecturally blocked at
- *    the totality step regardless of invertibility traits.  Lifting
- *    this would require a new @c IsTotal certification path for
- *    exact carriers (e.g.\ "infinite-domain-total" or "exact").
- * 2. @b Species-trait specialisations.  Even with @c IsTotal lifted,
- *    the @c is_invertible_v<Rational<...>, std::multiplies> /
- *    @c inverse_trait specialisations would still be missing on the
- *    exact carriers under the active numeric policy.
- *
- * Until both blocks lift, carriers that pass @c Field_ℚ are
- * guaranteed the @b arithmetic of a field via @c HasFieldOperators
- * but not every law mechanically.
- */
-export template <typename Q, typename Z = int>
-concept Field_ℚ = IsRational<Q, Z> && dedekind::algebra::HasFieldOperators<Q>;
-
-/**
- * @concept Continuum_ℝ
- * @brief ℝ as a continuum-valued field carrier.
- *
- * @details Bundles the structural @c IsReal witness with @c IsContinuous and
- * the operational field-like arithmetic discipline.
- *
- * @see FIXME(#379): same retargeting story as @ref Field_ℚ ---
- * @c category::IsField exists (#375), but BOTH the @c IsTotal gate
- * (which currently admits only periodic/idempotent/saturating ops,
- * blocking exact carriers like @c ExactReal<>) AND the species-trait
- * specialisations would need lifting.
- */
-export template <typename T>
-concept Continuum_ℝ =
-    IsReal<T> && IsContinuous<T> && dedekind::algebra::HasFieldOperators<T>;
-
-/**
- * @concept Algebra_ℂ
- * @brief ℂ as an algebra over an underlying real-like field @c R.
- *
- * @see FIXME(#379): same retargeting story as @ref Field_ℚ ---
- * @c category::IsField exists (#375), but BOTH the @c IsTotal gate
- * (which currently admits only periodic/idempotent/saturating ops,
- * blocking exact carriers like @c Complex<ExactReal<>>) AND the
- * species-trait specialisations would need lifting.
- */
-export template <typename C, typename R>
-concept Algebra_ℂ = IsComplex<C, R> && dedekind::algebra::HasFieldOperators<C>;
 
 /** @section integer__Canonical_Species_Spine (ℤ)
  *

--- a/src/main/modules/dedekind/numbers/natural.cppm
+++ b/src/main/modules/dedekind/numbers/natural.cppm
@@ -17,13 +17,14 @@
  * We "Bless" the coordinate species by verifying their rungs on the ladder:
  * - IsNatural  : N (ℕ) - The Discrete Monoid.
  * - IsInteger  : Z (ℤ) - The Euclidean Group.
- * - IsRational : Q (ℚ) - The Countable Dense Field.
- * - IsReal     : R (ℝ) - The Continuous Dedekind-Complete Field.
+ * - Rational<I> : Q (ℚ) - The Countable Dense Field.
+ * - Real<I> / IEEE<F> : R (ℝ) - Exact and floating-point realisations.
  *
  * @section natural__Structural_Mapping
- * This is where we perform the final 'Lifting'. We prove that 'int'
- * satisfies 'Group_ℤ' and that 'double' is a hardware-constrained
- * approximation of 'Field_ℝ'.
+ * This is where we perform the final 'Lifting'. We prove that
+ * @c SignedExtensionalCardinal<> satisfies @c Group_ℤ (per the strict
+ * @c IsCommutativeRing witness pinned in @c integer.cppm) and that
+ * @c double is a hardware-constrained approximation of an exact field.
  *
  * @anchors C++ Fundamental Types: bool, char, int, long, float, double.
  *

--- a/src/main/modules/dedekind/numbers/rational.cppm
+++ b/src/main/modules/dedekind/numbers/rational.cppm
@@ -1042,8 +1042,9 @@ static_assert(
 // is_commutative_v) being lifted onto Rational<I> via the IsTotal
 // gate, and on a new IsTotal certification path for exact carriers
 // (none of periodic/idempotent/saturating apply).  Until that lifts,
-// the operator-shape witness HasFieldOperators<Rational<SignedEC<>>>
-// asserted below is the load-bearing guarantee.
+// the operator-shape witness
+// HasFieldOperators<Rational<SignedExtensionalCardinal<>>> asserted
+// below is the load-bearing guarantee.
 
 // ℚ-deal (#394, surface only): HasFieldOperators is the literal field-
 // operator surface (+, -, unary -, *, /, T{1}).  Rational<I>'s friend

--- a/src/main/modules/dedekind/numbers/rational.cppm
+++ b/src/main/modules/dedekind/numbers/rational.cppm
@@ -533,8 +533,7 @@ using ℚ_t = Rational<I>;
  *     registrations would still be missing on @c Rational under the
  *     active numeric policy.
  *
- *  See the @c FIXME(\#379) breadcrumb at the Field_ℚ definition in
- *  @c :integer.  Until both blocks lift, the operational
+ *  Until both blocks lift, the operational
  *  @c algebra::HasFieldOperators<Rational<default_integer>> is the
  *  load-bearing field-arithmetic guarantee.
  */
@@ -1037,24 +1036,21 @@ static_assert(
 // ℚ as the field of rationals: the canonical arbitrary-precision rational
 // carrier that the paper-facing showcases instantiate on.
 //
-// FIXME(#374): Field_ℚ does not yet certify on this carrier.  The
-// concept-vocabulary alignment of #374 has landed (the canonical
-// HasFieldOperators in algebra:field is the operator-shape predicate;
-// the strict IsField in category:total is the axiomatic one), but
-// Field_ℚ's body still transitively depends on the trait specialisations
-// (identity_v / is_associative_v / is_commutative_v) being lifted onto
-// Rational<I> via the IsTotal gate.  The remaining repair is the trait
-// auto-lifter (axiom hooks); until then the operator-shape witness
-// HasFieldOperators<Rational<SignedEC<>>> asserted below is the
-// load-bearing guarantee.
+// FIXME(#374): the strict category::IsField<Rational<I>, ...> does not
+// yet certify on this carrier.  The body transitively depends on the
+// trait specialisations (identity_v / is_associative_v /
+// is_commutative_v) being lifted onto Rational<I> via the IsTotal
+// gate, and on a new IsTotal certification path for exact carriers
+// (none of periodic/idempotent/saturating apply).  Until that lifts,
+// the operator-shape witness HasFieldOperators<Rational<SignedEC<>>>
+// asserted below is the load-bearing guarantee.
 
 // ℚ-deal (#394, surface only): HasFieldOperators is the literal field-
 // operator surface (+, -, unary -, *, /, T{1}).  Rational<I>'s friend
 // operators and inverse-via-T{1}/x route close strictly on Rational<I>
 // for any operationally-ring-like I; the witness fires regardless of
 // the strict-IsField FIXME above, since it is a syntactic shape claim
-// and not an axiomatic one.  The strict-and-literal seal (analogous to
-// IsArithmeticAdditiveGroup on ℤ) lands when the FIXME above closes.
+// and not an axiomatic one.
 static_assert(dedekind::algebra::HasFieldOperators<Rational<default_integer>>,
               "Rational<default_integer> has the literal field-operator "
               "surface: +, -, unary -, *, / all close on Rational, and "

--- a/src/main/modules/dedekind/numbers/real.cppm
+++ b/src/main/modules/dedekind/numbers/real.cppm
@@ -510,8 +510,8 @@ static_assert(dedekind::algebra::HasFieldOperators<ExactReal<>>,
  *     architectural @c IsTotal gate (currently periodic/idempotent/
  *     saturating only --- exact carriers are none of those) and the
  *     species-trait specialisations on @c Rational / @c ExactReal
- *     under the active numeric policy.  See the @c FIXME(\#379) at
- *     the @c Field_ℚ definition in @c :integer for the full chain.
+ *     under the active numeric policy (FIXME \#379, full chain in
+ *     the @c IsField block of @c rational.cppm).
  * (4) Primitive-type arrow: ℝ ↔ @c double is the open #398 work
  *     (explicit @c embed_double / @c realize_to_double morphisms).
  *     The current trivial direction is @c Real<double>{x} for the

--- a/src/main/modules/dedekind/numbers/real.cppm
+++ b/src/main/modules/dedekind/numbers/real.cppm
@@ -510,8 +510,9 @@ static_assert(dedekind::algebra::HasFieldOperators<ExactReal<>>,
  *     architectural @c IsTotal gate (currently periodic/idempotent/
  *     saturating only --- exact carriers are none of those) and the
  *     species-trait specialisations on @c Rational / @c ExactReal
- *     under the active numeric policy (FIXME \#379, full chain in
- *     the @c IsField block of @c rational.cppm).
+ *     under the active numeric policy (full chain in the @c IsField
+ *     block of @c rational.cppm; the architectural blocker is the
+ *     @c IsTotal exact-path lift, not @c #379).
  * (4) Primitive-type arrow: ℝ ↔ @c double is the open #398 work
  *     (explicit @c embed_double / @c realize_to_double morphisms).
  *     The current trivial direction is @c Real<double>{x} for the


### PR DESCRIPTION
**Draft** PR — dead-code trim of the *Like cluster in `numbers:integer`, flagged for removal under FIXME(#379) since the alignment sweep.  The cluster's concepts are either tautological aliases, syntactically wrong (*Continuous / *Discrete partition `std::regular` by `std::integral` which says nothing about mathematical density), or duplicates of canonical concepts shipped elsewhere.

## Removed
- `IsRationalLike` — duplicate of `algebra::HasFieldOperators` modulo the `T{1}` clause.
- `IsFieldLike` — tautological alias of `IsRationalLike`.
- `IsRational<Q, Z>` — vacuous wrapper around `IsFieldLike` + `IsInteger`.
- `IsRealLike` — used only by `IsReal`.
- `IsReal` — loose disjunction "is approximately real" with no structural content.
- `IsContinuous` / `IsDiscrete` — syntactic split by `std::integral`, not mathematically meaningful (the `order:completeness` `IsDiscrete` is a separate, private, locally-scoped concept and stays).
- `IsComplex<C, R>` — used only by `Algebra_ℂ`.
- `Field_ℚ` — vacuous; `HasFieldOperators<Rational<I>>` is the load-bearing witness, as documented in `rational.cppm`.
- `Continuum_ℝ` — no callsites; bundled `IsReal` + `IsContinuous` + `HasFieldOperators` which are themselves dead/tautological.
- `Algebra_ℂ` — one comment-only reference in `field.cppm`; bundle of `IsComplex` + `HasFieldOperators`.

## Kept
- `IsInteger` — structural concept; wide use.
- `Group_ℤ` — active use in `sint_test.cpp` + `rational.cppm` `static_assert`s.
- The original FIXME(#379) doc-comment block has been removed (it called for this cleanup; mission accomplished).

## Dangling-reference cleanup
- `natural.cppm:17-26` — removed bullets for `IsRational` / `IsReal` / `Field_ℝ` in the species-ladder docstring; updated to name the surviving `Group_ℤ` witness.
- `rational.cppm:1040-1049` — replaced FIXME(#374) comment block referencing `Field_ℚ` with a tighter one referencing the strict `category::IsField` gate directly.
- `real.cppm:514` — dropped reference to "Field_ℚ definition in :integer".
- `field.cppm:236` — dropped "Refined by its use in `Algebra_ℂ`" comment.

## Test plan
- [ ] CI green: all libraries link clean (verified locally — `libdedekind_category`, `libdedekind_ieee`, `libdedekind_sets`, `libdedekind_order`, `libdedekind_topology`, `libdedekind_sequences`, `libdedekind_algebra`, `libdedekind_morphologies`, `libdedekind_geometry`, `libdedekind_numbers`).
- [ ] `test_numbers` and the broader test suite pass (verified locally on the pre-rebase WIP commit).
- [ ] Doc cross-references updated (no remaining `IsRational` / `IsReal` / `Field_ℚ` / `Algebra_ℂ` strings in `src/`).

Closes #379.

🤖 Generated with [Claude Code](https://claude.com/claude-code)