### PR TITLE
feat(numbers): #602 layer 1 — set-level lift embed_𝔹_𝕂3 (sister of #624)

### DIFF
--- a/src/main/modules/dedekind/numbers/boolean.cppm
+++ b/src/main/modules/dedekind/numbers/boolean.cppm
@@ -319,18 +319,24 @@ constexpr auto embed_𝔹_𝕂3(S&& s) {
 // monic-arrow registration lives in @c :natural (registered there as
 // @c is_monic_arrow_v = true on @c embed_𝔹_uint_).
 
-// (5a) Set-level lift witness: @c embed_𝔹_𝕂3 on @c SingletonSet<true>
-// lands in @c SingletonSet<Ternary> at @c Ternary::True, exercising the
-// runtime dispatch through @c sets::image(arrow, SingletonSet) at the
-// type level.  Sister anchor to PR #624's @c embed_𝔹_ℕ witness in
-// @c :natural; same pattern, different codomain.
+// (5a) Set-level lift witnesses: @c embed_𝔹_𝕂3 on @c SingletonSet<true>
+// lands at @c Ternary::True, and on @c SingletonSet<false> at
+// @c Ternary::False.  Both pinned at the @b value level so the
+// pivot equality is constant-evaluated, not just the codomain type
+// (the type-only form would only check that we land in some
+// @c SingletonSet<Ternary>, not which inhabitant).  Sister anchor
+// to PR #624's @c embed_𝔹_ℕ witness in @c :natural --- same shape,
+// different codomain.
 static_assert(
-    std::same_as<decltype(embed_𝔹_𝕂3(
-                     dedekind::sets::SingletonSet<bool, ClassicalLogic>{true})),
-                 dedekind::sets::SingletonSet<dedekind::category::Ternary,
-                                              ClassicalLogic>>,
-    "embed_𝔹_𝕂3(Singleton<true>) lands in the Singleton at "
-    "Ternary::True on the 𝕂3 carrier.");
+    embed_𝔹_𝕂3(dedekind::sets::SingletonSet<bool, ClassicalLogic>{true})
+            .pivot == dedekind::category::Ternary::True,
+    "embed_𝔹_𝕂3(Singleton<true>) lands at Ternary::True on the 𝕂3 "
+    "carrier.");
+static_assert(
+    embed_𝔹_𝕂3(dedekind::sets::SingletonSet<bool, ClassicalLogic>{false})
+            .pivot == dedekind::category::Ternary::False,
+    "embed_𝔹_𝕂3(Singleton<false>) lands at Ternary::False on the 𝕂3 "
+    "carrier.");
 
 }  // namespace dedekind::numbers
 

--- a/src/main/modules/dedekind/numbers/boolean.cppm
+++ b/src/main/modules/dedekind/numbers/boolean.cppm
@@ -39,6 +39,7 @@ module;
 #include <concepts>
 #include <functional>
 #include <type_traits>  // std::remove_cvref_t for the post-#559 universe-witness static_asserts
+#include <utility>  // std::forward (used in embed_𝔹_𝕂3's set-level lift)
 
 export module dedekind.numbers:boolean;
 
@@ -286,10 +287,50 @@ export inline constexpr auto embed_𝔹_𝕂3_ =
                    : dedekind::category::Ternary::False;
         });
 
+/**
+ * @brief Set-level lift of @c embed_𝔹_𝕂3_: image of a Boolean set
+ *        @c S under the canonical mono 𝔹 ↪ 𝕂3.
+ *
+ * @details Layer-1 entry per #602 (sister to @c embed_𝔹_ℕ in
+ * @c :numbers:natural, PR #624).  Names the construction at the call
+ * site rather than re-spelling @c image(embed_𝔹_𝕂3_, S).  Accepted
+ * input @c S is anything @c dedekind::sets::image already dispatches
+ * on --- @c SingletonSet (@c :sets:singleton),
+ * @c std::set<bool> / @c std::unordered_set<bool> (@c :sets:extensional);
+ * lazy predicate sets join the dispatch table when #602's layer 2
+ * lands.
+ *
+ * Mathematically: the image of @c S under the canonical mono
+ * 𝔹 ↪ 𝕂3 is a subset of @c {Ternary::False, @c Ternary::True} ⊂ 𝕂3
+ * containing whichever @c bool elements are in @c S.
+ * @c Ternary::Unknown is by construction @b not in the image --- the
+ * structural reason the arrow is monic but not surjective.
+ */
+export template <typename S>
+  requires requires(S&& s) {
+    dedekind::sets::image(embed_𝔹_𝕂3_, std::forward<S>(s));
+  }
+constexpr auto embed_𝔹_𝕂3(S&& s) {
+  return dedekind::sets::image(embed_𝔹_𝕂3_, std::forward<S>(s));
+}
+
 // (5) Adjacent-set arrow: 𝔹 ↪ ℕ via @c embed_𝔹_uint_ in @c :natural.
 // This partition is upstream of @c :natural, so the witness for the
 // monic-arrow registration lives in @c :natural (registered there as
 // @c is_monic_arrow_v = true on @c embed_𝔹_uint_).
+
+// (5a) Set-level lift witness: @c embed_𝔹_𝕂3 on @c SingletonSet<true>
+// lands in @c SingletonSet<Ternary> at @c Ternary::True, exercising the
+// runtime dispatch through @c sets::image(arrow, SingletonSet) at the
+// type level.  Sister anchor to PR #624's @c embed_𝔹_ℕ witness in
+// @c :natural; same pattern, different codomain.
+static_assert(
+    std::same_as<decltype(embed_𝔹_𝕂3(
+                     dedekind::sets::SingletonSet<bool, ClassicalLogic>{true})),
+                 dedekind::sets::SingletonSet<dedekind::category::Ternary,
+                                              ClassicalLogic>>,
+    "embed_𝔹_𝕂3(Singleton<true>) lands in the Singleton at "
+    "Ternary::True on the 𝕂3 carrier.");
 
 }  // namespace dedekind::numbers
 

--- a/src/main/modules/dedekind/numbers/boolean.cppm
+++ b/src/main/modules/dedekind/numbers/boolean.cppm
@@ -327,16 +327,16 @@ constexpr auto embed_𝔹_𝕂3(S&& s) {
 // @c SingletonSet<Ternary>, not which inhabitant).  Sister anchor
 // to PR #624's @c embed_𝔹_ℕ witness in @c :natural --- same shape,
 // different codomain.
-static_assert(
-    embed_𝔹_𝕂3(dedekind::sets::SingletonSet<bool, ClassicalLogic>{true})
-            .pivot == dedekind::category::Ternary::True,
-    "embed_𝔹_𝕂3(Singleton<true>) lands at Ternary::True on the 𝕂3 "
-    "carrier.");
-static_assert(
-    embed_𝔹_𝕂3(dedekind::sets::SingletonSet<bool, ClassicalLogic>{false})
-            .pivot == dedekind::category::Ternary::False,
-    "embed_𝔹_𝕂3(Singleton<false>) lands at Ternary::False on the 𝕂3 "
-    "carrier.");
+static_assert(embed_𝔹_𝕂3(dedekind::sets::SingletonSet<bool, ClassicalLogic>{
+                             true})
+                      .pivot == dedekind::category::Ternary::True,
+              "embed_𝔹_𝕂3(Singleton<true>) lands at Ternary::True on the 𝕂3 "
+              "carrier.");
+static_assert(embed_𝔹_𝕂3(dedekind::sets::SingletonSet<bool, ClassicalLogic>{
+                             false})
+                      .pivot == dedekind::category::Ternary::False,
+              "embed_𝔹_𝕂3(Singleton<false>) lands at Ternary::False on the 𝕂3 "
+              "carrier.");
 
 }  // namespace dedekind::numbers
 

--- a/src/test/cpp/modules/dedekind/numbers/initial_ring_test.cpp
+++ b/src/test/cpp/modules/dedekind/numbers/initial_ring_test.cpp
@@ -308,6 +308,23 @@ TEST_CASE(
   CHECK(embed_𝔹_𝕂3_(false) != Ternary::Unknown);
 }
 
+TEST_CASE(
+    "carrier-lattice: embed_𝔹_𝕂3 (set-level lift) on Singleton<true> lands at "
+    "Singleton<Ternary::True> in 𝕂3",
+    "[carrier-lattice][boolean][kleene][embed][image]") {
+  // Set-level lift exercises the runtime dispatch through
+  // dedekind::sets::image(arrow, SingletonSet) — covers the
+  // forwarding-reference body for codecov.  Sister of PR #624's
+  // embed_𝔹_ℕ test; same pattern, different codomain.
+  constexpr SingletonSet<bool, ClassicalLogic> s_true{true};
+  const auto image_set = embed_𝔹_𝕂3(s_true);
+  CHECK(image_set.pivot == Ternary::True);
+
+  constexpr SingletonSet<bool, ClassicalLogic> s_false{false};
+  const auto image_set_false = embed_𝔹_𝕂3(s_false);
+  CHECK(image_set_false.pivot == Ternary::False);
+}
+
 // ===========================================================================
 // (6a) embed_𝔹_ℕ_ operational behaviour (covers the lambda body for
 //      codecov; sister of embed_𝔹_uint_ landing in the variant

--- a/src/test/cpp/modules/dedekind/numbers/initial_ring_test.cpp
+++ b/src/test/cpp/modules/dedekind/numbers/initial_ring_test.cpp
@@ -312,10 +312,12 @@ TEST_CASE(
     "carrier-lattice: embed_𝔹_𝕂3 (set-level lift) on Singleton<true> lands at "
     "Singleton<Ternary::True> in 𝕂3",
     "[carrier-lattice][boolean][kleene][embed][image]") {
-  // Set-level lift exercises the runtime dispatch through
-  // dedekind::sets::image(arrow, SingletonSet) — covers the
-  // forwarding-reference body for codecov.  Sister of PR #624's
-  // embed_𝔹_ℕ test; same pattern, different codomain.
+  // The per-shape dispatch (which sets::image overload to use) is
+  // resolved at compile time via template overload resolution; this
+  // test invokes the resulting code at runtime so the lambda /
+  // forwarding-reference body show up as covered for codecov.
+  // Sister of PR #624's embed_𝔹_ℕ test; same pattern, different
+  // codomain.
   constexpr SingletonSet<bool, ClassicalLogic> s_true{true};
   const auto image_set = embed_𝔹_𝕂3(s_true);
   CHECK(image_set.pivot == Ternary::True);


### PR DESCRIPTION
## Summary

Sister to PR #624's `embed_𝔹_ℕ`: same shape, different codomain. Both are bottom-row monos in the carrier-lattice's embed-arrow zoo that #602 layer 1 lifts from value to set level:

```
embed_𝔹_𝕂3 :  𝔹  ↪  𝕂3   (Ternary; classical → Kleene)
embed_𝔹_ℕ  :  𝔹  ↪  ℕ    (Cardinality; classical → ℕ-proxy, #624)
```

## What ships

- **Set-level wrapper** `embed_𝔹_𝕂3(IsSet auto S)` in `:numbers:boolean` — single forwarding-reference template that delegates to `dedekind::sets::image(embed_𝔹_𝕂3_, std::forward<S>(s))`. Inherits whatever per-shape dispatch `image` already provides (`SingletonSet`, `std::set<bool>`, `std::unordered_set<bool>`; lazy predicate sets when #602 layer 2 lands).
- **`#include <utility>`** added (std::forward) — same hygiene as #624 / e83503d9.
- **Source-side type-level static_assert** anchoring `embed_𝔹_𝕂3(Singleton<true>) ≡ Singleton<Ternary::True>` at the type level.
- **Runtime tests** in `initial_ring_test.cpp` next to the existing `embed_𝔹_𝕂3_` value-level test and PR #624's `embed_𝔹_ℕ` set-level test. Two assertions covering Singleton<true> and Singleton<false>.

## Pure-additive note

No structural overlap with the in-flight dedup work — the slice is a thin wrapper around an existing arrow plus one TEST_CASE. No rewiring of existing concepts, types, or partitions.

## Test plan

- [x] `cmake --build build --target test_numbers` clean.
- [x] New TEST_CASE passes locally (2 assertions).
- [x] Source-side static_assert fires.

🤖 Generated with [Claude Code](https://claude.com/claude-code)