### PR TITLE
feat(category): #607 slice 1 — Juliet-clean IsSet lifts on std::set / std::unordered_set

### DIFF
--- a/src/main/modules/dedekind/category/etcs.cppm
+++ b/src/main/modules/dedekind/category/etcs.cppm
@@ -43,7 +43,9 @@ module;
 
 #include <concepts>
 #include <functional>
+#include <set>
 #include <type_traits>
+#include <unordered_set>
 #include <utility>
 
 export module dedekind.category:etcs;
@@ -388,6 +390,95 @@ export template <typename A, typename Pred>
 constexpr auto ambient_set(Pred&& predicate) {
   return classify<A>(std::forward<Pred>(predicate));
 }
+
+// ---------------------------------------------------------------------------
+// Juliet-clean lifts: std::set / std::unordered_set ↪ IsSet directly (#607).
+//
+// These overloads let std-container values lift to IsSet without going
+// through a project-shipped wrapper (no @c ExtensionalSet, no
+// @c FiniteBooleanSet, just std).  Each overload wraps the container's
+// @c contains member as a callable predicate and forwards to the
+// universal @c ambient_set<A>(Pred) above.
+//
+// Lifetime contract:
+//   * lvalue overload — captures the container by reference; the caller
+//     keeps the container alive for as long as the lifted Subobject is
+//     reachable.  Zero-copy.
+//   * rvalue overload — moves the container into the lambda; the lifted
+//     Subobject owns its predicate's data.  One std-level move, no
+//     wrapper-level copy.
+//
+// This is slice 1 of #607's wrapper-dissolution plan: no removals yet,
+// but std types are now first-class IsSet citizens via the lift.
+// Subsequent slices will dissolve @c ExtensionalSet, @c SingletonSet,
+// @c UniversalSet, @c Ø in favour of these overloads (and an analogous
+// SingletonSet-replacement that takes a single @c T value).
+// ---------------------------------------------------------------------------
+
+/** @brief Lift @c std::unordered_set<T, ...> by const-ref into an IsSet
+ *         object.  Borrows lifetime; zero copy. (#607 slice 1) */
+export template <typename T, typename Hash, typename Equal, typename Alloc>
+constexpr auto ambient_set(
+    const std::unordered_set<T, Hash, Equal, Alloc>& s)
+  requires IsSpecies<T>
+{
+  return ambient_set<T>(
+      [&s](const T& x) -> bool { return s.contains(x); });
+}
+
+/** @brief Lift @c std::unordered_set<T, ...> by rvalue.  Moves the
+ *         container into the predicate; lifted Subobject owns the data.
+ *         (#607 slice 1) */
+export template <typename T, typename Hash, typename Equal, typename Alloc>
+constexpr auto ambient_set(std::unordered_set<T, Hash, Equal, Alloc>&& s)
+  requires IsSpecies<T>
+{
+  return ambient_set<T>([s = std::move(s)](const T& x) -> bool {
+    return s.contains(x);
+  });
+}
+
+/** @brief Lift @c std::set<T, ...> by const-ref.  Borrows lifetime;
+ *         zero copy. (#607 slice 1) */
+export template <typename T, typename Compare, typename Alloc>
+constexpr auto ambient_set(const std::set<T, Compare, Alloc>& s)
+  requires IsSpecies<T>
+{
+  return ambient_set<T>(
+      [&s](const T& x) -> bool { return s.contains(x); });
+}
+
+/** @brief Lift @c std::set<T, ...> by rvalue.  Moves the container
+ *         into the predicate. (#607 slice 1) */
+export template <typename T, typename Compare, typename Alloc>
+constexpr auto ambient_set(std::set<T, Compare, Alloc>&& s)
+  requires IsSpecies<T>
+{
+  return ambient_set<T>([s = std::move(s)](const T& x) -> bool {
+    return s.contains(x);
+  });
+}
+
+// Witnesses: std-containers satisfy IsSet directly via the lift.
+static_assert(
+    IsSet<decltype(ambient_set(
+        std::declval<const std::unordered_set<int>&>()))>,
+    "std::unordered_set<int> lifts to IsSet via ambient_set (lvalue) "
+    "without a project-shipped wrapper.");
+
+static_assert(
+    IsSet<decltype(ambient_set(
+        std::declval<std::unordered_set<int>&&>()))>,
+    "std::unordered_set<int> lifts to IsSet via ambient_set (rvalue).");
+
+static_assert(
+    IsSet<decltype(ambient_set(
+        std::declval<const std::set<int>&>()))>,
+    "std::set<int> lifts to IsSet via ambient_set (lvalue).");
+
+static_assert(
+    IsSet<decltype(ambient_set(std::declval<std::set<int>&&>()))>,
+    "std::set<int> lifts to IsSet via ambient_set (rvalue).");
 
 /**
  * @section etcs__IsSet_entails_CCC_directional_witness

--- a/src/main/modules/dedekind/category/etcs.cppm
+++ b/src/main/modules/dedekind/category/etcs.cppm
@@ -418,12 +418,10 @@ constexpr auto ambient_set(Pred&& predicate) {
 /** @brief Lift @c std::unordered_set<T, ...> by const-ref into an IsSet
  *         object.  Borrows lifetime; zero copy. (#607 slice 1) */
 export template <typename T, typename Hash, typename Equal, typename Alloc>
-constexpr auto ambient_set(
-    const std::unordered_set<T, Hash, Equal, Alloc>& s)
+constexpr auto ambient_set(const std::unordered_set<T, Hash, Equal, Alloc>& s)
   requires IsSpecies<T>
 {
-  return ambient_set<T>(
-      [&s](const T& x) -> bool { return s.contains(x); });
+  return ambient_set<T>([&s](const T& x) -> bool { return s.contains(x); });
 }
 
 /** @brief Lift @c std::unordered_set<T, ...> by rvalue.  Moves the
@@ -433,9 +431,8 @@ export template <typename T, typename Hash, typename Equal, typename Alloc>
 constexpr auto ambient_set(std::unordered_set<T, Hash, Equal, Alloc>&& s)
   requires IsSpecies<T>
 {
-  return ambient_set<T>([s = std::move(s)](const T& x) -> bool {
-    return s.contains(x);
-  });
+  return ambient_set<T>(
+      [s = std::move(s)](const T& x) -> bool { return s.contains(x); });
 }
 
 /** @brief Lift @c std::set<T, ...> by const-ref.  Borrows lifetime;
@@ -444,8 +441,7 @@ export template <typename T, typename Compare, typename Alloc>
 constexpr auto ambient_set(const std::set<T, Compare, Alloc>& s)
   requires IsSpecies<T>
 {
-  return ambient_set<T>(
-      [&s](const T& x) -> bool { return s.contains(x); });
+  return ambient_set<T>([&s](const T& x) -> bool { return s.contains(x); });
 }
 
 /** @brief Lift @c std::set<T, ...> by rvalue.  Moves the container
@@ -454,31 +450,26 @@ export template <typename T, typename Compare, typename Alloc>
 constexpr auto ambient_set(std::set<T, Compare, Alloc>&& s)
   requires IsSpecies<T>
 {
-  return ambient_set<T>([s = std::move(s)](const T& x) -> bool {
-    return s.contains(x);
-  });
+  return ambient_set<T>(
+      [s = std::move(s)](const T& x) -> bool { return s.contains(x); });
 }
 
 // Witnesses: std-containers satisfy IsSet directly via the lift.
-static_assert(
-    IsSet<decltype(ambient_set(
-        std::declval<const std::unordered_set<int>&>()))>,
-    "std::unordered_set<int> lifts to IsSet via ambient_set (lvalue) "
-    "without a project-shipped wrapper.");
+static_assert(IsSet<decltype(ambient_set(
+                  std::declval<const std::unordered_set<int>&>()))>,
+              "std::unordered_set<int> lifts to IsSet via ambient_set (lvalue) "
+              "without a project-shipped wrapper.");
 
 static_assert(
-    IsSet<decltype(ambient_set(
-        std::declval<std::unordered_set<int>&&>()))>,
+    IsSet<decltype(ambient_set(std::declval<std::unordered_set<int>&&>()))>,
     "std::unordered_set<int> lifts to IsSet via ambient_set (rvalue).");
 
 static_assert(
-    IsSet<decltype(ambient_set(
-        std::declval<const std::set<int>&>()))>,
+    IsSet<decltype(ambient_set(std::declval<const std::set<int>&>()))>,
     "std::set<int> lifts to IsSet via ambient_set (lvalue).");
 
-static_assert(
-    IsSet<decltype(ambient_set(std::declval<std::set<int>&&>()))>,
-    "std::set<int> lifts to IsSet via ambient_set (rvalue).");
+static_assert(IsSet<decltype(ambient_set(std::declval<std::set<int>&&>()))>,
+              "std::set<int> lifts to IsSet via ambient_set (rvalue).");
 
 /**
  * @section etcs__IsSet_entails_CCC_directional_witness

--- a/src/test/cpp/modules/dedekind/category/etcs_test.cpp
+++ b/src/test/cpp/modules/dedekind/category/etcs_test.cpp
@@ -2,7 +2,6 @@
 #include <catch2/catch_test_macros.hpp>
 #include <set>
 #include <unordered_set>
-#include <utility>
 
 import dedekind.category;
 

--- a/src/test/cpp/modules/dedekind/category/etcs_test.cpp
+++ b/src/test/cpp/modules/dedekind/category/etcs_test.cpp
@@ -1,6 +1,10 @@
 /** @file test/cpp/modules/dedekind/category/etcs_test.cpp */
 #include <catch2/catch_test_macros.hpp>
 
+#include <set>
+#include <unordered_set>
+#include <utility>
+
 import dedekind.category;
 
 using namespace dedekind::category;
@@ -165,4 +169,81 @@ TEST_CASE("ETCS: embedding-mediated membership avoids subset claims",
   CHECK(in(-1, naturals) == false);
   CHECK(in(7, naturals) == true);
   CHECK(in_via(7u, embed_unsigned_in_N, naturals) == true);
+}
+
+TEST_CASE("ETCS: std containers lift to IsSet directly via ambient_set (#607)",
+          "[category][etcs][juliet][stdcontainer]") {
+  // Slice 1 of #607's wrapper-dissolution: std::set / std::unordered_set
+  // values lift to IsSet without going through a project-shipped wrapper.
+  // Each overload wraps `.contains(x)` as the membership predicate.
+
+  SECTION("std::unordered_set lvalue lift — borrows lifetime, zero copy") {
+    const std::unordered_set<int> primes{2, 3, 5, 7, 11};
+    const auto S = ambient_set(primes);
+    STATIC_CHECK(IsSet<decltype(S)>);
+    CHECK(S.χ(2));
+    CHECK(S.χ(3));
+    CHECK(S.χ(5));
+    CHECK(S.χ(7));
+    CHECK(S.χ(11));
+    CHECK_FALSE(S.χ(4));
+    CHECK_FALSE(S.χ(0));
+    CHECK_FALSE(S.χ(-1));
+  }
+
+  SECTION("std::unordered_set rvalue lift — moves into the predicate") {
+    auto S = ambient_set(std::unordered_set<int>{1, 2, 4, 8, 16});
+    STATIC_CHECK(IsSet<decltype(S)>);
+    CHECK(S.χ(1));
+    CHECK(S.χ(2));
+    CHECK(S.χ(4));
+    CHECK(S.χ(8));
+    CHECK(S.χ(16));
+    CHECK_FALSE(S.χ(3));
+    CHECK_FALSE(S.χ(7));
+  }
+
+  SECTION("std::set lvalue lift — borrows lifetime, zero copy") {
+    const std::set<int> evens{0, 2, 4, 6, 8};
+    const auto S = ambient_set(evens);
+    STATIC_CHECK(IsSet<decltype(S)>);
+    CHECK(S.χ(0));
+    CHECK(S.χ(2));
+    CHECK(S.χ(8));
+    CHECK_FALSE(S.χ(1));
+    CHECK_FALSE(S.χ(7));
+  }
+
+  SECTION("std::set rvalue lift — moves into the predicate") {
+    auto S = ambient_set(std::set<int>{10, 20, 30});
+    STATIC_CHECK(IsSet<decltype(S)>);
+    CHECK(S.χ(10));
+    CHECK(S.χ(20));
+    CHECK(S.χ(30));
+    CHECK_FALSE(S.χ(15));
+    CHECK_FALSE(S.χ(0));
+  }
+
+  SECTION("std::unordered_set<bool>: 𝔹 as a listed extensional set") {
+    const std::unordered_set<bool> B{false, true};
+    const auto S = ambient_set(B);
+    STATIC_CHECK(IsSet<decltype(S)>);
+    CHECK(S.χ(false));
+    CHECK(S.χ(true));
+  }
+
+  SECTION("Lifetime: lvalue overload tracks the underlying container") {
+    // The lvalue overload captures by reference; mutating the container
+    // after the lift is reflected in subsequent χ queries.  This is the
+    // documented contract: caller keeps the container alive, and the
+    // lifted Subobject sees its current state.
+    std::unordered_set<int> evolving{1, 2, 3};
+    const auto S = ambient_set(evolving);
+    CHECK(S.χ(2));
+    CHECK_FALSE(S.χ(4));
+    evolving.insert(4);
+    CHECK(S.χ(4));  // ← the lift saw the mutation
+    evolving.erase(2);
+    CHECK_FALSE(S.χ(2));  // ← and the deletion
+  }
 }

--- a/src/test/cpp/modules/dedekind/category/etcs_test.cpp
+++ b/src/test/cpp/modules/dedekind/category/etcs_test.cpp
@@ -1,6 +1,5 @@
 /** @file test/cpp/modules/dedekind/category/etcs_test.cpp */
 #include <catch2/catch_test_macros.hpp>
-
 #include <set>
 #include <unordered_set>
 #include <utility>


### PR DESCRIPTION
First slice of issue #607's wrapper-dissolution plan.  No removals; just adds the foundational lift overloads that let std-container values satisfy `IsSet` directly, without going through a project-shipped wrapper.

## What this slice adds

Four `ambient_set` overloads in `category:etcs` (placed right after the existing `ambient_set<A>(Pred)`):

| Overload | Lifetime | Cost |
|---|---|---|
| `ambient_set(const std::unordered_set<T, ...>&)` | borrows | zero copy |
| `ambient_set(std::unordered_set<T, ...>&&)` | takes ownership | one std-level move |
| `ambient_set(const std::set<T, Compare, ...>&)` | borrows | zero copy |
| `ambient_set(std::set<T, Compare, ...>&&)` | takes ownership | one std-level move |

Each forwards to the universal `ambient_set<A>(Pred)` by wrapping the container's `.contains(x)` as a callable predicate.

## Breadcrumbs

Four `static_assert` lines pin the claim — std types satisfy `IsSet` directly via the lift:

```cpp
static_assert(IsSet<decltype(ambient_set(std::declval<const std::unordered_set<int>&>()))>);
static_assert(IsSet<decltype(ambient_set(std::declval<std::unordered_set<int>&&>()))>);
static_assert(IsSet<decltype(ambient_set(std::declval<const std::set<int>&>()))>);
static_assert(IsSet<decltype(ambient_set(std::declval<std::set<int>&&>()))>);
```

(Using `std::declval` because std containers aren't constexpr-default-constructible with non-empty contents in C++23.)

## What's not in this slice

* No wrapper deletions yet.  `ExtensionalSet`, `SingletonSet`, `UniversalSet`, `Ø` all remain.
* No `IsSet` concept-body changes.  The existing nested-alias-based `IsSet<S>` still requires `S::Ambient`; the new overloads work because the `ambient_set<A>(Pred)` forward returns a `Subobject<A, Lambda>` which already satisfies `IsSet`.
* No call-site migrations.  Python facade, tests, etc. still go through `ExtensionalSet` / `from_std`.

## Why this shape

Per the user-driven scoping conversation on PR #605: dedekind aspires to be a *math certificate authority*, not a math library that ships its own carriers.  std::unordered_set and std::set ARE the user's containers; this slice makes them first-class IsSet citizens.  Subsequent slices will dissolve the project-shipped wrappers in favour of these overloads.

The lift also matches the F-algebra reading committed to in §2.1 of the paper: each std container's `contains` IS the bundled structure arrow's component for that algebra.

## Subsequent slices (this PR doesn't ship them)

Per #607's body:

* **Slice 2**: dissolve `ExtensionalSet` (replace usages with the std lifts; touches Python facade, tests, report prose).
* **Slice 3**: dissolve `SingletonSet` (add `ambient_set(T value)` overload returning the singleton-shape Subobject; replace SingletonSet construction with this).
* **Slice 4**: dissolve `UniversalSet` and `Ø` (lambda-based replacements).
* **Slice 5**: cardinality reframe (`IsFiniteSet` duck-typed, not carrier-tagged).
* **Slice 6**: paper prose update (§2.1 reads cleanly once the wrappers are gone).

## Coordination

* **PR #604** (image-on-Singleton, ready) is on the dissolution path; the user's call is to land both in parallel.  Slice 3 of this issue will rewrite #604's image function in the post-wrapper shape.
* This slice is independent of #604 — they don't interact at the patch level.

## Test plan

- [x] `make compile` clean (367/367 targets local).
- [x] All four `static_assert` breadcrumbs evaluate at compile time.
- [ ] CI build-and-deploy confirms the nanobind path (lesson from #605: don't trust local alone).

🤖 Generated with [Claude Code](https://claude.com/claude-code)