### PR TITLE
docs(paper): #461 paper sweep — §2.1 Ω relocation, hub-and-spoke prose realignment, (A,F) consolidation

### DIFF
--- a/docs/paper/paper.tex
+++ b/docs/paper/paper.tex
@@ -463,7 +463,7 @@ Figure~\ref{fig:hub-spoke-bnz} sketches three concrete algebraic hubs ($\mathbb{
 An example subset of $\mathbf{Alg}(\Sigma)$: the carriers $\mathbb{B}$, $\mathbb{N}$, $\mathbb{Z}$.
 Each carrier is depicted with its underlying set as the single object ($\{\mathrm{false}, \mathrm{true}\}$, $\{0, 1, 2, \ldots\}$, $\{\ldots, -1, 0, 1, \ldots\}$) and selected endo-operations as loops: the affine translation $x \mapsto x \oplus 1$ on $\mathbb{B}$ (i.e.\ logical negation, which on $\mathbb{F}_2$ is the additive translation by 1), squaring $x \mapsto x^2$ on $\mathbb{N}$, negation $x \mapsto -x$ on $\mathbb{Z}$.
 This is a cartoon of the carrier-as-a-category picture, in the spirit of Mac Lane~\cite{maclane1971categories} §I.1's monoid $\leftrightarrow$ one-object-category bijection.
-Equivalently (Pierce~\cite{pierce1991basic} §2.2): each loop is a component of the bundled structure arrow $\alpha : F_\Sigma(A) \to A$ for the carrier's signature.
+Equivalently (Pierce~\cite{pierce1991basic} §2.2): each loop is a component of the bundled structure arrow $\alpha : F_\Sigma(A) \to A$, where $A$ is the carrier, for the carrier's signature.
 A strict realisation would draw one morphism per carrier element, impractical here, so only a few representative loops are shown.
 The set's elements are not drawn separately; in this layer they live \emph{inside} the single object, exactly as in the category $\mathbf{Mon}$ of monoids.
 Inter-hub arrows are typed maps $\mathrm{T} \to \mathrm{S}$.

--- a/docs/paper/paper.tex
+++ b/docs/paper/paper.tex
@@ -439,8 +439,9 @@ In the context of \texttt{dedekind}, we further restrict our attention to a subs
 The Booleans $\mathbb B$ with logical operations, the integers $\mathbb Z$ with addition and subtraction and so on.
 In algebra textbook terminology: the universal-algebra category $\mathbf{Alg}(\Sigma)$~\cite{burris1981universalalgebra} for a fixed algebraic signature $\Sigma$ (a list of operation symbols with their arities).
 In functional programming terminology, this corresponds to $F_\Sigma$-algebras: for each signature $\Sigma$ there is a polynomial endofunctor $F_\Sigma$ on $\mathbf{Set}$, and Pierce~\cite{pierce1991basic} (§2.2) gives the isomorphism $\mathbf{Alg}(\Sigma) \cong F_\Sigma\text{-}\mathbf{Alg}$ that lets the same fragment read coherently to both audiences.
+
 In the language of software architecture, the picture might be described as a hub-and-spoke layout.
-Each hub is a carrier type $\mathrm{T}$, and the spokes are the maps that compose with it.
+Each hub is a is a named algebraic signature or rule-set (the Functor) carrier type $\mathrm{T}$, and the spokes are the carrier types \(\mathrm{T}\) that inhabit it.
 Operator overloads ($\mathrm{T} \times \mathrm{T} \to \mathrm{T}$), free-function actions on the carrier, trait specialisations registering structural facts about $\mathrm{T}$, and named embedding arrows $\mathrm{T} \to \mathrm{S}$ crossing to a sibling hub.
 The library lifts this pattern directly into the build graph.
 Each named module declares one or more hubs and owns its spokes.
@@ -471,6 +472,22 @@ Most arrows on each hub and most inter-hub arrows are suppressed for clarity. Th
 }
 \label{fig:hub-spoke-bnz}
 \end{figure}
+
+\begin{figure}[htbp]
+\centering
+\begin{tikzcd}[column sep=large, row sep=large, ampersand replacement=\&]
+\& \text{Algebra}(T, F) \arrow[d, "\text{Axioms}"] \& \\
+\& \text{Monoid} \arrow[dl, "\text{Inverses}"'] \arrow[dr, "\text{Distributive}"] \& \\
+\text{Group} \arrow[rr, "\text{Second Op}"] \& \& \text{Ring} \arrow[d, "\text{Invertibility}"] \\
+\& \& \text{Field}
+\end{tikzcd}
+\caption{
+Sketching with Gemini based on \texttt{algebra:universal}.
+A hub is a specific pairing of a carrier and its operations (the closure tier), while the spokes are the axiomatic refinements that identify its symmetries.
+}
+\label{fig:hub-spoke-bnz-2}
+\end{figure}
+
 
 While it may now be tempting to start formalizing operations such as $\neg, \vee, \wedge, \cup, \cap, +, \times, \ldots$, we \emph{deliberately leave $\Sigma$ unbound for now}.\footnote{When $\Sigma$ stays unbound throughout a discussion, we sometimes write $\mathbf{Alg}(-)$ for the family $\bigcup_\Sigma \mathbf{Alg}(\Sigma)$ over the signatures the library names.  The dash is a typographic placeholder meaning ``fill in any signature here'' (Mac Lane's standard argument-blank convention~\cite{maclane1971categories}, same family as $\mathrm{Hom}(-, -)$ for the hom-bifunctor and $(-)^{\mathrm{op}}$ for the opposite-category functor); it is \emph{not} a unary minus.  The notation reappears in §\ref{sec:cpp-stlc-mapping}.}
 The binding of concrete operator-shape signatures is deferred to later sections~\ref{sec:cpp-stlc-mapping}, \ref{sec:sets-rules}.

--- a/docs/paper/paper.tex
+++ b/docs/paper/paper.tex
@@ -2740,15 +2740,14 @@ programmer chooses which policy to apply.
 \label{sec:carrier-rosetta}
 
 A \emph{carrier} in this paper is the underlying set on which an
-algebraic structure lives --- the substrate of operations.  Following
-the universal-algebra convention~\cite{burris1981universalalgebra} an
-algebra is the pair $(A, F)$ of a carrier $A$ together with a family
-$F$ of finitary operations satisfying axioms.  The same set may serve
-as carrier for several distinct algebras (e.g.\ $\mathbb{B}$ as
-$(\{0,1\}, \lor, \land)$ vs as $(\mathbb{F}_2, \oplus, \land)$); and
-the same algebra may be obtained as either a primitive (a chosen
-carrier) or as the result of a construction (a quotient, free, or
-localisation functor) applied to a smaller carrier.  $\mathbb{Q}$ is
+algebraic structure lives --- the substrate of operations.  The
+universal-algebra formulation is introduced in §\ref{sec:alg-sigma}
+and applies here.  The same set may serve as carrier for several
+distinct algebras (e.g.\ $\mathbb{B}$ as $(\{0,1\}, \lor, \land)$
+vs as $(\mathbb{F}_2, \oplus, \land)$); and the same algebra may be
+obtained as either a primitive (a chosen carrier) or as the result
+of a construction (a quotient, free, or localisation functor)
+applied to a smaller carrier.  $\mathbb{Q}$ is
 both a carrier (the rationals, used as base for
 \cppinline{Rational<I>}) and the field-of-fractions construction
 $\operatorname{Frac}(\mathbb{Z})$~\cite{lang2002algebra}; $\mathbb{C}$

--- a/docs/paper/paper.tex
+++ b/docs/paper/paper.tex
@@ -494,6 +494,7 @@ With \texttt{NaN} in play, that theorem quietly breaks, because neither $x < \te
 $x \geq \texttt{NaN}$ is true.
 In $\mathbb{K}_3$, $P \lor \neg P = \mathit{Unknown}$ is a calm, unremarkable identity.
 The paradox was never in the floats; it was in our choice of $\Omega$.
+$\Omega$ parameterises membership truth values while the \beth_1 ceiling parameterises carrier size; the two are orthogonal.
 
 \subsection{A Well-Behaved Structure in C++: the Juliet Posture $\mathbf{Jlt}$}
 \label{sec:jlt}

--- a/docs/paper/paper.tex
+++ b/docs/paper/paper.tex
@@ -436,7 +436,7 @@ For the more casual reader of this text, it should be sufficient to remember tha
 It tells us what clicks together (the arrows compose), what doesn't, and how things might be rearranged or simplified.
 
 In the context of \texttt{dedekind}, we further restrict our attention to a subset that most readers will be familiar with: algebras, i.e.\ sets equipped with operations.\footnote{We use ``algebra'' here in the universal-algebra sense (a $\Sigma$-algebra: a carrier set together with operations realising a signature $\Sigma$); the unrelated algebraic-geometry usage of ``algebraic set'' for the zero locus of a system of polynomials is \emph{not} what we mean.}
-The Booleans $\mathbb B$ with logical operations, the integers $\mathbb Z$ with addition and subtraction and so on.
+The Booleans $\mathbb{B}$ with logical operations, the integers $\mathbb{Z}$ with addition and subtraction and so on.
 In algebra textbook terminology: the universal-algebra category $\mathbf{Alg}(\Sigma)$~\cite{burris1981universalalgebra} for a fixed algebraic signature $\Sigma$ (a list of operation symbols with their arities).
 In functional programming terminology, this corresponds to $F_\Sigma$-algebras: for each signature $\Sigma$ there is a polynomial endofunctor $F_\Sigma$ on $\mathbf{Set}$, and Pierce~\cite{pierce1991basic} (§2.2) gives the isomorphism $\mathbf{Alg}(\Sigma) \cong F_\Sigma\text{-}\mathbf{Alg}$ that lets the same fragment read coherently to both audiences.
 

--- a/docs/paper/paper.tex
+++ b/docs/paper/paper.tex
@@ -441,7 +441,7 @@ In algebra textbook terminology: the universal-algebra category $\mathbf{Alg}(\S
 In functional programming terminology, this corresponds to $F_\Sigma$-algebras: for each signature $\Sigma$ there is a polynomial endofunctor $F_\Sigma$ on $\mathbf{Set}$, and Pierce~\cite{pierce1991basic} (§2.2) gives the isomorphism $\mathbf{Alg}(\Sigma) \cong F_\Sigma\text{-}\mathbf{Alg}$ that lets the same fragment read coherently to both audiences.
 
 In the language of software architecture, the picture might be described as a hub-and-spoke layout.
-Each hub is a is a named algebraic signature or rule-set (the Functor) carrier type $\mathrm{T}$, and the spokes are the carrier types \(\mathrm{T}\) that inhabit it.
+Each hub is a carrier type $\mathrm{T}$, and the spokes are the maps that compose with it.
 Operator overloads ($\mathrm{T} \times \mathrm{T} \to \mathrm{T}$), free-function actions on the carrier, trait specialisations registering structural facts about $\mathrm{T}$, and named embedding arrows $\mathrm{T} \to \mathrm{S}$ crossing to a sibling hub.
 The library lifts this pattern directly into the build graph.
 Each named module declares one or more hubs and owns its spokes.
@@ -463,7 +463,7 @@ Figure~\ref{fig:hub-spoke-bnz} sketches three concrete algebraic hubs ($\mathbb{
 An example subset of $\mathbf{Alg}(\Sigma)$: the carriers $\mathbb{B}$, $\mathbb{N}$, $\mathbb{Z}$.
 Each carrier is depicted with its underlying set as the single object ($\{\mathrm{false}, \mathrm{true}\}$, $\{0, 1, 2, \ldots\}$, $\{\ldots, -1, 0, 1, \ldots\}$) and selected endo-operations as loops: the affine translation $x \mapsto x \oplus 1$ on $\mathbb{B}$ (i.e.\ logical negation, which on $\mathbb{F}_2$ is the additive translation by 1), squaring $x \mapsto x^2$ on $\mathbb{N}$, negation $x \mapsto -x$ on $\mathbb{Z}$.
 This is a cartoon of the carrier-as-a-category picture, in the spirit of Mac Lane~\cite{maclane1971categories} §I.1's monoid $\leftrightarrow$ one-object-category bijection.
-Equivalently (Pierce~\cite{pierce1991basic} §2.2): each loop is a component of the bundled structure arrow $\alpha : F\Sigma(A) \to A$ for the carrier's signature.
+Equivalently (Pierce~\cite{pierce1991basic} §2.2): each loop is a component of the bundled structure arrow $\alpha : F_\Sigma(A) \to A$ for the carrier's signature.
 A strict realisation would draw one morphism per carrier element, impractical here, so only a few representative loops are shown.
 The set's elements are not drawn separately; in this layer they live \emph{inside} the single object, exactly as in the category $\mathbf{Mon}$ of monoids.
 Inter-hub arrows are typed maps $\mathrm{T} \to \mathrm{S}$.
@@ -481,19 +481,18 @@ We note though that while $\mathbf{Alg}(\Sigma)$ is only a small fragment of $\m
 We further restrict our attention to the \emph{small} slice $\mathbf{Alg}(\Sigma)_{\beth_1}$ --- the $\beth_1$-small algebras, i.e.\ algebras whose underlying carrier has cardinality at most that of the continuum.\footnote{The standard mathematical workaround for ``a category whose objects are all sets / all categories'' is a Grothendieck universe hierarchy~\cite{maclane1971categories} (Mac Lane, §I.6): pick a universe $U$, define $\mathbf{Set}_U$ as the category of $U$-small sets, then let $\mathbf{Set}_U$ live as an object of a larger-universe $\mathbf{Cat}_{U'}$.  The hierarchy stratifies; no level contains itself.  The $\beth_1$ subscript here pins the smallness ceiling at the cardinality of the continuum --- enough to admit $\mathbb{R}$-sized carriers, small enough to forbid proper-class self-reference.}
 Pinning the object-size at $\beth_1$ admits the transfinite carriers required for Dedekind-cut arithmetic ($\mathbb{R}$, §\ref{sec:numeric-tension}) and the continuum-sized $\mathbb{C}$, $\mathbb{D}$ used in §\ref{sec:linalg}, while keeping a foundational ceiling that forbids the self-referential paradoxes of the proper-class meta-categories $\mathbf{Set}$ and $\mathbf{Cat}$.
 
-The general thrust of the architecture is then to view these small, algebraic categories as universal underlying carrier sets with specific sets being characterized in the ETCS sense by a 
- subobject classifier $\Omega$:.
- A predicate $P : A \to \Omega$ maps ambient elements to \emph{truth values}, and $\Omega$ is the type those truth values live in.
+The general thrust of the architecture is then to view these small, algebraic categories as universal underlying carrier sets, with specific sets characterised in the ETCS sense by a subobject classifier $\Omega$.
+A predicate $P : A \to \Omega$ maps ambient elements to \emph{truth values}, and $\Omega$ is the type those truth values live in.
 Change $\Omega$, and you change what counts as membership.
-The default is the one every programmer expects: $\Omega = \mathbb B = \{\top, \bot\}$, classical two-valued logic.
+The default is the one every programmer expects: $\Omega = \mathbb{B} = \{\top, \bot\}$, classical two-valued logic.
 Plug it in and you get ordinary set theory.
-But set structures with undecidable membership (e.g. the Mandelbrot set) can be supported this way also.
-Swap it for Kleene K3---$\Omega = \mathbb K3 = \{-1, 0, +1\}$ and something more interesting happens.
-In the case of \cppinline{double}, the extra value is \emph{Unknown} is where \texttt{NaN} lives.
+But set structures with undecidable membership (e.g.\ the Mandelbrot set) can be supported this way also.
+Swap it for Kleene $\mathbb{K}_3 = \{-1, 0, +1\}$ and something more interesting happens.
+In the case of \cppinline{double}, the extra value \emph{Unknown} is where \texttt{NaN} lives.
 In classical logic, $P \lor \neg P = \top$ is a theorem.
 With \texttt{NaN} in play, that theorem quietly breaks, because neither $x < \texttt{NaN}$ nor
 $x \geq \texttt{NaN}$ is true.
-In K3, $P \lor \neg P = \mathit{Unknown}$ is a calm, unremarkable identity.
+In $\mathbb{K}_3$, $P \lor \neg P = \mathit{Unknown}$ is a calm, unremarkable identity.
 The paradox was never in the floats; it was in our choice of $\Omega$.
 
 \subsection{A Well-Behaved Structure in C++: the Juliet Posture $\mathbf{Jlt}$}

--- a/docs/paper/paper.tex
+++ b/docs/paper/paper.tex
@@ -478,6 +478,21 @@ We note though that while $\mathbf{Alg}(\Sigma)$ is only a small fragment of $\m
 We further restrict our attention to the \emph{small} slice $\mathbf{Alg}(\Sigma)_{\beth_1}$ --- the $\beth_1$-small algebras, i.e.\ algebras whose underlying carrier has cardinality at most that of the continuum.\footnote{The standard mathematical workaround for ``a category whose objects are all sets / all categories'' is a Grothendieck universe hierarchy~\cite{maclane1971categories} (Mac Lane, §I.6): pick a universe $U$, define $\mathbf{Set}_U$ as the category of $U$-small sets, then let $\mathbf{Set}_U$ live as an object of a larger-universe $\mathbf{Cat}_{U'}$.  The hierarchy stratifies; no level contains itself.  The $\beth_1$ subscript here pins the smallness ceiling at the cardinality of the continuum --- enough to admit $\mathbb{R}$-sized carriers, small enough to forbid proper-class self-reference.}
 Pinning the object-size at $\beth_1$ admits the transfinite carriers required for Dedekind-cut arithmetic ($\mathbb{R}$, §\ref{sec:numeric-tension}) and the continuum-sized $\mathbb{C}$, $\mathbb{D}$ used in §\ref{sec:linalg}, while keeping a foundational ceiling that forbids the self-referential paradoxes of the proper-class meta-categories $\mathbf{Set}$ and $\mathbf{Cat}$.
 
+The general thrust of the architecture is then to view these small, algebraic categories as universal underlying carrier sets with specific sets being characterized in the ETCS sense by a 
+ subobject classifier $\Omega$:.
+ A predicate $P : A \to \Omega$ maps ambient elements to \emph{truth values}, and $\Omega$ is the type those truth values live in.
+Change $\Omega$, and you change what counts as membership.
+The default is the one every programmer expects: $\Omega = \mathbb B = \{\top, \bot\}$, classical two-valued logic.
+Plug it in and you get ordinary set theory.
+But set structures with undecidable membership (e.g. the Mandelbrot set) can be supported this way also.
+Swap it for Kleene K3---$\Omega = \mathbb K3 = \{-1, 0, +1\}$ and something more interesting happens.
+In the case of \cppinline{double}, the extra value is \emph{Unknown} is where \texttt{NaN} lives.
+In classical logic, $P \lor \neg P = \top$ is a theorem.
+With \texttt{NaN} in play, that theorem quietly breaks, because neither $x < \texttt{NaN}$ nor
+$x \geq \texttt{NaN}$ is true.
+In K3, $P \lor \neg P = \mathit{Unknown}$ is a calm, unremarkable identity.
+The paradox was never in the floats; it was in our choice of $\Omega$.
+
 \subsection{A Well-Behaved Structure in C++: the Juliet Posture}
 \label{sec:jlt}
 
@@ -538,13 +553,8 @@ The manual-certification pattern is the path the committee left open.\footnote{T
 
 The trait-registry mechanics --- which axioms propagate under which constructors, how per-carrier specialisations are organised, how the \emph{Honest Rejection} policy maps to varieties, and how the algebra-side machinery composes with the C++-side concept layer --- are deferred to §\ref{sec:pruning} (\emph{Algebraic Lattice}) and §\ref{sec:numeric-tension} (\emph{The Traits Registry: Abstract Naturals vs.\ IEEE Numerics}).
 
-A welcome side effect: the disciplined subset that aligns with $\mathbf{Alg}(\Sigma)$ also turns out to be a faithful image of System~F (Pierce~\cite{pierce2002tapl} ch.~23, 29) and of the simply-typed $\lambda$-calculus under Lambek--Scott~\cite{lambek1988introduction}.
-The same surface reads in either tradition.
-This was not the design goal.
-The paper began as an engineering exercise on $\mathbf{Alg}(\Sigma)$, and the System-F reading announced itself afterwards.
-The triangulation across System~F, the Juliet Posture, and Bourbaki structuralism~\cite{marquis2022structuralist} is reported as an observation rather than a guarantee.
-Some discipline is required of the engineer for the reading to hold.
-The precise admissibility rules and a row-by-row mapping across the three vocabularies are deferred to Appendix~\ref{app:jlt-systemf}.
+An unintended but most welcome side effect: the disciplined subset that aligns with $\mathbf{Alg}(\Sigma)$ also turns out to be a faithful image of System~F (Pierce~\cite{pierce2002tapl} ch.~23, 29) and of the simply-typed $\lambda$-calculus under Lambek--Scott~\cite{lambek1988introduction}.
+Details of this observation are discussed in Appendix~\ref{app:jlt-systemf}.
 
 Call this disciplined subset $\mathbf{Jlt} \subset \mathbf{Cpp}$ (mnemonically: \emph{Juliet}, after the \emph{rose by any other name} reading of structural-over-nominal typing).
 In $\mathbf{Jlt}$ the objects are \cppinline{std::regular} types and the values they classify, and the morphisms are the arrows the language admits between them.
@@ -704,27 +714,6 @@ The 2-categorical layer above thus becomes the engineer's honesty obligation, na
 \section{Sets and Sequences}
 \label{sec:sets-rules}
 % ============================================================
-
-\subsection{The Subobject Classifier $\Omega$}
-
-Here is what $\Omega$ is doing for us. A predicate $P : A \to \Omega$ maps ambient
-elements to \emph{truth values}, and $\Omega$ is the type those truth values live
-in. Change $\Omega$, and you change what counts as membership.
-
-The default is the one every programmer expects: $\Omega = \{\top, \bot\}$,
-classical two-valued logic. Plug it in and you get ordinary set theory.
-
-Swap it for Kleene K3---$\Omega = \{-1, 0, +1\}$---and something more interesting
-happens. The extra value is \emph{Unknown}, and it is where \texttt{NaN} lives.
-In classical logic, $P \lor \neg P = \top$ is a theorem; with \texttt{NaN} in
-play, that theorem quietly breaks, because neither $x < \texttt{NaN}$ nor
-$x \geq \texttt{NaN}$ is true. In K3, $P \lor \neg P = \mathit{Unknown}$ is a
-calm, unremarkable identity. The paradox was never in the floats; it was in our
-choice of $\Omega$.
-
-That is the payoff: the same comprehension machinery handles exact domains
-(pick classical $\Omega$) and floating-point domains (pick K3) with no change to
-the API. The logic is a parameter.
 
 % ============================================================
 \subsection{Intensional First, Realize When You Mean It}

--- a/docs/paper/paper.tex
+++ b/docs/paper/paper.tex
@@ -427,7 +427,7 @@ The strategy of this section is a three-step intersection.
 Both category theory and modern C++23 are large and occasionally intimidating beasts; each, however, admits a tractable subset with somewhat simpler atomic building blocks and clear composition rules.
 The \texttt{dedekind} library lives at their intersection.
 
-\subsection{A Well-Behaved Structure in Category Theory: $\mathbf{Alg}(\Sigma)$}
+\subsection{A Well-Behaved Structure in Category Theory: $\mathbf{Alg}(-)_{\beth_1}$}
 \label{sec:alg-sigma}
 
 The choice of anchoring the library's domain in category theory on the mathematical side is neither new nor arbitrary and follows a well-trodden path.
@@ -463,6 +463,7 @@ Figure~\ref{fig:hub-spoke-bnz} sketches three concrete algebraic hubs ($\mathbb{
 An example subset of $\mathbf{Alg}(\Sigma)$: the carriers $\mathbb{B}$, $\mathbb{N}$, $\mathbb{Z}$.
 Each carrier is depicted with its underlying set as the single object ($\{\mathrm{false}, \mathrm{true}\}$, $\{0, 1, 2, \ldots\}$, $\{\ldots, -1, 0, 1, \ldots\}$) and selected endo-operations as loops: the affine translation $x \mapsto x \oplus 1$ on $\mathbb{B}$ (i.e.\ logical negation, which on $\mathbb{F}_2$ is the additive translation by 1), squaring $x \mapsto x^2$ on $\mathbb{N}$, negation $x \mapsto -x$ on $\mathbb{Z}$.
 This is a cartoon of the carrier-as-a-category picture, in the spirit of Mac Lane~\cite{maclane1971categories} §I.1's monoid $\leftrightarrow$ one-object-category bijection.
+Equivalently (Pierce~\cite{pierce1991basic} §2.2): each loop is a component of the bundled structure arrow $\alpha : F\Sigma(A) \to A$ for the carrier's signature.
 A strict realisation would draw one morphism per carrier element, impractical here, so only a few representative loops are shown.
 The set's elements are not drawn separately; in this layer they live \emph{inside} the single object, exactly as in the category $\mathbf{Mon}$ of monoids.
 Inter-hub arrows are typed maps $\mathrm{T} \to \mathrm{S}$.
@@ -471,21 +472,6 @@ $\mathbb{N} \rightleftarrows \mathbb{Z}$: forward $x \mapsto -x$ (negation, well
 Most arrows on each hub and most inter-hub arrows are suppressed for clarity. The diagram shows one of each kind.
 }
 \label{fig:hub-spoke-bnz}
-\end{figure}
-
-\begin{figure}[htbp]
-\centering
-\begin{tikzcd}[column sep=large, row sep=large, ampersand replacement=\&]
-\& \text{Algebra}(T, F) \arrow[d, "\text{Axioms}"] \& \\
-\& \text{Monoid} \arrow[dl, "\text{Inverses}"'] \arrow[dr, "\text{Distributive}"] \& \\
-\text{Group} \arrow[rr, "\text{Second Op}"] \& \& \text{Ring} \arrow[d, "\text{Invertibility}"] \\
-\& \& \text{Field}
-\end{tikzcd}
-\caption{
-Sketching with Gemini based on \texttt{algebra:universal}.
-A hub is a specific pairing of a carrier and its operations (the closure tier), while the spokes are the axiomatic refinements that identify its symmetries.
-}
-\label{fig:hub-spoke-bnz-2}
 \end{figure}
 
 
@@ -510,7 +496,7 @@ $x \geq \texttt{NaN}$ is true.
 In K3, $P \lor \neg P = \mathit{Unknown}$ is a calm, unremarkable identity.
 The paradox was never in the floats; it was in our choice of $\Omega$.
 
-\subsection{A Well-Behaved Structure in C++: the Juliet Posture}
+\subsection{A Well-Behaved Structure in C++: the Juliet Posture $\mathbf{Jlt}$}
 \label{sec:jlt}
 
 
@@ -577,7 +563,7 @@ Call this disciplined subset $\mathbf{Jlt} \subset \mathbf{Cpp}$ (mnemonically: 
 In $\mathbf{Jlt}$ the objects are \cppinline{std::regular} types and the values they classify, and the morphisms are the arrows the language admits between them.
 The Juliet Posture deliberately rejects type erasure on the categorical surface: erased witnesses are opaque to both the concept checker and the LLVM optimizer, so erased layers degrade the gate's sharpness and the structural-pruning power that §\ref{sec:compiler-wall} and §\ref{sec:pruning} rest on.
 
-\subsection{The Structuralist Intersection: $\mathbf{Ddk} = \mathbf{Jlt} \cap \mathbf{Alg}(-)_{\beth_1}$}
+\subsection{A Common Ground: $\mathbf{Ddk} = \mathbf{Jlt} \cap \mathbf{Alg}(-)_{\beth_1}$}
 \label{sec:cpp-stlc-mapping}
 
 The \texttt{dedekind} types and combinators are the inhabitants of $\mathbf{Jlt} \cap \mathbf{Alg}(-)_{\beth_1}$.

--- a/docs/paper/paper.tex
+++ b/docs/paper/paper.tex
@@ -494,7 +494,7 @@ With \texttt{NaN} in play, that theorem quietly breaks, because neither $x < \te
 $x \geq \texttt{NaN}$ is true.
 In $\mathbb{K}_3$, $P \lor \neg P = \mathit{Unknown}$ is a calm, unremarkable identity.
 The paradox was never in the floats; it was in our choice of $\Omega$.
-$\Omega$ parameterises membership truth values while the \beth_1 ceiling parameterises carrier size; the two are orthogonal.
+$\Omega$ parameterises membership truth values while the $\beth_1$ ceiling parameterises carrier size; the two are orthogonal.
 
 \subsection{A Well-Behaved Structure in C++: the Juliet Posture $\mathbf{Jlt}$}
 \label{sec:jlt}


### PR DESCRIPTION
Follow-up to https://github.com/vincentk/dedekind/pull/585.

## What landed in this slice

### Structural moves
- **Subobject classifier $\Omega$ shifted from §3.0 to §2.1.** The Ω discussion now sits inside the universal-algebra subsection where its categorical ambient already lives, immediately after the $\beth_1$ smallness paragraph.  The §3.0 subsection is removed; the prose collapses into the §2.1 narrative.  One added clarifying sentence: $\Omega$ parameterises membership truth-values while the $\beth_1$ ceiling parameterises carrier size — the two are orthogonal knobs (Gemini concern about conflation defused).
- **§2.2 System F prose trimmed** to a one-line pointer at Appendix~B.  Long triangulation discussion now lives entirely in the appendix where it belongs (Gemini concern about scattered System F references — addressed for §2.2; §1 / §B not yet swept).

### Figure rationalisation
- **Figure 2 (Gemini-sketched concept-lattice refinement diagram) dropped** from §2.1.  It was solving a different problem than §2.1 has — algebraic-theory refinement, not hub-and-spoke architecture — and forcing it into hub/spoke vocabulary inverted the metaphor.  The hub-and-spoke story is carried by Figure~1 alone.
- **Figure 1 caption gains an F-algebra anchor sentence**: each loop is a component of the bundled structure arrow $\alpha : F_\Sigma(A) \to A$ for the carrier's signature.  Ties the cartoon to the Pierce isomorphism §2.1 already cites.

### Hub-and-spoke prose alignment
- **Hub-and-spoke vocabulary realigned to the rosetta**:
  - Hub = (carrier, structure) algebra (a single-species category in $\mathbf{IsCategory}$ form, equivalently an $(A, F)$ pair in Burris-Sankappanavar form).
  - Spoke = arrow within a hub (component of the bundled structure arrow $\alpha : F_\Sigma(A) \to A$).
  - Hub-arrow = arrow between hubs (functor / homomorphism).
- The §2.1 prose was reverted to its yesterday form ("Each hub is a carrier type T, and the spokes are the maps that compose with it") — the briefly-tried "hub = signature/Functor, spokes = inhabitants" framing inverted the metaphor and conflicted with both Figure 1's caption and the codebase's `IsHubArrow` / `IsSpokeArrow` naming.

### Consolidation / dedup
- **Universal Algebra (A, F) definition consolidated in §2.1** (Gemini feedback).  The redundant restatement at the appendix carrier-rosetta subsubsection was replaced with a one-line cross-reference to §\ref{sec:alg-sigma}.  Pure deletion + one cross-ref.

### Section-title polish
- §2.1: $\mathbf{Alg}(\Sigma) \to \mathbf{Alg}(-)_{\beth_1}$ (consistent with the dash-convention footnote and the $\beth_1$ smallness commitment).
- §2.2: title carries the symbol $\mathbf{Jlt}$ explicitly.
- §2.3: "The Structuralist Intersection" → "A Common Ground" (less heavy-handed).

### Typesetting fixes
- Figure 1 caption typo `F\Sigma(A)` → `F_\Sigma(A)`.
- §2.1 Ω paragraph: stray `:.`, duplicated "is", and `\mathbb K3` / `\mathbb B = ...` normalised to `\mathbb{K}_3` / `\mathbb{B}` for consistency with the project's existing math-mode conventions.

## Follow-up: Gemini feedback NOT in this PR's scope

The original PR body listed several Gemini observations from the morning sweep.  This PR addresses the structural ones (Ω relocation, System F trim for §2.2, (A,F) consolidation, hub-and-spoke alignment).  The remaining items — listed here for the audit trail — are paper-sweep round 2+ work and will be addressed in follow-up issues:

- **Algebraic Signature Σ → `HasRingOperators` framing (§2.2)**: the transition from unbound Σ in §2.1 to concrete `HasRingOperators` in §2.2 is abrupt; needs framing as a "concrete candidate signature".
- **Syntactic vs. semantic gateway (§2.2)**: clarify the distinction between `std::regular` (syntactic baseline) and the Trait Registry (semantic filter).
- **Thesis loop pruning (§1)**: the one-sentence thesis appears in Abstract, §1, and §7; trim §1's repetition.
- **Introductory hook (§1)**: the "i) ignore, ii) police, iii) encode" list is wordy; merge the `std::vector` example into the recurring-tension paragraph.
- **Category Theory mapping**: Gemini suggested a bulleted CT ↔ C++ list for §2.1; the richer hub/spoke ↔ CT ↔ algebra rosetta has been built in conversation and should land as a table or list in §2.1 in a follow-up.
- **Figure 3 dashed-line tie-in**: the two-axes figure has a dashed line marking mechanical-verifiable vs engineer-certified; add explicit prose tying the two.
- **System F sweep (§1, §B)**: §2.2 is done; §1 / §B may still have orphan references — quick grep needed.
- **Codebase docstring sweep**: `category:functor`'s "Hub = the functor / Spoke = an arrow value" docstring uses an intensional/extensional cut that overlaps with but doesn't fully align with the paper's hub-and-spoke (which is categorical-level: hub = (A, F) algebra, spoke = arrow within).  Modest docstring refactor; named identifiers (`IsHubArrow`, `IsSpokeArrow`) are already aligned and don't need rename.

## Test plan

- [x] `lualatex -halt-on-error` clean (51 pp, no errors).
- [x] Build verified after the rebase that brought in the orthogonality sentence (math-mode fix on `\beth_1`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)