### PR TITLE
feat(category): #572 generic Set ↪ Cat exhibit — discrete_lift_t<S> for any IsSet-witnessing carrier

### DIFF
--- a/src/main/modules/dedekind/category/etcs.cppm
+++ b/src/main/modules/dedekind/category/etcs.cppm
@@ -48,8 +48,13 @@ module;
 
 export module dedekind.category:etcs;
 
+import :adjunction;  // HasAdjunctionShape / IsAdjunction — the bona fide
+                     // adjunction machinery used to witness Disc ⊣ U at the
+                     // type level (#572 review).
 import :cartesian;
-import :discrete;  // DiscreteCategory<T> — target of the Set ↪ Cat lift (#572)
+import :discrete;    // DiscreteCategory<T> — target of the Set ↪ Cat lift (#572)
+import :functor;     // identity_functor — the structural-shape witness for
+                     // the discrete-restriction Disc ⊣ U adjunction (#572).
 import :limit;
 import :logic;
 import :morphism;
@@ -416,8 +421,7 @@ static_assert(
  * @brief The canonical Set ↪ Cat lift for any IsSet-witnessing carrier.
  *
  * @details For every @c IsSet<S>, the lift @c S @c → @c Disc(S) sits in
- * @c Cat as a discrete category --- the textbook Disc ⊣ U adjunction
- * realised at the type level.  The lift uses @c S itself (not its
+ * @c Cat as a discrete category.  The lift uses @c S itself (not its
  * ambient species) as the carrier of the discrete category, so distinct
  * @c IsSet types over the same ambient remain distinct after lifting:
  * a refined subset and an unrefined ambient are different sets and
@@ -430,12 +434,35 @@ static_assert(
  * Companion to:
  *   - The Set_to_Cat_Embedding doc-section in @c :discrete.
  *   - The @c IsSet aggregator above (the source side of the lift).
+ *   - @c HasAdjunctionShape / @c IsAdjunction in @c :adjunction (the
+ *     bona fide adjunction machinery, instantiated for this lift below).
  *
- * The construction is the left adjoint to the underlying-objects
- * functor @c U @c : @c Cat @c → @c Set; under @c Disc @c ⊣ @c U the
- * @c IsSet-witnessing carriers of the project's set DSL each lift to
- * a discrete category whose objects are the set's elements and whose
- * arrows are identities.
+ * @section etcs__Disc_dashv_U_adjunction
+ *
+ * In the textbook @c Disc @c : @c Set @c → @c Cat is the left adjoint
+ * of the underlying-objects functor @c U @c : @c Cat @c → @c Set.  The
+ * adjunction @c Disc @c ⊣ @c U lives between the @b meta-categories
+ * @c Set and @c Cat.  This codebase encodes categories per-ambient
+ * (one @c Species per @c IsCategory type), so the @b meta-categorical
+ * statement is one level above what the type system can express
+ * directly --- there is no @c category_of_sets or @c
+ * category_of_categories type whose @c Species ranges over all sets
+ * or all categories.  What @b is type-level expressible is the @b
+ * restriction of the adjunction to a single discrete carrier: on
+ * @c Disc(S) every functor that respects the discrete shape is the
+ * identity on objects and arrows, so @c Disc and @c U restricted to
+ * @c Disc(S) collapse to the trivial self-adjunction
+ *
+ *   @c Id_{Disc(S)} @c ⊣ @c Id_{Disc(S)}
+ *
+ * with identity unit / counit naturals.  The witnesses below
+ * mechanically exhibit this restriction using the bona fide
+ * @c HasAdjunctionShape / @c IsAdjunction concepts from
+ * @c :adjunction --- the same surfaces that gate the trivial
+ * self-adjunction exhibit in @c functor_test.cpp:138.  The full
+ * meta-categorical @c Disc @c ⊣ @c U is left as future work (it
+ * needs @c category_of_sets / @c category_of_categories types that
+ * the project does not yet model).
  *
  * Filed and addressed under #572.
  */
@@ -456,5 +483,59 @@ static_assert(std::same_as<discrete_lift_t<_isset_witness_t>,
               "Set ↪ Cat lift: discrete_lift_t<S> resolves to "
               "DiscreteCategory<S>; subobject information in S is "
               "preserved by lifting S itself rather than S::Ambient.");
+
+/**
+ * @brief Structural-shape witness type for the @c Disc @c ⊣ @c U
+ *        adjunction, restricted to the discrete carrier @c Disc(S).
+ *
+ * @details A functor type with @c Σ_cat @c = @c Τ_cat @c = @c Disc(S);
+ * it is the @c identity_functor on @c Disc(S), pinned under a name
+ * that documents its role as the discrete-restriction representative
+ * of the textbook @c Disc.  Aliased rather than wrapped so the
+ * existing @c IsAdjunction proof in @c functor_test.cpp:138 (the
+ * trivial self-adjunction) generalises mechanically.
+ */
+export template <typename S>
+  requires IsSet<S>
+using disc_self_endofunctor_t = identity_functor<discrete_lift_t<S>>;
+
+/**
+ * @brief Identity unit / counit natural transformation for the
+ *        discrete-restriction @c Disc @c ⊣ @c U self-adjunction.
+ */
+export template <typename S>
+  requires IsSet<S>
+using disc_self_unit_t = identity_transformation<disc_self_endofunctor_t<S>>;
+
+// Bona fide adjunction-machinery witnesses on the representative
+// IsSet carrier.  These are the type-level mechanical realisation of
+// the prose claim above --- every IsSet S has a @c Disc(S) that
+// participates in the @c HasAdjunctionShape / @c IsAdjunction surface
+// from @c :adjunction.  The trivial-self-adjunction shape is the most
+// the type system can certify here; the full meta-categorical
+// @c Disc @c ⊣ @c U is acknowledged as future work in the doc block.
+static_assert(
+    IsFunctor<disc_self_endofunctor_t<_isset_witness_t>>,
+    "Set ↪ Cat lift: the discrete-restriction Disc-functor is a bona "
+    "fide functor on Disc(S).");
+static_assert(
+    HasAdjunctionShape<disc_self_endofunctor_t<_isset_witness_t>,
+                       disc_self_endofunctor_t<_isset_witness_t>>,
+    "Set ↪ Cat lift: the discrete-restriction Disc and U satisfy the "
+    "structural shape of an adjunction (Σ_cat / Τ_cat cross-pair).");
+static_assert(
+    IsNaturalTransformation<disc_self_unit_t<_isset_witness_t>,
+                            disc_self_endofunctor_t<_isset_witness_t>,
+                            disc_self_endofunctor_t<_isset_witness_t>>,
+    "Set ↪ Cat lift: the identity unit/counit is a bona fide natural "
+    "transformation between the discrete-restriction functors.");
+static_assert(
+    IsAdjunction<disc_self_endofunctor_t<_isset_witness_t>,
+                 disc_self_endofunctor_t<_isset_witness_t>,
+                 disc_self_unit_t<_isset_witness_t>,
+                 disc_self_unit_t<_isset_witness_t>>,
+    "Set ↪ Cat lift: discrete_lift_t<S> participates in the bona fide "
+    "IsAdjunction surface --- the discrete-restriction encoding of the "
+    "textbook Disc ⊣ U adjunction.");
 
 }  // namespace dedekind::category

--- a/src/main/modules/dedekind/category/etcs.cppm
+++ b/src/main/modules/dedekind/category/etcs.cppm
@@ -49,6 +49,7 @@ module;
 export module dedekind.category:etcs;
 
 import :cartesian;
+import :discrete;  // DiscreteCategory<T> — target of the Set ↪ Cat lift (#572)
 import :limit;
 import :logic;
 import :morphism;
@@ -410,5 +411,47 @@ static_assert(!IsSet<_isset_witness_t> ||
 static_assert(
     IsSetInCanonicalCCC<_isset_witness_t>,
     "Mnemonic check: ETCS set objects live over a canonical CCC ambient.");
+
+/**
+ * @brief The canonical Set ↪ Cat lift for any IsSet-witnessing carrier.
+ *
+ * @details For every @c IsSet<S>, the canonical embedding
+ * @c S @c → @c Disc(S) sits in @c Cat as a discrete category --- the
+ * textbook Disc ⊣ U adjunction realised mechanically.  The lift takes
+ * the set's ambient species (@c S::Ambient) and wraps it in
+ * @c DiscreteCategory<>.  Per @c :discrete, the resulting type
+ * satisfies @c IsDiscreteCategory and @c IsCategory, witnessed by the
+ * static_asserts at the @c DiscreteCategory definition site.
+ *
+ * Companion to:
+ *   - The Set_to_Cat_Embedding doc-section in @c :discrete.
+ *   - The @c IsSet aggregator above (the source side of the lift).
+ *
+ * The construction is the left adjoint to the underlying-objects
+ * functor @c U @c : @c Cat @c → @c Set; under @c Disc @c ⊣ @c U the
+ * @c IsSet-witnessing carriers of the project's set DSL each lift to
+ * a discrete category whose objects are the set's elements and whose
+ * arrows are identities.
+ *
+ * Filed and addressed under #572.
+ */
+export template <typename S>
+  requires IsSet<S>
+using discrete_lift_t = DiscreteCategory<typename S::Ambient>;
+
+// Witness that the lift produces a discrete category for the
+// representative @c IsSet-witnessing carrier from above.
+static_assert(IsDiscreteCategory<discrete_lift_t<_isset_witness_t>>,
+              "Set ↪ Cat lift: discrete_lift_t<S> is a DiscreteCategory "
+              "for every IsSet-witnessing S.");
+static_assert(
+    IsCategory<discrete_lift_t<_isset_witness_t>>,
+    "Set ↪ Cat lift: discrete_lift_t<S> satisfies the general Category "
+    "contract (subsumed by IsDiscreteCategory above; pinned for clarity).");
+static_assert(
+    std::same_as<discrete_lift_t<_isset_witness_t>,
+                 DiscreteCategory<typename _isset_witness_t::Ambient>>,
+    "Set ↪ Cat lift: discrete_lift_t<S> resolves structurally to "
+    "DiscreteCategory<S::Ambient>.");
 
 }  // namespace dedekind::category

--- a/src/main/modules/dedekind/category/etcs.cppm
+++ b/src/main/modules/dedekind/category/etcs.cppm
@@ -436,6 +436,10 @@ static_assert(
  *   - The @c IsSet aggregator above (the source side of the lift).
  *   - @c HasAdjunctionShape / @c IsAdjunction in @c :adjunction (the
  *     bona fide adjunction machinery, instantiated for this lift below).
+ *   - @c disc_self_endofunctor_t / @c disc_self_unit_t in @c :natural
+ *     (the named entities reifying the textbook @c Disc / @c U / @c η /
+ *     @c ε under the discrete restriction; consumed by the static_asserts
+ *     below).
  *
  * @section etcs__Disc_dashv_U_adjunction
  *
@@ -484,54 +488,37 @@ static_assert(std::same_as<discrete_lift_t<_isset_witness_t>,
               "DiscreteCategory<S>; subobject information in S is "
               "preserved by lifting S itself rather than S::Ambient.");
 
-/**
- * @brief Structural-shape witness type for the @c Disc @c ⊣ @c U
- *        adjunction, restricted to the discrete carrier @c Disc(S).
- *
- * @details A functor type with @c Σ_cat @c = @c Τ_cat @c = @c Disc(S);
- * it is the @c identity_functor on @c Disc(S), pinned under a name
- * that documents its role as the discrete-restriction representative
- * of the textbook @c Disc.  Aliased rather than wrapped so the
- * existing @c IsAdjunction proof in @c functor_test.cpp:138 (the
- * trivial self-adjunction) generalises mechanically.
- */
-export template <typename S>
-  requires IsSet<S>
-using disc_self_endofunctor_t = identity_functor<discrete_lift_t<S>>;
-
-/**
- * @brief Identity unit / counit natural transformation for the
- *        discrete-restriction @c Disc @c ⊣ @c U self-adjunction.
- */
-export template <typename S>
-  requires IsSet<S>
-using disc_self_unit_t = identity_transformation<disc_self_endofunctor_t<S>>;
-
 // Bona fide adjunction-machinery witnesses on the representative
 // IsSet carrier.  These are the type-level mechanical realisation of
 // the prose claim above --- every IsSet S has a @c Disc(S) that
 // participates in the @c HasAdjunctionShape / @c IsAdjunction surface
-// from @c :adjunction.  The trivial-self-adjunction shape is the most
-// the type system can certify here; the full meta-categorical
+// from @c :adjunction, anchored on the @c disc_self_endofunctor_t /
+// @c disc_self_unit_t named entities reified in @c :natural (#583
+// review).  The trivial-self-adjunction shape is the most the type
+// system can certify here; the full meta-categorical
 // @c Disc @c ⊣ @c U is acknowledged as future work in the doc block.
-static_assert(IsFunctor<disc_self_endofunctor_t<_isset_witness_t>>,
-              "Set ↪ Cat lift: the discrete-restriction Disc-functor is a bona "
-              "fide functor on Disc(S).");
-static_assert(HasAdjunctionShape<disc_self_endofunctor_t<_isset_witness_t>,
-                                 disc_self_endofunctor_t<_isset_witness_t>>,
-              "Set ↪ Cat lift: the discrete-restriction Disc and U satisfy the "
-              "structural shape of an adjunction (Σ_cat / Τ_cat cross-pair).");
 static_assert(
-    IsNaturalTransformation<disc_self_unit_t<_isset_witness_t>,
-                            disc_self_endofunctor_t<_isset_witness_t>,
-                            disc_self_endofunctor_t<_isset_witness_t>>,
+    IsFunctor<disc_self_endofunctor_t<discrete_lift_t<_isset_witness_t>>>,
+    "Set ↪ Cat lift: the discrete-restriction Disc-functor is a bona "
+    "fide functor on Disc(S).");
+static_assert(
+    HasAdjunctionShape<
+        disc_self_endofunctor_t<discrete_lift_t<_isset_witness_t>>,
+        disc_self_endofunctor_t<discrete_lift_t<_isset_witness_t>>>,
+    "Set ↪ Cat lift: the discrete-restriction Disc and U satisfy the "
+    "structural shape of an adjunction (Σ_cat / Τ_cat cross-pair).");
+static_assert(
+    IsNaturalTransformation<
+        disc_self_unit_t<discrete_lift_t<_isset_witness_t>>,
+        disc_self_endofunctor_t<discrete_lift_t<_isset_witness_t>>,
+        disc_self_endofunctor_t<discrete_lift_t<_isset_witness_t>>>,
     "Set ↪ Cat lift: the identity unit/counit is a bona fide natural "
     "transformation between the discrete-restriction functors.");
 static_assert(
-    IsAdjunction<disc_self_endofunctor_t<_isset_witness_t>,
-                 disc_self_endofunctor_t<_isset_witness_t>,
-                 disc_self_unit_t<_isset_witness_t>,
-                 disc_self_unit_t<_isset_witness_t>>,
+    IsAdjunction<disc_self_endofunctor_t<discrete_lift_t<_isset_witness_t>>,
+                 disc_self_endofunctor_t<discrete_lift_t<_isset_witness_t>>,
+                 disc_self_unit_t<discrete_lift_t<_isset_witness_t>>,
+                 disc_self_unit_t<discrete_lift_t<_isset_witness_t>>>,
     "Set ↪ Cat lift: discrete_lift_t<S> participates in the bona fide "
     "IsAdjunction surface --- the discrete-restriction encoding of the "
     "textbook Disc ⊣ U adjunction.");

--- a/src/main/modules/dedekind/category/etcs.cppm
+++ b/src/main/modules/dedekind/category/etcs.cppm
@@ -52,9 +52,9 @@ import :adjunction;  // HasAdjunctionShape / IsAdjunction — the bona fide
                      // adjunction machinery used to witness Disc ⊣ U at the
                      // type level (#572 review).
 import :cartesian;
-import :discrete;    // DiscreteCategory<T> — target of the Set ↪ Cat lift (#572)
-import :functor;     // identity_functor — the structural-shape witness for
-                     // the discrete-restriction Disc ⊣ U adjunction (#572).
+import :discrete;  // DiscreteCategory<T> — target of the Set ↪ Cat lift (#572)
+import :functor;   // identity_functor — the structural-shape witness for
+                   // the discrete-restriction Disc ⊣ U adjunction (#572).
 import :limit;
 import :logic;
 import :morphism;
@@ -514,15 +514,13 @@ using disc_self_unit_t = identity_transformation<disc_self_endofunctor_t<S>>;
 // from @c :adjunction.  The trivial-self-adjunction shape is the most
 // the type system can certify here; the full meta-categorical
 // @c Disc @c ⊣ @c U is acknowledged as future work in the doc block.
-static_assert(
-    IsFunctor<disc_self_endofunctor_t<_isset_witness_t>>,
-    "Set ↪ Cat lift: the discrete-restriction Disc-functor is a bona "
-    "fide functor on Disc(S).");
-static_assert(
-    HasAdjunctionShape<disc_self_endofunctor_t<_isset_witness_t>,
-                       disc_self_endofunctor_t<_isset_witness_t>>,
-    "Set ↪ Cat lift: the discrete-restriction Disc and U satisfy the "
-    "structural shape of an adjunction (Σ_cat / Τ_cat cross-pair).");
+static_assert(IsFunctor<disc_self_endofunctor_t<_isset_witness_t>>,
+              "Set ↪ Cat lift: the discrete-restriction Disc-functor is a bona "
+              "fide functor on Disc(S).");
+static_assert(HasAdjunctionShape<disc_self_endofunctor_t<_isset_witness_t>,
+                                 disc_self_endofunctor_t<_isset_witness_t>>,
+              "Set ↪ Cat lift: the discrete-restriction Disc and U satisfy the "
+              "structural shape of an adjunction (Σ_cat / Τ_cat cross-pair).");
 static_assert(
     IsNaturalTransformation<disc_self_unit_t<_isset_witness_t>,
                             disc_self_endofunctor_t<_isset_witness_t>,

--- a/src/main/modules/dedekind/category/etcs.cppm
+++ b/src/main/modules/dedekind/category/etcs.cppm
@@ -466,9 +466,9 @@ static_assert(
  * self-adjunction exhibit in @c functor_test.cpp:138.  The full
  * meta-categorical @c Disc @c ⊣ @c U is left as future work (it
  * needs @c category_of_sets / @c category_of_categories types that
- * the project does not yet model).
+ * the project does not yet model); tracked under #587.
  *
- * Filed and addressed under #572.
+ * Discrete-restriction lift filed and addressed under #572.
  */
 export template <typename S>
   requires IsSet<S>

--- a/src/main/modules/dedekind/category/etcs.cppm
+++ b/src/main/modules/dedekind/category/etcs.cppm
@@ -501,19 +501,17 @@ static_assert(
     IsFunctor<disc_self_endofunctor_t<discrete_lift_t<_isset_witness_t>>>,
     "Set ↪ Cat lift: the discrete-restriction Disc-functor is a bona "
     "fide functor on Disc(S).");
-static_assert(
-    HasAdjunctionShape<
-        disc_self_endofunctor_t<discrete_lift_t<_isset_witness_t>>,
-        disc_self_endofunctor_t<discrete_lift_t<_isset_witness_t>>>,
-    "Set ↪ Cat lift: the discrete-restriction Disc and U satisfy the "
-    "structural shape of an adjunction (Σ_cat / Τ_cat cross-pair).");
-static_assert(
-    IsNaturalTransformation<
-        disc_self_unit_t<discrete_lift_t<_isset_witness_t>>,
-        disc_self_endofunctor_t<discrete_lift_t<_isset_witness_t>>,
-        disc_self_endofunctor_t<discrete_lift_t<_isset_witness_t>>>,
-    "Set ↪ Cat lift: the identity unit/counit is a bona fide natural "
-    "transformation between the discrete-restriction functors.");
+static_assert(HasAdjunctionShape<
+                  disc_self_endofunctor_t<discrete_lift_t<_isset_witness_t>>,
+                  disc_self_endofunctor_t<discrete_lift_t<_isset_witness_t>>>,
+              "Set ↪ Cat lift: the discrete-restriction Disc and U satisfy the "
+              "structural shape of an adjunction (Σ_cat / Τ_cat cross-pair).");
+static_assert(IsNaturalTransformation<
+                  disc_self_unit_t<discrete_lift_t<_isset_witness_t>>,
+                  disc_self_endofunctor_t<discrete_lift_t<_isset_witness_t>>,
+                  disc_self_endofunctor_t<discrete_lift_t<_isset_witness_t>>>,
+              "Set ↪ Cat lift: the identity unit/counit is a bona fide natural "
+              "transformation between the discrete-restriction functors.");
 static_assert(
     IsAdjunction<disc_self_endofunctor_t<discrete_lift_t<_isset_witness_t>>,
                  disc_self_endofunctor_t<discrete_lift_t<_isset_witness_t>>,

--- a/src/main/modules/dedekind/category/etcs.cppm
+++ b/src/main/modules/dedekind/category/etcs.cppm
@@ -415,13 +415,17 @@ static_assert(
 /**
  * @brief The canonical Set ↪ Cat lift for any IsSet-witnessing carrier.
  *
- * @details For every @c IsSet<S>, the canonical embedding
- * @c S @c → @c Disc(S) sits in @c Cat as a discrete category --- the
- * textbook Disc ⊣ U adjunction realised mechanically.  The lift takes
- * the set's ambient species (@c S::Ambient) and wraps it in
- * @c DiscreteCategory<>.  Per @c :discrete, the resulting type
- * satisfies @c IsDiscreteCategory and @c IsCategory, witnessed by the
- * static_asserts at the @c DiscreteCategory definition site.
+ * @details For every @c IsSet<S>, the lift @c S @c → @c Disc(S) sits in
+ * @c Cat as a discrete category --- the textbook Disc ⊣ U adjunction
+ * realised at the type level.  The lift uses @c S itself (not its
+ * ambient species) as the carrier of the discrete category, so distinct
+ * @c IsSet types over the same ambient remain distinct after lifting:
+ * a refined subset and an unrefined ambient are different sets and
+ * therefore different discrete categories.  This mirrors the textbook:
+ * @c Disc(\{0, 1, 2\}) and @c Disc(\mathbb{N}) are not the same
+ * category.  The resulting type follows the @c IsDiscreteCategory
+ * concept definition by construction; the per-instance witnesses
+ * below pin it on the project's representative @c IsSet carrier.
  *
  * Companion to:
  *   - The Set_to_Cat_Embedding doc-section in @c :discrete.
@@ -437,21 +441,20 @@ static_assert(
  */
 export template <typename S>
   requires IsSet<S>
-using discrete_lift_t = DiscreteCategory<typename S::Ambient>;
+using discrete_lift_t = DiscreteCategory<S>;
 
 // Witness that the lift produces a discrete category for the
 // representative @c IsSet-witnessing carrier from above.
+static_assert(IsCategory<discrete_lift_t<_isset_witness_t>>,
+              "Set ↪ Cat lift: discrete_lift_t<S> satisfies the "
+              "general Category contract.");
 static_assert(IsDiscreteCategory<discrete_lift_t<_isset_witness_t>>,
               "Set ↪ Cat lift: discrete_lift_t<S> is a DiscreteCategory "
               "for every IsSet-witnessing S.");
-static_assert(
-    IsCategory<discrete_lift_t<_isset_witness_t>>,
-    "Set ↪ Cat lift: discrete_lift_t<S> satisfies the general Category "
-    "contract (subsumed by IsDiscreteCategory above; pinned for clarity).");
-static_assert(
-    std::same_as<discrete_lift_t<_isset_witness_t>,
-                 DiscreteCategory<typename _isset_witness_t::Ambient>>,
-    "Set ↪ Cat lift: discrete_lift_t<S> resolves structurally to "
-    "DiscreteCategory<S::Ambient>.");
+static_assert(std::same_as<discrete_lift_t<_isset_witness_t>,
+                           DiscreteCategory<_isset_witness_t>>,
+              "Set ↪ Cat lift: discrete_lift_t<S> resolves to "
+              "DiscreteCategory<S>; subobject information in S is "
+              "preserved by lifting S itself rather than S::Ambient.");
 
 }  // namespace dedekind::category

--- a/src/main/modules/dedekind/category/natural.cppm
+++ b/src/main/modules/dedekind/category/natural.cppm
@@ -366,7 +366,9 @@ struct horizontal_composition {
 //
 // The full meta-categorical @c Disc @c ⊣ @c U with cross-category source /
 // target is left as future work; it requires meta-categories of sets and
-// categories that the project does not yet model.  Filed under #572.
+// categories that the project does not yet model.  Tracked under #587.
+// (The discrete-restriction representatives below were filed and addressed
+// under #572.)
 
 /**
  * @brief Discrete-restriction representative of the textbook @c Disc / @c U

--- a/src/main/modules/dedekind/category/natural.cppm
+++ b/src/main/modules/dedekind/category/natural.cppm
@@ -62,6 +62,8 @@ module;
 
 export module dedekind.category:natural;
 
+import :discrete;  // IsDiscreteCategory — constraint on the trivial-self-
+                   // adjunction aliases below (#583 review).
 import :functor;
 import :small;
 import :morphism;
@@ -349,5 +351,51 @@ struct horizontal_composition {
            β(static_cast<typename G::Σ_cat::Arrow::Domain>(c));
   }
 };
+
+// =============================================================================
+// Discrete-restriction representatives of the textbook Disc ⊣ U adjunction.
+// =============================================================================
+//
+// For any @c IsDiscreteCategory @c C, the meta-categorical @c Disc and @c U
+// functors collapse to the identity endofunctor on @c C, and their unit /
+// counit collapse to the identity natural transformation on that endofunctor.
+// The aliases below pin those collapsed entities under their textbook role
+// names so call sites reading @c Disc @c ⊣ @c U as a @b natural-transformation
+// -anchored adjunction can refer to bona fide named types in @c :natural
+// rather than to documentary commentary.
+//
+// The full meta-categorical @c Disc @c ⊣ @c U with cross-category source /
+// target is left as future work; it requires meta-categories of sets and
+// categories that the project does not yet model.  Filed under #572.
+
+/**
+ * @brief Discrete-restriction representative of the textbook @c Disc / @c U
+ *        functor: the identity endofunctor on a discrete category @c C.
+ *
+ * @details In the meta-categorical @c Disc @c ⊣ @c U adjunction, both
+ * @c Disc and @c U restrict to identity-on-objects-and-arrows when their
+ * source / target collapses to a single discrete category @c C.  This
+ * alias pins the identity endofunctor under that textbook role name so
+ * the adjunction-machinery static_asserts can refer to it directly.
+ */
+export template <typename C>
+  requires IsDiscreteCategory<C>
+using disc_self_endofunctor_t = identity_functor<C>;
+
+/**
+ * @brief Discrete-restriction representative of the textbook unit @c η /
+ *        counit @c ε of the @c Disc @c ⊣ @c U adjunction: the identity
+ *        natural transformation on @c disc_self_endofunctor_t<C>.
+ *
+ * @details In the meta-categorical adjunction the unit @c η_S sends each
+ * element of @c S to its embedding in @c U(F(S)); under the discrete
+ * restriction @c F = U = Id and @c η = @c ε is the identity natural
+ * transformation on the identity endofunctor.  Pinned under the
+ * textbook role name so the adjunction machinery sees a bona fide named
+ * type rather than documentary commentary.
+ */
+export template <typename C>
+  requires IsDiscreteCategory<C>
+using disc_self_unit_t = identity_transformation<disc_self_endofunctor_t<C>>;
 
 }  // namespace dedekind::category

--- a/src/test/cpp/modules/dedekind/category/discrete_lift_test.cpp
+++ b/src/test/cpp/modules/dedekind/category/discrete_lift_test.cpp
@@ -1,0 +1,78 @@
+/** @file test/cpp/modules/dedekind/category/discrete_lift_test.cpp
+ *
+ * Short-range test for the @c discrete_lift_t<S> template added in
+ * @c category:etcs (#572).  Exercises the lift on primitive
+ * @c IsSet-witnessing carriers built directly from @c ambient_set<T>;
+ * the long-range test that runs the same lift across the project's
+ * concrete numeric tower lives in @c numbers/discrete_lift_test.cpp.
+ */
+#include <catch2/catch_test_macros.hpp>
+
+import dedekind.category;
+
+using namespace dedekind::category;
+
+TEST_CASE("discrete_lift_t produces a DiscreteCategory for any IsSet carrier",
+          "[category][etcs][discrete][lift]") {
+  // Build several IsSet-witnessing carriers from primitive ambients.
+  const auto int_non_negative =
+      ambient_set<int>([](const int& x) { return x >= 0; });
+  const auto bool_true = ambient_set<bool>([](const bool& x) { return x; });
+  const auto uint_even =
+      ambient_set<unsigned>([](const unsigned& x) { return (x % 2u) == 0u; });
+
+  using IntNonNegSet = decltype(int_non_negative);
+  using BoolTrueSet = decltype(bool_true);
+  using UIntEvenSet = decltype(uint_even);
+
+  // Each carrier is an IsSet (sanity sister-check).
+  STATIC_CHECK(IsSet<IntNonNegSet>);
+  STATIC_CHECK(IsSet<BoolTrueSet>);
+  STATIC_CHECK(IsSet<UIntEvenSet>);
+
+  // The lift fires on each carrier and produces a DiscreteCategory.
+  STATIC_CHECK(IsDiscreteCategory<discrete_lift_t<IntNonNegSet>>);
+  STATIC_CHECK(IsDiscreteCategory<discrete_lift_t<BoolTrueSet>>);
+  STATIC_CHECK(IsDiscreteCategory<discrete_lift_t<UIntEvenSet>>);
+
+  // IsDiscreteCategory subsumes IsCategory; pin it for clarity.
+  STATIC_CHECK(IsCategory<discrete_lift_t<IntNonNegSet>>);
+  STATIC_CHECK(IsCategory<discrete_lift_t<BoolTrueSet>>);
+  STATIC_CHECK(IsCategory<discrete_lift_t<UIntEvenSet>>);
+
+  // The lift uses S itself, not S::Ambient — the static-type witness.
+  STATIC_CHECK(
+      std::same_as<discrete_lift_t<IntNonNegSet>, DiscreteCategory<IntNonNegSet>>);
+}
+
+TEST_CASE("discrete_lift_t preserves subobject identity (Disc(S1) /= Disc(S2))",
+          "[category][etcs][discrete][lift][subobject]") {
+  // Two distinct subobjects of the same ambient int.  Predicate
+  // selection differs (non-negative vs. strictly positive); the
+  // resulting set types are distinct, and so should be their lifts —
+  // textbook reading: Disc({0,1,2,...}) is not the same category as
+  // Disc({1,2,3,...}).
+  const auto int_non_negative =
+      ambient_set<int>([](const int& x) { return x >= 0; });
+  const auto int_positive =
+      ambient_set<int>([](const int& x) { return x > 0; });
+
+  using S1 = decltype(int_non_negative);
+  using S2 = decltype(int_positive);
+
+  // Both have the same Ambient (int) but are structurally distinct
+  // IsSet types.
+  STATIC_CHECK(std::same_as<typename S1::Ambient, int>);
+  STATIC_CHECK(std::same_as<typename S2::Ambient, int>);
+  STATIC_CHECK_FALSE(std::same_as<S1, S2>);
+
+  // The lift therefore produces distinct discrete categories — the
+  // subobject information survives the lift.
+  STATIC_CHECK_FALSE(
+      std::same_as<discrete_lift_t<S1>, discrete_lift_t<S2>>);
+
+  // Both still satisfy IsDiscreteCategory; the distinction is in
+  // identity, not concept-membership.
+  STATIC_CHECK(IsDiscreteCategory<discrete_lift_t<S1>>);
+  STATIC_CHECK(IsDiscreteCategory<discrete_lift_t<S2>>);
+}

--- a/src/test/cpp/modules/dedekind/category/discrete_lift_test.cpp
+++ b/src/test/cpp/modules/dedekind/category/discrete_lift_test.cpp
@@ -75,3 +75,32 @@ TEST_CASE("discrete_lift_t preserves subobject identity (Disc(S1) /= Disc(S2))",
   STATIC_CHECK(IsDiscreteCategory<discrete_lift_t<S1>>);
   STATIC_CHECK(IsDiscreteCategory<discrete_lift_t<S2>>);
 }
+
+TEST_CASE("discrete_lift_t participates in the bona fide adjunction surface",
+          "[category][etcs][discrete][lift][adjunction]") {
+  // The textbook Disc ⊣ U lives between meta-categories Set and Cat;
+  // the project's per-ambient single-species category encoding can
+  // exhibit only the discrete-restriction shadow of that adjunction.
+  // What's witnessed below is exactly what the adjunction.cppm
+  // machinery certifies: every IsSet S has a Disc(S) on which the
+  // trivial self-adjunction Id ⊣ Id is mechanically true.
+  const auto int_set = ambient_set<int>([](const int& x) { return x >= 0; });
+  using S = decltype(int_set);
+
+  using DiscF = disc_self_endofunctor_t<S>;
+  using UnitT = disc_self_unit_t<S>;
+
+  // The Disc-functor on Disc(S) is a bona fide IsFunctor (not just a
+  // type alias).
+  STATIC_CHECK(IsFunctor<DiscF>);
+
+  // The unit/counit is a bona fide natural transformation (the
+  // identity transformation on DiscF).
+  STATIC_CHECK(IsNaturalTransformation<UnitT, DiscF, DiscF>);
+
+  // Structural-shape witness: Disc and U cross-pair on Σ_cat / Τ_cat.
+  STATIC_CHECK(HasAdjunctionShape<DiscF, DiscF>);
+
+  // Full 4-parameter adjunction witness with explicit unit / counit.
+  STATIC_CHECK(IsAdjunction<DiscF, DiscF, UnitT, UnitT>);
+}

--- a/src/test/cpp/modules/dedekind/category/discrete_lift_test.cpp
+++ b/src/test/cpp/modules/dedekind/category/discrete_lift_test.cpp
@@ -41,8 +41,8 @@ TEST_CASE("discrete_lift_t produces a DiscreteCategory for any IsSet carrier",
   STATIC_CHECK(IsCategory<discrete_lift_t<UIntEvenSet>>);
 
   // The lift uses S itself, not S::Ambient — the static-type witness.
-  STATIC_CHECK(
-      std::same_as<discrete_lift_t<IntNonNegSet>, DiscreteCategory<IntNonNegSet>>);
+  STATIC_CHECK(std::same_as<discrete_lift_t<IntNonNegSet>,
+                            DiscreteCategory<IntNonNegSet>>);
 }
 
 TEST_CASE("discrete_lift_t preserves subobject identity (Disc(S1) /= Disc(S2))",
@@ -68,8 +68,7 @@ TEST_CASE("discrete_lift_t preserves subobject identity (Disc(S1) /= Disc(S2))",
 
   // The lift therefore produces distinct discrete categories — the
   // subobject information survives the lift.
-  STATIC_CHECK_FALSE(
-      std::same_as<discrete_lift_t<S1>, discrete_lift_t<S2>>);
+  STATIC_CHECK_FALSE(std::same_as<discrete_lift_t<S1>, discrete_lift_t<S2>>);
 
   // Both still satisfy IsDiscreteCategory; the distinction is in
   // identity, not concept-membership.

--- a/src/test/cpp/modules/dedekind/category/discrete_lift_test.cpp
+++ b/src/test/cpp/modules/dedekind/category/discrete_lift_test.cpp
@@ -86,9 +86,12 @@ TEST_CASE("discrete_lift_t participates in the bona fide adjunction surface",
   // trivial self-adjunction Id ⊣ Id is mechanically true.
   const auto int_set = ambient_set<int>([](const int& x) { return x >= 0; });
   using S = decltype(int_set);
+  using DiscS = discrete_lift_t<S>;
 
-  using DiscF = disc_self_endofunctor_t<S>;
-  using UnitT = disc_self_unit_t<S>;
+  // disc_self_endofunctor_t / disc_self_unit_t live in :natural,
+  // parameterized on a discrete category C (not on the source IsSet).
+  using DiscF = disc_self_endofunctor_t<DiscS>;
+  using UnitT = disc_self_unit_t<DiscS>;
 
   // The Disc-functor on Disc(S) is a bona fide IsFunctor (not just a
   // type alias).

--- a/src/test/cpp/modules/dedekind/numbers/discrete_lift_test.cpp
+++ b/src/test/cpp/modules/dedekind/numbers/discrete_lift_test.cpp
@@ -2,11 +2,15 @@
  *
  * Long-range test for @c discrete_lift_t<S> from @c category:etcs (#572).
  * Exercises the lift on @c IsSet-witnessing carriers built from the
- * project's concrete numeric tower (@c int, @c unsigned, @c Rational,
- * @c Real) — illustrates that the textbook @c Set @c ↪ @c Cat
- * embedding fires at every rung of the carrier ladder, not only on
- * primitive int.  The short-range test that pins the lift on
- * primitive ambients lives in @c category/discrete_lift_test.cpp.
+ * project's concrete numeric tower (@c bool, @c unsigned, @c int,
+ * @c Rational) — illustrates that the textbook @c Set @c ↪ @c Cat
+ * embedding fires at every rung of the carrier ladder reached here,
+ * not only on primitive int.  The @c Real rung lifts identically
+ * once the canonical @c Real carrier is dog-fooded on @c IsSet
+ * (#586); for now the rung is reached transitively via
+ * @c Rational<default_integer>'s scalar role inside @c ExactReal.
+ * The short-range test that pins the lift on primitive ambients
+ * lives in @c category/discrete_lift_test.cpp.
  */
 #include <catch2/catch_test_macros.hpp>
 
@@ -116,6 +120,10 @@ TEST_CASE("discrete_lift_t adjunction witnesses fire across the numeric tower",
       IsAdjunction<disc_self_endofunctor_t<DiscNat>,
                    disc_self_endofunctor_t<DiscNat>, disc_self_unit_t<DiscNat>,
                    disc_self_unit_t<DiscNat>>);
+  STATIC_CHECK(
+      IsAdjunction<disc_self_endofunctor_t<DiscInt>,
+                   disc_self_endofunctor_t<DiscInt>, disc_self_unit_t<DiscInt>,
+                   disc_self_unit_t<DiscInt>>);
   STATIC_CHECK(
       IsAdjunction<disc_self_endofunctor_t<DiscRat>,
                    disc_self_endofunctor_t<DiscRat>, disc_self_unit_t<DiscRat>,

--- a/src/test/cpp/modules/dedekind/numbers/discrete_lift_test.cpp
+++ b/src/test/cpp/modules/dedekind/numbers/discrete_lift_test.cpp
@@ -1,0 +1,86 @@
+/** @file test/cpp/modules/dedekind/numbers/discrete_lift_test.cpp
+ *
+ * Long-range test for @c discrete_lift_t<S> from @c category:etcs (#572).
+ * Exercises the lift on @c IsSet-witnessing carriers built from the
+ * project's concrete numeric tower (@c int, @c unsigned, @c Rational,
+ * @c Real) — illustrates that the textbook @c Set @c ↪ @c Cat
+ * embedding fires at every rung of the carrier ladder, not only on
+ * primitive int.  The short-range test that pins the lift on
+ * primitive ambients lives in @c category/discrete_lift_test.cpp.
+ */
+#include <catch2/catch_test_macros.hpp>
+
+import dedekind.category;
+import dedekind.numbers;
+
+using namespace dedekind::category;
+using namespace dedekind::numbers;
+
+TEST_CASE("discrete_lift_t fires across the numeric tower",
+          "[numbers][category][etcs][discrete][lift][tower]") {
+  // Build IsSet-witnessing carriers at concrete tower positions.
+  // Each predicate selects a non-trivial subobject so the lift's
+  // subobject-preservation behaviour is observable.
+  const auto naturals_under_10 =
+      ambient_set<unsigned>([](const unsigned& n) { return n < 10u; });
+  const auto integers_in_range =
+      ambient_set<int>([](const int& n) { return n >= -5 && n <= 5; });
+  const auto positive_rationals = ambient_set<Rational<default_integer>>(
+      [](const Rational<default_integer>& q) { return q.num() > 0; });
+
+  using NatSubset = decltype(naturals_under_10);
+  using IntSubset = decltype(integers_in_range);
+  using RationalSubset = decltype(positive_rationals);
+
+  // Each carrier is a bona fide IsSet over its tower-rung Ambient.
+  STATIC_CHECK(IsSet<NatSubset>);
+  STATIC_CHECK(IsSet<IntSubset>);
+  STATIC_CHECK(IsSet<RationalSubset>);
+
+  // The lift fires at every tower rung; the textbook Set ↪ Cat
+  // embedding is mechanically observable per concrete carrier.
+  STATIC_CHECK(IsDiscreteCategory<discrete_lift_t<NatSubset>>);
+  STATIC_CHECK(IsDiscreteCategory<discrete_lift_t<IntSubset>>);
+  STATIC_CHECK(IsDiscreteCategory<discrete_lift_t<RationalSubset>>);
+
+  // IsCategory falls out of IsDiscreteCategory; pinned for clarity.
+  STATIC_CHECK(IsCategory<discrete_lift_t<NatSubset>>);
+  STATIC_CHECK(IsCategory<discrete_lift_t<IntSubset>>);
+  STATIC_CHECK(IsCategory<discrete_lift_t<RationalSubset>>);
+}
+
+TEST_CASE("discrete_lift_t distinguishes refined subobjects of ℚ",
+          "[numbers][category][etcs][discrete][lift][rational]") {
+  // Two distinct subobjects of ℚ — the strictly-positive rationals
+  // and the rationals strictly between 0 and 1.  Both share the
+  // same Ambient (Rational<default_integer>), but the predicates
+  // pick out different subobjects; the lift should produce
+  // distinct discrete categories (the textbook
+  // Disc(ℚ_{>0}) /= Disc(ℚ_{(0,1)}) reading).
+  const auto positive = ambient_set<Rational<default_integer>>(
+      [](const Rational<default_integer>& q) { return q.num() > 0; });
+  const auto open_unit_interval = ambient_set<Rational<default_integer>>(
+      [](const Rational<default_integer>& q) {
+        return q.num() > 0 && q.num() < q.den();
+      });
+
+  using S1 = decltype(positive);
+  using S2 = decltype(open_unit_interval);
+
+  // Same ambient, distinct types.
+  STATIC_CHECK(
+      std::same_as<typename S1::Ambient, Rational<default_integer>>);
+  STATIC_CHECK(
+      std::same_as<typename S2::Ambient, Rational<default_integer>>);
+  STATIC_CHECK_FALSE(std::same_as<S1, S2>);
+
+  // The lift produces distinct discrete categories — subobject
+  // information is preserved through Set ↪ Cat.
+  STATIC_CHECK_FALSE(
+      std::same_as<discrete_lift_t<S1>, discrete_lift_t<S2>>);
+
+  // Both still satisfy IsDiscreteCategory; the distinction is in
+  // identity, not concept-membership.
+  STATIC_CHECK(IsDiscreteCategory<discrete_lift_t<S1>>);
+  STATIC_CHECK(IsDiscreteCategory<discrete_lift_t<S2>>);
+}

--- a/src/test/cpp/modules/dedekind/numbers/discrete_lift_test.cpp
+++ b/src/test/cpp/modules/dedekind/numbers/discrete_lift_test.cpp
@@ -81,3 +81,112 @@ TEST_CASE("discrete_lift_t distinguishes refined subobjects of ℚ",
   STATIC_CHECK(IsDiscreteCategory<discrete_lift_t<S1>>);
   STATIC_CHECK(IsDiscreteCategory<discrete_lift_t<S2>>);
 }
+
+TEST_CASE("discrete_lift_t adjunction witnesses fire across the numeric tower",
+          "[numbers][category][etcs][discrete][lift][adjunction][tower]") {
+  // The bona fide adjunction surface (HasAdjunctionShape /
+  // IsAdjunction from category:adjunction) is type-level mechanical
+  // for every IsSet-witnessing carrier from the numeric tower —
+  // matching the short-range exhibit in category/discrete_lift_test.
+  const auto naturals_under_10 =
+      ambient_set<unsigned>([](const unsigned& n) { return n < 10u; });
+  const auto integers_in_range =
+      ambient_set<int>([](const int& n) { return n >= -5 && n <= 5; });
+  const auto positive_rationals = ambient_set<Rational<default_integer>>(
+      [](const Rational<default_integer>& q) { return q.num() > 0; });
+
+  using NatSubset = decltype(naturals_under_10);
+  using IntSubset = decltype(integers_in_range);
+  using RationalSubset = decltype(positive_rationals);
+
+  // Structural-shape witness fires at every tower rung.
+  STATIC_CHECK(HasAdjunctionShape<disc_self_endofunctor_t<NatSubset>,
+                                  disc_self_endofunctor_t<NatSubset>>);
+  STATIC_CHECK(HasAdjunctionShape<disc_self_endofunctor_t<IntSubset>,
+                                  disc_self_endofunctor_t<IntSubset>>);
+  STATIC_CHECK(HasAdjunctionShape<disc_self_endofunctor_t<RationalSubset>,
+                                  disc_self_endofunctor_t<RationalSubset>>);
+
+  // Full IsAdjunction with identity-transformation unit/counit fires
+  // on the full tower as well.
+  STATIC_CHECK(IsAdjunction<disc_self_endofunctor_t<NatSubset>,
+                            disc_self_endofunctor_t<NatSubset>,
+                            disc_self_unit_t<NatSubset>,
+                            disc_self_unit_t<NatSubset>>);
+  STATIC_CHECK(IsAdjunction<disc_self_endofunctor_t<RationalSubset>,
+                            disc_self_endofunctor_t<RationalSubset>,
+                            disc_self_unit_t<RationalSubset>,
+                            disc_self_unit_t<RationalSubset>>);
+}
+
+TEST_CASE("discrete_lift_t illustrates 'simple set vs. complex algebra' on 𝔹",
+          "[numbers][category][etcs][discrete][lift][adjunction][boolean]") {
+  // Pedagogical anchor for the textbook Free / Forgetful adjunction
+  // intuition (Pierce §2.6 / Mac Lane Ch. IV; conversation framing
+  // shared by the author): the @c bool species is the underlying
+  // carrier for two structurally distinct upgrades --
+  //
+  //   * the @b simple view: 𝔹 as the 2-element set @c {false, true},
+  //     which lifts to a discrete category with two objects via Disc;
+  //   * the @b complex view: 𝔹 as the idempotent commutative semiring
+  //     in @c numbers:boolean / @c algebra:boolean (addition = OR,
+  //     multiplication = AND, identities = false / true).
+  //
+  // The Disc ⊣ U adjunction (this PR's exhibit) lives over the simple
+  // view and is mechanically witnessed below.  The Free-Boolean-
+  // Semiring ⊣ U-to-Set adjunction over the complex view is a sister
+  // carrier-side adjunction listed in adjunction.cppm; the project
+  // does not yet wire it as a type-level HasAdjunctionShape exhibit.
+  // The two views are independent "upgrades" of the same bool
+  // ambient: Disc only sees the cardinality / element identity; the
+  // semiring upgrade sees the algebraic operations.
+  //
+  // FIXME(#586): the canonical 𝔹 carrier @c FiniteBooleanSet<L>
+  // does not directly satisfy @c IsSet (no @c Ambient member), so we
+  // detour through @c ambient_set<bool>(...) here.  Issue #586 tracks
+  // dog-fooding the canonical carriers on the @c IsSet aggregator so
+  // tests can write @c discrete_lift_t<FiniteBooleanSet<L>> directly.
+  const auto bool_set =
+      ambient_set<bool>([](const bool&) { return true; });  // 𝔹 = {0, 1}
+  using BoolSet = decltype(bool_set);
+
+  // Simple-view structural facts.
+  STATIC_CHECK(IsSet<BoolSet>);
+  STATIC_CHECK(std::same_as<typename BoolSet::Ambient, bool>);
+
+  // Disc(𝔹) is the discrete category on the 2-element ambient.
+  using DiscB = discrete_lift_t<BoolSet>;
+  STATIC_CHECK(IsDiscreteCategory<DiscB>);
+  STATIC_CHECK(std::same_as<typename DiscB::Species, BoolSet>);
+
+  // Bona fide adjunction surface fires on Disc(𝔹) -- same machinery
+  // as for the int / Rational examples above.  This is the
+  // discrete-restriction encoding of the meta-categorical Disc ⊣ U.
+  using DiscFB = disc_self_endofunctor_t<BoolSet>;
+  using UnitTB = disc_self_unit_t<BoolSet>;
+  STATIC_CHECK(IsFunctor<DiscFB>);
+  STATIC_CHECK(IsNaturalTransformation<UnitTB, DiscFB, DiscFB>);
+  STATIC_CHECK(HasAdjunctionShape<DiscFB, DiscFB>);
+  STATIC_CHECK(IsAdjunction<DiscFB, DiscFB, UnitTB, UnitTB>);
+
+  // Operational unit / counit witness: per the textbook, the unit
+  // η_S sends each "object" of S to its embedding in U(F(S)); for
+  // the discrete-restriction encoding F = U = Id and η is the
+  // identity natural transformation, so η(c) = id_c.
+  //
+  // A note on object granularity: in the project's encoding,
+  // discrete_lift_t<S> = DiscreteCategory<S>, so the @b objects of
+  // Disc(BoolSet) are values of type @c BoolSet (the subobject), not
+  // values of type @c bool (the elements).  This is the price of
+  // preserving subobject identity through the lift (the original #583
+  // Copilot finding): @c Disc({false,true}) and @c Disc(𝔹) are
+  // distinct types, but the trade-off is that "objects" lift to the
+  // subobject-as-singleton level rather than to the element level.
+  // The textbook "objects = elements" reading would require lifting
+  // to @c DiscreteCategory<S::Member> instead, which collapses
+  // distinct subobjects of the same ambient.  Pinning at the
+  // subobject-value level below.
+  const auto adjunction = make_adjunction(DiscFB{}, DiscFB{}, UnitTB{}, UnitTB{});
+  STATIC_CHECK(IsArrow<decltype(adjunction.unit(bool_set))>);
+  STATIC_CHECK(IsArrow<decltype(adjunction.counit(bool_set))>);
+}

--- a/src/test/cpp/modules/dedekind/numbers/discrete_lift_test.cpp
+++ b/src/test/cpp/modules/dedekind/numbers/discrete_lift_test.cpp
@@ -68,16 +68,13 @@ TEST_CASE("discrete_lift_t distinguishes refined subobjects of ℚ",
   using S2 = decltype(open_unit_interval);
 
   // Same ambient, distinct types.
-  STATIC_CHECK(
-      std::same_as<typename S1::Ambient, Rational<default_integer>>);
-  STATIC_CHECK(
-      std::same_as<typename S2::Ambient, Rational<default_integer>>);
+  STATIC_CHECK(std::same_as<typename S1::Ambient, Rational<default_integer>>);
+  STATIC_CHECK(std::same_as<typename S2::Ambient, Rational<default_integer>>);
   STATIC_CHECK_FALSE(std::same_as<S1, S2>);
 
   // The lift produces distinct discrete categories — subobject
   // information is preserved through Set ↪ Cat.
-  STATIC_CHECK_FALSE(
-      std::same_as<discrete_lift_t<S1>, discrete_lift_t<S2>>);
+  STATIC_CHECK_FALSE(std::same_as<discrete_lift_t<S1>, discrete_lift_t<S2>>);
 
   // Both still satisfy IsDiscreteCategory; the distinction is in
   // identity, not concept-membership.

--- a/src/test/cpp/modules/dedekind/numbers/discrete_lift_test.cpp
+++ b/src/test/cpp/modules/dedekind/numbers/discrete_lift_test.cpp
@@ -112,14 +112,14 @@ TEST_CASE("discrete_lift_t adjunction witnesses fire across the numeric tower",
 
   // Full IsAdjunction with identity-transformation unit/counit fires
   // on the full tower as well.
-  STATIC_CHECK(IsAdjunction<disc_self_endofunctor_t<DiscNat>,
-                            disc_self_endofunctor_t<DiscNat>,
-                            disc_self_unit_t<DiscNat>,
-                            disc_self_unit_t<DiscNat>>);
-  STATIC_CHECK(IsAdjunction<disc_self_endofunctor_t<DiscRat>,
-                            disc_self_endofunctor_t<DiscRat>,
-                            disc_self_unit_t<DiscRat>,
-                            disc_self_unit_t<DiscRat>>);
+  STATIC_CHECK(
+      IsAdjunction<disc_self_endofunctor_t<DiscNat>,
+                   disc_self_endofunctor_t<DiscNat>, disc_self_unit_t<DiscNat>,
+                   disc_self_unit_t<DiscNat>>);
+  STATIC_CHECK(
+      IsAdjunction<disc_self_endofunctor_t<DiscRat>,
+                   disc_self_endofunctor_t<DiscRat>, disc_self_unit_t<DiscRat>,
+                   disc_self_unit_t<DiscRat>>);
 }
 
 TEST_CASE("discrete_lift_t illustrates 'simple set vs. complex algebra' on 𝔹",

--- a/src/test/cpp/modules/dedekind/numbers/discrete_lift_test.cpp
+++ b/src/test/cpp/modules/dedekind/numbers/discrete_lift_test.cpp
@@ -109,10 +109,10 @@ TEST_CASE("discrete_lift_t adjunction witnesses fire across the numeric tower",
 
   // Full IsAdjunction with identity-transformation unit/counit fires
   // on the full tower as well.
-  STATIC_CHECK(IsAdjunction<disc_self_endofunctor_t<NatSubset>,
-                            disc_self_endofunctor_t<NatSubset>,
-                            disc_self_unit_t<NatSubset>,
-                            disc_self_unit_t<NatSubset>>);
+  STATIC_CHECK(
+      IsAdjunction<disc_self_endofunctor_t<NatSubset>,
+                   disc_self_endofunctor_t<NatSubset>,
+                   disc_self_unit_t<NatSubset>, disc_self_unit_t<NatSubset>>);
   STATIC_CHECK(IsAdjunction<disc_self_endofunctor_t<RationalSubset>,
                             disc_self_endofunctor_t<RationalSubset>,
                             disc_self_unit_t<RationalSubset>,
@@ -186,7 +186,8 @@ TEST_CASE("discrete_lift_t illustrates 'simple set vs. complex algebra' on 𝔹"
   // to @c DiscreteCategory<S::Member> instead, which collapses
   // distinct subobjects of the same ambient.  Pinning at the
   // subobject-value level below.
-  const auto adjunction = make_adjunction(DiscFB{}, DiscFB{}, UnitTB{}, UnitTB{});
+  const auto adjunction =
+      make_adjunction(DiscFB{}, DiscFB{}, UnitTB{}, UnitTB{});
   STATIC_CHECK(IsArrow<decltype(adjunction.unit(bool_set))>);
   STATIC_CHECK(IsArrow<decltype(adjunction.counit(bool_set))>);
 }

--- a/src/test/cpp/modules/dedekind/numbers/discrete_lift_test.cpp
+++ b/src/test/cpp/modules/dedekind/numbers/discrete_lift_test.cpp
@@ -95,28 +95,31 @@ TEST_CASE("discrete_lift_t adjunction witnesses fire across the numeric tower",
   const auto positive_rationals = ambient_set<Rational<default_integer>>(
       [](const Rational<default_integer>& q) { return q.num() > 0; });
 
-  using NatSubset = decltype(naturals_under_10);
-  using IntSubset = decltype(integers_in_range);
-  using RationalSubset = decltype(positive_rationals);
+  // disc_self_endofunctor_t / disc_self_unit_t (in :natural) take a
+  // discrete category C, not the source IsSet directly.  Each tower
+  // rung's lifted Disc(S) is the discrete-category arg.
+  using DiscNat = discrete_lift_t<decltype(naturals_under_10)>;
+  using DiscInt = discrete_lift_t<decltype(integers_in_range)>;
+  using DiscRat = discrete_lift_t<decltype(positive_rationals)>;
 
   // Structural-shape witness fires at every tower rung.
-  STATIC_CHECK(HasAdjunctionShape<disc_self_endofunctor_t<NatSubset>,
-                                  disc_self_endofunctor_t<NatSubset>>);
-  STATIC_CHECK(HasAdjunctionShape<disc_self_endofunctor_t<IntSubset>,
-                                  disc_self_endofunctor_t<IntSubset>>);
-  STATIC_CHECK(HasAdjunctionShape<disc_self_endofunctor_t<RationalSubset>,
-                                  disc_self_endofunctor_t<RationalSubset>>);
+  STATIC_CHECK(HasAdjunctionShape<disc_self_endofunctor_t<DiscNat>,
+                                  disc_self_endofunctor_t<DiscNat>>);
+  STATIC_CHECK(HasAdjunctionShape<disc_self_endofunctor_t<DiscInt>,
+                                  disc_self_endofunctor_t<DiscInt>>);
+  STATIC_CHECK(HasAdjunctionShape<disc_self_endofunctor_t<DiscRat>,
+                                  disc_self_endofunctor_t<DiscRat>>);
 
   // Full IsAdjunction with identity-transformation unit/counit fires
   // on the full tower as well.
-  STATIC_CHECK(
-      IsAdjunction<disc_self_endofunctor_t<NatSubset>,
-                   disc_self_endofunctor_t<NatSubset>,
-                   disc_self_unit_t<NatSubset>, disc_self_unit_t<NatSubset>>);
-  STATIC_CHECK(IsAdjunction<disc_self_endofunctor_t<RationalSubset>,
-                            disc_self_endofunctor_t<RationalSubset>,
-                            disc_self_unit_t<RationalSubset>,
-                            disc_self_unit_t<RationalSubset>>);
+  STATIC_CHECK(IsAdjunction<disc_self_endofunctor_t<DiscNat>,
+                            disc_self_endofunctor_t<DiscNat>,
+                            disc_self_unit_t<DiscNat>,
+                            disc_self_unit_t<DiscNat>>);
+  STATIC_CHECK(IsAdjunction<disc_self_endofunctor_t<DiscRat>,
+                            disc_self_endofunctor_t<DiscRat>,
+                            disc_self_unit_t<DiscRat>,
+                            disc_self_unit_t<DiscRat>>);
 }
 
 TEST_CASE("discrete_lift_t illustrates 'simple set vs. complex algebra' on 𝔹",
@@ -162,8 +165,8 @@ TEST_CASE("discrete_lift_t illustrates 'simple set vs. complex algebra' on 𝔹"
   // Bona fide adjunction surface fires on Disc(𝔹) -- same machinery
   // as for the int / Rational examples above.  This is the
   // discrete-restriction encoding of the meta-categorical Disc ⊣ U.
-  using DiscFB = disc_self_endofunctor_t<BoolSet>;
-  using UnitTB = disc_self_unit_t<BoolSet>;
+  using DiscFB = disc_self_endofunctor_t<DiscB>;
+  using UnitTB = disc_self_unit_t<DiscB>;
   STATIC_CHECK(IsFunctor<DiscFB>);
   STATIC_CHECK(IsNaturalTransformation<UnitTB, DiscFB, DiscFB>);
   STATIC_CHECK(HasAdjunctionShape<DiscFB, DiscFB>);


### PR DESCRIPTION
## Summary

Filed as #572 (2026-05-04) from the discrete-category cross-reference work in #571.  The textbook embedding $\mathbf{Set} \hookrightarrow \mathbf{Cat}$ via the discrete-category functor $\mathrm{Disc}: \mathbf{Set} \to \mathbf{Cat}$ was partially encoded: the project had both halves (`IsSet<S>` in `category:etcs`, `IsDiscreteCategory<Cat>` and `DiscreteCategory<T>` in `category:discrete`) but no exhibit tied them together for a generic `IsSet`-witnessing carrier.

This PR adds the generic lift, the bona fide adjunction-machinery witnesses (per the second-pass review), and short-range / long-range tests across the numeric tower.

## What lands

### The lift

```cpp
export template <typename S>
  requires IsSet<S>
using discrete_lift_t = DiscreteCategory<S>;
```

The lift uses `S` itself (not its ambient species) as the carrier of the discrete category, so distinct `IsSet` types over the same ambient remain distinct after lifting — a refined subset and an unrefined ambient are different sets and therefore different discrete categories (the textbook `Disc({0,1,2}) /= Disc(ℕ)` reading).  Updated in `039d007b` per the first-pass Copilot review (the original draft used `DiscreteCategory<S::Ambient>` which collapsed subobjects).

### Bona fide adjunction witnesses (second-pass review, option (c))

Per the user's "do it the right way" direction, the lift is wired into the bona fide `HasAdjunctionShape` / `IsAdjunction` machinery from `category:adjunction`.  Two new template aliases live in `category:natural` (parameterised on `IsDiscreteCategory<C>`, not on the source `IsSet`):

```cpp
template <typename C> requires IsDiscreteCategory<C>
using disc_self_endofunctor_t = identity_functor<C>;

template <typename C> requires IsDiscreteCategory<C>
using disc_self_unit_t = identity_transformation<disc_self_endofunctor_t<C>>;
```

These reify the discrete-restriction representatives of the textbook `Disc / U / η / ε` under their textbook role names, so call sites can refer to bona fide named exports rather than to documentary commentary.  Static_assert exhibits on the representative `IsSet`-witnessing carrier in `category:etcs`:

- `IsFunctor<disc_self_endofunctor_t<discrete_lift_t<S>>>`
- `IsNaturalTransformation<disc_self_unit_t<...>, ...>`
- `HasAdjunctionShape<disc_self_endofunctor_t<...>, disc_self_endofunctor_t<...>>`
- Full 4-parameter `IsAdjunction<..., ..., disc_self_unit_t<...>, disc_self_unit_t<...>>`

The doc-block names the encoding constraint honestly: the meta-categorical `Disc ⊣ U` lives between `Set` and `Cat` as meta-categories the project doesn't yet model, so what's type-level expressible is the discrete-restriction shadow on `Disc(S)`.  The full meta-categorical lift is acknowledged future work (tracked under #587).

### DAG placement

`category:etcs` gets new `import :adjunction;` and `import :functor;` so the adjunction machinery and `identity_functor` are in scope.  `category:natural` gets `import :discrete;` so `IsDiscreteCategory` is in scope for the new aliases.  All three are downstream of where they are imported from; no DAG cycles.

### Tests

- **Short-range** (`category/discrete_lift_test.cpp`): primitive-ambient carriers (int / bool / unsigned), subobject-preservation sister-check (Disc(S1) /= Disc(S2)), and the bona fide adjunction surface on the representative carrier.
- **Long-range** (`numbers/discrete_lift_test.cpp`): numeric-tower carriers (unsigned / int / Rational), the ℚ-subobject distinction (Disc(ℚ_{>0}) /= Disc(ℚ_{(0,1)})), the adjunction surface across the tower (NatSubset / IntSubset / RationalSubset), and a 𝔹 illustrative TEST_CASE anchoring the user's pedagogical conversation about Free / Forgetful (simple set view of bool vs complex algebra view as Boolean semiring).

## Why it earns its place

- **Paper §3 exhibit**: closes the loop on the `Set ↪ Cat` narrative.  The `Disc ⊣ U` adjunction was load-bearing in the §3 introduction-to-CT prose; the witnessed `static_assert`s exhibit it mechanically.
- **Companion to #570's quotient operator**: same shape of structural claim — the construction is named in textbook terms and witnessed in code.  ℚ via quotient (#570), `Set ↪ Cat` via discrete lift (this PR) — both add to the §3 narrative arc.
- **Anchor for the §2 ceiling argument** (PR #585): the §2.3 closing paragraph names this PR's witnesses as the worked anchor for "meta-categorical statements live as prose; mechanically-witnessed restrictions to a single small slice are the type-level evidence".

## Test plan

- [x] CI green: `dedekind_category` and `dedekind_numbers` compile clean (verified locally — 391/391 targets).
- [x] `static_assert`s in `etcs.cppm` fire on `_isset_witness_t`.
- [x] `IsAdjunction` fires across the tower (NatSubset / IntSubset / RationalSubset / BoolSet).
- [x] No regressions in downstream consumers of `category:etcs`, `category:discrete`, or `category:natural`.

Closes #572.  Follow-up tracked at #587 (full meta-categorical Disc ⊣ U as cross-category functor).

🤖 Generated with [Claude Code](https://claude.com/claude-code)