### PR TITLE
docs(paper): #498 NEW-D — name Frac / Free / Quotient functors explicitly in §2.3

### DIFF
--- a/docs/paper/paper.tex
+++ b/docs/paper/paper.tex
@@ -688,11 +688,11 @@ static_assert(IsFunctor<maybe_functor<int>>);  // mechanical verification
 The hub--carrier split (\cppinline{maybe_functor<T>} carries the functorial proof obligation; \cppinline{std::optional<T>} stays a Plain Old C++ Object) is the §\ref{sec:alg-sigma} architectural pattern played at the next kind level.
 This is the same after-the-fact membership above: \cppinline{std::optional} ships in the C++ standard and cannot opt into anything upstream, but the moment a hub naming the functorial structure passes the concept gate, the carrier inhabits $\mathbf{Ddk}$ as a functor.
 
-The carrier-lattice's higher-kinded constructions fall into three functorial families, each a textbook universal-property construction:
-\emph{Frac} (field of fractions: a left adjoint to the inclusion $\mathbf{Field} \hookrightarrow \mathbf{IntegralDomain}$, giving $\mathbb{Q} = \operatorname{Frac}(\mathbb{Z})$);
+The carrier-lattice's higher-kinded constructions are populated by several functorial families, each a textbook universal-property construction; representative anchors include:
+\emph{Frac} (field of fractions: a left adjoint to the inclusion $\mathbf{Field} \hookrightarrow \mathbf{IntegralDomain}$, giving $\mathbb{Q} = \operatorname{Frac}(\mathbb{Z})$, with $\operatorname{Cuts}$ as a sister carrier-strength completion giving $\mathbb{R} = \operatorname{Cuts}(\mathbb{Q})$);
 \emph{Free} (free module: a left adjoint to the forgetful $U: \mathrm{Mod}_R \to \mathbf{Set}$, giving $V_n(R) = \operatorname{Free}_n(R) = R^n$ and dually the internal hom $\operatorname{End}_R(V_n) = M_n(R)$);
 and \emph{Quotient} (quotient by a congruence: an H operation in the HSP sense, giving $\mathbb{C} = \mathbb{R}[i]/(i^2+1)$ and $\mathbb{D} = \mathbb{R}[\varepsilon]/(\varepsilon^2)$).
-Each construction is named in the carrier-lattice diagram (Figure~\ref{fig:carrier-lattice}) and exhibited concretely in §\ref{sec:linalg}; the discipline of this section is that each functor lifts at the type level the moment a hub naming it passes the concept gate, and the corresponding carrier (\cppinline{Rational<I>}, \cppinline{Vec2V<T>} / \cppinline{Mat2x2V<T>}, \cppinline{Complex<R>} / \cppinline{Dual<F>}) inhabits $\mathbf{Ddk}$ at that kind level without modifying the underlying scalar storage.
+Each construction is named in the carrier-lattice diagram (Figure~\ref{fig:carrier-lattice}) and exhibited concretely in §\ref{sec:linalg}; the discipline of this section is that each functor lifts at the type level the moment a hub naming it passes the concept gate, and the corresponding carrier (\cppinline{Rational<I>}, \cppinline{Vec2V<T>} / \cppinline{Matrix2x2V<T>}, \cppinline{Complex<R>} / \cppinline{Dual<F>}) inhabits $\mathbf{Ddk}$ at that kind level without modifying the underlying scalar storage.
 
 \paragraph{The intersection's deliberate scope.}
 Two distinct mechanisms compose into the intersection $\mathbf{Ddk} = \mathbf{Jlt} \cap \mathbf{Alg}(-)_{\beth_1}$, and naming them separately matters because they pay for different things.
@@ -1019,10 +1019,11 @@ the simpler set at compile time.
 
 The third pillar.  The carrier lattice of Figure~\ref{fig:carrier-lattice}
 in load-bearing form: HSP propagation lifts axioms componentwise
-along quotients (\textbf{H}, e.g. \texttt{Frac}, \texttt{Complex},
+along quotients (\textbf{H}, e.g. \texttt{Complex},
 \texttt{Dual}) and direct products (\textbf{P}, e.g. $V_n(R)$,
-\texttt{Diagonal}); $\operatorname{End}_R$ is the partial-axiom
-rank-$n$ extension.  The algebraic lattice's compile-time-reduction
+\texttt{Diagonal}); localizations such as \texttt{Frac} sit alongside
+HSP rather than inside it, and $\operatorname{End}_R$ is the
+partial-axiom rank-$n$ extension.  The algebraic lattice's compile-time-reduction
 showcases live in the sister section §\ref{sec:linalg}
 \emph{Linear Algebra}: linear programming
 (§\ref{sec:lp-centrepiece}), forward-mode automatic differentiation

--- a/docs/paper/paper.tex
+++ b/docs/paper/paper.tex
@@ -687,7 +687,12 @@ static_assert(IsFunctor<maybe_functor<int>>);  // mechanical verification
 
 The hub--carrier split (\cppinline{maybe_functor<T>} carries the functorial proof obligation; \cppinline{std::optional<T>} stays a Plain Old C++ Object) is the §\ref{sec:alg-sigma} architectural pattern played at the next kind level.
 This is the same after-the-fact membership above: \cppinline{std::optional} ships in the C++ standard and cannot opt into anything upstream, but the moment a hub naming the functorial structure passes the concept gate, the carrier inhabits $\mathbf{Ddk}$ as a functor.
-The pattern generalises across the carrier-tower's other higher-kinded constructions ($V_n(R)$, $\mathrm{End}_R$, $\mathrm{Frac}$, $\mathrm{Complex}$, $\mathrm{Dual}$); §\ref{sec:linalg} carries the worked instances.
+
+The carrier-lattice's higher-kinded constructions fall into three functorial families, each a textbook universal-property construction:
+\emph{Frac} (field of fractions: a left adjoint to the inclusion $\mathbf{Field} \hookrightarrow \mathbf{IntegralDomain}$, giving $\mathbb{Q} = \operatorname{Frac}(\mathbb{Z})$);
+\emph{Free} (free module: a left adjoint to the forgetful $U: \mathrm{Mod}_R \to \mathbf{Set}$, giving $V_n(R) = \operatorname{Free}_n(R) = R^n$ and dually the internal hom $\operatorname{End}_R(V_n) = M_n(R)$);
+and \emph{Quotient} (quotient by a congruence: an H operation in the HSP sense, giving $\mathbb{C} = \mathbb{R}[i]/(i^2+1)$ and $\mathbb{D} = \mathbb{R}[\varepsilon]/(\varepsilon^2)$).
+Each construction is named in the carrier-lattice diagram (Figure~\ref{fig:carrier-lattice}) and exhibited concretely in §\ref{sec:linalg}; the discipline of this section is that each functor lifts at the type level the moment a hub naming it passes the concept gate, and the corresponding carrier (\cppinline{Rational<I>}, \cppinline{Vec2V<T>} / \cppinline{Mat2x2V<T>}, \cppinline{Complex<R>} / \cppinline{Dual<F>}) inhabits $\mathbf{Ddk}$ at that kind level without modifying the underlying scalar storage.
 
 \paragraph{The intersection's deliberate scope.}
 Two distinct mechanisms compose into the intersection $\mathbf{Ddk} = \mathbf{Jlt} \cap \mathbf{Alg}(-)_{\beth_1}$, and naming them separately matters because they pay for different things.
@@ -1012,7 +1017,7 @@ the simpler set at compile time.
 \label{fig:two-axes}
 \end{figure}
 
-The third pillar.  The carrier tower of Figure~\ref{fig:carrier-lattice}
+The third pillar.  The carrier lattice of Figure~\ref{fig:carrier-lattice}
 in load-bearing form: HSP propagation lifts axioms componentwise
 along quotients (\textbf{H}, e.g. \texttt{Frac}, \texttt{Complex},
 \texttt{Dual}) and direct products (\textbf{P}, e.g. $V_n(R)$,


### PR DESCRIPTION
Closes part of #498 (NEW-D sub-task: §2 / §5 CT-vocabulary pass).

## Summary

§2.3's "Higher-kinded inhabitants" closing paragraph already mentioned the carrier-lattice's higher-kinded constructions ($V_n(R)$, $\mathrm{End}_R$, $\mathrm{Frac}$, $\mathrm{Complex}$, $\mathrm{Dual}$) but didn't name them as *functors* with their universal-property roles.  This PR sharpens the vocabulary: three functorial families, each a textbook universal-property construction, named explicitly.

## What lands

- **Frac**: field of fractions, left adjoint to $\mathbf{Field} \hookrightarrow \mathbf{IntegralDomain}$, giving $\mathbb{Q} = \operatorname{Frac}(\mathbb{Z})$.
- **Free**: free module, left adjoint to the forgetful $U: \mathrm{Mod}_R \to \mathbf{Set}$, giving $V_n(R) = \operatorname{Free}_n(R) = R^n$ and dually the internal hom $\operatorname{End}_R(V_n) = M_n(R)$.
- **Quotient**: quotient by a congruence, an H operation in the HSP sense, giving $\mathbb{C} = \mathbb{R}[i]/(i^2+1)$ and $\mathbb{D} = \mathbb{R}[\varepsilon]/(\varepsilon^2)$.

Each construction lifts at the type level once a hub naming it passes the concept gate; the corresponding named carrier (`Rational<I>`, `Vec2V<T>` / `Mat2x2V<T>`, `Complex<R>` / `Dual<F>`) inhabits $\mathbf{Ddk}$ at that kind level without modifying the underlying scalar storage.

## Sister tweak

"carrier-tower" → "carrier-lattice" / "carrier lattice" per terminology preference.  The figure label is `fig:carrier-lattice`, and the prose was inconsistent across §2.3 and §pruning; both repointed.

## What stays unchanged

§5.3 (`sec:lin-alg-embedding`) already names $\operatorname{Cplx}$, $\operatorname{Dual}$, $\operatorname{Free}_2$, $\operatorname{End}_R$ as functors composed in a natural-transformation schema (`lst:lin-alg-embeddings` and surrounding prose).  No vocabulary gap there; this PR's only target is §2.3.

## Test plan

- [x] Single-pass lualatex green (52 pages, no errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)