### PR TITLE
feat(sets): #602 layer-1 slice 1 — image(f, SingletonSet) per-arrow set lift

### DIFF
--- a/src/main/modules/dedekind/morphologies/archimedean.cppm
+++ b/src/main/modules/dedekind/morphologies/archimedean.cppm
@@ -21,7 +21,7 @@ export module dedekind.morphologies:archimedean;
 
 import dedekind.category; // IsArrow (#602 layer-1 breadcrumb)
 import dedekind.sequences;
-import dedekind.sets;     // SingletonSet, singleton, image (#602 layer-1)
+import dedekind.sets; // SingletonSet, singleton, image (#602 layer-1)
 
 namespace dedekind::morphologies {
 using namespace dedekind::sequences;
@@ -208,14 +208,13 @@ static_assert(dedekind::category::IsArrow<succ_arrow>,
               "Breadcrumb (i): the Peano-successor witness arrow "
               "S(x) = x + 1 satisfies IsArrow.");
 
-inline constexpr auto s0 =
-    dedekind::sets::SingletonSet<int>{0};
+inline constexpr auto s0 = dedekind::sets::SingletonSet<int>{0};
 inline constexpr auto s1 = dedekind::sets::image(succ_arrow{}, s0);
 
-static_assert(std::is_same_v<decltype(s1),
-                             const dedekind::sets::SingletonSet<int>>,
-              "Breadcrumb (ii): image preserves the SingletonSet shape; "
-              "Cod(F) == int folds back to SingletonSet<int>.");
+static_assert(
+    std::is_same_v<decltype(s1), const dedekind::sets::SingletonSet<int>>,
+    "Breadcrumb (ii): image preserves the SingletonSet shape; "
+    "Cod(F) == int folds back to SingletonSet<int>.");
 static_assert(dedekind::sets::IsExtensional<decltype(s1)>,
               "Breadcrumb (ii): image preserves IsExtensional.");
 static_assert(dedekind::sets::IsPointedSet<decltype(s1), int>,
@@ -227,9 +226,10 @@ static_assert(s1 == dedekind::sets::singleton(succ_arrow{}(s0.pivot)),
               "Breadcrumb (iii): image(f, s) == singleton(f(s.pivot)) — "
               "the cardinality-1 instance of the powerset-monad Kleisli "
               "bind, factored through η.");
-static_assert(s1 == (s0 >>= [](int x) {
-                return dedekind::sets::singleton(succ_arrow{}(x));
-              }),
+static_assert(s1 == (s0 >>=
+                     [](int x) {
+                       return dedekind::sets::singleton(succ_arrow{}(x));
+                     }),
               "Breadcrumb (iii): image factors through the existing "
               "Singleton-monad Kleisli bind (>>=).");
 

--- a/src/main/modules/dedekind/morphologies/archimedean.cppm
+++ b/src/main/modules/dedekind/morphologies/archimedean.cppm
@@ -16,6 +16,7 @@ module;
 
 #include <cmath>
 #include <concepts>
+#include <type_traits>  // std::is_same_v for the image-of-Singleton breadcrumb
 
 export module dedekind.morphologies:archimedean;
 

--- a/src/main/modules/dedekind/morphologies/archimedean.cppm
+++ b/src/main/modules/dedekind/morphologies/archimedean.cppm
@@ -19,7 +19,9 @@ module;
 
 export module dedekind.morphologies:archimedean;
 
+import dedekind.category; // IsArrow (#602 layer-1 breadcrumb)
 import dedekind.sequences;
+import dedekind.sets;     // SingletonSet, singleton, image (#602 layer-1)
 
 namespace dedekind::morphologies {
 using namespace dedekind::sequences;
@@ -170,5 +172,67 @@ static_assert(
     "double must satisfy IsOrderedField (regular + totally ordered).");
 static_assert(IsArchimedeanField<double>,
               "double must satisfy IsArchimedeanField (x + 1 is defined).");
+
+/**
+ * @section archimedean__Image_Of_Singleton_Under_Peano_Successor
+ * Categorical breadcrumbs for @c image(f, @c SingletonSet) (#602 layer-1).
+ *
+ * The witness arrow is the Peano successor S(x) = x + 1, the canonical
+ * carrier-level instance of the @c successor / @c generator vocabulary
+ * this partition already names (see the §archimedean__Vocabulary_Notes_388
+ * block).  We pin three structural claims so the type-checker carries the
+ * proof of @c image's behaviour on the cardinality-1 case:
+ *
+ *   (i)   @c image is defined for @c IsArrow inputs.
+ *   (ii)  Tier preservation: cardinality 1 ↦ 1, @c IsExtensional and
+ *         @c IsPointedSet preserved on the codomain side.
+ *   (iii) Kleisli factoring: @c image(f, @c s) is the cardinality-1
+ *         instance of the powerset-monad bind @c s @c >>= @c (η @c ∘ @c f),
+ *         witnessed by @c image(f, @c s) @c == @c singleton(f(s.pivot))
+ *         and @c image(f, @c s) @c == @c (s @c >>= @c (η @c ∘ @c f)).
+ *
+ * Placing the witness here rather than in @c :sets:singleton keeps the
+ * upstream partition free of its own assertion machinery; @c :archimedean
+ * is downstream of @c :sets and is the natural home for a Peano-successor
+ * test (per PR #604 review).
+ */
+namespace singleton_image_breadcrumb {
+
+struct succ_arrow {
+  using Domain = int;
+  using Codomain = int;
+  constexpr int operator()(int x) const { return x + 1; }
+};
+
+static_assert(dedekind::category::IsArrow<succ_arrow>,
+              "Breadcrumb (i): the Peano-successor witness arrow "
+              "S(x) = x + 1 satisfies IsArrow.");
+
+inline constexpr auto s0 =
+    dedekind::sets::SingletonSet<int>{0};
+inline constexpr auto s1 = dedekind::sets::image(succ_arrow{}, s0);
+
+static_assert(std::is_same_v<decltype(s1),
+                             const dedekind::sets::SingletonSet<int>>,
+              "Breadcrumb (ii): image preserves the SingletonSet shape; "
+              "Cod(F) == int folds back to SingletonSet<int>.");
+static_assert(dedekind::sets::IsExtensional<decltype(s1)>,
+              "Breadcrumb (ii): image preserves IsExtensional.");
+static_assert(dedekind::sets::IsPointedSet<decltype(s1), int>,
+              "Breadcrumb (ii): image preserves IsPointedSet.");
+static_assert(s1.size() == 1,
+              "Breadcrumb (ii): cardinality is preserved (1 ↦ 1).");
+
+static_assert(s1 == dedekind::sets::singleton(succ_arrow{}(s0.pivot)),
+              "Breadcrumb (iii): image(f, s) == singleton(f(s.pivot)) — "
+              "the cardinality-1 instance of the powerset-monad Kleisli "
+              "bind, factored through η.");
+static_assert(s1 == (s0 >>= [](int x) {
+                return dedekind::sets::singleton(succ_arrow{}(x));
+              }),
+              "Breadcrumb (iii): image factors through the existing "
+              "Singleton-monad Kleisli bind (>>=).");
+
+}  // namespace singleton_image_breadcrumb
 
 }  // namespace dedekind::morphologies

--- a/src/main/modules/dedekind/sets/singleton.cppm
+++ b/src/main/modules/dedekind/sets/singleton.cppm
@@ -263,6 +263,90 @@ constexpr auto operator<<=(const SingletonSet<T, L>& s, Func&& f) {
   return SingletonSet<U, L>{std::forward<Func>(f)(s)};
 }
 
+/**
+ * @section singleton__Image
+ * @brief Image of a @c SingletonSet under an @c IsArrow.
+ *
+ * @details For an arrow @c f @c : @c T @c → @c U and a singleton
+ * @c {x} @c ⊂ @c T, the categorical image is @c f({x}) @c = @c {f(x)}
+ * @c ⊂ @c U.  This is the cardinality-1 instance of the powerset-monad
+ * Kleisli bind: equivalent to @c s @c >>= @c (η @c ∘ @c f), where @c η
+ * wraps a value in a singleton (the Singleton-monad unit).
+ *
+ * @section singleton__Image_Categorical_Anchor
+ * Type-level breadcrumbs (the static_asserts below) tie the image
+ * construction back to:
+ *   - @c IsArrow: the source-side requirement.  @c f's @c Domain must
+ *     match the singleton's @c pivot type.
+ *   - The Kleisli triple's @c >>= (above): @c image(f, @c s) @c is the
+ *     Singleton specialisation of the Set-monad's bind, factored
+ *     through @c η.
+ *   - The image's tier (@c IsCompileTimeEnumerable, @c IsFiniteSet,
+ *     @c HasDecidableMembership): all preserved by the lift, since
+ *     @c SingletonSet has cardinality 1 in both source and target.
+ *
+ * Filed under #602's layer-1 plan: per-shape image dispatch, Singleton
+ * source as the entry point.  The same shape generalises to
+ * @c FiniteExtensionalSet (sister source under #598) and predicate
+ * sets (lazy / iso-witnessed cases).
+ */
+export template <typename T, typename L, dedekind::category::IsArrow F>
+  requires std::same_as<dedekind::category::Dom<std::remove_cvref_t<F>>, T>
+constexpr auto image(F&& f, const SingletonSet<T, L>& s) {
+  using U = dedekind::category::Cod<std::remove_cvref_t<F>>;
+  return SingletonSet<U, L>{std::forward<F>(f)(s.pivot)};
+}
+
+// ---------------------------------------------------------------------------
+// Categorical breadcrumbs for `image(f, SingletonSet)` (#602 layer 1).
+//
+// The static_asserts below pin three load-bearing claims so the
+// type-checker always carries the proof:
+//
+//   (i)   `image` is defined for @c IsArrow inputs (the source-side
+//         requirement; the @c requires-clause already enforces
+//         Dom(F) == T at instantiation).
+//   (ii)  Tier preservation: @c SingletonSet remains @c IsExtensional
+//         and @c IsPointedSet on the codomain side.  Cardinality is
+//         preserved by construction (size 1 ↦ size 1).
+//   (iii) Kleisli factoring: @c image(f, s) == singleton(f(s.pivot))
+//         — i.e. the cardinality-1 instance of the powerset-monad
+//         bind @c s @c >>= @c (η @c ∘ @c f).
+//
+// The witness arrow stays inline so the breadcrumb is self-contained
+// (no upstream import of @c dedekind.numbers — that would be a cycle).
+// ---------------------------------------------------------------------------
+namespace singleton_image_breadcrumb {
+struct succ_arrow {
+  using Domain = int;
+  using Codomain = int;
+  constexpr int operator()(int x) const { return x + 1; }
+};
+static_assert(dedekind::category::IsArrow<succ_arrow>,
+              "Breadcrumb (i): the witness arrow satisfies IsArrow.");
+
+inline constexpr auto s0 = SingletonSet<int>{0};
+inline constexpr auto s1 = image(succ_arrow{}, s0);
+
+static_assert(std::is_same_v<decltype(s1), const SingletonSet<int>>,
+              "Breadcrumb (ii): image preserves the SingletonSet shape; "
+              "Cod(F) == int folds back to SingletonSet<int>.");
+static_assert(IsExtensional<decltype(s1)>,
+              "Breadcrumb (ii): image preserves IsExtensional.");
+static_assert(IsPointedSet<decltype(s1), int>,
+              "Breadcrumb (ii): image preserves IsPointedSet.");
+static_assert(s1.size() == 1,
+              "Breadcrumb (ii): cardinality is preserved (1 ↦ 1).");
+
+static_assert(s1 == singleton(succ_arrow{}(s0.pivot)),
+              "Breadcrumb (iii): image(f, s) == singleton(f(s.pivot)) — "
+              "the cardinality-1 instance of the powerset-monad Kleisli "
+              "bind, factored through η.");
+static_assert(s1 == (s0 >>= [](int x) { return singleton(succ_arrow{}(x)); }),
+              "Breadcrumb (iii): image factors through the existing "
+              "Singleton-monad Kleisli bind (>>=).");
+}  // namespace singleton_image_breadcrumb
+
 };  // namespace dedekind::sets
 
 /** @section singleton__The_Final_Ontology_Proof

--- a/src/main/modules/dedekind/sets/singleton.cppm
+++ b/src/main/modules/dedekind/sets/singleton.cppm
@@ -287,8 +287,10 @@ constexpr auto operator<<=(const SingletonSet<T, L>& s, Func&& f) {
  *
  * Filed under #602's layer-1 plan: per-shape image dispatch, Singleton
  * source as the entry point.  The same shape generalises to
- * @c FiniteExtensionalSet (sister source under #598) and predicate
- * sets (lazy / iso-witnessed cases).
+ * @c ExtensionalSet (sister source post-#598) and predicate sets
+ * (lazy / iso-witnessed cases).  Note: the per-wrapper overload shape
+ * is itself due for dissolution under #607's Juliet-clean refactor;
+ * this slice lands the entry-point breadcrumbs in their current form.
  */
 export template <typename L, dedekind::category::IsArrow F>
 constexpr auto image(

--- a/src/main/modules/dedekind/sets/singleton.cppm
+++ b/src/main/modules/dedekind/sets/singleton.cppm
@@ -298,55 +298,16 @@ constexpr auto image(
   return SingletonSet<U, L>{std::forward<F>(f)(s.pivot)};
 }
 
-// ---------------------------------------------------------------------------
-// Categorical breadcrumbs for `image(f, SingletonSet)` (#602 layer 1).
-//
-// The static_asserts below pin three load-bearing claims so the
-// type-checker always carries the proof:
-//
-//   (i)   `image` is defined for @c IsArrow inputs (the source-side
-//         requirement; the @c requires-clause already enforces
-//         Dom(F) == T at instantiation).
-//   (ii)  Tier preservation: @c SingletonSet remains @c IsExtensional
-//         and @c IsPointedSet on the codomain side.  Cardinality is
-//         preserved by construction (size 1 ↦ size 1).
-//   (iii) Kleisli factoring: @c image(f, s) == singleton(f(s.pivot))
-//         — i.e. the cardinality-1 instance of the powerset-monad
-//         bind @c s @c >>= @c (η @c ∘ @c f).
-//
-// The witness arrow stays inline so the breadcrumb is self-contained
-// (no upstream import of @c dedekind.numbers — that would be a cycle).
-// ---------------------------------------------------------------------------
-namespace singleton_image_breadcrumb {
-struct succ_arrow {
-  using Domain = int;
-  using Codomain = int;
-  constexpr int operator()(int x) const { return x + 1; }
-};
-static_assert(dedekind::category::IsArrow<succ_arrow>,
-              "Breadcrumb (i): the witness arrow satisfies IsArrow.");
-
-inline constexpr auto s0 = SingletonSet<int>{0};
-inline constexpr auto s1 = image(succ_arrow{}, s0);
-
-static_assert(std::is_same_v<decltype(s1), const SingletonSet<int>>,
-              "Breadcrumb (ii): image preserves the SingletonSet shape; "
-              "Cod(F) == int folds back to SingletonSet<int>.");
-static_assert(IsExtensional<decltype(s1)>,
-              "Breadcrumb (ii): image preserves IsExtensional.");
-static_assert(IsPointedSet<decltype(s1), int>,
-              "Breadcrumb (ii): image preserves IsPointedSet.");
-static_assert(s1.size() == 1,
-              "Breadcrumb (ii): cardinality is preserved (1 ↦ 1).");
-
-static_assert(s1 == singleton(succ_arrow{}(s0.pivot)),
-              "Breadcrumb (iii): image(f, s) == singleton(f(s.pivot)) — "
-              "the cardinality-1 instance of the powerset-monad Kleisli "
-              "bind, factored through η.");
-static_assert(s1 == (s0 >>= [](int x) { return singleton(succ_arrow{}(x)); }),
-              "Breadcrumb (iii): image factors through the existing "
-              "Singleton-monad Kleisli bind (>>=).");
-}  // namespace singleton_image_breadcrumb
+// Breadcrumbs for `image(f, SingletonSet)` live downstream in
+// `morphologies:archimedean` (the natural home for Peano-successor
+// witnesses).  The structural claims pinned there:
+//   (i)   `image` is defined for @c IsArrow inputs.
+//   (ii)  Tier preservation: cardinality 1 ↦ 1, @c IsExtensional and
+//         @c IsPointedSet preserved on the codomain side.
+//   (iii) Kleisli factoring: @c image(f, s) == @c (s @c >>= @c (η @c ∘ @c f))
+//         — the cardinality-1 instance of the powerset-monad bind.
+// Placing the witness downstream lets us avoid contaminating
+// @c :singleton with its own assertion machinery (per PR #604 review).
 
 };  // namespace dedekind::sets
 

--- a/src/main/modules/dedekind/sets/singleton.cppm
+++ b/src/main/modules/dedekind/sets/singleton.cppm
@@ -48,6 +48,8 @@ module;
 #include <compare>
 #include <concepts>
 #include <functional>
+#include <type_traits>  // std::remove_cvref_t for the IsArrow Dom/Cod plumbing
+#include <utility>      // std::forward for the image() overload
 
 export module dedekind.sets:singleton;
 
@@ -274,8 +276,9 @@ constexpr auto operator<<=(const SingletonSet<T, L>& s, Func&& f) {
  * wraps a value in a singleton (the Singleton-monad unit).
  *
  * @section singleton__Image_Categorical_Anchor
- * Type-level breadcrumbs (the static_asserts below) tie the image
- * construction back to:
+ * Type-level breadcrumbs (placed downstream in
+ * @c morphologies:archimedean rather than below in this partition; see
+ * the closing note for why) tie the image construction back to:
  *   - @c IsArrow: the source-side requirement.  @c f's @c Domain must
  *     match the singleton's @c pivot type.
  *   - The Kleisli triple's @c >>= (above): @c image(f, @c s) @c is the

--- a/src/main/modules/dedekind/sets/singleton.cppm
+++ b/src/main/modules/dedekind/sets/singleton.cppm
@@ -290,9 +290,10 @@ constexpr auto operator<<=(const SingletonSet<T, L>& s, Func&& f) {
  * @c FiniteExtensionalSet (sister source under #598) and predicate
  * sets (lazy / iso-witnessed cases).
  */
-export template <typename T, typename L, dedekind::category::IsArrow F>
-  requires std::same_as<dedekind::category::Dom<std::remove_cvref_t<F>>, T>
-constexpr auto image(F&& f, const SingletonSet<T, L>& s) {
+export template <typename L, dedekind::category::IsArrow F>
+constexpr auto image(
+    F&& f,
+    const SingletonSet<dedekind::category::Dom<std::remove_cvref_t<F>>, L>& s) {
   using U = dedekind::category::Cod<std::remove_cvref_t<F>>;
   return SingletonSet<U, L>{std::forward<F>(f)(s.pivot)};
 }


### PR DESCRIPTION
First slice of issue #602's **layer-1** plan: per-arrow set-level image lifts.  Singleton-source as the cardinality-1 entry point.

## What lands in this slice

* `image(f, SingletonSet<Dom<F>, L>)` — for any `IsArrow F`, returns `SingletonSet<Cod<F>, L>` containing `f(s.pivot)`.  Located in [sets/singleton.cppm](src/main/modules/dedekind/sets/singleton.cppm).
* Categorical breadcrumbs (5 `static_assert` lines + `succ_arrow` witness) relocated to [morphologies/archimedean.cppm](src/main/modules/dedekind/morphologies/archimedean.cppm) — fits next to the existing successor / generator vocabulary block, downstream of `:sets` so testing imports cleanly.

The breadcrumbs pin three structural claims: (i) `IsArrow` source-side requirement; (ii) tier preservation (cardinality 1 ↦ 1, `IsExtensional`, `IsPointedSet`); (iii) Kleisli factoring (`image(f, s) == singleton(f(s.pivot))`, equivalent to the cardinality-1 instance of the powerset-monad bind).

## Architectural note

This per-wrapper overload shape is the kind of construct **#607's Juliet-clean dissolution** is going to sweep.  Once `SingletonSet` either becomes a type alias for `Subobject<T, Lambda>` or dissolves entirely, this function will be replaced by a generic `image(f, S) requires IsSet<S>` over the dissolved-wrapper world.

Landing slice 1 anyway, in parallel with #607, on the user's call: forward progress matters; the eventual sweep is part of the project's experimental cadence (per the project's stated stance on API breaks during structural refactors).

## Coordination with #605 / #607

* **Post-#605 sync**: the docstring reference `FiniteExtensionalSet (sister source under #598)` was updated to `ExtensionalSet (sister source post-#598)` to match the squashed names.
* **#607 (wrapper dissolution)**: open in parallel.  This PR does not block it; #607's slices will rewrite the dispatch shape when they land.

## Review threads

* **T-redundancy (resolved)**: collapsed via `image(F&& f, const SingletonSet<Dom<F>, L>& s)` — direct type-pattern matching at the parameter, no redundant `T` template parameter.
* **Breadcrumb relocation (resolved)**: moved from `singleton_image_breadcrumb` namespace in `:singleton` to `morphologies:archimedean` per review.
* **"Root in `category` module / pushout"** (still open): the structural question of where `image()` itself lives is the larger #607 conversation — image-as-coequalizer-of-kernel-pair lives in `category:` once the dispatch shape stabilises.  Deferring to #607.

## Test plan

- [x] `make compile` clean (371/371 targets local).
- [x] All five `static_assert` breadcrumbs evaluate at compile time.
- [ ] CI build-and-deploy confirms the nanobind path (the `_dedekind` target) — this PR doesn't touch the Python facade, so the risk is low, but the lesson from #605 is to wait on CI.
- [ ] Slice 2 (image on `ExtensionalSet`) — superseded by #607's wrapper dissolution; will land there in the new shape, not as a sister slice here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)