### PR TITLE
feat(category): :topoi+:image — IsQuotient + IsCoequalizer (proper)

### DIFF
--- a/src/main/modules/dedekind/category/image.cppm
+++ b/src/main/modules/dedekind/category/image.cppm
@@ -1,18 +1,20 @@
 /**
  * @file dedekind/category/image.cppm
  * @partition :image
- * @brief The image of an arrow as a structurally-named subobject of its
- *        codomain — `IsImageOf<S, F>`.
+ * @brief Image-as-coequalizer-of-kernel-pair: @c IsImageOf<S, F> on the
+ *        mono side and @c IsCoequalizer<Q, F, G> on the quotient side.
  *
  * @copyright 2026 The Dedekind Authors
  * Licensed under the Apache License, Version 2.0.
  *
  * @section image__Motivation
  *
- * Lifts the @em image role to first-class concept status, completing
- * the kernel-pair / parallel-pair naming chain set up in @c :pullback:
+ * Hosts the canonical epi-mono factorisation chain set up by
+ * @c :pullback (kernel pair, parallel pair) and @c :topoi (subobject,
+ * quotient):
  *
- *   @c IsKernelPair @c → @c IsParallelPair @c → @c IsImageOf
+ *   @c IsKernelPair @c → @c IsParallelPair @c → @c IsCoequalizer @c → @c
+ * IsImageOf
  *
  * For an arrow @c F @c : @c A @c → @c B, the @b image @c Im(F) is the
  * coequalizer of the kernel pair of @c F:
@@ -27,15 +29,19 @@
  *   @c A @c → @c Im(F) @c → @c B
  *
  * with @c e regular-epi (the coequalizer projection) and @c m mono
- * (the inclusion of the image into the codomain).  The two readings —
- * @em quotient @em of @em domain (kernel-pair coequalizer) and
- * @em subobject @em of @em codomain (mono part of the factorisation)
- * — are isomorphic in a topos.  This partition pins the
- * @b mono-side reading as @c IsImageOf<S, F>: @c S is a Subobject of
- * @c Cod<F>.  The dual quotient-side reading awaits an @c IsQuotient
- * sister to @c IsSubobject; until then @c :pullback names only the
- * structural input shape ( @c IsParallelPair) rather than a
- * not-yet-pinnable @c IsCoequalizer.
+ * (the inclusion of the image into the codomain).  Two structurally
+ * named concepts pin the two sides:
+ *
+ *   - @b mono @b side: @c IsImageOf<S, F> --- @c S is a Subobject of
+ *     @c Cod<F> realising the image.
+ *   - @b quotient @b side: @c IsCoequalizer<Q, F, G> --- @c Q is a
+ *     Quotient of @c Cod<F> equating the parallel pair @c F, @c G.
+ *
+ * Both are co-located here in @c :image since the image-as-coequalizer
+ * reading is the structural payoff that ties them together.  The
+ * universal-property obligations (smallest such subobject, canonical
+ * factorisation, regular-epi universality of @c q) remain the
+ * engineer's honesty obligation in the @c IsNNO style.
  *
  * @section image__Structural_vs_Universal
  *
@@ -94,8 +100,9 @@ module;
 
 export module dedekind.category:image;
 
-import :morphism;  // For IsArrow / Cod
-import :topoi;     // For IsSubobject
+import :morphism;  // For IsArrow / Cod / Dom
+import :pullback;  // For IsParallelPair
+import :topoi;     // For IsSubobject / IsQuotient
 
 namespace dedekind::category {
 
@@ -120,5 +127,53 @@ namespace dedekind::category {
  */
 export template <typename S, typename F>
 concept IsImageOf = IsArrow<F> && IsSubobject<S, Cod<F>>;
+
+/**
+ * @concept IsCoequalizer
+ * @brief The categorical dual of @c IsEqualizer --- a Quotient of
+ *        @c Cod<F> equating two parallel arrows @c F, @c G.
+ *
+ * @details For a parallel pair @c F, @c G @c : @c A @c → @c B, the
+ * coequalizer is the smallest quotient @c Q of @c B together with a
+ * regular epi @c q @c : @c B @c → @c Q satisfying the equalising
+ * condition
+ *
+ *   @c q @c ∘ @c F @c = @c q @c ∘ @c G                 (equalising)
+ *
+ * universal among such: any other arrow @c B @c → @c X equating @c F
+ * and @c G factors uniquely through @c q.  In a topos the coequalizer
+ * is the regular-epi onto the quotient by the smallest equivalence
+ * relation containing the image of the parallel pair.
+ *
+ * Where @c IsEqualizer pins the structural shape via
+ * @c IsSubobject<E, @c Dom<F>>, the dual @c IsCoequalizer pins it via
+ * @c IsQuotient<Q, @c Cod<F>> (in @c :topoi as the dual to
+ * @c IsSubobject).  The universal property's $\forall$ ---
+ * @em existence and @em uniqueness of the unique factoring map for any
+ * arrow that equates the kernel relation, plus the equalising
+ * condition @c q∘F @c = @c q∘G --- is the engineer's honesty
+ * obligation, as for @c IsNNO.
+ *
+ * @section image__Image_as_coequalizer
+ *
+ * For a single arrow @c F @c : @c A @c → @c B with kernel pair
+ * @c π_1, @c π_2 @c : @c P @c ⇒ @c A (@c P satisfying
+ * @c IsKernelPair<P, @c F> in @c :pullback), the @em image of @c F is
+ * the coequalizer of @c (π_1, @c π_2) --- the canonical epi-mono
+ * factorisation
+ *
+ *   @c A @c → @c Im(F) @c → @c B
+ *
+ * read off as "collapse the equivalence relation 'same F-image'".
+ * The mono side @c Im(F) @c ↪ @c B is what @c IsImageOf above pins;
+ * the quotient side @c A @c ↠ @c A/~ is what @c IsCoequalizer here
+ * pins (with @c F = @c π_1, @c G = @c π_2 over the kernel pair).
+ *
+ * @tparam Q The candidate coequalizer species (a Quotient of @c Cod<F>).
+ * @tparam F The first parallel arrow @c F @c : @c A @c → @c B.
+ * @tparam G The second parallel arrow @c G @c : @c A @c → @c B.
+ */
+export template <typename Q, typename F, typename G>
+concept IsCoequalizer = IsParallelPair<F, G> && IsQuotient<Q, Cod<F>>;
 
 }  // namespace dedekind::category

--- a/src/main/modules/dedekind/category/image.cppm
+++ b/src/main/modules/dedekind/category/image.cppm
@@ -90,9 +90,12 @@
  * carriers are available ( @c sets:extensional for std-container
  * carriers; @c sequences:path for the NNO-morphism reading).
  *
- * @note "There is geometry in the humming of the strings, there is
- *        music in the spacing of the spheres."
- *       — Pythagoras, fragment.
+ * @note "ἁρμονία δὲ πολυμιγέων ἕνωσις καὶ δίχα φρονεόντων
+ *        συμφρόνησις."
+ *       ("Harmony is the unification of things many-mixed, and the
+ *        same-mindedness of things thinking-apart.")
+ *       — Philolaus of Croton, fragment B10 DK,
+ *         apud Stobaeus, @em Anthology I.21.7d.
  */
 module;
 

--- a/src/main/modules/dedekind/category/pullback.cppm
+++ b/src/main/modules/dedekind/category/pullback.cppm
@@ -38,28 +38,20 @@
  *   concept level.
  *
  * - **Parallel pair** (`IsParallelPair<F, G>`): the structural
- *   precondition shared by an equalizer's input @b and a (future)
- *   coequalizer's input --- two arrows @c F, @c G with matching
- *   @c Dom and @c Cod.  Used here as the input shape for the
- *   image-as-coequalizer reading: the kernel pair of @c F supplies
- *   two parallel projections @c π_1, @c π_2 @c : @c P @c ⇒ @c Dom<F>,
- *   and the image is the coequalizer of that parallel pair.
+ *   precondition shared by an equalizer's input @b and a coequalizer's
+ *   input --- two arrows @c F, @c G with matching @c Dom and @c Cod.
+ *   Used here as the input shape for the image-as-coequalizer reading:
+ *   the kernel pair of @c F supplies two parallel projections
+ *   @c π_1, @c π_2 @c : @c P @c ⇒ @c Dom<F>, and the image is the
+ *   coequalizer of that parallel pair.
  *
- * The full @b coequalizer concept --- the smallest quotient of
- * @c Cod<F> that equates @c F and @c G, witnessed by a regular epi
- * @c q @c : @c Cod<F> @c → @c Q satisfying @c q∘F @c = @c q∘G ---
- * cannot yet be pinned at the C++-concept level: it requires an
- * @c IsQuotient sister to @c IsSubobject (with a "co-classifier"
- * surface), which the codebase does not yet reify.  Naming an
- * @c IsCoequalizer concept whose body is just the parallel-pair
- * precondition would overpromise; @c IsParallelPair is the honest
- * shape until the quotient surface lands.  Image of a single
- * arrow @c F still reads, mathematically, as
- * @f$\mathrm{Im}(F) @f$ @f$=@f$
- * @f$\mathrm{coeq}(\pi_1, \pi_2 : \mathrm{KernelPair}(F) \rightrightarrows
- * \mathrm{Dom}(F))@f$ --- the canonical epi-mono factorisation;
- * the @em mono side of that factorisation is what the
- * @c :image partition pins as @c IsImageOf<S, F>.
+ * The full coequalizer concept ( @c IsCoequalizer<Q, F, G> ---
+ * @c IsParallelPair<F, G> @c && @c IsQuotient<Q, @c Cod<F>>) lives
+ * in @c :image alongside @c IsImageOf, since the image-as-coequalizer
+ * reading is the structural payoff that ties the two sides of the
+ * canonical epi-mono factorisation together.  @c IsQuotient itself
+ * (the dual of @c IsSubobject, the "co-classifier" surface) lives in
+ * @c :topoi where the subobject classifier already lives.
  *
  * Wikipedia: Pullback (category theory), Equaliser (mathematics)
  *

--- a/src/main/modules/dedekind/category/topoi.cppm
+++ b/src/main/modules/dedekind/category/topoi.cppm
@@ -392,6 +392,62 @@ constexpr auto classify(F&& f) {
   return Subobject<A, std::remove_cvref_t<F>>{std::forward<F>(f)};
 }
 
+/**
+ * @concept IsQuotient
+ * @brief The categorical witness of a regular epimorphism @c q: A ↠ Q ---
+ *        the dual of @c IsSubobject.
+ *
+ * @details A quotient @c Q of @c A is given by:
+ *
+ *   - @c q.q @c : @c A @c ⟶⟶ @c Q::Class --- the regular-epi
+ *     projection onto equivalence classes,
+ *   - @c q.r @c : @c A @c × @c A @c ⟶ @c Ω --- the kernel relation
+ *     (the @em co-classifier, dual to @c χ for @c IsSubobject):
+ *     two elements @c x, @c y @c ∈ @c A are equated by @c q iff
+ *     @c r(x, y) @c = @c True.
+ *
+ * In a topos, just as every subobject is uniquely classified by a
+ * unary characteristic morphism @c χ @c : @c A @c → @c Ω (membership
+ * predicate), every regular-epi quotient is uniquely co-classified by
+ * its kernel relation @c r @c : @c A @c × @c A @c → @c Ω (binary
+ * equivalence predicate).  This concept names the dual surface so
+ * downstream concepts ( @c IsCoequalizer in @c :image, future
+ * pushouts) can constrain the quotient leg of a colimit at the type
+ * level.
+ *
+ * The @b structural shape pinned here is the operational signatures.
+ * The @em equivalence-relation laws on @c r (reflexivity, symmetry,
+ * transitivity) and the @em regular-epi universality of @c q
+ * (existence and uniqueness of the unique factoring map for any
+ * arrow that equates the kernel relation) are the engineer's honesty
+ * obligation, as for @c IsNNO and @c IsSubobject --- C++ concepts can
+ * pin shape, not the $\forall$ in the universal property.
+ *
+ * @tparam Q The Quotient Species (The "Quotient Body").
+ * @tparam A The Ambient Species (The "Source Space").
+ */
+export template <typename Q, typename A>
+concept IsQuotient = requires(Q q, A a, A b) {
+  /**
+   * @brief q: A ⟶⟶ Q::Class
+   * The regular-epi projection.  Every member of A is mapped to its
+   * equivalence class in Q.
+   */
+  { q.q(a) } -> std::same_as<typename Q::Class>;
+
+  /**
+   * @brief r: A × A ⟶ Ω
+   * The kernel relation --- co-classifier of the quotient.  Two A's are
+   * equivalent under @c q iff @c r(x, y) @c = @c True.
+   */
+  { q.r(a, b) } -> LogicalValue;
+
+  // Metadata verification: declared ambient must match A.
+  typename Q::Ambient;
+  typename Q::Class;
+  requires std::same_as<typename Q::Ambient, A>;
+};
+
 /** @brief Logical Conjunction (Intersection): Synthesizes a rule for A ∩ B.
  *  @note Textbook term: meet (∧) in the internal Heyting/Boolean algebra of Ω.
  */

--- a/src/main/modules/dedekind/category/topoi.cppm
+++ b/src/main/modules/dedekind/category/topoi.cppm
@@ -400,20 +400,30 @@ constexpr auto classify(F&& f) {
  * @details A quotient @c Q of @c A is given by:
  *
  *   - @c q.q @c : @c A @c ⟶⟶ @c Q::Class --- the regular-epi
- *     projection onto equivalence classes,
+ *     projection onto equivalence classes (an @c IsArrow),
  *   - @c q.r @c : @c A @c × @c A @c ⟶ @c Ω --- the kernel relation
- *     (the @em co-classifier, dual to @c χ for @c IsSubobject):
- *     two elements @c x, @c y @c ∈ @c A are equated by @c q iff
- *     @c r(x, y) @c = @c True.
+ *     (the @em co-classifier, dual to @c χ for @c IsSubobject), pinned
+ *     as an @c IsPredicate whose domain is a product object @c IsProduct
+ *     of @c A and @c A: two elements @c x, @c y @c ∈ @c A are equated
+ *     by @c q iff @c r((x, y)) @c = @c True.
  *
  * In a topos, just as every subobject is uniquely classified by a
  * unary characteristic morphism @c χ @c : @c A @c → @c Ω (membership
  * predicate), every regular-epi quotient is uniquely co-classified by
  * its kernel relation @c r @c : @c A @c × @c A @c → @c Ω (binary
- * equivalence predicate).  This concept names the dual surface so
- * downstream concepts ( @c IsCoequalizer in @c :image, future
- * pushouts) can constrain the quotient leg of a colimit at the type
- * level.
+ * equivalence predicate over a product object).  This concept names
+ * the dual surface so downstream concepts ( @c IsCoequalizer in
+ * @c :image, future pushouts) can constrain the quotient leg of a
+ * colimit at the type level.
+ *
+ * @b Symmetry @b with @c IsSubobject: where @c IsSubobject pins
+ * @c s.χ as an @c IsPredicate with @c Dom<χ> @c = @c A,
+ * @c IsQuotient pins @c q.q as an @c IsArrow with
+ * @c Dom<q> @c = @c A and @c Cod<q> @c = @c Q::Class, and @c q.r as
+ * an @c IsPredicate over a product domain @c IsProduct<Dom<r>, A, A>.
+ * Both members are proper morphisms (carrying @c Domain / @c Codomain
+ * typedefs) so they compose with the rest of the @c :category arrow
+ * machinery uniformly --- raw callables won't satisfy this concept.
  *
  * The @b structural shape pinned here is the operational signatures.
  * The @em equivalence-relation laws on @c r (reflexivity, symmetry,
@@ -427,25 +437,32 @@ constexpr auto classify(F&& f) {
  * @tparam A The Ambient Species (The "Source Space").
  */
 export template <typename Q, typename A>
-concept IsQuotient = requires(Q q, A a, A b) {
+concept IsQuotient = requires(Q q) {
   /**
    * @brief q: A ⟶⟶ Q::Class
-   * The regular-epi projection.  Every member of A is mapped to its
-   * equivalence class in Q.
+   * The regular-epi projection, pinned as an @c IsArrow so it composes
+   * uniformly with the rest of @c :category.
    */
-  { q.q(a) } -> std::same_as<typename Q::Class>;
+  { q.q } -> IsArrow;
 
   /**
    * @brief r: A × A ⟶ Ω
-   * The kernel relation --- co-classifier of the quotient.  Two A's are
-   * equivalent under @c q iff @c r(x, y) @c = @c True.
+   * The kernel relation --- co-classifier of the quotient, pinned as
+   * an @c IsPredicate over a product domain.
    */
-  { q.r(a, b) } -> LogicalValue;
+  { q.r } -> IsPredicate;
 
   // Metadata verification: declared ambient must match A.
   typename Q::Ambient;
   typename Q::Class;
   requires std::same_as<typename Q::Ambient, A>;
+
+  // Arrow signatures: q : A ⟶ Q::Class.
+  requires std::same_as<Dom<decltype(q.q)>, A>;
+  requires std::same_as<Cod<decltype(q.q)>, typename Q::Class>;
+
+  // Predicate domain: r is over a product object IsProduct<Dom<r>, A, A>.
+  requires IsProduct<Dom<decltype(q.r)>, A, A>;
 };
 
 /** @brief Logical Conjunction (Intersection): Synthesizes a rule for A ∩ B.

--- a/src/main/modules/dedekind/sequences/path.cppm
+++ b/src/main/modules/dedekind/sequences/path.cppm
@@ -717,11 +717,11 @@ static_assert(
 // sense — is the orbit of @c a₀ under iterated @c s in @c T: the
 // smallest @c s-stable subobject of @c T containing @c a₀, equivalently
 // @f$\mathrm{coeq}(\mathbb{N} \times_T \mathbb{N} \rightrightarrows
-// \mathbb{N})@f$.  The kernel-pair / parallel-pair / image concepts
-// now live in @c :category — see @c IsKernelPair and @c IsParallelPair
-// in @c :pullback and @c IsImageOf in @c :image.  (The @c IsCoequalizer
-// concept proper is on hold pending an @c IsQuotient sister to
-// @c IsSubobject; @c :pullback's partition header explains why.)
+// \mathbb{N})@f$.  The kernel-pair / parallel-pair / coequalizer /
+// image / quotient concepts now live in @c :category --- see
+// @c IsKernelPair and @c IsParallelPair in @c :pullback,
+// @c IsImageOf and @c IsCoequalizer in @c :image, and
+// @c IsQuotient (sister to @c IsSubobject) in @c :topoi.
 // The @c static_assert below pins the @c IsImageOf shape on @c Path<T>
 // at the type level: any subobject of @c T qualifies structurally as a
 // candidate image-witness for a @c Path<T>; the concrete orbit-closure


### PR DESCRIPTION
## Summary

Closes the structural chain set up by #615 + #616 by adding the previously-missing colimit-side concepts:

```
IsKernelPair → IsParallelPair → IsCoequalizer → IsImageOf
```

## What's in this PR

- **`:topoi`** gains `IsQuotient<Q, A>` as the categorical dual of `IsSubobject`:
  - `q.q : A ⟶⟶ Q::Class` — the regular-epi projection
  - `q.r : A × A ⟶ Ω` — the kernel relation (the *co-classifier*, dual to χ for IsSubobject)

  Topos-internal-logic primitive: every regular-epi quotient is uniquely co-classified by its kernel relation, just as every subobject is uniquely classified by its characteristic morphism.

- **`:image`** gains `IsCoequalizer<Q, F, G>` = `IsParallelPair<F, G> && IsQuotient<Q, Cod<F>>`. Co-located with `IsImageOf` rather than placed in `:pullback` because the image-as-coequalizer reading is the structural payoff that ties the quotient and mono sides of the canonical epi-mono factorisation together.

- **`:pullback`** stays focused on its Pierce *Basic Category Theory for Computer Scientists* §-section identity (kernel pair / equalizer / parallel pair as limit-side primitives). Partition header updated to drop the "IsCoequalizer is on hold" caveat and point at `:image` / `:topoi` for the colimit side.

- **`:sequences:path`** breadcrumb prose updated similarly.

## Honesty obligations (engineer's, not concept-pinned)

- The equivalence-relation laws on `q.r` (reflexivity, symmetry, transitivity).
- The regular-epi universality of `q.q` (existence + uniqueness of the unique factoring map for any arrow that equates the kernel relation).
- The equalising condition `q∘F == q∘G` for `IsCoequalizer`.

C++ concepts pin shape; the ∀ in the universal property stays in the audit trail, in the IsNNO style.

## Layout decision

`:image` graduates from "one concept" to "the home of the canonical epi-mono factorisation" (mono via IsImageOf, quotient via IsCoequalizer). This honors the "image etc. deserve their own partition" nudge without splintering: IsQuotient lives next to its dual IsSubobject in `:topoi`, IsCoequalizer goes where it's used in `:image`.

## Test plan

- [x] `cmake --build build --target dedekind_sequences` clean (entire downstream chain compiles).
- [ ] Concrete IsQuotient witnesses (e.g. for set-quotients on `std::set`-backed carriers) live in follow-up slices.

## Follow-ups

- `:pullback` → `:limit` consolidation: dropped per [conversation](https://github.com/vincentk/dedekind/pull/616#discussion_r…) — `:pullback` keeps its Pierce-Section identity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)