### PR TITLE
feat(numbers, sets): #602 layer 1 — embed_𝔹_ℕ_ + set-level lift embed_𝔹_ℕ

### DIFF
--- a/src/main/modules/dedekind/numbers/natural.cppm
+++ b/src/main/modules/dedekind/numbers/natural.cppm
@@ -53,6 +53,7 @@ module;
 
 #include <concepts>
 #include <functional>
+#include <utility>  // std::forward (used in embed_𝔹_ℕ's set-level lift)
 
 export module dedekind.numbers:natural;
 
@@ -162,15 +163,20 @@ export inline constexpr auto embed_𝔹_ℕ_ =
     });
 
 /**
- * @brief Set-level lift of @c embed_𝔹_ℕ_: image of an @c IsSet @c S
- *        under the canonical mono 𝔹 ↪ ℕ.
+ * @brief Set-level lift of @c embed_𝔹_ℕ_: image of a Boolean set
+ *        @c S under the canonical mono 𝔹 ↪ ℕ.
  *
  * @details Layer-1 entry per #602: names the construction at the
- * call site rather than re-spelling @c image(embed_𝔹_ℕ_, S).
- * Delegates to @c dedekind::sets::image, inheriting whatever
- * per-shape dispatch @c image already provides (Singleton on
- * @c :sets:singleton, std-containers on @c :sets:extensional;
- * lazy predicate sets when #602's layer 2 lands).
+ * call site rather than re-spelling @c image(embed_𝔹_ℕ_, S).  The
+ * accepted input @c S is anything @c dedekind::sets::image already
+ * dispatches on --- @c SingletonSet (@c :sets:singleton),
+ * @c std::set<bool> / @c std::unordered_set<bool> (@c :sets:extensional);
+ * lazy predicate sets join the dispatch table when #602's layer 2
+ * lands.  This is structurally the union of the @c IsSet
+ * universe-value carriers and the std-container carriers that
+ * @c image accepts today; the requires-clause checks well-formedness
+ * directly rather than gating through a single concept (which would
+ * exclude one or the other tier).
  *
  * Mathematically: the image of @c S under the canonical mono
  * 𝔹 ↪ ℕ is a subset of @c {0, @c 1} ⊂ @c ℕ containing whichever

--- a/src/main/modules/dedekind/numbers/natural.cppm
+++ b/src/main/modules/dedekind/numbers/natural.cppm
@@ -145,6 +145,46 @@ export inline constexpr auto embed_𝔹_uint_ =
     arrow<bool, unsigned>([](const bool& b) noexcept { return b ? 1u : 0u; });
 
 /**
+ * @brief Canonical embedding 𝔹 ↪ ℕ: bool → Cardinality.
+ * @details False maps to @c finite_cardinality(0), True to
+ *          @c finite_cardinality(1).
+ *
+ * Sister arrow to @c embed_𝔹_uint_ above; this one lands in the
+ * @c Cardinality carrier (the canonical @c IsNatural witness of
+ * @c ℕ in the set-builder layer) directly, without routing through
+ * the machine-width @c unsigned proxy.  Filed against #602 layer 1
+ * (the set-level lift @c embed_𝔹_ℕ below uses this arrow to delegate
+ * through the existing @c sets::image dispatch).
+ */
+export inline constexpr auto embed_𝔹_ℕ_ =
+    arrow<bool, Cardinality>([](const bool& b) noexcept -> Cardinality {
+      return finite_cardinality(b ? 1 : 0);
+    });
+
+/**
+ * @brief Set-level lift of @c embed_𝔹_ℕ_: image of an @c IsSet @c S
+ *        under the canonical mono 𝔹 ↪ ℕ.
+ *
+ * @details Layer-1 entry per #602: names the construction at the
+ * call site rather than re-spelling @c image(embed_𝔹_ℕ_, S).
+ * Delegates to @c dedekind::sets::image, inheriting whatever
+ * per-shape dispatch @c image already provides (Singleton on
+ * @c :sets:singleton, std-containers on @c :sets:extensional;
+ * lazy predicate sets when #602's layer 2 lands).
+ *
+ * Mathematically: the image of @c S under the canonical mono
+ * 𝔹 ↪ ℕ is a subset of @c {0, @c 1} ⊂ @c ℕ containing whichever
+ * @c bool elements are in @c S.
+ */
+export template <typename S>
+  requires requires(S&& s) {
+    dedekind::sets::image(embed_𝔹_ℕ_, std::forward<S>(s));
+  }
+constexpr auto embed_𝔹_ℕ(S&& s) {
+  return dedekind::sets::image(embed_𝔹_ℕ_, std::forward<S>(s));
+}
+
+/**
  * @brief Canonical injection from `std::unsigned_integral` into any
  *        `IsNatural` domain `N` via its single-argument constructor.
  *
@@ -328,6 +368,30 @@ static_assert(N(-7) == ClassicalLogic::False,
 // (downstream), as @c embed_uint_sint_; the canonical variant-layer
 // ℕ @c ↪ @c ℤ embedding is @c lift_ℕ_ℤ_ (also in @c :integer).
 
+// (5a) Value- and set-level witnesses for @c embed_𝔹_ℕ_ — the variant-
+// layer canonical mono 𝔹 ↪ ℕ landing directly in @c Cardinality.
+// Filed against #602 layer 1: the set-level lift is the entry-point
+// example called out in the issue's acceptance criteria.
+static_assert(embed_𝔹_ℕ_(false) == finite_cardinality(0),
+              "embed_𝔹_ℕ_(false) = 0 in the variant ℕ-proxy carrier.");
+static_assert(embed_𝔹_ℕ_(true) == finite_cardinality(1),
+              "embed_𝔹_ℕ_(true)  = 1 in the variant ℕ-proxy carrier.");
+
+// Set-level lift: image of a Singleton<true, _> bool-set under
+// 𝔹 ↪ ℕ is the Singleton in ℕ at @c finite_cardinality(1).  Uses
+// the existing @c image(F, SingletonSet) overload from
+// @c sets:singleton; the named @c embed_𝔹_ℕ surface delegates
+// through it.  Witness pinned at the type level so a downstream
+// per-shape generalisation (extensional std-containers, lazy
+// predicate sets in #602 layer 2) can extend the dispatch table
+// without touching this anchor.
+static_assert(
+    std::same_as<decltype(embed_𝔹_ℕ(
+                     dedekind::sets::SingletonSet<bool, ClassicalLogic>{true})),
+                 dedekind::sets::SingletonSet<Cardinality, ClassicalLogic>>,
+    "embed_𝔹_ℕ(Singleton<true>) lands in the Singleton at "
+    "finite_cardinality(1) on the Cardinality carrier.");
+
 // (6) The @c std::unsigned_integral family classification (textbook
 //     @c ℤ/2^wℤ stance, the universal lift @c
 //     embed_uint_ℕ, the @c Modular<N> / @c IsCyclic
@@ -397,4 +461,12 @@ inline constexpr bool
 static_assert(
     IsInjective<std::decay_t<decltype(dedekind::numbers::embed_𝔹_uint_)>>,
     "embed_𝔹_uint_ (𝔹 ↪ ℕ) is registered injective.");
+
+template <>
+inline constexpr bool
+    is_monic_arrow_v<std::decay_t<decltype(dedekind::numbers::embed_𝔹_ℕ_)>> =
+        true;
+static_assert(
+    IsInjective<std::decay_t<decltype(dedekind::numbers::embed_𝔹_ℕ_)>>,
+    "embed_𝔹_ℕ_ (𝔹 ↪ ℕ via Cardinality) is registered injective.");
 }  // namespace dedekind::category

--- a/src/test/cpp/modules/dedekind/numbers/initial_ring_test.cpp
+++ b/src/test/cpp/modules/dedekind/numbers/initial_ring_test.cpp
@@ -309,6 +309,43 @@ TEST_CASE(
 }
 
 // ===========================================================================
+// (6a) embed_𝔹_ℕ_ operational behaviour (covers the lambda body for
+//      codecov; sister of embed_𝔹_uint_ landing in the variant
+//      Cardinality carrier directly per #602 layer 1, PR #624).
+// ===========================================================================
+
+TEST_CASE(
+    "carrier-lattice: embed_𝔹_ℕ_ maps true to finite_cardinality(1) and false "
+    "to finite_cardinality(0) (𝔹 ↪ ℕ via the variant Cardinality carrier)",
+    "[carrier-lattice][boolean][cardinality][embed]") {
+  CHECK(embed_𝔹_ℕ_(true) == finite_cardinality(1));
+  CHECK(embed_𝔹_ℕ_(false) == finite_cardinality(0));
+  // ℵ_0 (the saturating sentinel for transfinite cardinalities) is by
+  // construction NOT in the image of the canonical embedding — it
+  // models values past the representable range, which 𝔹 does not
+  // reach.  This negative fact is the structural reason the arrow is
+  // monic but not surjective.
+  CHECK(embed_𝔹_ℕ_(true) != Cardinality{ℵ_0{}});
+  CHECK(embed_𝔹_ℕ_(false) != Cardinality{ℵ_0{}});
+}
+
+TEST_CASE(
+    "carrier-lattice: embed_𝔹_ℕ (set-level lift) on Singleton<true> lands at "
+    "Singleton<finite_cardinality(1)> in ℕ",
+    "[carrier-lattice][boolean][cardinality][embed][image]") {
+  // Set-level lift exercises the runtime dispatch through
+  // dedekind::sets::image(arrow, SingletonSet) — covers the
+  // forwarding-reference body for codecov.
+  constexpr SingletonSet<bool, ClassicalLogic> s_true{true};
+  const auto image_set = embed_𝔹_ℕ(s_true);
+  CHECK(image_set.pivot == finite_cardinality(1));
+
+  constexpr SingletonSet<bool, ClassicalLogic> s_false{false};
+  const auto image_set_false = embed_𝔹_ℕ(s_false);
+  CHECK(image_set_false.pivot == finite_cardinality(0));
+}
+
+// ===========================================================================
 // (7) Carrier-lattice lift unification (#455): existential-proof
 //     dispatch on the central (Cardinality, SignedCardinality) pair.
 // ===========================================================================


### PR DESCRIPTION
## Summary

Lands the layer-1 entry called out in #602's acceptance criteria: *"the obvious entry is `embed_𝔹_ℕ(IsSet auto S)` since α′ already references it."*

Two pieces:

### (a) Value-level arrow `embed_𝔹_ℕ_` : `bool → Cardinality`

Sister to the existing `embed_𝔹_uint_` (`bool → unsigned`), but landing in the variant `Cardinality` carrier directly — the canonical `IsNatural` witness of `ℕ` in the set-builder layer (post-#559 / #427). `false ↦ finite_cardinality(0)`; `true ↦ finite_cardinality(1)`. Registered monic so `IsInjective` fires.

### (b) Set-level lift `embed_𝔹_ℕ(IsSet auto S)`

Names the construction at the call site rather than re-spelling `image(embed_𝔹_ℕ_, S)`. Body delegates to `dedekind::sets::image`, inheriting whatever per-shape dispatch `image` already provides:
- `Singleton<v>` on `:sets:singleton` (#604).
- `std::set<bool>` / `std::unordered_set<bool>` on `:sets:extensional` (#610).
- Lazy predicate sets when #602's layer 2 lands.

## Witnesses

```cpp
// Value level:
static_assert(embed_𝔹_ℕ_(false) == finite_cardinality(0));
static_assert(embed_𝔹_ℕ_(true)  == finite_cardinality(1));

// Set level (Singleton input):
static_assert(std::same_as<
    decltype(embed_𝔹_ℕ(SingletonSet<bool, ClassicalLogic>{true})),
    SingletonSet<Cardinality, ClassicalLogic>>);
```

## Relation to α′ §3 listing

α′ (#621, merged) substituted out the cross-carrier nugget because `embed_𝔹_ℕ` wasn't reified. With this slice, the substitution becomes optional — folding the nugget back into α′ is a follow-up gated on routing the existing `image()` dispatch through predicate-set inputs (the comprehension form `Set{in<𝔹> | …}` from the original α′ candidate), which is #602's layer-2 territory.

## Test plan

- [x] `cmake --build build --target dedekind_numbers` clean.
- [x] All `static_assert`s fire (value level + set level on Singleton).
- [ ] Per-shape extensions (std-container inputs, lazy predicate sets) live in #602 layer 2 follow-ups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)