### PR TITLE
feat(category, numbers, paper): #591 category:equivalence partition + std::integral pilot (uint↔ℕ, int↔ℤ)

### DIFF
--- a/docs/paper/references.bib
+++ b/docs/paper/references.bib
@@ -873,16 +873,16 @@
 }
 
 @incollection{mazur2008equal,
-  author    = {Mazur, Barry},
-  title     = {When is one thing equal to some other thing?},
-  booktitle = {Proof and Other Dilemmas: Mathematics and Philosophy},
-  editor    = {Gold, Bonnie and Simons, Roger A.},
-  publisher = {Mathematical Association of America},
-  series    = {Spectrum},
-  pages     = {221--242},
-  year      = {2008},
-  url       = {https://www.math.harvard.edu/~mazur/preprints/when_is_one.pdf},
-  note      = {Structuralist reading of mathematical equality: objects are individuated by behaviour up to isomorphism, not strict identity. Anchors the category:equivalence partition's up-to-equivalence relaxation of strict == on machine carriers.}
+  author       = {Mazur, Barry},
+  title        = {When is one thing equal to some other thing?},
+  booktitle    = {Proof and Other Dilemmas: Mathematics and Philosophy},
+  editor       = {Gold, Bonnie and Simons, Roger A.},
+  publisher    = {Mathematical Association of America},
+  series       = {Spectrum},
+  pages        = {221--242},
+  year         = {2008},
+  howpublished = {\url{https://www.math.harvard.edu/~mazur/preprints/when_is_one.pdf}},
+  note         = {Structuralist reading of mathematical equality: objects are individuated by behaviour up to isomorphism, not strict identity. Anchors the category:equivalence partition's up-to-equivalence relaxation of strict == on machine carriers.}
 }
 
 @book{dantzig1963simplex,

--- a/docs/paper/references.bib
+++ b/docs/paper/references.bib
@@ -872,6 +872,19 @@
   note         = {Disclosure-of-assistance policy: tools used, tasks, oversight; AI is acknowledged, not co-authored}
 }
 
+@incollection{mazur2008equal,
+  author    = {Mazur, Barry},
+  title     = {When is one thing equal to some other thing?},
+  booktitle = {Proof and Other Dilemmas: Mathematics and Philosophy},
+  editor    = {Gold, Bonnie and Simons, Roger A.},
+  publisher = {Mathematical Association of America},
+  series    = {Spectrum},
+  pages     = {221--242},
+  year      = {2008},
+  url       = {https://www.math.harvard.edu/~mazur/preprints/when_is_one.pdf},
+  note      = {Structuralist reading of mathematical equality: objects are individuated by behaviour up to isomorphism, not strict identity. Anchors the category:equivalence partition's up-to-equivalence relaxation of strict == on machine carriers.}
+}
+
 @book{dantzig1963simplex,
   author    = {Dantzig, George B.},
   title     = {Linear Programming and Extensions},

--- a/src/main/modules/dedekind/category/category.cppm
+++ b/src/main/modules/dedekind/category/category.cppm
@@ -41,11 +41,12 @@
 export module dedekind.category;
 
 // Level 0: The Taxonomic Bricks (Atoms)
-export import :species;    // The Raw Machine Data
-export import :morphism;   // The Base Arrow (Prerequisite for everything)
-export import :mereology;  // Parthood (Prerequisite for Logic/Sets)
-export import :equivalence;  // Equivalence relations (Mazur up-to relaxation; #591)
-export import :logic;      // The Subobject Classifier (Truth)
+export import :species;      // The Raw Machine Data
+export import :morphism;     // The Base Arrow (Prerequisite for everything)
+export import :mereology;    // Parthood (Prerequisite for Logic/Sets)
+export import :equivalence;  // Equivalence relations (Mazur up-to relaxation;
+                             // #591)
+export import :logic;        // The Subobject Classifier (Truth)
 
 // Level 0.5: The Structural Infrastructure
 export import :posetal;    // Partial Orders (Verified by Logic)

--- a/src/main/modules/dedekind/category/category.cppm
+++ b/src/main/modules/dedekind/category/category.cppm
@@ -44,6 +44,7 @@ export module dedekind.category;
 export import :species;    // The Raw Machine Data
 export import :morphism;   // The Base Arrow (Prerequisite for everything)
 export import :mereology;  // Parthood (Prerequisite for Logic/Sets)
+export import :equivalence;  // Equivalence relations (Mazur up-to relaxation; #591)
 export import :logic;      // The Subobject Classifier (Truth)
 
 // Level 0.5: The Structural Infrastructure

--- a/src/main/modules/dedekind/category/equivalence.cppm
+++ b/src/main/modules/dedekind/category/equivalence.cppm
@@ -59,6 +59,11 @@
  *      @em to @em some @em other @em thing?, in Gold \& Simons (eds.),
  *      @em Proof @em and @em Other @em Dilemmas: @em Mathematics @em
  *      and @em Philosophy, MAA, pp.\ 221--242.
+ *
+ * @note "No entity without identity."
+ *       — Willard Van Orman Quine, @em Theories @em and @em Things
+ *         (Harvard University Press, 1981), Ch.\ "Things and Their
+ *         Place in Theories".
  */
 module;
 

--- a/src/main/modules/dedekind/category/equivalence.cppm
+++ b/src/main/modules/dedekind/category/equivalence.cppm
@@ -121,30 +121,40 @@ inline constexpr bool is_symmetric_v = is_symmetric<T, Rel>::value;
  */
 export template <typename T, typename Rel>
 concept IsSymmetric = requires(T a, T b) {
-  { Rel{}(a, b) };
-  { Rel{}(b, a) };
+  { Rel{}(a, b) } -> std::convertible_to<bool>;
+  { Rel{}(b, a) } -> std::convertible_to<bool>;
 } && requires { requires is_symmetric_v<T, Rel>; };
 
 // ---------------------------------------------------------------------------
-// std::equal_to<T> as the canonical equivalence relation.
+// std::equal_to<T> as the canonical equivalence relation on integral
+// (non-floating-point) carriers.
 // ---------------------------------------------------------------------------
 //
 // std::equal_to<T> is the project's canonical equivalence relation on any
-// std::regular T: == is reflexive, symmetric, and transitive by the
-// std::regular contract (which inherits from std::equality_comparable).
-// Pin all three traits via partial specialisation so the canonical case
-// fires without per-carrier opt-in.
+// std::regular T whose == is bit-perfect: reflexive, symmetric, and
+// transitive by the std::regular contract.  We deliberately exclude
+// floating-point carriers here because IEEE-754 NaN breaks reflexivity
+// (NaN == NaN is false), so std::equal_to<double> is NOT a textbook
+// equivalence relation despite double being std::regular.  The Mazur-
+// equivalence escape hatch (#591) is the right home for the floating-
+// point case; ε-equivalence rather than == is the operative relation
+// there.
+//
+// The integral constraint matches the policy in @c category:cartesian
+// (which anchors integral-only registrations on the same axis).  Pin
+// all three traits via partial specialisation so the canonical integral
+// case fires without per-carrier opt-in.
 
 template <typename T>
-  requires std::regular<T>
+  requires std::regular<T> && (!std::floating_point<T>)
 struct is_reflexive<T, std::equal_to<T>> : std::true_type {};
 
 template <typename T>
-  requires std::regular<T>
+  requires std::regular<T> && (!std::floating_point<T>)
 struct is_symmetric<T, std::equal_to<T>> : std::true_type {};
 
 template <typename T>
-  requires std::regular<T>
+  requires std::regular<T> && (!std::floating_point<T>)
 struct is_transitive<T, std::equal_to<T>> : std::true_type {};
 
 // ---------------------------------------------------------------------------

--- a/src/main/modules/dedekind/category/equivalence.cppm
+++ b/src/main/modules/dedekind/category/equivalence.cppm
@@ -1,0 +1,187 @@
+/**
+ * @file dedekind/category/equivalence.cppm
+ * @partition :equivalence
+ * @brief Equivalence relations: reflexive + symmetric + transitive predicates,
+ *        composing the existing axiom traits in @c :species with a new
+ *        symmetry trait.
+ *
+ * @copyright 2026 The Dedekind Authors
+ * Licensed under the Apache License, Version 2.0.
+ *
+ * @section equivalence__Motivation
+ *
+ * The textbook equivalence relation @c R on a carrier @c T is reflexive
+ * (@c R(x, x)), symmetric (@c R(x, y) @c ⇔ @c R(y, x)), and transitive
+ * (@c R(x, y) @c ∧ @c R(y, z) @c ⇒ @c R(x, z)).  These three properties
+ * are universal-property territory: the type system can name the
+ * predicate @b shape (a binary relation on @c T returning a logical
+ * value), but cannot quantify over all @c x, @c y, @c z to verify the
+ * axioms.  Per the project's @b honesty @b obligation pattern, each axiom
+ * is an engineer-supplied trait specialisation; the compiler trusts the
+ * declaration; the public review process is the audit trail.
+ *
+ * Reflexivity and transitivity already live in @c :species
+ * (@c is_reflexive_v<T, Rel> and @c is_transitive_v<T, Rel>, with the
+ * canonical specialisations on @c std::less_equal that the partial-order
+ * machinery in @c :posetal builds on).  This partition adds the missing
+ * @b symmetry trait and bundles all three into a single
+ * @c IsEquivalence<T, Rel> concept.
+ *
+ * @section equivalence__The_Mazur_Reading
+ *
+ * Per Barry Mazur's @em When @em is @em one @em thing @em equal @em to
+ * @em some @em other @em thing? (in Gold \& Simons (eds.), @em Proof
+ * @em and @em Other @em Dilemmas, MAA 2008), an equivalence relation
+ * is the principled way to relax strict equality without abandoning
+ * the algebraic gate: a carrier @c T can be treated as inhabiting a
+ * stricter algebraic concept when the laws hold @b up @b to a named
+ * equivalence relation, even if they don't hold under @c == in the
+ * bit-perfect sense.  This partition lays the structural foundation
+ * for that escape hatch (filed under #591); the first concrete pilot
+ * is @c std::unsigned_integral as @c ℕ for ``sufficiently small''
+ * inputs, wired in @c numbers:uint.
+ *
+ * @section equivalence__Use_cases
+ *
+ *   - @b Bounded equivalence: @c uint64_t under modular arithmetic
+ *     equates to @c ℕ for inputs strictly less than @c 2^64; the
+ *     equivalence captures the ``sufficiently small'' qualification at
+ *     the type level.  Pilot in @c numbers:uint.
+ *   - @b ε-equivalence on IEEE doubles: @c |a @c - @c b| @c < @c eps;
+ *     lifts @c double's non-strict-field arithmetic into the algebraic
+ *     gate.  Future work; depends on the unsigned pilot landing first.
+ *   - @b Quotient algebras: @c A/~ as a carrier requires the
+ *     equivalence relation @c ~ on @c A that defines the quotient
+ *     (sister motivation to @c IsQuotientAlgebra in
+ *     @c algebra:quotient).
+ *
+ * @see Mazur, B. (2008), @em When @em is @em one @em thing @em equal
+ *      @em to @em some @em other @em thing?, in Gold \& Simons (eds.),
+ *      @em Proof @em and @em Other @em Dilemmas: @em Mathematics @em
+ *      and @em Philosophy, MAA, pp.\ 221--242.
+ */
+module;
+
+#include <concepts>
+#include <functional>
+#include <type_traits>
+
+export module dedekind.category:equivalence;
+
+import :morphism;
+import :species;  // is_reflexive_v / is_transitive_v / IsReflexive /
+                  // IsTransitive
+
+namespace dedekind::category {
+
+// The heterogeneous-shape concept @c IsBinaryRelation<R, @c A, @c B> lives
+// in @c :cartesian (Level 0.5 of the DAG).  Equivalence relations are
+// the homogeneous case @c A @c = @c B @c = @c T, but we don't reach for
+// @c :cartesian from here so this partition stays at Level 0 alongside
+// @c :mereology / @c :logic.  The structural-shape requirement (Rel{}
+// is callable on @c T @c × @c T → @c bool) is carried by the
+// @c IsReflexive / @c IsSymmetric / @c IsTransitive concepts directly,
+// each of which already includes the @c Rel{}(a, b) callable check.
+
+// ---------------------------------------------------------------------------
+// is_symmetric: the missing axiom trait, completing the reflexive /
+// symmetric / transitive triad already started in :species.
+// ---------------------------------------------------------------------------
+
+/**
+ * @brief Engineer-supplied trait: relation @c Rel on @c T is symmetric
+ *        (∀x, y: @c Rel(x, @c y) @c ⇔ @c Rel(y, @c x)).
+ *
+ * @details Default @c false; specialise to @c true to declare symmetry.
+ * Follows the same shape as @c :species's @c is_reflexive /
+ * @c is_transitive: a class template specialised by partial
+ * specialisation, with a member-detection bridge from @c T's nested
+ * @c is_symmetric_v static.
+ */
+export template <typename T, typename Rel>
+struct is_symmetric : std::false_type {};
+
+// Discovery: Look for a member variable 'is_symmetric_v' on T.
+template <typename T, typename Rel>
+  requires requires { T::template is_symmetric_v<Rel>; }
+struct is_symmetric<T, Rel>
+    : std::bool_constant<T::template is_symmetric_v<Rel>> {};
+
+/** @brief The "v" helper following the @c :species convention. */
+export template <typename T, typename Rel>
+inline constexpr bool is_symmetric_v = is_symmetric<T, Rel>::value;
+
+/**
+ * @concept IsSymmetric
+ * @brief @b Formal verification: @c Rel(a, @c b) @c ⇔ @c Rel(b, @c a).
+ *
+ * Mirrors @c IsReflexive / @c IsTransitive in @c :species: structural
+ * shape (@c Rel{} is callable on the symmetric pair) plus the
+ * engineer-supplied trait declaration.
+ */
+export template <typename T, typename Rel>
+concept IsSymmetric = requires(T a, T b) {
+  { Rel{}(a, b) };
+  { Rel{}(b, a) };
+} && requires { requires is_symmetric_v<T, Rel>; };
+
+// ---------------------------------------------------------------------------
+// std::equal_to<T> as the canonical equivalence relation.
+// ---------------------------------------------------------------------------
+//
+// std::equal_to<T> is the project's canonical equivalence relation on any
+// std::regular T: == is reflexive, symmetric, and transitive by the
+// std::regular contract (which inherits from std::equality_comparable).
+// Pin all three traits via partial specialisation so the canonical case
+// fires without per-carrier opt-in.
+
+template <typename T>
+  requires std::regular<T>
+struct is_reflexive<T, std::equal_to<T>> : std::true_type {};
+
+template <typename T>
+  requires std::regular<T>
+struct is_symmetric<T, std::equal_to<T>> : std::true_type {};
+
+template <typename T>
+  requires std::regular<T>
+struct is_transitive<T, std::equal_to<T>> : std::true_type {};
+
+// ---------------------------------------------------------------------------
+// IsEquivalence: the textbook equivalence-relation concept.
+// ---------------------------------------------------------------------------
+
+/**
+ * @concept IsEquivalence
+ * @brief A binary relation on @c T that is reflexive, symmetric, and
+ *        transitive --- the textbook equivalence-relation axioms.
+ *
+ * @details Composes the structural shape (@c IsBinaryRelation) with the
+ * three engineer-supplied axiom concepts (@c IsReflexive @b /
+ * @c IsSymmetric @b / @c IsTransitive).  The runtime laws stay the
+ * engineer's honesty obligation; the type system pins the @b shape
+ * mechanically and the @b combination of axiom claims structurally.
+ *
+ * The Mazur @em up @em to @em equivalence reading (see partition
+ * docstring) treats this concept as the principled relaxation of strict
+ * equality: stating @c IsEquivalence<T, Rel> is a structural declaration
+ * that @c Rel is the equivalence relation under which algebraic concepts
+ * on @c T are to be read.
+ *
+ * @tparam T   The carrier on which @c Rel is a relation.
+ * @tparam Rel The relation type.
+ */
+export template <typename T, typename Rel>
+concept IsEquivalence =
+    IsReflexive<T, Rel> && IsSymmetric<T, Rel> && IsTransitive<T, Rel>;
+
+// Witnesses: std::equal_to<T> on std::regular T satisfies IsEquivalence
+// for the canonical primitive carriers.
+
+static_assert(IsEquivalence<int, std::equal_to<int>>,
+              "std::equal_to<int> must satisfy IsEquivalence on int (the "
+              "canonical witness over std::regular<T>).");
+static_assert(IsEquivalence<bool, std::equal_to<bool>>,
+              "std::equal_to<bool> must satisfy IsEquivalence on bool.");
+
+}  // namespace dedekind::category

--- a/src/main/modules/dedekind/numbers/sint.cppm
+++ b/src/main/modules/dedekind/numbers/sint.cppm
@@ -319,8 +319,9 @@ static_assert(
 
 // ===========================================================================
 // Mazur-equivalence pilot (#591): @c std::signed_integral as @c ℤ for
-// inputs in @c [INT_MIN, @c INT_MAX] (the unsigned partition's natural
-// progression).
+// inputs in @c [std::numeric_limits<S>::min(), @c
+// std::numeric_limits<S>::max()] (the unsigned partition's natural
+// progression, generalised across the @c std::signed_integral family).
 // ===========================================================================
 //
 // Per Mazur's @em When @em is @em one @em thing @em equal @em to @em some

--- a/src/main/modules/dedekind/numbers/sint.cppm
+++ b/src/main/modules/dedekind/numbers/sint.cppm
@@ -316,4 +316,45 @@ static_assert(
     IsInjective<std::decay_t<decltype(dedekind::numbers::embed_sint_ℤ_)>>,
     "embed_sint_ℤ_ (int → SignedCardinality) is "
     "registered injective.");
+
+// ===========================================================================
+// Mazur-equivalence pilot (#591): @c std::signed_integral as @c ℤ for
+// inputs in @c [INT_MIN, @c INT_MAX] (the unsigned partition's natural
+// progression).
+// ===========================================================================
+//
+// Per Mazur's @em When @em is @em one @em thing @em equal @em to @em some
+// @em other @em thing? (Proof and Other Dilemmas 2008), the principled
+// relaxation of strict equality on a carrier is a named equivalence
+// relation under which the algebraic laws hold even when they don't hold
+// in the bit-perfect sense.
+//
+// For @c std::signed_integral @c S, the relation @c std::equal_to<S> IS
+// a textbook equivalence relation on @c S (reflexive / symmetric /
+// transitive by the std::regular contract).  Together with the @c
+// embed_sint_ℤ_ injection above (S → SignedCardinality, registered monic
+// / injective), this pins the structural reading: @c S modulo @c
+// std::equal_to<S> is equivalent (in the Mazur sense) to a bounded slice
+// of @c ℤ for inputs in @c [std::numeric_limits<S>::min(), @c
+// std::numeric_limits<S>::max()].  Outside that bound, signed-overflow
+// UB makes the equivalence non-classical --- the unbounded variant
+// carrier @c SignedCardinality is the right home for inputs in the
+// saturation regime.
+//
+// This is the signed-side natural progression of the unsigned-as-ℕ
+// slice in @c numbers:uint (#591); together they cover the std::integral
+// family.  The @c double @c ↔ @c ℝ slice (ε-equivalence) is the harder
+// case deferred until both integer slices stabilise.
+
+static_assert(IsEquivalence<int, std::equal_to<int>>,
+              "Mazur (#591): std::equal_to<int> must satisfy IsEquivalence; "
+              "together with embed_sint_ℤ_ this pins (int / ==) ≡ ℤ for "
+              "inputs in [INT_MIN, INT_MAX].");
+static_assert(IsEquivalence<long, std::equal_to<long>>,
+              "Mazur (#591): std::equal_to<long> must satisfy IsEquivalence; "
+              "sister witness for the wider signed rung.");
+static_assert(
+    IsEquivalence<long long, std::equal_to<long long>>,
+    "Mazur (#591): std::equal_to<long long> must satisfy IsEquivalence; "
+    "the widest std::signed_integral rung.");
 }  // namespace dedekind::category

--- a/src/main/modules/dedekind/numbers/uint.cppm
+++ b/src/main/modules/dedekind/numbers/uint.cppm
@@ -405,7 +405,10 @@ static_assert(
 static_assert(IsEquivalence<unsigned int, std::equal_to<unsigned int>>,
               "Mazur (#591): std::equal_to<unsigned int> must satisfy "
               "IsEquivalence; together with embed_uint_ℕ_ this pins "
-              "(unsigned int / ==) ≡ ℕ for inputs < 2^32.");
+              "(unsigned int / ==) ≡ ℕ for inputs < "
+              "2^std::numeric_limits<unsigned int>::digits "
+              "(platform-dependent; typically 2^32 but not guaranteed by "
+              "the C++ standard).");
 static_assert(IsEquivalence<unsigned long, std::equal_to<unsigned long>>,
               "Mazur (#591): std::equal_to<unsigned long> must satisfy "
               "IsEquivalence; sister witness for the wider unsigned rung.");

--- a/src/main/modules/dedekind/numbers/uint.cppm
+++ b/src/main/modules/dedekind/numbers/uint.cppm
@@ -370,4 +370,51 @@ static_assert(
     IsInjective<std::decay_t<decltype(dedekind::numbers::embed_uint_ℕ_)>>,
     "embed_uint_ℕ_ (unsigned → Cardinality) is "
     "registered injective.");
+
+// ===========================================================================
+// Mazur-equivalence pilot (#591): @c std::unsigned_integral as @c ℕ for
+// inputs strictly less than @c 2^width.
+// ===========================================================================
+//
+// Per Mazur's @em When @em is @em one @em thing @em equal @em to @em some
+// @em other @em thing? (Proof and Other Dilemmas 2008), the principled
+// relaxation of strict equality on a carrier is a named equivalence
+// relation under which the algebraic laws hold even when they don't hold
+// in the bit-perfect sense.
+//
+// For @c std::unsigned_integral T, the relation @c std::equal_to<T>
+// IS a textbook equivalence relation on T (reflexive / symmetric /
+// transitive by the std::regular contract that std::unsigned_integral
+// inherits).  Together with the @c embed_uint_ℕ_ injection above
+// (T-as-modular-ring → Cardinality-as-ℕ, registered monic / injective),
+// this pins the structural reading: @c T modulo @c std::equal_to<T> is
+// equivalent (in the Mazur sense) to a bounded prefix of @c ℕ for inputs
+// strictly less than @c 2^width(T).  Above the bound, modular wraparound
+// makes the equivalence non-classical --- the unbounded variant carrier
+// @c Cardinality is the right home for inputs in the saturation regime.
+//
+// This is the unsigned-side @b first @b slice of the Mazur-equivalence
+// escape hatch (#591); the @c double @c ↔ @c ℝ slice (ε-equivalence)
+// will follow once the unsigned wiring stabilises.
+//
+// The witnesses below pin the equivalence concept from
+// @c category:equivalence on the std::unsigned_integral family, paired
+// with the existing @c embed_uint_ℕ_ injection that already names the
+// structural map @c T @c → @c ℕ.
+
+static_assert(IsEquivalence<unsigned int, std::equal_to<unsigned int>>,
+              "Mazur (#591): std::equal_to<unsigned int> must satisfy "
+              "IsEquivalence; together with embed_uint_ℕ_ this pins "
+              "(unsigned int / ==) ≡ ℕ for inputs < 2^32.");
+static_assert(IsEquivalence<unsigned long, std::equal_to<unsigned long>>,
+              "Mazur (#591): std::equal_to<unsigned long> must satisfy "
+              "IsEquivalence; sister witness for the wider unsigned rung.");
+static_assert(
+    IsEquivalence<unsigned long long, std::equal_to<unsigned long long>>,
+    "Mazur (#591): std::equal_to<unsigned long long> must satisfy "
+    "IsEquivalence; the widest std::unsigned_integral rung.");
+static_assert(IsEquivalence<std::size_t, std::equal_to<std::size_t>>,
+              "Mazur (#591): std::equal_to<std::size_t> must satisfy "
+              "IsEquivalence; the canonical bounded-cardinality witness "
+              "for the indexing surface.");
 }  // namespace dedekind::category


### PR DESCRIPTION
First slice of #591 (Mazur-equivalence escape hatch).  Per the direction in [#591#issuecomment-4382072367](https://github.com/vincentk/dedekind/issues/591#issuecomment-4382072367) — `category:equivalence` as the partition home; `std::unsigned_integral ↔ ℕ` before `double ↔ ℝ`; `numbers:uint` implementation site — and the user's natural-progression hint extending the pilot to `std::signed_integral`.

## What lands

### `category:equivalence` (new partition, Level 0)

- `IsSymmetric<T, Rel>` concept + `is_symmetric` / `is_symmetric_v` traits following the existing `:species` pattern (`is_reflexive` / `is_transitive` already live there).  Completes the reflexive / symmetric / transitive triad without duplication.
- `IsEquivalence<T, Rel>` concept composing `IsReflexive` (from `:species`) + `IsSymmetric` (this partition) + `IsTransitive` (from `:species`).  Engineer-supplied axiom traits stay the honesty obligation; the type system pins the structural shape and the combination of axiom claims.
- `std::equal_to<T>` certified as the canonical equivalence on `std::regular<T>` via partial specialisation of all three axiom traits.  Witnesses on `int`, `bool` pinned in `:equivalence` itself.

### `numbers:uint` pilot (unsigned ↔ ℕ)

```cpp
static_assert(IsEquivalence<unsigned int,       std::equal_to<unsigned int>>);
static_assert(IsEquivalence<unsigned long,      std::equal_to<unsigned long>>);
static_assert(IsEquivalence<unsigned long long, std::equal_to<unsigned long long>>);
static_assert(IsEquivalence<std::size_t,        std::equal_to<std::size_t>>);
```

Mazur reading: `U modulo std::equal_to<U>` is equivalent (in the Mazur sense) to a bounded prefix of `ℕ` for inputs strictly less than `2^width(U)`; above the bound, modular wraparound makes the equivalence non-classical, and the unbounded variant carrier `Cardinality` is the right home for the saturation regime.  Composes with the existing `embed_uint_ℕ_` injection (registered monic / injective).

### `numbers:sint` natural progression (signed ↔ ℤ)

```cpp
static_assert(IsEquivalence<int,       std::equal_to<int>>);
static_assert(IsEquivalence<long,      std::equal_to<long>>);
static_assert(IsEquivalence<long long, std::equal_to<long long>>);
```

Mazur reading: `S modulo std::equal_to<S>` is equivalent to a bounded slice of `ℤ` for inputs in `[std::numeric_limits<S>::min(), std::numeric_limits<S>::max()]`; outside the bound, signed-overflow UB makes the equivalence non-classical (the `SignedCardinality` variant carrier is the saturation home).  Composes with the existing `embed_sint_ℤ_` injection.

### Mazur citation

`docs/paper/references.bib` gains `@incollection{mazur2008equal, ...}` for [Barry Mazur, *When is one thing equal to some other thing?*](https://www.math.harvard.edu/~mazur/preprints/when_is_one.pdf), in *Proof and Other Dilemmas* (eds. Gold & Simons, MAA 2008), pp. 221–242.  Ready for paper-side §1 / §2.3 / §discussion prose to cite.

## Out of scope (deferred)

- **`StructuralAlias<T, Eq, Axioms...>` wrapper** from the original Mazur sketch — the unbounded `std::equal_to` framing is sufficient for the integer pilots; the wrapper escape hatch becomes meaningful when ε-equivalence on doubles lands.
- **Bounded-equivalence as a partial relation** (`x < bound ∧ x == y`) on `Modular<N>` — follow-up if the unbounded framing turns out coarse.
- **`double ↔ ℝ` ε-equivalence** — explicit deferral; the integer slices stabilise first.
- **§2.3 paper-side prose extension** naming the Mazur escape hatch — paper-polish slice; the bibliography entry lands now so the cite is ready.

## Test plan

- [x] `make compile` green (360/360, exit 0).
- [x] `IsEquivalence<{int, bool}, std::equal_to<...>>` static_asserts fire in `:equivalence`.
- [x] Sister witnesses fire across the `std::integral` family in `numbers:uint` and `numbers:sint`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)