### PR TITLE
docs(paper): #549 §CT.5 nesting decision — keep under §S; repoint stale cross-ref

### DIFF
--- a/docs/paper/paper.tex
+++ b/docs/paper/paper.tex
@@ -803,11 +803,11 @@ $\mathbb{R} = \operatorname{Cuts}(\mathbb{Q})$,
 $\mathbb{C} = \operatorname{Cplx}(\mathbb{R})$,
 $\mathbb{D} = \operatorname{Dual}(\mathbb{R})$, and the rank lift
 $\operatorname{Free}_n(R) = R^n$ /
-$\operatorname{End}_R(R^n) = M_n(R)$ are all named as functors
-in §\ref{sec:axiomatic}, paragraph \emph{Named functors that
-build the library's carriers}; carriers are named by the
-universal property that defines them, not by the storage scheme
-they happen to use.}
+$\operatorname{End}_R(R^n) = M_n(R)$ are named as functors and
+itemised in the carrier-rosetta tables in
+§\ref{sec:carrier-rosetta} of the appendix; carriers are named by
+the universal property that defines them, not by the storage
+scheme they happen to use.}
 
 \subsection{The Comprehension View: Sets Are Rules, Not Buckets}
 


### PR DESCRIPTION
Closes #549.

## Resolution

The issue's premise ("§CT.5 currently sits under §CT") is no longer accurate on current `main`: §3.2 *Intensional First, Realize When You Mean It* sits under §S (Sets and Sequences), having been relocated during intermediate spine restructuring.  The placement is correct — the intensional-first methodology (predicates as sets, comprehension, deferred materialisation) is exactly the §S story, and the section's internal cross-references (Dedekind cuts, halfspaces, comprehension) tie into adjacent §S material.

**Option 2 (keep nested under §S)** is therefore the chosen resolution.  The only concrete remaining fix is a stale cross-reference noted while investigating: the *Forms before carriers* footnote at §3.2 (lines 800-810) referenced `§\ref{sec:axiomatic}, paragraph "Named functors that build the library's carriers"`, but that paragraph doesn't exist at `sec:axiomatic` — the carrier-functor naming actually lives in `sec:carrier-rosetta` (the appendix carrier-rosetta tables).

## What lands

- Updated the §3.2 "Forms before carriers" footnote to point at `§\ref{sec:carrier-rosetta}` instead of the dangling `§\ref{sec:axiomatic}` reference.  Reads as "named as functors and itemised in the carrier-rosetta tables in §sec:carrier-rosetta of the appendix" — accurate, current, actionable for a reader following the cross-reference.

## Why not Options 1 or 3

- **Option 1 (lift "Forms before carriers" to §A)**: rejected because that paragraph grounds the intensional-first rule in concrete carriers; lifting it isolates the methodology from its motivating examples.
- **Option 3 (promote §3.2 to top-level §Intensional)**: rejected because the methodology and the §S framing are inseparable; promoting would orphan the comprehension cross-references that follow §3.2 in §S.

## Out of scope

- Restructuring §3.2's internal content (separate concern).
- Page-count optimisation (covered by #486).

## Test plan

- [x] Single-pass lualatex green (51 pages).
- [x] No new undefined references introduced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)