### PR TITLE
docs(paper): #545 dedicated AI-assistance Acknowledgements per ‹Programming› policy

### DIFF
--- a/docs/paper/paper.tex
+++ b/docs/paper/paper.tex
@@ -2562,8 +2562,10 @@ increasingly, of programming language.
 \label{sec:acknowledgements}
 % ============================================================
 
-The development of \texttt{dedekind} relied substantively on AI-assisted authorship throughout, and this paper does too.
+The development of \texttt{dedekind} relied substantively on AI assistance throughout, and the writing of this paper did so as well.
 The disclosure here is the concrete instance of the cost-benefit-calculus claim in §\ref{sec:introduction}: that paragraph names the shift in the abstract; this one names how it shifted on this artefact.
+Per the ‹Programming› journal's policy on AI tools~\cite{programming_journal_ai_policy}, the use of these tools is acknowledged and disclosed; the AI systems named below are tools whose contribution is recorded here as assistance, not authorship.
+The author is a single human person, named in the byline, who bears full responsibility for content, scope, correctness, and editorial judgement.
 
 The primary assistant was Anthropic's \emph{Claude} family (Sonnet and Opus across the project's lifetime; the 1M-context Opus 4.7 variant for the most recent slices, where reproducibility against extended-context interactions matters), invoked through the Claude Code CLI.
 Google's Gemini was used for second-opinion structural critique on substantive mathematical claims (size-restriction notation, adjunction-encoding feasibility, foundational-vs-mechanical disentanglement).
@@ -2571,8 +2573,7 @@ GitHub Copilot's pull-request reviewer was invoked on every PR for scope-vs-clai
 The assistance covered draft generation (prose, code, listings, tabular structured elements), structural refactoring (concept naming, partition placement, hub-and-spoke dispatch shape), test scaffolding, review-thread response drafting, and CI / GitHub workflow scaffolding.
 
 The pattern is visible at commit-level granularity in the public repository at \url{https://github.com/vincentk/dedekind}: every commit message, every pull-request review thread, and the public CI build log compose into a complete audit trail.
-Reviewers can inspect the assistance pattern at any commit; the author bears 100\% responsibility for content, scope, correctness, and editorial judgement.
-The framing follows the ‹Programming› journal's policy on AI tools~\cite{programming_journal_ai_policy}: AI is a tool whose use is disclosed, not a co-author whose contribution is named in the byline.
+Reviewers can inspect the assistance pattern at any commit.
 ``Assisted'' rather than ``co-authored'' is the operative voice throughout, both for this paper and for the codebase it documents.
 
 \printbibliography

--- a/docs/paper/paper.tex
+++ b/docs/paper/paper.tex
@@ -153,7 +153,7 @@ compress the time and expertise needed to author opt-in trait
 specialisations, axiom-shape concepts, and the surrounding library
 scaffolding, turning what was an academic specialism into an
 actionable workflow for working software engineers.
-The meta-claim is not ours to originate; we make it here so the body's executable exhibit can be read in that light.
+The meta-claim is not ours to originate; we make it here so the body's executable exhibit can be read in that light, and the §\ref{sec:acknowledgements} disclosure documents how the calculus actually shifted on this paper specifically (which tools, which tasks, what oversight pattern).
 
 We present \texttt{dedekind}~\cite{dedekind2026}, an
 open-source C++23 library (Apache-2.0), as that exhibit. It embeds
@@ -2556,6 +2556,24 @@ artefacts on comparable timescales, irrespective of host language or
 of how the keystrokes were generated.  The discipline is meant to
 outlast any particular generation of authoring tool---and,
 increasingly, of programming language.
+
+% ============================================================
+\section*{Acknowledgements}
+\label{sec:acknowledgements}
+% ============================================================
+
+The development of \texttt{dedekind} relied substantively on AI-assisted authorship throughout, and this paper does too.
+The disclosure here is the concrete instance of the cost-benefit-calculus claim in §\ref{sec:introduction}: that paragraph names the shift in the abstract; this one names how it shifted on this artefact.
+
+The primary assistant was Anthropic's \emph{Claude} family (Sonnet and Opus across the project's lifetime; the 1M-context Opus 4.7 variant for the most recent slices, where reproducibility against extended-context interactions matters), invoked through the Claude Code CLI.
+Google's Gemini was used for second-opinion structural critique on substantive mathematical claims (size-restriction notation, adjunction-encoding feasibility, foundational-vs-mechanical disentanglement).
+GitHub Copilot's pull-request reviewer was invoked on every PR for scope-vs-claim consistency checks at the prose / table / listing level.
+The assistance covered draft generation (prose, code, listings, tabular structured elements), structural refactoring (concept naming, partition placement, hub-and-spoke dispatch shape), test scaffolding, review-thread response drafting, and CI / GitHub workflow scaffolding.
+
+The pattern is visible at commit-level granularity in the public repository at \url{https://github.com/vincentk/dedekind}: every commit message, every pull-request review thread, and the public CI build log compose into a complete audit trail.
+Reviewers can inspect the assistance pattern at any commit; the author bears 100\% responsibility for content, scope, correctness, and editorial judgement.
+The framing follows the ‹Programming› journal's policy on AI tools~\cite{programming_journal_ai_policy}: AI is a tool whose use is disclosed, not a co-author whose contribution is named in the byline.
+``Assisted'' rather than ``co-authored'' is the operative voice throughout, both for this paper and for the codebase it documents.
 
 \printbibliography
 

--- a/docs/paper/references.bib
+++ b/docs/paper/references.bib
@@ -866,6 +866,12 @@
   note         = {Open-access journal for programming-related research; ISSN 2473-7321}
 }
 
+@misc{programming_journal_ai_policy,
+  title        = {{<Programming>} Journal --- Policy on the Use of {AI} Tools in Submitted Manuscripts},
+  howpublished = {\url{https://programming-journal.org/purpose/ai.html}},
+  note         = {Disclosure-of-assistance policy: tools used, tasks, oversight; AI is acknowledged, not co-authored}
+}
+
 @book{dantzig1963simplex,
   author    = {Dantzig, George B.},
   title     = {Linear Programming and Extensions},


### PR DESCRIPTION
Closes #545.

## Summary

Drafts the dedicated Acknowledgements paragraph that the ‹Programming› journal's [policy on AI tools](https://programming-journal.org/purpose/ai.html) requires.  The §1 cost-benefit-calculus paragraph is the meta-claim about the field; this new section is the disclosure of how the calculus actually shifted on this paper specifically.

## What lands

- New `\section*{Acknowledgements}` (with label `sec:acknowledgements`) between the §Conclusion close and `\printbibliography`.
- Five required disclosure axes covered (per the journal policy + the internal `feedback_programming_journal_ai_disclosure.md` memory):
  1. **Tool** — Anthropic's Claude family (Sonnet / Opus); 1M-context Opus 4.7 for recent slices; Claude Code CLI as the invocation surface; Gemini for second-opinion structural critique; GitHub Copilot's pull-request reviewer for scope-vs-claim checks.
  2. **Tasks** — concrete list (draft generation, structural refactoring, test scaffolding, review-thread response drafting, CI / GitHub workflow scaffolding).
  3. **Where** — the public repo at https://github.com/vincentk/dedekind as the audit trail; commit messages, PR review threads, and the public CI build log compose into commit-level granularity.
  4. **Author oversight** — single human author named in the byline, bearing full responsibility for content, scope, correctness, editorial judgement.
  5. **Voice** — ``assisted'' / ``assistance'' throughout; never ``co-authored''.
- Bidirectional cross-reference: §1 cost-benefit-calculus paragraph now points forward to §sec:acknowledgements as the concrete instance; the Acknowledgements section points back to §1 as the abstract claim.
- New bibliography entry `programming_journal_ai_policy` citing https://programming-journal.org/purpose/ai.html.

## Authorship-claim safety

Per the user's pre-submission caution: the wording is unambiguously single-author with disclosed assistance, not co-authorship.  ``AI-assisted authorship'' was tightened to ``AI assistance'' (drops the noun that could read as the AI possessing authorship rights), and an explicit single-human-byline statement up front anchors the locus of authorship.

## Out of scope

- Tonal-register attribution to Piponi / Elliott / etc. — kept internal per `feedback_attribution_respect.md`; verbatim quotes (e.g. `elliott2018simple` already cited in §AD) remain cited at their use site.
- Trim of the §1 cost-benefit-calculus meta-claim itself — sibling work tracked under #486.

## Test plan

- [x] lualatex -halt-on-error single-pass green (51 pages)
- [x] Cross-reference §sec:acknowledgements resolves on the second pass
- [x] No new undefined references introduced (pre-existing ones unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)