### PR TITLE
feat(numbers): #602 layer 1 — set-level lift embed_sint_ℤ (sister of #628)

### DIFF
--- a/src/main/modules/dedekind/numbers/sint.cppm
+++ b/src/main/modules/dedekind/numbers/sint.cppm
@@ -71,6 +71,8 @@
 module;
 
 #include <concepts>
+#include <cstddef>  // std::size_t (used in the digits-width static_assert
+                    // in embed_sint_ℤ's per-value entry point)
 #include <functional>
 #include <limits>
 #include <type_traits>  // std::remove_cvref_t (no-narrowing pin in
@@ -186,13 +188,14 @@ export inline constexpr auto embed_sint_ℤ_ =
 // (e.g. @c long, @c long @c long) or over @c unsigned would
 // satisfy the bare @c image-well-formedness requires-clause via
 // implicit conversion at the per-element @c embed_sint_ℤ_ call site,
-// silently truncating (long@→int) or sign-reinterpreting (unsigned@→int)
-// and bypassing the @c digits-safety @c static_assert in the per-value
-// @c embed_sint_ℤ(S).  We pin both the @c Domain-exposing carriers
-// (SingletonSet, dedekind::sets::Set, …) and the @c value_type-exposing
-// carriers (std::set, std::unordered_set) in a single disjunctive
-// constraint — either typedef must match exactly @c int for the overload
-// to fire.  Same shape as PR #628's @c embed_uint_ℕ no-narrowing pin.
+// silently truncating (long@→int) or applying the
+// implementation-defined unsigned@→int narrowing conversion, in
+// either case bypassing the @c digits-safety @c static_assert in
+// the per-value @c embed_sint_ℤ(S).  We pin both the @c Domain-exposing
+// carriers (SingletonSet, dedekind::sets::Set, …) and the @c
+// value_type-exposing carriers (std::set, std::unordered_set) in a single
+// disjunctive constraint — either typedef must match exactly @c int for the
+// overload to fire.  Same shape as PR #628's @c embed_uint_ℕ no-narrowing pin.
 export template <typename S>
   requires(
               requires {

--- a/src/main/modules/dedekind/numbers/sint.cppm
+++ b/src/main/modules/dedekind/numbers/sint.cppm
@@ -73,6 +73,9 @@ module;
 #include <concepts>
 #include <functional>
 #include <limits>
+#include <type_traits>  // std::remove_cvref_t (no-narrowing pin in
+                        // embed_sint_ℤ's set-level overload)
+#include <utility>      // std::forward (used in embed_sint_ℤ's set-level lift)
 
 export module dedekind.numbers:sint;
 
@@ -149,6 +152,86 @@ export inline constexpr auto embed_sint_ℤ_ =
         [](const int& i) noexcept -> dedekind::sets::SignedCardinality {
           return embed_sint_ℤ(i);
         });
+
+/**
+ * @brief Set-level lift of @c embed_sint_ℤ_: image of an @c int-set
+ *        @c S under the canonical mono @c int ↪ ℤ.
+ *
+ * @details Layer-1 entry per #602, sister to @c embed_𝔹_ℕ (PR #624),
+ * @c embed_𝔹_𝕂3 (PR #626), and @c embed_uint_ℕ (PR #628): names the
+ * construction at the call site rather than re-spelling
+ * @c image(embed_sint_ℤ_, S).  Accepted input @c S is anything
+ * @c dedekind::sets::image already dispatches on —
+ * @c SingletonSet (@c :sets:singleton),
+ * @c std::set<int> / @c std::unordered_set<int>
+ * (@c :sets:extensional); lazy predicate sets join the dispatch
+ * table when #602's layer 2 lands.
+ *
+ * @note This overload is on the @b set side; the per-value entry
+ * point @c embed_sint_ℤ(S @c v) — the templated function above for
+ * any @c std::signed_integral @c S — is unchanged and kept for the
+ * value-level call sites in @c :sint and @c :integer.  Overload
+ * resolution disambiguates via the @c requires-clause: the per-value
+ * overload requires @c std::signed_integral, this one requires
+ * the set's element type to be exactly @c int (the no-narrowing pin
+ * below) and @c image to be well-formed; no @c S satisfies both at
+ * once.
+ *
+ * Mathematically: the image of @c S under the canonical mono
+ * @c int @c ↪ @c ℤ is a subset of the finite fragment of @c
+ * SignedCardinality containing whichever @c int values are in @c S.
+ */
+// No-narrowing pin: the source set's element type must be EXACTLY
+// @c int.  Without this gate, sets over a wider signed type
+// (e.g. @c long, @c long @c long) or over @c unsigned would
+// satisfy the bare @c image-well-formedness requires-clause via
+// implicit conversion at the per-element @c embed_sint_ℤ_ call site,
+// silently truncating (long@→int) or sign-reinterpreting (unsigned@→int)
+// and bypassing the @c digits-safety @c static_assert in the per-value
+// @c embed_sint_ℤ(S).  We pin both the @c Domain-exposing carriers
+// (SingletonSet, dedekind::sets::Set, …) and the @c value_type-exposing
+// carriers (std::set, std::unordered_set) in a single disjunctive
+// constraint — either typedef must match exactly @c int for the overload
+// to fire.  Same shape as PR #628's @c embed_uint_ℕ no-narrowing pin.
+export template <typename S>
+  requires(
+              requires {
+                typename std::remove_cvref_t<S>::Domain;
+                requires std::same_as<typename std::remove_cvref_t<S>::Domain,
+                                      int>;
+              } ||
+              requires {
+                typename std::remove_cvref_t<S>::value_type;
+                requires std::same_as<
+                    typename std::remove_cvref_t<S>::value_type, int>;
+              }) &&
+          requires(S&& s) {
+            dedekind::sets::image(embed_sint_ℤ_, std::forward<S>(s));
+          }
+constexpr auto embed_sint_ℤ(S&& s) {
+  return dedekind::sets::image(embed_sint_ℤ_, std::forward<S>(s));
+}
+
+// Set-level lift witnesses: @c embed_sint_ℤ on @c SingletonSet<int>{42}
+// lands at @c finite_signed_cardinality(42), and on @c SingletonSet<int>{-7}
+// at @c finite_signed_cardinality(-7).  Pinned at the @b value level so
+// the pivot equality is constant-evaluated, not just the codomain type.
+// Mirrors PR #624 / #626 / #628's witnesses — same shape, different
+// (carrier, codomain) pair.
+static_assert(
+    embed_sint_ℤ(
+        dedekind::sets::SingletonSet<int, dedekind::category::ClassicalLogic>{
+            42})
+            .pivot == dedekind::sets::finite_signed_cardinality(42),
+    "embed_sint_ℤ(SingletonSet<int>{42}) lands at "
+    "finite_signed_cardinality(42) on the SignedCardinality carrier.");
+static_assert(embed_sint_ℤ(dedekind::sets::SingletonSet<
+                               int, dedekind::category::ClassicalLogic>{-7})
+                      .pivot == dedekind::sets::finite_signed_cardinality(-7),
+              "embed_sint_ℤ(SingletonSet<int>{-7}) lands at "
+              "finite_signed_cardinality(-7) on the SignedCardinality carrier "
+              "(negative-value witness — the symmetric complement to "
+              "embed_uint_ℕ's non-negative-only fragment).");
 
 /**
  * @brief Type-honest absolute value at the machine layer:


### PR DESCRIPTION
## Summary

- Adds a set-level overload of `embed_sint_ℤ` in `:numbers:sint` lifting an `int`-set `S` to its image under the canonical mono `int ↪ ℤ` (landing in the variant `SignedCardinality` carrier).
- Symmetric signed-side companion to PR #628's `embed_uint_ℕ`; together with #624 (`embed_𝔹_ℕ`) and #626 (`embed_𝔹_𝕂3`), pins the layer-1 set-level lifts on the four canonical machine→variant arrows.
- Two value-level `static_assert` witnesses pinned at the call site, including a negative-value witness (`SingletonSet<int>{-7}`) — the symmetric complement to `embed_uint_ℕ`'s non-negative-only fragment.

## Coexistence with the existing per-value `embed_sint_ℤ`

The existing templated `embed_sint_ℤ(S v)` (`std::signed_integral S → SignedCardinality`) is unchanged and kept for value-level call sites in `:sint` and downstream `embed_*_*_` surfaces. Overload resolution disambiguates via the `requires`-clause:

| Overload | Constraint | Accepted argument | Returns |
|---|---|---|---|
| Per-value (existing) | `std::signed_integral<S>` | `S` (any signed width) | `SignedCardinality` |
| Set-level (new) | `Domain == int` or `value_type == int` (no-narrowing pin) AND `image(embed_sint_ℤ_, …)` well-formed | `SingletonSet<int>`, `std::set<int>`, `std::unordered_set<int>`, … | image-set in `SignedCardinality` |

No `S` satisfies both constraints simultaneously — `std::signed_integral` types do not have a `dedekind::sets::image(…)` dispatch, and the set carriers are not `std::signed_integral`.

## No-narrowing pin (lessons from PR #628 iteration 2)

Without the pin, sets over wider signed types (`long`, `long long`) or over `unsigned` would silently truncate or sign-reinterpret at the per-element call site, breaking the canonical-mono contract and bypassing the `digits`-safety `static_assert` in the per-value `embed_sint_ℤ`. The disjunctive constraint over `Domain`-exposing carriers (SingletonSet, `dedekind::sets::Set`, …) and `value_type`-exposing carriers (`std::set`, `std::unordered_set`) blocks this — both spellings require exact match to `int`.

## Test plan

- [ ] CI build-and-deploy green
- [x] Two value-level `static_assert`s in `sint.cppm` pin the witnesses at the +/- sides (no separate test file needed for layer-1 slice; static_asserts ARE the structural proof — same convention as #624/#626/#628)

## Adjacent

- Closes one slice of #602 layer 1 (per-arrow set lifts).
- Sister PRs already merged: #624 (`embed_𝔹_ℕ`), #626 (`embed_𝔹_𝕂3`), #627 (#624 follow-up), #628 (`embed_uint_ℕ`).
- Layer 1 status post-this-PR: the four canonical machine→variant arrows have set-level lifts; the remaining open layer-1 directions are the Quotient functors (`Frac`, `Cplx`, `Dual`) and the `IsProduct` witnesses for Quotient-flavored carriers (`Complex`, `Rational`, `Frac`, `Dual`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)