### PR TITLE
feat(algebra): #573 follow-up — Z/2^N Z HasCarrier witness as sister to F_2

### DIFF
--- a/src/main/modules/dedekind/algebra/universal.cppm
+++ b/src/main/modules/dedekind/algebra/universal.cppm
@@ -352,6 +352,23 @@ static_assert(
     "satisfy the concept end-to-end (algebra side via IsAlgebra<bool, ⊕, ∧>; "
     "mereology side via IsPartOfRelation + arrow_drill_down).");
 
+// Concrete-algebra witness: Z/2^N Z (the canonical modular ring on
+// std::unsigned_integral wide carriers) wired through algebra_view.
+// IsAlgebra<unsigned int, std::plus<unsigned int>, std::multiplies<unsigned int>>
+// certifies the algebra-side closure (the standard modular ring under
+// periodic wraparound at 2^N — see ring.cppm:451 for the full IsRing
+// certification on wide unsigned types).  Validates HasCarrier on a
+// non-trivial infinite-cardinality-up-to-machine-width algebra,
+// distinct in shape from the 2-element F_2 witness above.
+static_assert(
+    HasCarrier<_has_carrier_witness::algebra_view<unsigned int>, unsigned int,
+               std::plus<unsigned int>, std::multiplies<unsigned int>>,
+    "HasCarrier (#573): Z/2^N Z = (unsigned int, +, *) wired through "
+    "algebra_view must satisfy the concept end-to-end (algebra side via "
+    "IsAlgebra<unsigned int, +, *>; mereology side via IsPartOfRelation + "
+    "arrow_drill_down).  Sister witness to F_2 above; same concept, "
+    "different algebra shape (Galois field vs modular ring).");
+
 // ---------------------------------------------------------------------------
 // Phase 2: Homomorphisms — arrows between algebras (#506).
 // ---------------------------------------------------------------------------

--- a/src/main/modules/dedekind/algebra/universal.cppm
+++ b/src/main/modules/dedekind/algebra/universal.cppm
@@ -354,8 +354,8 @@ static_assert(
 
 // Concrete-algebra witness: Z/2^N Z (the canonical modular ring on
 // std::unsigned_integral wide carriers) wired through algebra_view.
-// IsAlgebra<unsigned int, std::plus<unsigned int>, std::multiplies<unsigned int>>
-// certifies the algebra-side closure (the standard modular ring under
+// IsAlgebra<unsigned int, std::plus<unsigned int>, std::multiplies<unsigned
+// int>> certifies the algebra-side closure (the standard modular ring under
 // periodic wraparound at 2^N — see ring.cppm:451 for the full IsRing
 // certification on wide unsigned types).  Validates HasCarrier on a
 // non-trivial infinite-cardinality-up-to-machine-width algebra,

--- a/src/main/modules/dedekind/algebra/universal.cppm
+++ b/src/main/modules/dedekind/algebra/universal.cppm
@@ -356,10 +356,11 @@ static_assert(
 // std::unsigned_integral wide carriers) wired through algebra_view.
 // IsAlgebra<unsigned int, std::plus<unsigned int>, std::multiplies<unsigned
 // int>> certifies the algebra-side closure (the standard modular ring under
-// periodic wraparound at 2^N — see ring.cppm:451 for the full IsRing
+// periodic wraparound at 2^N — algebra:ring carries the strict IsRing
 // certification on wide unsigned types).  Validates HasCarrier on a
-// non-trivial infinite-cardinality-up-to-machine-width algebra,
-// distinct in shape from the 2-element F_2 witness above.
+// non-trivial finite algebra of order 2^N (with N =
+// std::numeric_limits<unsigned int>::digits) — distinct in shape from the
+// 2-element F_2 witness above; same Galois-flavored axiom story.
 static_assert(
     HasCarrier<_has_carrier_witness::algebra_view<unsigned int>, unsigned int,
                std::plus<unsigned int>, std::multiplies<unsigned int>>,
@@ -368,6 +369,25 @@ static_assert(
     "IsAlgebra<unsigned int, +, *>; mereology side via IsPartOfRelation + "
     "arrow_drill_down).  Sister witness to F_2 above; same concept, "
     "different algebra shape (Galois field vs modular ring).");
+
+// Concrete-algebra witness: the Boolean ring on std::unsigned_integral
+// (per vincentk's review note on PR #593: focusing on bitwise operators
+// gives a *proper* algebraic structure --- a Boolean ring on 2^N bits ---
+// rather than just the operator surface that Z/2^N Z under +,* gives).
+// (unsigned int, ⊕, ∧) is the F_2-vector-space view of unsigned int as a
+// 2^N-element Boolean ring: addition is bitwise XOR (idempotent under ⊕⊕,
+// involutive: a⊕a=0), multiplication is bitwise AND (idempotent: a∧a=a,
+// commutative, distributes over ⊕).  Strictly stronger algebraic claim
+// than the +,* arithmetic witness above — these axioms hold by inspection
+// on the bit-vector interpretation, no functor-surface caveat.
+static_assert(
+    HasCarrier<_has_carrier_witness::algebra_view<unsigned int>, unsigned int,
+               std::bit_xor<unsigned int>, std::bit_and<unsigned int>>,
+    "HasCarrier (#573): the Boolean ring (unsigned int, ⊕, ∧) wired "
+    "through algebra_view must satisfy the concept end-to-end.  This is "
+    "the F_2-vector-space lift of the F_2 witness above to wider unsigned "
+    "carriers; the same axioms hold by inspection on the bit-vector "
+    "interpretation (idempotent ∧, involutive ⊕).");
 
 // ---------------------------------------------------------------------------
 // Phase 2: Homomorphisms — arrows between algebras (#506).


### PR DESCRIPTION
Small follow-up to #573 / PR #589.  Adds a second concrete-algebra `HasCarrier` witness alongside the existing $\mathbb{F}_2 = (\mathbb{B}, \oplus, \wedge)$ one in `algebra:universal`.

## Summary

```cpp
static_assert(
    HasCarrier<algebra_view<unsigned int>, unsigned int,
               std::plus<unsigned int>, std::multiplies<unsigned int>>);
```

$\mathbb{Z}/2^N\mathbb{Z}$ is the canonical modular ring on `std::unsigned_integral` wide carriers (`algebra/ring.cppm:451` already certifies the strict `IsRing` half via periodic wraparound).  Validates that `HasCarrier` fires on a non-trivial algebra distinct in shape from the 2-element Galois-field $\mathbb{F}_2$ witness: periodic wraparound vs idempotent-XOR-on-bool.

Same `algebra_view` wrapper, same `IsPartOfRelation` + `arrow_drill_down` mereology arms.  No paper-side change (the §1 footnote already names $\mathbb{F}_2$ as the witness; the additional $\mathbb{Z}/2^N\mathbb{Z}$ one is a code-level exhibit).

## Test plan

- [x] `make compile` green (exit 0).
- [x] `HasCarrier<algebra_view<unsigned int>, unsigned int, +, *>` static_assert fires alongside the F_2 witness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)