### PR TITLE
feat(category): :image — IsImageOf<S, F> structural anchor

### DIFF
--- a/src/main/modules/dedekind/category/category.cppm
+++ b/src/main/modules/dedekind/category/category.cppm
@@ -61,8 +61,9 @@ export import :pullback;   // The Universal Construction "Sink"
 export import :image;      // IsImageOf<S, F> — image of an arrow as
                            // a structurally-named subobject of Cod<F>;
                            // mono side of the canonical epi-mono
-                           // factorisation, dual to :pullback's
-                           // IsCoequalizer.
+                           // factorisation.  The dual quotient side
+                           // awaits an IsQuotient sister to IsSubobject;
+                           // see :pullback's partition header.
 
 // Level 1: The Ideal (Total Algebra)
 export import :total;

--- a/src/main/modules/dedekind/category/category.cppm
+++ b/src/main/modules/dedekind/category/category.cppm
@@ -58,6 +58,11 @@ export import :limit;      // Universal Limits
 export import :cartesian;  // Products/Coproducts, CCC Foundations
 export import :topoi;      // Internal Logic of the Topos
 export import :pullback;   // The Universal Construction "Sink"
+export import :image;      // IsImageOf<S, F> — image of an arrow as
+                           // a structurally-named subobject of Cod<F>;
+                           // mono side of the canonical epi-mono
+                           // factorisation, dual to :pullback's
+                           // IsCoequalizer.
 
 // Level 1: The Ideal (Total Algebra)
 export import :total;

--- a/src/main/modules/dedekind/category/image.cppm
+++ b/src/main/modules/dedekind/category/image.cppm
@@ -10,9 +10,9 @@
  * @section image__Motivation
  *
  * Lifts the @em image role to first-class concept status, completing
- * the kernel-pair / coequalizer naming chain set up in @c :pullback:
+ * the kernel-pair / parallel-pair naming chain set up in @c :pullback:
  *
- *   @c IsKernelPair @c → @c IsCoequalizer @c → @c IsImageOf
+ *   @c IsKernelPair @c → @c IsParallelPair @c → @c IsImageOf
  *
  * For an arrow @c F @c : @c A @c → @c B, the @b image @c Im(F) is the
  * coequalizer of the kernel pair of @c F:
@@ -32,8 +32,10 @@
  * @em subobject @em of @em codomain (mono part of the factorisation)
  * — are isomorphic in a topos.  This partition pins the
  * @b mono-side reading as @c IsImageOf<S, F>: @c S is a Subobject of
- * @c Cod<F>.  The dual quotient-side reading is named in
- * @c :pullback as @c IsCoequalizer.
+ * @c Cod<F>.  The dual quotient-side reading awaits an @c IsQuotient
+ * sister to @c IsSubobject; until then @c :pullback names only the
+ * structural input shape ( @c IsParallelPair) rather than a
+ * not-yet-pinnable @c IsCoequalizer.
  *
  * @section image__Structural_vs_Universal
  *
@@ -43,7 +45,7 @@
  *   - @c S is a Subobject of @c Cod<F> ( @c IsSubobject<S, @c Cod<F>>).
  *
  * What @c IsImageOf @b cannot pin (engineer's honesty obligation, as
- * for @c IsNNO and @c IsCoequalizer):
+ * for @c IsNNO):
  *
  *   - That @c S is the @b smallest such subobject (universality of the
  *     image factorisation),
@@ -110,9 +112,8 @@ namespace dedekind::category {
  *
  * The universality (smallest such subobject; canonical epi-mono
  * factorisation @c F @c = @c m @c ∘ @c e) is the engineer's honesty
- * obligation, as for @c IsNNO and @c IsCoequalizer.  C++ concepts
- * cannot quantify over the universal property; they pin the
- * operational signature only.
+ * obligation, as for @c IsNNO.  C++ concepts cannot quantify over
+ * the universal property; they pin the operational signature only.
  *
  * @tparam S The candidate image species (a Subobject of @c Cod<F>).
  * @tparam F The arrow whose image @c S claims to realise.

--- a/src/main/modules/dedekind/category/image.cppm
+++ b/src/main/modules/dedekind/category/image.cppm
@@ -1,0 +1,123 @@
+/**
+ * @file dedekind/category/image.cppm
+ * @partition :image
+ * @brief The image of an arrow as a structurally-named subobject of its
+ *        codomain — `IsImageOf<S, F>`.
+ *
+ * @copyright 2026 The Dedekind Authors
+ * Licensed under the Apache License, Version 2.0.
+ *
+ * @section image__Motivation
+ *
+ * Lifts the @em image role to first-class concept status, completing
+ * the kernel-pair / coequalizer naming chain set up in @c :pullback:
+ *
+ *   @c IsKernelPair @c → @c IsCoequalizer @c → @c IsImageOf
+ *
+ * For an arrow @c F @c : @c A @c → @c B, the @b image @c Im(F) is the
+ * coequalizer of the kernel pair of @c F:
+ *
+ *   @f$\mathrm{Im}(F) @f$ @f$=@f$ @f$\mathrm{coeq}(\pi_1, \pi_2 :
+ *   \mathrm{KernelPair}(F) \rightrightarrows A)@f$.
+ *
+ * Equivalently (in a topos) the image is the smallest @b subobject of
+ * @c B through which @c F factors, giving the canonical epi-mono
+ * factorisation @c F @c = @c m @c ∘ @c e:
+ *
+ *   @c A @c → @c Im(F) @c → @c B
+ *
+ * with @c e regular-epi (the coequalizer projection) and @c m mono
+ * (the inclusion of the image into the codomain).  The two readings —
+ * @em quotient @em of @em domain (kernel-pair coequalizer) and
+ * @em subobject @em of @em codomain (mono part of the factorisation)
+ * — are isomorphic in a topos.  This partition pins the
+ * @b mono-side reading as @c IsImageOf<S, F>: @c S is a Subobject of
+ * @c Cod<F>.  The dual quotient-side reading is named in
+ * @c :pullback as @c IsCoequalizer.
+ *
+ * @section image__Structural_vs_Universal
+ *
+ * What @c IsImageOf @b can pin (structural shape):
+ *
+ *   - @c F is an arrow ( @c IsArrow<F>),
+ *   - @c S is a Subobject of @c Cod<F> ( @c IsSubobject<S, @c Cod<F>>).
+ *
+ * What @c IsImageOf @b cannot pin (engineer's honesty obligation, as
+ * for @c IsNNO and @c IsCoequalizer):
+ *
+ *   - That @c S is the @b smallest such subobject (universality of the
+ *     image factorisation),
+ *   - That @c F factors through @c S as @c m @c ∘ @c e with @c e
+ *     regular-epi and @c m mono,
+ *   - That the factorisation is unique up to isomorphism.
+ *
+ * C++ concepts cannot quantify over the universal property's $\forall$;
+ * they can only pin operational signatures.  The naming here is the
+ * structural anchor — a downstream carrier witness declares
+ * @c IsImageOf<MyImageSet, @c MyArrow> to record the @b intent that
+ * its subobject realises the image.  The audit (that this is in fact
+ * the smallest containing subobject) lives in the witness's
+ * documentation and review.
+ *
+ * @section image__Realisation_Regimes
+ *
+ * The §3 paper outline (`Functions on Sets: Filtering and
+ * Transforming`) names three realisation regimes for the abstract
+ * image, each pinned by @c IsImageOf with a different @c S:
+ *
+ *   - @b Extensional (finite carriers): @c S is a concrete
+ *     std-container subobject realised by iteration in
+ *     @c sets:extensional ( @c image(f, @c std::unordered_set<T>) etc.).
+ *   - @b Intensional (NNO-domain transforms): @c S is the orbit closure
+ *     of an iterated step, naturally pinnable on @c Path<T> in
+ *     @c sequences:path (categorical-anchor breadcrumbs land in the
+ *     follow-up slice).
+ *   - @b Symbolic (Tier C, future): @c S is a deferred set expression
+ *     under an inhabitancy DSL (#603), evaluated lazily.
+ *
+ * @section image__Layering
+ *
+ * Upstream-of-everything-numeric.  Lives in @c :category alongside
+ * @c :pullback; carrier witnesses register downstream where the
+ * carriers are available ( @c sets:extensional for std-container
+ * carriers; @c sequences:path for the NNO-morphism reading).
+ *
+ * @note "There is geometry in the humming of the strings, there is
+ *        music in the spacing of the spheres."
+ *       — Pythagoras, fragment.
+ */
+module;
+
+#include <concepts>
+
+export module dedekind.category:image;
+
+import :morphism;  // For IsArrow / Cod
+import :topoi;     // For IsSubobject
+
+namespace dedekind::category {
+
+/**
+ * @concept IsImageOf
+ * @brief @c S realises the image of arrow @c F as a Subobject of @c Cod<F>.
+ *
+ * @details Structurally, @c IsImageOf<S, F> is exactly @c IsArrow<F>
+ * @c && @c IsSubobject<S, @c Cod<F>>.  The added value over the bare
+ * conjunction is the @b naming: a downstream witness declaring this
+ * concept records the intent that its subobject @b is the image of
+ * @c F (the smallest subobject of @c Cod<F> through which @c F
+ * factors), not just any subobject of @c Cod<F>.
+ *
+ * The universality (smallest such subobject; canonical epi-mono
+ * factorisation @c F @c = @c m @c ∘ @c e) is the engineer's honesty
+ * obligation, as for @c IsNNO and @c IsCoequalizer.  C++ concepts
+ * cannot quantify over the universal property; they pin the
+ * operational signature only.
+ *
+ * @tparam S The candidate image species (a Subobject of @c Cod<F>).
+ * @tparam F The arrow whose image @c S claims to realise.
+ */
+export template <typename S, typename F>
+concept IsImageOf = IsArrow<F> && IsSubobject<S, Cod<F>>;
+
+}  // namespace dedekind::category

--- a/src/main/modules/dedekind/sequences/path.cppm
+++ b/src/main/modules/dedekind/sequences/path.cppm
@@ -719,8 +719,8 @@ static_assert(
 // @f$\mathrm{coeq}(\mathbb{N} \times_T \mathbb{N} \rightrightarrows
 // \mathbb{N})@f$.  The kernel-pair / parallel-pair / image concepts
 // now live in @c :category — see @c IsKernelPair and @c IsParallelPair
-// in @c :pullback and @c IsImageOf in @c :image.  ( @c IsCoequalizer
-// the concept proper is on hold pending an @c IsQuotient sister to
+// in @c :pullback and @c IsImageOf in @c :image.  (The @c IsCoequalizer
+// concept proper is on hold pending an @c IsQuotient sister to
 // @c IsSubobject; @c :pullback's partition header explains why.)
 // The @c static_assert below pins the @c IsImageOf shape on @c Path<T>
 // at the type level: any subobject of @c T qualifies structurally as a

--- a/src/main/modules/dedekind/sequences/path.cppm
+++ b/src/main/modules/dedekind/sequences/path.cppm
@@ -717,10 +717,13 @@ static_assert(
 // sense — is the orbit of @c a₀ under iterated @c s in @c T: the
 // smallest @c s-stable subobject of @c T containing @c a₀, equivalently
 // @f$\mathrm{coeq}(\mathbb{N} \times_T \mathbb{N} \rightrightarrows
-// \mathbb{N})@f$.  The general @c image-as-coequalizer machinery in
-// @c :category is filed for a separate slice; this section pins the
-// structural reading at the @c :sequences end so CI verifies the
-// connection at the type level.
+// \mathbb{N})@f$.  The general kernel-pair / coequalizer / image
+// concepts now live in @c :category — see @c IsKernelPair and
+// @c IsCoequalizer in @c :pullback and @c IsImageOf in @c :image.
+// The @c static_assert below pins the @c IsImageOf shape on @c Path<T>
+// at the type level: any subobject of @c T qualifies structurally as a
+// candidate image-witness for a @c Path<T>; the concrete orbit-closure
+// carrier is the downstream witness slice.
 //
 // The @c using aliases below give the textbook names @b Sequence and
 // @b Net as type-level synonyms for @c Path; the @c static_asserts
@@ -773,6 +776,18 @@ using Net = Path<T>;
 static_assert(IsNet<Path<int>>,
               "Path<int> is a morphism from a directed set (ℕ): the "
               "@c IsNet structural shape that @c IsSequence refines.");
+
+// IsImageOf<S, Path<T>> structural fit: any Subobject of @c T qualifies
+// as a candidate image-witness for a @c Path<T>.  The orbit-closure
+// carrier is the downstream concrete witness; this assertion validates
+// that the concept-level fit holds at the @c :sequences boundary, so a
+// future witness can drop in without re-checking the structural shape.
+static_assert(
+    IsImageOf<decltype(classify<int>([](const int&) { return true; })),
+              Path<int>>,
+    "@c IsImageOf<S, Path<int>> is structurally well-typed for any "
+    "Subobject S of @c int: Cod<Path<int>> = int, and S is required "
+    "to be a Subobject of int.");
 
 // Sanity: the textbook-name aliases resolve to Path.
 static_assert(std::same_as<Sequence<int>, Path<int>>,

--- a/src/main/modules/dedekind/sequences/path.cppm
+++ b/src/main/modules/dedekind/sequences/path.cppm
@@ -717,9 +717,11 @@ static_assert(
 // sense — is the orbit of @c a₀ under iterated @c s in @c T: the
 // smallest @c s-stable subobject of @c T containing @c a₀, equivalently
 // @f$\mathrm{coeq}(\mathbb{N} \times_T \mathbb{N} \rightrightarrows
-// \mathbb{N})@f$.  The general kernel-pair / coequalizer / image
-// concepts now live in @c :category — see @c IsKernelPair and
-// @c IsCoequalizer in @c :pullback and @c IsImageOf in @c :image.
+// \mathbb{N})@f$.  The kernel-pair / parallel-pair / image concepts
+// now live in @c :category — see @c IsKernelPair and @c IsParallelPair
+// in @c :pullback and @c IsImageOf in @c :image.  ( @c IsCoequalizer
+// the concept proper is on hold pending an @c IsQuotient sister to
+// @c IsSubobject; @c :pullback's partition header explains why.)
 // The @c static_assert below pins the @c IsImageOf shape on @c Path<T>
 // at the type level: any subobject of @c T qualifies structurally as a
 // candidate image-witness for a @c Path<T>; the concrete orbit-closure


### PR DESCRIPTION
## Summary

Lifts the *image* role to first-class concept status in a new `:image` partition, completing the kernel-pair / parallel-pair naming chain set up upstream in `:pullback` (#615, merged):

```
IsKernelPair → IsParallelPair → IsImageOf
```

For an arrow F : A → B, `IsImageOf<S, F>` declares that S is a Subobject of `Cod<F>` realising the image of F. Structurally pinned: `IsArrow<F> && IsSubobject<S, Cod<F>>`.

This is the *mono-side* of the canonical epi-mono factorisation F = m ∘ e (S = Im(F) ↪ B). The dual *quotient-side* reading (Im(F) as coequalizer of F's kernel pair) awaits an `IsQuotient` sister to `IsSubobject`; until then `:pullback` names only the input shape (`IsParallelPair`) rather than a not-yet-pinnable `IsCoequalizer`. The `:pullback` partition header spells out why.

Universality — smallest such subobject; uniqueness up to iso — is the engineer's honesty obligation, consistent with `IsNNO`. C++ concepts pin shape; the ∀ stays in the audit trail.

## What's in this PR

- New `:image` partition (`src/main/modules/dedekind/category/image.cppm`) defining `IsImageOf<S, F>`.
- `:image` re-exported from the `dedekind.category` umbrella.
- A type-checked `IsImageOf<…, Path<int>>` `static_assert` in `:sequences:path`, validating the concept-level fit at the `:sequences` boundary. The orbit-closure carrier is the next downstream slice; this assertion uses a generic `Subobject<int, …>` stand-in so future witnesses can drop in without re-checking the structural shape.
- Surrounding prose breadcrumb updated to point at the now-landed `:pullback` (`IsKernelPair` / `IsParallelPair`) and `:image` (`IsImageOf`) concepts.

## Three realisation regimes (per §3 paper outline #612)

- **Extensional**: std-container subobjects in `:sets:extensional` (already landed for `std::set` / `std::unordered_set`).
- **Intensional**: orbit closure on `Path<T>` in `:sequences` — concrete witness is the next slice.
- **Symbolic**: deferred set expression under inhabitancy DSL (#603, future).

## Test plan

- [x] `cmake --build build --target dedekind_category` clean.
- [x] `cmake --build build --target dedekind_sequences` clean (Path<T> `IsImageOf` static_assert verified at compile time).
- [ ] Concrete orbit-closure carrier witness lands in a follow-up slice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)