### PR TITLE
feat(paper): #603 — α′ §3 single-listing nugget walk on ℕ

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -201,6 +201,10 @@ add_library(set-pruning-ir-fixture STATIC EXCLUDE_FROM_ALL
     src/test/cpp/modules/dedekind/python/showcase_07_lattice_real_interval.cpp
     src/test/cpp/modules/dedekind/python/showcase_08_halfspace_2d_product.cpp
     src/test/cpp/modules/dedekind/python/showcase_09_lp_vertex_typed_constant.cpp
+    # showcase_alpha_prime.cpp is added for compile-time validation of the
+    # paper §3 α′ listing; it has no checked-in `.ll` fixture because its
+    # IR demo is reused from showcase_03 (the empty-meet structural pattern).
+    # See showcase_alpha_prime.cpp's header for the cross-reference.
     src/test/cpp/modules/dedekind/python/showcase_alpha_prime.cpp)
 
 set_target_properties(set-pruning-ir-fixture PROPERTIES

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -200,7 +200,8 @@ add_library(set-pruning-ir-fixture STATIC EXCLUDE_FROM_ALL
     src/test/cpp/modules/dedekind/python/showcase_06_halfspace_interval_42.cpp
     src/test/cpp/modules/dedekind/python/showcase_07_lattice_real_interval.cpp
     src/test/cpp/modules/dedekind/python/showcase_08_halfspace_2d_product.cpp
-    src/test/cpp/modules/dedekind/python/showcase_09_lp_vertex_typed_constant.cpp)
+    src/test/cpp/modules/dedekind/python/showcase_09_lp_vertex_typed_constant.cpp
+    src/test/cpp/modules/dedekind/python/showcase_alpha_prime.cpp)
 
 set_target_properties(set-pruning-ir-fixture PROPERTIES
     CXX_STANDARD 23

--- a/docs/paper/paper.tex
+++ b/docs/paper/paper.tex
@@ -884,20 +884,19 @@ Together, the two stances put $\{f(x) \mid x \in S, p(x)\}$ --- the textbook def
 The payoff of the comprehension view is that the LLVM backend can \emph{prune} a
 set expression to a no-op when its predicate is statically unsatisfiable.
 
-% Source: src/test/cpp/modules/dedekind/python/showcase_03_halfspace_contradiction.cpp
+% Source: src/test/cpp/modules/dedekind/python/showcase_alpha_prime.cpp
 \begin{listing}[htbp]
-\caption{Contradictory predicates collapse to the empty-set type $\varnothing$. Uses the \cppinline{Halfspace}-NTTP DSL to pin both bounds in the type signature, so the contradiction is resolved at translation time.}
+\caption{α′ — a single listing across the §3 narrative arc \emph{rule\,→\,tested\,→\,trimmed\,→\,collapsed\,→\,contradicted\,→\,certified} on $\mathbb{N}$.  Each line is one structural reduction the compiler discharges.  The \cppinline{== L::True} membership form lifts \cppinline{Ternary} (the natural-logic species over the transfinite $\mathbb{N}$) into a \cppinline{static_assert}-eligible boolean; a halfspace-elevation refinement that carries decidability back into bare \cppinline{static_assert(S.contains(7u))} reading is on the future-DSL list.  The cardinality-1 collapse \cppinline{S & {<7}} → \cppinline{Singleton<6>} and the law-of-excluded-middle reduction \cppinline{S & !S} → $\varnothing$ are both type-level discharges; the IR in Listing~\ref{lst:pruning_ir} witnesses the latter at the machine-code level.}
 \label{lst:pruning}
 \begin{cpp}
-constexpr auto n = element<ℕ>;
-
-// Two halfspace-structured sets, with pivots (5 and 3) carried as NTTPs.
-constexpr auto gt_5 = Set{n | (n > bound<5>)};
-constexpr auto lt_3 = Set{n | (n < bound<3>)};
-
-// Compile-time theorem: the meet IS the empty set on ℕ.
-constexpr Ø<Cardinality> empty_meet = gt_5 & lt_3;
-static_assert(empty_meet == Ø{});
+constexpr auto S = Set{in<ℕ> | (in<ℕ> > bound<5>)};                       // rule
+using L = decltype(S)::logic_species;                                       // ℕ → TernaryLogic
+static_assert(S.contains(7u) == L::True);                                    // tested
+constexpr auto T = set_difference(S, Set{in<ℕ> | (in<ℕ> > bound<10>)});      // trimmed
+static_assert(T.contains(8u) == L::True && T.contains(11u) == L::False);
+constexpr Singleton<6> a = S & Set{in<ℕ> | (in<ℕ> < bound<7>)};              // collapsed
+constexpr Ø<Cardinality> b = S & !S;                                         // contradicted
+static_assert(IsCompileTimeEnumerable<decltype(a)> && IsCompileTimeEnumerable<decltype(b)>);  // certified
 \end{cpp}
 \end{listing}
 

--- a/docs/paper/paper.tex
+++ b/docs/paper/paper.tex
@@ -900,8 +900,8 @@ static_assert(IsCompileTimeEnumerable<decltype(a)> && IsCompileTimeEnumerable<de
 \end{cpp}
 \end{listing}
 
-The generated binary contains no membership-test code for
-\cppinline{empty_meet}: the type-level contradiction rule resolves the
+The \cppinline{S & !S} collapse on line 7 of Listing~\ref{lst:pruning} generates no
+membership-test code: the type-level contradiction rule resolves the
 result to $\varnothing$ \emph{before} code generation, and the
 computability tier of $\varnothing$ is fully top
 (extensional/classical/element-in-type).

--- a/docs/paper/paper.tex
+++ b/docs/paper/paper.tex
@@ -886,15 +886,15 @@ set expression to a no-op when its predicate is statically unsatisfiable.
 
 % Source: src/test/cpp/modules/dedekind/python/showcase_alpha_prime.cpp
 \begin{listing}[htbp]
-\caption{α′ — a single listing across the §3 narrative arc \emph{rule\,→\,tested\,→\,trimmed\,→\,collapsed\,→\,contradicted\,→\,certified} on $\mathbb{N}$.  Each line is one structural reduction the compiler discharges.  The \cppinline{== L::True} membership form lifts \cppinline{Ternary} (the natural-logic species over the transfinite $\mathbb{N}$) into a \cppinline{static_assert}-eligible boolean; a halfspace-elevation refinement that carries decidability back into bare \cppinline{static_assert(S.contains(7u))} reading is on the future-DSL list.  The cardinality-1 collapse \cppinline{S & {<7}} → \cppinline{Singleton<6>} and the law-of-excluded-middle reduction \cppinline{S & !S} → $\varnothing$ are both type-level discharges; the IR in Listing~\ref{lst:pruning_ir} witnesses the latter at the machine-code level.}
+\caption{α′ — a single listing across the §3 narrative arc \emph{rule\,→\,tested\,→\,trimmed\,→\,collapsed\,→\,contradicted\,→\,certified} on $\mathbb{N}$.  Each line is one structural reduction the compiler discharges.  The \cppinline{== L::True} membership form lifts \cppinline{Ternary} (the natural-logic species over the transfinite $\mathbb{N}$) into a \cppinline{static_assert}-eligible boolean; a halfspace-elevation refinement that carries decidability back into bare \cppinline{static_assert(S.contains(7u))} reading is on the future-DSL list.  The cardinality-1 collapse \cppinline{S & {<7}} → \cppinline{Singleton<6>} and the law-of-excluded-middle reduction \cppinline{S & !S} → $\varnothing$ are both type-level discharges; Listing~\ref{lst:pruning_ir} demonstrates the same empty-meet structural pattern at the IR level via a sibling halfspace-contradiction witness in \texttt{showcase\_03\_halfspace\_contradiction.cpp}.}
 \label{lst:pruning}
 \begin{cpp}
-constexpr auto S = Set{in<ℕ> | (in<ℕ> > bound<5>)};                       // rule
+constexpr auto S = Set{in<ℕ> | in<ℕ> > bound<5>};                         // rule
 using L = decltype(S)::logic_species;                                       // ℕ → TernaryLogic
 static_assert(S.contains(7u) == L::True);                                    // tested
-constexpr auto T = set_difference(S, Set{in<ℕ> | (in<ℕ> > bound<10>)});      // trimmed
+constexpr auto T = set_difference(S, Set{in<ℕ> | in<ℕ> > bound<10>});        // trimmed
 static_assert(T.contains(8u) == L::True && T.contains(11u) == L::False);
-constexpr Singleton<6> a = S & Set{in<ℕ> | (in<ℕ> < bound<7>)};              // collapsed
+constexpr Singleton<6> a = S & Set{in<ℕ> | in<ℕ> < bound<7>};                // collapsed
 constexpr Ø<Cardinality> b = S & !S;                                         // contradicted
 static_assert(IsCompileTimeEnumerable<decltype(a)> && IsCompileTimeEnumerable<decltype(b)>);  // certified
 \end{cpp}

--- a/src/main/modules/dedekind/sets/expressions.cppm
+++ b/src/main/modules/dedekind/sets/expressions.cppm
@@ -225,10 +225,14 @@ inline constexpr BoundScout<Ambient> element{};
  *  Disambiguation: this is a variable template at value-as-NTTP
  *  position ( @c in<Ambient>), structurally distinct from the ETCS
  *  free function @c dedekind::category::in(x, @c S) at call position.
- *  The two live in different namespaces and use different syntactic
- *  shapes, so no ambiguity arises in practice.  Membership queries in
- *  the @c sets DSL idiomatically route through @c S.contains(x) on
- *  the set value itself. */
+ *  However: when @b both namespaces are pulled in via @c using
+ *  @c namespace, unqualified-lookup of the name @c in is ambiguous --
+ *  C++ name lookup happens before syntactic discrimination by argument
+ *  shape.  Call-site fix: omit @c using @c namespace
+ *  @c dedekind::category and spell category names fully qualified, or
+ *  reach for the @c sets::in<...> qualified form.  Membership queries
+ *  in the @c sets DSL idiomatically route through @c S.contains(x) on
+ *  the set value itself, sidestepping the conflict. */
 export template <auto Ambient>
 inline constexpr BoundScout<Ambient> const& in = element<Ambient>;
 

--- a/src/test/cpp/modules/dedekind/python/showcase_alpha_prime.cpp
+++ b/src/test/cpp/modules/dedekind/python/showcase_alpha_prime.cpp
@@ -16,13 +16,16 @@
  *   5. complement-via-LEM: @c S @c ∩ @c ¬S @c = @c ∅ at compile time,
  *   6. tier elevation lands on both reductions.
  *
- * The α′ candidate listing in #603 enumerates seven nuggets; this
- * showcase ships the six that compile against current main.  The
- * remaining two — a cross-carrier @c embed_𝔹_ℕ embedding and a
- * transformation nugget @c {2x @c | @c x @c ∈ @c S} — are deferred
- * follow-ups (the embedding function is not yet reified; the
- * transformation nugget is gated on the expression-template DSL leg
- * of #603's four-leg ordering).
+ * The α′ candidate listing in #603 enumerates seven base nuggets,
+ * with an eighth @em transformation nugget @c {2x @c | @c x @c ∈ @c S}
+ * added in the 2026-05-06 design update.  This showcase ships the six
+ * that compile against current main: of the seven base nuggets, one
+ * (the cross-carrier @c embed_𝔹_ℕ embedding) is dropped because
+ * @c embed_𝔹_ℕ is not yet reified; the transformation nugget is
+ * deferred because it is gated on the expression-template DSL leg
+ * of #603's four-leg ordering.  Six ship, one is dropped, one is
+ * deferred --- eight total candidate nuggets in the design,
+ * six implemented today.
  *
  * @copyright 2026 The Dedekind Authors
  * Licensed under the Apache License, Version 2.0.
@@ -46,7 +49,7 @@ using namespace dedekind::order;
 // (1) Rule.  Intensional ℕ-comprehension via the soft alias `in<>` (post-#620).
 //     Reads "the set of x ∈ ℕ such that x > 5" — bar, "in" on the LHS, the
 //     textbook membership shape.
-constexpr auto S = Set{in<ℕ> | (in<ℕ> > bound<5>)};
+constexpr auto S = Set{in<ℕ> | in<ℕ> > bound<5>};
 
 // ℕ = Ω<Cardinality> routes through NaturalLogic → TernaryLogic (because
 // ℵ_0 is transfinite), so `S.contains(...)` returns Ternary rather than bool;
@@ -67,7 +70,7 @@ static_assert(S.contains(7u) == NLogic::True);
 //     across `NegatedPredicate` (so `T & {<7}` would collapse to the literal
 //     interval [6, 6]) is a future DSL refinement; membership on T still
 //     constant-folds via the predicate.
-constexpr auto T = set_difference(S, Set{in<ℕ> | (in<ℕ> > bound<10>)});
+constexpr auto T = set_difference(S, Set{in<ℕ> | in<ℕ> > bound<10>});
 static_assert(T.contains(8u) == NLogic::True);    // 5 < 8 ≤ 10 ✓
 static_assert(T.contains(11u) == NLogic::False);  // 11 > 10 ✗
 
@@ -78,7 +81,7 @@ static_assert(T.contains(11u) == NLogic::False);  // 11 > 10 ✗
 //     `T & {== bound<6>}` form would land the same Singleton via the
 //     trimmed `T` and an equality-classifier reduction; both refinements
 //     are separate future slices.)
-constexpr Singleton<6> a = S & Set{in<ℕ> | (in<ℕ> < bound<7>)};
+constexpr Singleton<6> a = S & Set{in<ℕ> | in<ℕ> < bound<7>};
 
 // (5) Contradicted.  Complement-via-LEM: any S has empty meet with its
 //     complement.  `structured_and` reduces this to `Ø<Cardinality>` at

--- a/src/test/cpp/modules/dedekind/python/showcase_alpha_prime.cpp
+++ b/src/test/cpp/modules/dedekind/python/showcase_alpha_prime.cpp
@@ -1,0 +1,108 @@
+/**
+ * @file
+ * src/test/cpp/modules/dedekind/python/showcase_alpha_prime.cpp
+ * @brief Showcase α′ — the §3 single-listing nugget walk
+ *        (rule → tested → trimmed → collapsed → contradicted → certified).
+ *
+ * Source companion to paper Listing α′ (#603).  Each line lands one
+ * structural nugget exhibiting a different ingredient of the
+ * type-system-as-set-DSL story:
+ *
+ *   1. intensional ℕ-comprehension (post-#620 @c in<...> alias),
+ *   2. compile-time membership query,
+ *   3. set difference via @c set_difference (substituted from textbook ∖),
+ *   4. cardinality reduction → 1 (intensional → extensional, halfspace
+ *      collapse to @c Singleton),
+ *   5. complement-via-LEM: @c S @c ∩ @c ¬S @c = @c ∅ at compile time,
+ *   6. tier elevation lands on both reductions.
+ *
+ * The α′ candidate listing in #603 enumerates seven nuggets; this
+ * showcase ships the six that compile against current main.  The
+ * remaining two — a cross-carrier @c embed_𝔹_ℕ embedding and a
+ * transformation nugget @c {2x @c | @c x @c ∈ @c S} — are deferred
+ * follow-ups (the embedding function is not yet reified; the
+ * transformation nugget is gated on the expression-template DSL leg
+ * of #603's four-leg ordering).
+ *
+ * @copyright 2026 The Dedekind Authors
+ * Licensed under the Apache License, Version 2.0.
+ */
+
+import dedekind.category;
+import dedekind.sets;
+import dedekind.algebra;
+import dedekind.numbers;
+import dedekind.order;
+
+// Deliberately omitting `using namespace dedekind::category;`: the soft-alias
+// `dedekind::sets::in<Ambient>` (post-#620) collides with the free function
+// `dedekind::category::in(x, S)` under unqualified name lookup.  `category`
+// names used here are spelled fully qualified.
+using namespace dedekind::sets;
+using namespace dedekind::algebra;
+using namespace dedekind::numbers;
+using namespace dedekind::order;
+
+// (1) Rule.  Intensional ℕ-comprehension via the soft alias `in<>` (post-#620).
+//     Reads "the set of x ∈ ℕ such that x > 5" — bar, "in" on the LHS, the
+//     textbook membership shape.
+constexpr auto S = Set{in<ℕ> | (in<ℕ> > bound<5>)};
+
+// ℕ = Ω<Cardinality> routes through NaturalLogic → TernaryLogic (because
+// ℵ_0 is transfinite), so `S.contains(...)` returns Ternary rather than bool;
+// the comparison against `Logic::True` lifts the result back into
+// boolean / static_assert-eligible form.  A halfspace-elevation refinement
+// (carry the membership decidability through the carrier's logic-routing so
+// `static_assert(S.contains(7u))` reads bare) is on the future-DSL list.
+using NLogic = typename decltype(S)::logic_species;
+
+// (2) Tested.  Compile-time membership query — the rule is the type, so
+//     `S.contains(7u) == True` is constant-evaluable.
+static_assert(S.contains(7u) == NLogic::True);
+
+// (3) Trimmed.  Set difference: A ∖ B = {x | x ∈ A ∧ x ∉ B}.  The textbook
+//     `S \ T` would be the natural spelling; substituted here as
+//     `set_difference(S, T)` (free function in :sets:relational) since `\`
+//     is not a C++ operator.  T is a lazy lambda-Set: structural reduction
+//     across `NegatedPredicate` (so `T & {<7}` would collapse to the literal
+//     interval [6, 6]) is a future DSL refinement; membership on T still
+//     constant-folds via the predicate.
+constexpr auto T = set_difference(S, Set{in<ℕ> | (in<ℕ> > bound<10>)});
+static_assert(T.contains(8u) == NLogic::True);    // 5 < 8 ≤ 10 ✓
+static_assert(T.contains(11u) == NLogic::False);  // 11 > 10 ✗
+
+// (4) Collapsed.  Cardinality reduction → 1 (intensional → extensional).
+//     `S` (= {x : x > 5}) intersected with {x : x < 7} on ℕ has cardinality
+//     exactly 1, and `structured_and` reduces the meet to the `Singleton<6>`
+//     extensional carrier at compile time.  (The candidate listing's
+//     `T & {== bound<6>}` form would land the same Singleton via the
+//     trimmed `T` and an equality-classifier reduction; both refinements
+//     are separate future slices.)
+constexpr Singleton<6> a = S & Set{in<ℕ> | (in<ℕ> < bound<7>)};
+
+// (5) Contradicted.  Complement-via-LEM: any S has empty meet with its
+//     complement.  `structured_and` reduces this to `Ø<Cardinality>` at
+//     compile time — the law-of-excluded-middle made type-level.
+constexpr Ø<Cardinality> b = S & !S;
+
+// (6) Certified.  Tier elevation: both reductions (Singleton<6>,
+// Ø<Cardinality>)
+//     are compile-time enumerable, even though their parent S is not — the
+//     reduction crosses the realisation boundary, lifting an intensional
+//     description on a transfinite carrier into decidable, finite,
+//     type-level semantics.
+static_assert(IsCompileTimeEnumerable<decltype(a)>);
+static_assert(IsCompileTimeEnumerable<decltype(b)>);
+
+/**
+ * @brief Showcase α′: the §3 walk's compile-time payoff lifted to a
+ *        runtime witness.
+ *
+ * @c S.contains(7u) is constant-evaluable (7 > 5 lands in the halfspace),
+ * so the compiler should constant-fold the body to @c true.
+ *
+ * Expected IR: `ret i1 true`
+ */
+extern "C" __attribute__((noinline)) bool witness_alpha_prime() {
+  return S.contains(7u) == NLogic::True;
+}


### PR DESCRIPTION
## Summary

Closes #603's leg-4 fallback: α′ lands as the §3 single listing without the transformation nugget (gated on the expression-template DSL leg) and without the cross-carrier `embed_𝔹_ℕ` nugget (function not yet reified). Six nuggets ship today, walking the §3 narrative arc:

```
rule → tested → trimmed → collapsed → contradicted → certified
```

Each line is one structural reduction the compiler discharges:

| Line | Form | Nugget |
|---|---|---|
| 1 | `Set{in<ℕ> | (in<ℕ> > bound<5>)}` | comprehension |
| 2 | `S.contains(7u) == L::True` | compile-time membership |
| 3 | `set_difference(S, {>10})` | set difference (free fn) |
| 4 | `S & {<7}  →  Singleton<6>` | cardinality reduction → 1 |
| 5 | `S & !S    →  Ø<Cardinality>` | complement-LEM |
| 6 | `IsCompileTimeEnumerable<a> && <b>` | tier elevation |

## What ships

- **Paper Listing α′** in §3.4 — replaces `lst:pruning`'s 4-line empty-meet demo (label `lst:pruning` kept so cross-refs survive). 8 lines, 6 nuggets.
- **Companion test**: `src/test/cpp/modules/dedekind/python/showcase_alpha_prime.cpp` exercises every line as `static_assert` and provides a runtime witness for IR generation. Wired into `set-pruning-ir-fixture` in `CMakeLists.txt`.
- **Docstring fix on `in<Ambient>`** (the soft alias from #620): the previous claim that "no ambiguity arises in practice" was wrong — when both `dedekind::category` and `dedekind::sets` namespaces are pulled in via `using namespace`, C++ name lookup hits both `dedekind::category::in(x, S)` and `dedekind::sets::in<Ambient>` and complains (lookup is two-phase: name lookup happens before syntactic discrimination by argument shape). Updated to accurately describe the conflict and recommend either qualified spelling (`sets::in<...>`) or routing through `S.contains(x)`.

## Caveats surfaced during implementation

Three idealisations from the #603 candidate listing don't yet hold in current main:

1. **`ℕ` routes through `TernaryLogic`** (not `ClassicalLogic`) because `Ω<Cardinality>` is transfinite via `NaturalLogic`. So `S.contains(7u)` returns `Ternary`, not `bool` — bare `static_assert(S.contains(7u))` fails. Substituted with `== L::True` lift. Future DSL refinement: a halfspace-elevation that carries decidability through the carrier's logic-routing.

2. **`set_difference(a, b)` ≡ `a & !b` produces a lazy lambda-Set** whose intersection with another halfspace doesn't reduce structurally through `NegatedPredicate`. Membership on T still constant-folds via the predicate. Future DSL refinement: structural pass-through across `NegatedPredicate`.

3. **Equality-classifier reduction** doesn't yet exist: the candidate's `T & {== bound<6>}` form would land `Singleton<6>` via that path. Substituted with `S & {<7}` (the halfspace-intersection form) which does reduce structurally today.

These caveats are documented in the showcase and reflected in the listing caption.

## Test plan

- [x] `cmake --build build --target set-pruning-ir-fixture` clean (every static_assert in showcase_alpha_prime.cpp passes).
- [x] `lualatex paper.tex` clean (only unrelated hyperref/citation warnings).
- [ ] Verify rendered PDF Listing α′ readability (post-merge — local lualatex run does not need to be one-shot).

## Sequencing per #603

- [x] (Leg 1) Soft alias `in<T>` — #620.
- [ ] (Leg 2) #604 layer-1 + follow-up image-dispatch slices — partial.
- [ ] (Leg 3) Expression-template DSL for transformation-nugget.
- [x] (Leg 4 fallback) α′ listing without transformation nugget — this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)