### PR TITLE
fix(numbers): #602 / #624 follow-up — strengthen embed_𝔹_ℕ static_assert to value-level

### DIFF
--- a/src/main/modules/dedekind/numbers/natural.cppm
+++ b/src/main/modules/dedekind/numbers/natural.cppm
@@ -383,20 +383,26 @@ static_assert(embed_𝔹_ℕ_(false) == finite_cardinality(0),
 static_assert(embed_𝔹_ℕ_(true) == finite_cardinality(1),
               "embed_𝔹_ℕ_(true)  = 1 in the variant ℕ-proxy carrier.");
 
-// Set-level lift: image of a Singleton<true, _> bool-set under
-// 𝔹 ↪ ℕ is the Singleton in ℕ at @c finite_cardinality(1).  Uses
-// the existing @c image(F, SingletonSet) overload from
+// Set-level lift witnesses: @c embed_𝔹_ℕ on @c SingletonSet<true>
+// lands at @c finite_cardinality(1), and on @c SingletonSet<false>
+// at @c finite_cardinality(0).  Both pinned at the @b value level so
+// the pivot equality is constant-evaluated, not just the codomain
+// type (the type-only form would only check that we land in some
+// @c SingletonSet<Cardinality>, not which inhabitant).  Uses the
+// existing @c image(F, SingletonSet) overload from
 // @c sets:singleton; the named @c embed_𝔹_ℕ surface delegates
-// through it.  Witness pinned at the type level so a downstream
-// per-shape generalisation (extensional std-containers, lazy
-// predicate sets in #602 layer 2) can extend the dispatch table
-// without touching this anchor.
+// through it.  Sister anchor to PR #626's @c embed_𝔹_𝕂3 witness in
+// @c :boolean --- same shape, different codomain.
 static_assert(
-    std::same_as<decltype(embed_𝔹_ℕ(
-                     dedekind::sets::SingletonSet<bool, ClassicalLogic>{true})),
-                 dedekind::sets::SingletonSet<Cardinality, ClassicalLogic>>,
-    "embed_𝔹_ℕ(Singleton<true>) lands in the Singleton at "
-    "finite_cardinality(1) on the Cardinality carrier.");
+    embed_𝔹_ℕ(dedekind::sets::SingletonSet<bool, ClassicalLogic>{true}).pivot ==
+        finite_cardinality(1),
+    "embed_𝔹_ℕ(Singleton<true>) lands at finite_cardinality(1) on the "
+    "Cardinality carrier.");
+static_assert(
+    embed_𝔹_ℕ(dedekind::sets::SingletonSet<bool, ClassicalLogic>{false})
+            .pivot == finite_cardinality(0),
+    "embed_𝔹_ℕ(Singleton<false>) lands at finite_cardinality(0) on the "
+    "Cardinality carrier.");
 
 // (6) The @c std::unsigned_integral family classification (textbook
 //     @c ℤ/2^wℤ stance, the universal lift @c


### PR DESCRIPTION
## Summary

Follow-up to PR #624 (the embed_𝔹_ℕ slice). PR #626's CP review caught that the sibling `embed_𝔹_𝕂3` static_assert was checking only the *type*, while the message made a *value* claim — fixed there at value level. PR #624 introduced the same shape in `:numbers:natural` and was already merged; this PR closes the parallel gap.

## What ships

Replaces the type-only static_assert in `:numbers:natural`:

```cpp
// Before — type-only, message overclaims:
static_assert(
    std::same_as<decltype(embed_𝔹_ℕ(SingletonSet<bool, ClassicalLogic>{true})),
                 SingletonSet<Cardinality, ClassicalLogic>>,
    "embed_𝔹_ℕ(Singleton<true>) lands in the Singleton at "
    "finite_cardinality(1) on the Cardinality carrier.");
```

with two value-level checks pinning `.pivot` equality:

```cpp
// After — value-level, end-to-end constexpr-evaluable:
static_assert(
    embed_𝔹_ℕ(SingletonSet<bool, ClassicalLogic>{true}).pivot
        == finite_cardinality(1),
    "embed_𝔹_ℕ(Singleton<true>) lands at finite_cardinality(1) on the Cardinality carrier.");
static_assert(
    embed_𝔹_ℕ(SingletonSet<bool, ClassicalLogic>{false}).pivot
        == finite_cardinality(0),
    "embed_𝔹_ℕ(Singleton<false>) lands at finite_cardinality(0) on the Cardinality carrier.");
```

## Why it works

- `SingletonSet`'s constructor is `constexpr`.
- `embed_𝔹_ℕ` (set-level lift) is `constexpr`.
- `sets::image`'s `SingletonSet` overload is `constexpr`.
- `.pivot` access is `constexpr`.

End-to-end the comparison is a compile-time literal evaluation.

## No structural overlap with the in-flight typedef-alignment work

Pure local edit in `:numbers:natural`, doesn't touch the `Domain` / `Ambient` typedef alignment in `:sets:boundaries` or `:topoi`.

## Test plan

- [x] `cmake --build build --target dedekind_numbers` clean.
- [x] Both `static_assert`s fire at compile time (build-and-deploy will confirm in CI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)