### PR TITLE
refactor(category): retire Box; Maybe-monad + std::tuple-Frobenius carrier-role split

### DIFF
--- a/docs/paper/paper.tex
+++ b/docs/paper/paper.tex
@@ -621,6 +621,11 @@ The algebraic structure each carrier provides (per \cppinline{IsAlgebraOnSet}, L
 The operations are arrows in $\mathbf{Ddk}$; axioms are equations between such arrows; the forgetful arrows the project ships ($\mathbf{Ring} \to \mathbf{AbGrp} \to \mathbf{Set}$, together with the \texttt{embed\_*\_*\_} family) drop operations as they move between carriers.
 Plain sets are the degenerate case where the operator tuple is empty.
 
+The architecture converges on a small grammar worth naming explicitly as target structure: an algebra HAS-A underlying set and HAS operations on that set; a set HAS-A ambient and HAS a subobject classifier $\chi$ on that ambient; the ambient IS-A small category, in the CCC sense of the previous paragraphs.
+The HAS-A reading is the same shape at both upper layers, but the kind of ``has'' differs --- an algebra carries behavioural structure (functions with axioms governing them), a set carries shape-only structure (the $\chi$ is the \cppinline{IsSubobject} contract's anchor, with the actual decision living in the predicate's \cppinline{operator()}).
+Three slots, mapped onto the codebase: the IS-A category lives in \texttt{category:cartesian}; the set HAS-A in \texttt{category:etcs}; the algebra HAS-A in \texttt{algebra:universal}.
+Every concept the project ships fits one of the three.
+
 % Source excerpt from dedekind.algebra:universal.
 \begin{listing}[ht]
 \caption{A type that type-checks against \cppinline{IsAlgebraOnSet} inhabits $\mathbf{Ddk}$.}

--- a/src/main/modules/dedekind/category/functor.cppm
+++ b/src/main/modules/dedekind/category/functor.cppm
@@ -59,6 +59,8 @@
  * The following types in this partition model @ref IsFunctor:
  * - @ref identity_functor: Cat -> Cat.
  * - @ref maybe_functor: Set<T> -> Set<Maybe<T>>.
+ * - @ref tuple_functor: Set<T> -> Set<std::tuple<T>> (the project's
+ *   bona-fide Frobenius carrier; #632).
  * - @ref trace_functor: Set<T> -> StringCategory.
  * - @ref composite_functor: composition G . F for any composable functors.
  *
@@ -84,6 +86,7 @@ module;
 #include <functional>
 #include <optional>
 #include <string>
+#include <tuple>  // tuple_functor — bona-fide Frobenius carrier (#632)
 
 export module dedekind.category:functor;
 
@@ -270,6 +273,44 @@ struct maybe_functor {
 
   constexpr Τ_cat operator()(const Σ_cat&) const noexcept { return {}; }
 };
+
+/**
+ * @brief The Intensional Functor for 1-tuple values.
+ *
+ * @details Concrete @ref IsFunctor model implementing
+ * Set<T> -> Set<std::tuple<T>>.  Pinned as the project's bona-fide
+ * Frobenius (= monad + comonad) carrier: std::tuple<T> always has a
+ * single element, so ε via std::get<0> is total (no Some-fragment
+ * concession), and δ wraps once more cleanly.  Sister to
+ * @ref maybe_functor (monad only) per the #632 carrier-role split.
+ */
+export template <typename T>
+struct tuple_functor {
+  using ArrowKind = hub_arrow_tag;
+  using Σ_cat = Set<T>;
+  using Τ_cat = Set<std::tuple<T>>;
+
+  using Domain = Σ_cat;
+  using Codomain = Τ_cat;
+
+  template <typename U>
+  using Shape = std::tuple<U>;
+
+  /** @brief φ: lift @c f: T → U to @c std::tuple<T> → std::tuple<U>
+   *  by mapping the single element. */
+  template <typename 𝗳>
+    requires IsArrow<std::remove_cvref_t<𝗳>>
+  constexpr auto φ(𝗳&& f) const {
+    return arrow([f = std::forward<𝗳>(f)](std::tuple<T> const& t) {
+      return std::tuple{std::invoke(f, std::get<0>(t))};
+    });
+  }
+
+  constexpr Τ_cat operator()(const Σ_cat&) const noexcept { return {}; }
+};
+
+static_assert(IsFunctor<tuple_functor<int>>,
+              "Verification Failed: tuple_functor must satisfy IsFunctor.");
 
 static_assert(IsFunctor<maybe_functor<int>>,
               "Verification Failed: maybe_functor must satisfy IsFunctor.");

--- a/src/main/modules/dedekind/category/functor.cppm
+++ b/src/main/modules/dedekind/category/functor.cppm
@@ -690,20 +690,31 @@ static_assert(
 /**
  * @brief The Maybe endofunctor T, implemented via std::optional.
  */
-template <typename T>
+export template <typename T>
 using Maybe = std::optional<T>;
 
 /**
  * @brief φ for Maybe (std::optional).
  * If ma has a value, applies f and wraps the result.
  */
-template <typename A, typename F>
+export template <typename A, typename F>
 constexpr auto φ(Maybe<A> const& ma, F&& f)
     -> Maybe<std::invoke_result_t<F, A>> {
   if (ma) {
     return std::make_optional(std::invoke(std::forward<F>(f), *ma));
   }
   return std::nullopt;
+}
+
+/**
+ * @brief φ for std::tuple<T> — Frobenius carrier (#632).
+ * Applies @c f to the single element, returning a 1-tuple of the result.
+ */
+export template <typename A, typename F>
+constexpr auto φ(std::tuple<A> const& ta, F&& f)
+    -> std::tuple<std::invoke_result_t<F, A>> {
+  return std::tuple<std::invoke_result_t<F, A>>{
+      std::invoke(std::forward<F>(f), std::get<0>(ta))};
 }
 
 /**

--- a/src/main/modules/dedekind/category/functor.cppm
+++ b/src/main/modules/dedekind/category/functor.cppm
@@ -43,7 +43,7 @@
  *
  * 2. The Spoke (Extensional Spoke / Matter):
  *    This is the concrete instance—an ordinary arrow (@ref IsArrow) or a data
- *    container (e.g., Box<T>). While the Hub provides the "How," the Spoke
+ *    container (e.g., Maybe<T>). While the Hub provides the "How," the Spoke
  *    provides the "What." The spoke is a resident of a category, but it
  *    does not own the mapping logic itself.
  *
@@ -58,7 +58,6 @@
  *
  * The following types in this partition model @ref IsFunctor:
  * - @ref identity_functor: Cat -> Cat.
- * - @ref box_functor: Set<T> -> Set<Box<T>>.
  * - @ref maybe_functor: Set<T> -> Set<Maybe<T>>.
  * - @ref trace_functor: Set<T> -> StringCategory.
  * - @ref composite_functor: composition G . F for any composable functors.
@@ -67,7 +66,7 @@
  * - @ref maybe_functor is a concrete @ref IsFunctor model in this partition,
  *   but under the current category choices it is not an @ref IsEndofunctor
  *   witness for @ref IsMonad (see `:monad` for the textbook constraint).
- * - Value-level overloads of φ for Maybe/Identity/Box at the end of this file
+ * - Value-level overloads of φ for Maybe/Identity at the end of this file
  *   are lifting utilities, not IsFunctor hub models by themselves.
  *
  *
@@ -232,7 +231,8 @@ struct morphic_engine {
     /**
      * 2. The Crucial Step:
      * Your Hub knows the Target Category (Τ_cat).
-     * We wrap the raw data 'ma' into that category's Species (e.g., Box<int>).
+     * We wrap the raw data 'ma' into that category's Species (e.g.,
+     * Maybe<int>).
      */
     using TargetSpecies = typename Hub::Τ_cat::Species;
 

--- a/src/main/modules/dedekind/category/functor.cppm
+++ b/src/main/modules/dedekind/category/functor.cppm
@@ -68,8 +68,8 @@
  * - @ref maybe_functor is a concrete @ref IsFunctor model in this partition,
  *   but under the current category choices it is not an @ref IsEndofunctor
  *   witness for @ref IsMonad (see `:monad` for the textbook constraint).
- * - Value-level overloads of φ for Maybe/Identity at the end of this file
- *   are lifting utilities, not IsFunctor hub models by themselves.
+ * - Value-level overloads of φ for Maybe / Identity / std::tuple at the end
+ *   of this file are lifting utilities, not IsFunctor hub models by themselves.
  *
  *
  * @note "If we do not succeed in solving a mathematical problem, the reason

--- a/src/main/modules/dedekind/category/functor.cppm
+++ b/src/main/modules/dedekind/category/functor.cppm
@@ -242,54 +242,6 @@ struct morphic_engine {
 };
 
 /**
- * @brief The Boxed Species (The F<T> Context).
- *
- * Reifies the "Box" as a categorical object that announces its
- * own species and shape, enabling 1-parameter functorial discovery.
- */
-export template <typename T>
-struct Box final {
-  /** @brief The physical payload. */
-  const T value;
-
-  /** @brief Equality for structural verification in static_asserts. */
-  constexpr bool operator==(const Box&) const = default;
-};
-
-/**
- * @brief The Intensional Hub for Boxed values.
- * @details Concrete @ref IsFunctor model. Acts as an endofunctor
- * Set<T> -> Set<Box<T>>.
- */
-export template <typename T>
-struct box_functor {
-  using ArrowKind = hub_arrow_tag;
-  using Σ_cat = Set<T>;
-  using Τ_cat = Set<Box<T>>;
-
-  // Requirement for IsArrow (Hub as 1-morphism in Cat)
-  using Domain = Σ_cat;
-  using Codomain = Τ_cat;
-
-  /** @brief F_obj: The Type Constructor */
-  template <typename U>
-  using Shape = Box<U>;
-
-  /** @brief F_mor (φ): The Morphic Lift */
-  template <typename 𝗳>
-    requires IsArrow<std::remove_cvref_t<𝗳>>
-  constexpr auto φ(𝗳&& f) const {
-    // We return an Arrow in the Target Category (Set<Box<T>>)
-    return arrow([f = std::forward<𝗳>(f)](Box<T> const& b) {
-      return Box{std::invoke(f, b.value)};
-    });
-  }
-
-  // Action on Objects
-  constexpr Τ_cat operator()(const Σ_cat&) const noexcept { return {}; }
-};
-
-/**
  * @brief The Intensional Functor for Optional (Maybe) values.
  * @details Concrete @ref IsFunctor model implementing
  * Set<T> -> Set<std::optional<T>>.
@@ -319,16 +271,8 @@ struct maybe_functor {
   constexpr Τ_cat operator()(const Σ_cat&) const noexcept { return {}; }
 };
 
-static_assert(IsFunctor<box_functor<int>>,
-              "Verification Failed: box_functor must satisfy IsFunctor.");
-
 static_assert(IsFunctor<maybe_functor<int>>,
               "Verification Failed: maybe_functor must satisfy IsFunctor.");
-
-static_assert(IsMorphicApplicator<morphic_engine<box_functor<int>, int>,
-                                  box_functor<int>, int>,
-              "Structural Integrity Failed: morphic_engine must satisfy "
-              "IsMorphicApplicator.");
 
 /**
  * @brief Stage 1: The Functorial Applicator.
@@ -343,11 +287,6 @@ struct functor_applicator {
     return morphic_engine<Hub, std::decay_t<Spoke>>{h, std::forward<Spoke>(ma)};
   }
 };
-
-static_assert(IsFunctorialApplicator<functor_applicator<box_functor<int>>,
-                                     box_functor<int>>,
-              "Structural Integrity Failed: functor_applicator must satisfy "
-              "IsFunctorialApplicator.");
 
 // Now fmap is just a factory for the Applicator
 template <typename Hub>
@@ -740,14 +679,6 @@ constexpr auto φ(Identity<A> const& id, F&& f)
   (void)id;
   (void)f;
   return category::id<std::invoke_result_t<F, A>>();
-}
-
-/**
- * @brief φ for Box.
- */
-template <typename A, typename F>
-constexpr auto φ(Box<A> const& box, F&& f) -> Box<std::invoke_result_t<F, A>> {
-  return {std::invoke(std::forward<F>(f), box.value)};
 }
 
 // The quotient-algebra meta-symmetry (Frac, Cplx, Dual as structural

--- a/src/main/modules/dedekind/category/kleisli.cppm
+++ b/src/main/modules/dedekind/category/kleisli.cppm
@@ -84,14 +84,24 @@ namespace dedekind::category {
  * counit / extend / IsCoKleisliExtension / IsFrobenius witnesses live.
  */
 
+namespace _kleisli_detail {
+template <typename U>
+struct is_maybe : std::false_type {};
+template <typename U>
+struct is_maybe<Maybe<U>> : std::true_type {};
+template <typename U>
+inline constexpr bool is_maybe_v = is_maybe<U>::value;
+}  // namespace _kleisli_detail
+
 // Bind: Maybe<T> >>= (T -> Maybe<U>) -> Maybe<U>.
-// Constrained to Kleisli arrows whose codomain is a @c Maybe-shaped
-// carrier — guarantees the @c Result{std::nullopt} branch is well-formed
-// and rules out accidental carrier-changing binds (Copilot review on
-// #632).
+// Constrained via SFINAE-friendly partial-specialization detector: the
+// Kleisli arrow's codomain must be exactly @c Maybe<U> (= @c
+// std::optional<U>), ruling out accidental carrier-changing binds to
+// unrelated types that happen to accept @c std::nullopt_t (Copilot
+// review on #632; mirror of the @c is_tuple1 detector below).
 export template <typename T, typename Func>
-  requires std::constructible_from<std::invoke_result_t<Func, T>,
-                                   std::nullopt_t>
+  requires _kleisli_detail::is_maybe_v<
+      std::remove_cvref_t<std::invoke_result_t<Func, T>>>
 constexpr auto operator>>=(const Maybe<T>& m, Func&& f) {
   using Result = std::invoke_result_t<Func, T>;
   return m.has_value() ? std::forward<Func>(f)(*m) : Result{std::nullopt};
@@ -461,9 +471,8 @@ concept IsKleisliDeref =
  * @details A Kleisli arrow lives in the Kleisli category indexed by a
  *          monad-hub tag @c M.  Its underlying map has shape
  *          @c e: @c A @c → @c T<B>, where @c T is the monadic carrier
- *          shape selected by the hub tag (@c Maybe for
- *          @c maybe_hub_tag, @c Identity for @c identity_hub_tag).  The @c M
- * slot is the
+ *          shape selected by the hub tag (@c Maybe for @c maybe_hub_tag,
+ *          @c Identity for @c identity_hub_tag).  The @c M slot is the
  *          @b monad-hub @b tag itself — a tag type that names which
  *          Kleisli category the arrow inhabits — not the class template.
  *          Constrained by @c IsDefaultHubTag to make the connection

--- a/src/main/modules/dedekind/category/kleisli.cppm
+++ b/src/main/modules/dedekind/category/kleisli.cppm
@@ -75,33 +75,6 @@ namespace dedekind::category {
 
 /** @section kleisli__The_Box_Action_Engine */
 
-// Bind: Box<T> >>= (T -> Box<U>) -> Box<U>
-export template <typename T, typename Func>
-constexpr auto operator>>=(const Box<T>& b, Func&& f) {
-  return std::forward<Func>(f)(b.value);
-}
-
-// Extend: Box<T> <<= (Box<T> -> U) -> Box<U>
-export template <typename T, typename Func>
-constexpr auto operator<<=(const Box<T>& b, Func&& f) {
-  using U = std::invoke_result_t<Func, Box<T>>;
-  return Box<U>{std::forward<Func>(f)(b)};
-}
-
-/** @section kleisli__The_Kleisli_Witnesses */
-
-// PR #508: removed template-template parameters from the public surface of
-// :kleisli to make the disciplined-fragment claim of the paper's
-// admissibility-rules table hold without exception.  The Hub indirection
-// follows the :functor precedent (PR introducing box_functor / maybe_functor
-// in :functor): higher-kindedness lives in a regular type's nested Shape<U>
-// alias rather than as a template-template parameter.  Carrier-side
-// specialisations in :sequences:path , :linear_algebra:tuple ,
-// :linear_algebra:matrix follow the same pattern, instantiating
-// unit_witness / counit_witness on box_functor<T> / path_functor<T> /
-// vec2_functor<T> / covec2_functor<T> / matrix2x2_functor<T>
-// (the canonical Hubs the *_functor partition already exports).
-
 /**
  * @brief unit_witness<Hub, T>: Generic Kleisli unit witness.
  * Lifts a value into the Kleisli extension named by @c Hub::template Shape<T>.
@@ -113,11 +86,6 @@ constexpr auto operator<<=(const Box<T>& b, Func&& f) {
 export template <typename Hub, typename T>
 struct unit_witness;
 
-export template <typename T>
-struct unit_witness<box_functor<T>, T> final {
-  constexpr auto operator()(T x) const { return Box<T>{std::move(x)}; }
-};
-
 /**
  * @brief counit_witness<Hub, T>: Generic Kleisli counit witness.
  * Samples a value from the co-Kleisli extension named by
@@ -125,11 +93,6 @@ struct unit_witness<box_functor<T>, T> final {
  */
 export template <typename Hub, typename T>
 struct counit_witness;
-
-export template <typename T>
-struct counit_witness<box_functor<T>, T> final {
-  constexpr T operator()(const Box<T>& b) const noexcept { return b.value; }
-};
 
 /** @section kleisli__Extension_Concepts */
 

--- a/src/main/modules/dedekind/category/kleisli.cppm
+++ b/src/main/modules/dedekind/category/kleisli.cppm
@@ -59,6 +59,7 @@ module;
 #include <functional>
 #include <ios>
 #include <optional>  // std::nullopt — used by the _kleisli_arrow_witness_380 skeleton
+#include <tuple>  // std::tuple<T> — bona-fide Frobenius carrier (#632)
 #include <utility>  // std::move / std::forward (kept self-contained per #521 review)
 
 export module dedekind.category:kleisli;
@@ -73,7 +74,14 @@ import :morphism;
 
 namespace dedekind::category {
 
-/** @section kleisli__The_Maybe_Action_Engine */
+/** @section kleisli__The_Maybe_Action_Engine
+ *
+ * @details Maybe is a monad, not a comonad — counit on @c std::nullopt
+ * has no honest answer.  This block defines only the monadic surface
+ * for @c Maybe<T> (bind, unit_witness).  The bona-fide Frobenius
+ * carrier (= monad + comonad) is @c std::tuple<T> below; that's where
+ * counit / extend / IsCoKleisliExtension / IsFrobenius witnesses live.
+ */
 
 // Bind: Maybe<T> >>= (T -> Maybe<U>) -> Maybe<U>.
 // Standard Maybe-monad bind: nullopt propagates; Some(x) feeds x into f.
@@ -83,27 +91,13 @@ constexpr auto operator>>=(const Maybe<T>& m, Func&& f) {
   return m.has_value() ? std::forward<Func>(f)(*m) : Result{std::nullopt};
 }
 
-// Extend: Maybe<T> <<= (Maybe<T> -> U) -> Maybe<U>.
-// The comonadic extend on Maybe.  Mathematically Maybe is not a true
-// comonad (counit on nullopt has no honest answer), so this overload
-// is well-defined only on the Some-fragment: when @c m is Some(x), the
-// result is @c Some(f(m)); when @c m is nullopt, the result is also
-// @c nullopt (the carrier propagates the indecision rather than
-// fabricating a value).  Sister to the Box-as-trivial-comonad
-// vestigial path retired in #632.
-export template <typename T, typename Func>
-constexpr auto operator<<=(const Maybe<T>& m, Func&& f) {
-  using U = std::invoke_result_t<Func, Maybe<T>>;
-  return m.has_value() ? Maybe<U>{std::forward<Func>(f)(m)}
-                       : Maybe<U>{std::nullopt};
-}
-
 /**
  * @brief unit_witness<Hub, T>: Generic Kleisli unit witness.
  * Lifts a value into the Kleisli extension named by @c Hub::template Shape<T>.
  *
  * @tparam Hub A regular type carrying a nested @c Shape<U> alias; canonical
- *             example is @c maybe_functor<U> from @c :functor.
+ *             examples are @c maybe_functor<U> (monad-only) and
+ *             @c tuple_functor<U> (Frobenius) from @c :functor.
  * @tparam T   The value type.
  */
 export template <typename Hub, typename T>
@@ -117,22 +111,46 @@ struct unit_witness<maybe_functor<T>, T> final {
 /**
  * @brief counit_witness<Hub, T>: Generic Kleisli counit witness.
  * Samples a value from the co-Kleisli extension named by
- * @c Hub::template Shape<T>.
- *
- * @note For @c maybe_functor<T> the counit is well-defined only on the
- * Some-fragment of @c Maybe<T>: dereferencing @c std::nullopt has no
- * honest answer and produces UB.  Callers exercise the witness on
- * Some-values; the comonadic-extend / IsCoKleisliExtension /
- * IsFrobenius witnesses inherit this restriction.  See the
- * "kleisli__The_Maybe_Action_Engine" section header for the broader
- * mathematical concession (Maybe is a monad, not a true comonad).
+ * @c Hub::template Shape<T>.  Defined for genuine comonadic carriers
+ * only; @c maybe_functor is not specialised here because Maybe is a
+ * monad, not a comonad (counit on nullopt has no honest answer).
  */
 export template <typename Hub, typename T>
 struct counit_witness;
 
+/** @section kleisli__The_Tuple_Frobenius_Engine
+ *
+ * @details @c std::tuple<T> is a 1-tuple — always has a single
+ * element, so @c std::get<0> is total.  This makes it the project's
+ * bona-fide Frobenius (= monad + comonad) carrier: both Kleisli and
+ * co-Kleisli laws hold without concession.  Replaces the vestigial
+ * Box-as-trivially-comonadic path retired in #632; the std-blessed
+ * @c std::tuple wrapper carries the Frobenius role going forward.
+ */
+
+// Bind: std::tuple<T> >>= (T -> std::tuple<U>) -> std::tuple<U>.
+export template <typename T, typename Func>
+constexpr auto operator>>=(const std::tuple<T>& t, Func&& f) {
+  return std::forward<Func>(f)(std::get<0>(t));
+}
+
+// Extend: std::tuple<T> <<= (std::tuple<T> -> U) -> std::tuple<U>.
+export template <typename T, typename Func>
+constexpr auto operator<<=(const std::tuple<T>& t, Func&& f) {
+  using U = std::invoke_result_t<Func, std::tuple<T>>;
+  return std::tuple<U>{std::forward<Func>(f)(t)};
+}
+
 export template <typename T>
-struct counit_witness<maybe_functor<T>, T> final {
-  constexpr T operator()(const Maybe<T>& m) const noexcept { return *m; }
+struct unit_witness<tuple_functor<T>, T> final {
+  constexpr auto operator()(T x) const { return std::tuple<T>{std::move(x)}; }
+};
+
+export template <typename T>
+struct counit_witness<tuple_functor<T>, T> final {
+  constexpr T operator()(const std::tuple<T>& t) const noexcept {
+    return std::get<0>(t);
+  }
 };
 
 /** @section kleisli__Extension_Concepts */

--- a/src/main/modules/dedekind/category/kleisli.cppm
+++ b/src/main/modules/dedekind/category/kleisli.cppm
@@ -63,8 +63,8 @@ module;
 
 export module dedekind.category:kleisli;
 
-import :functor;  // box_functor (canonical Hub for unit_witness/counit_witness;
-                  // #508)
+import :functor;  // maybe_functor (canonical Hub for unit_witness /
+                  // counit_witness; #508 / #632)
 import :natural;  // IsDefaultHubTag — type-checked constraint on the Kleisli M
                   // slot
 import :monad;
@@ -73,26 +73,67 @@ import :morphism;
 
 namespace dedekind::category {
 
-/** @section kleisli__The_Box_Action_Engine */
+/** @section kleisli__The_Maybe_Action_Engine */
+
+// Bind: Maybe<T> >>= (T -> Maybe<U>) -> Maybe<U>.
+// Standard Maybe-monad bind: nullopt propagates; Some(x) feeds x into f.
+export template <typename T, typename Func>
+constexpr auto operator>>=(const Maybe<T>& m, Func&& f) {
+  using Result = std::invoke_result_t<Func, T>;
+  return m.has_value() ? std::forward<Func>(f)(*m) : Result{std::nullopt};
+}
+
+// Extend: Maybe<T> <<= (Maybe<T> -> U) -> Maybe<U>.
+// The comonadic extend on Maybe.  Mathematically Maybe is not a true
+// comonad (counit on nullopt has no honest answer), so this overload
+// is well-defined only on the Some-fragment: when @c m is Some(x), the
+// result is @c Some(f(m)); when @c m is nullopt, the result is also
+// @c nullopt (the carrier propagates the indecision rather than
+// fabricating a value).  Sister to the Box-as-trivial-comonad
+// vestigial path retired in #632.
+export template <typename T, typename Func>
+constexpr auto operator<<=(const Maybe<T>& m, Func&& f) {
+  using U = std::invoke_result_t<Func, Maybe<T>>;
+  return m.has_value() ? Maybe<U>{std::forward<Func>(f)(m)}
+                       : Maybe<U>{std::nullopt};
+}
 
 /**
  * @brief unit_witness<Hub, T>: Generic Kleisli unit witness.
  * Lifts a value into the Kleisli extension named by @c Hub::template Shape<T>.
  *
  * @tparam Hub A regular type carrying a nested @c Shape<U> alias; canonical
- *             example is @c box_functor<U> from @c :functor.
+ *             example is @c maybe_functor<U> from @c :functor.
  * @tparam T   The value type.
  */
 export template <typename Hub, typename T>
 struct unit_witness;
 
+export template <typename T>
+struct unit_witness<maybe_functor<T>, T> final {
+  constexpr auto operator()(T x) const { return Maybe<T>{std::move(x)}; }
+};
+
 /**
  * @brief counit_witness<Hub, T>: Generic Kleisli counit witness.
  * Samples a value from the co-Kleisli extension named by
  * @c Hub::template Shape<T>.
+ *
+ * @note For @c maybe_functor<T> the counit is well-defined only on the
+ * Some-fragment of @c Maybe<T>: dereferencing @c std::nullopt has no
+ * honest answer and produces UB.  Callers exercise the witness on
+ * Some-values; the comonadic-extend / IsCoKleisliExtension /
+ * IsFrobenius witnesses inherit this restriction.  See the
+ * "kleisli__The_Maybe_Action_Engine" section header for the broader
+ * mathematical concession (Maybe is a monad, not a true comonad).
  */
 export template <typename Hub, typename T>
 struct counit_witness;
+
+export template <typename T>
+struct counit_witness<maybe_functor<T>, T> final {
+  constexpr T operator()(const Maybe<T>& m) const noexcept { return *m; }
+};
 
 /** @section kleisli__Extension_Concepts */
 
@@ -127,7 +168,7 @@ concept IsFrobenius =
  *   κ(ma, f) = μ(φ(ma, f))
  * This is the textbook Kleisli extension operation.
  *
- * @tparam MA The monadic type (e.g., Box<T>, Maybe<T>, Identity<T>)
+ * @tparam MA The monadic type (e.g., Maybe<T>, Identity<T>)
  * @tparam F The function type to apply (typically A → MA<B>)
  *
  * @param ma The monadic value to bind
@@ -147,7 +188,9 @@ constexpr auto κ(MA const& ma, F&& f) {
  *   σ(wa, f) = φ(δ(wa), f)
  * This is the textbook co-Kleisli extension operation (extend/cobind).
  *
- * @tparam WA The comonadic type (e.g., Box<T>, Identity<T>)
+ * @tparam WA The comonadic type (e.g., Identity<T>; Maybe<T> on the
+ *             Some-fragment per the @c kleisli__The_Maybe_Action_Engine
+ *             concession)
  * @tparam F The function type to apply (typically W<A> → B)
  *
  * @param wa The comonadic value to extend
@@ -333,8 +376,8 @@ concept HasComonadicExtendOperators =
 // comonadic carrier has two CT readings depending on the carrier
 // shape:
 //
-//   * @b Comonadic carrier (e.g. @c Box<T>, future smart-pointer-like
-//     comonads): @c m->member @c ≡ @c ε(m).member, where
+//   * @b Comonadic carrier (e.g. @c Identity<T>; future smart-pointer-
+//     like comonads): @c m->member @c ≡ @c ε(m).member, where
 //     @c ε: @c W<A> @c → @c A is the comonadic @b extract (Mac Lane
 //     @em CWM §VI; Wadler 1992 @em Comprehending @em Monads).
 //   * @b Monadic carrier with partial dereference (e.g. @c Maybe<T>):
@@ -359,7 +402,7 @@ concept HasArrowDereferenceOperator = requires(M const& m) { m.operator->(); };
 /** @brief @c is_kleisli_deref_v<M>: opt-in marker that the carrier's
  *         @c operator-> realises Kleisli dereference (for monadic
  *         carriers like @c Maybe<T>) or comonadic extract @c ε
- *         (for comonadic carriers like @c Box<T>).  Default false;
+ *         (for comonadic carriers like @c Identity<T>).  Default false;
  *         specialise to @c true at the carrier site. */
 export template <typename M>
 inline constexpr bool is_kleisli_deref_v = false;
@@ -379,8 +422,8 @@ concept IsKleisliDeref =
  *          monad-hub tag @c M.  Its underlying map has shape
  *          @c e: @c A @c → @c T<B>, where @c T is the monadic carrier
  *          shape selected by the hub tag (@c Maybe for
- *          @c maybe_hub_tag, @c Box for @c box_hub_tag, @c Identity for
- *          @c identity_hub_tag).  The @c M slot is the
+ *          @c maybe_hub_tag, @c Identity for @c identity_hub_tag).  The @c M
+ * slot is the
  *          @b monad-hub @b tag itself — a tag type that names which
  *          Kleisli category the arrow inhabits — not the class template.
  *          Constrained by @c IsDefaultHubTag to make the connection
@@ -437,9 +480,9 @@ static_assert(
     "Opt-in via is_kleisli_arrow_v<E, maybe_hub_tag> = true lifts the "
     "arrow into the IsKleisliArrow concept.");
 static_assert(
-    !IsKleisliArrow<toy_partial_realize, box_hub_tag>,
+    !IsKleisliArrow<toy_partial_realize, identity_hub_tag>,
     "Opt-in is per-(E, M) pair: a Maybe-shaped Kleisli arrow does not "
-    "automatically inhabit the Box Kleisli category.");
+    "automatically inhabit the Identity Kleisli category.");
 
 }  // namespace _kleisli_arrow_witness_380
 

--- a/src/main/modules/dedekind/category/kleisli.cppm
+++ b/src/main/modules/dedekind/category/kleisli.cppm
@@ -64,8 +64,9 @@ module;
 
 export module dedekind.category:kleisli;
 
-import :functor;  // maybe_functor (canonical Hub for unit_witness /
-                  // counit_witness; #508 / #632)
+import :functor;  // maybe_functor (canonical Hub for unit_witness, monad-only)
+                  // and tuple_functor (canonical Hub for both
+                  // unit_witness AND counit_witness; #508 / #632)
 import :natural;  // IsDefaultHubTag — type-checked constraint on the Kleisli M
                   // slot
 import :monad;
@@ -84,8 +85,13 @@ namespace dedekind::category {
  */
 
 // Bind: Maybe<T> >>= (T -> Maybe<U>) -> Maybe<U>.
-// Standard Maybe-monad bind: nullopt propagates; Some(x) feeds x into f.
+// Constrained to Kleisli arrows whose codomain is a @c Maybe-shaped
+// carrier — guarantees the @c Result{std::nullopt} branch is well-formed
+// and rules out accidental carrier-changing binds (Copilot review on
+// #632).
 export template <typename T, typename Func>
+  requires std::constructible_from<std::invoke_result_t<Func, T>,
+                                   std::nullopt_t>
 constexpr auto operator>>=(const Maybe<T>& m, Func&& f) {
   using Result = std::invoke_result_t<Func, T>;
   return m.has_value() ? std::forward<Func>(f)(*m) : Result{std::nullopt};
@@ -128,8 +134,22 @@ struct counit_witness;
  * @c std::tuple wrapper carries the Frobenius role going forward.
  */
 
+namespace _kleisli_detail {
+template <typename U>
+struct is_tuple1 : std::false_type {};
+template <typename U>
+struct is_tuple1<std::tuple<U>> : std::true_type {};
+template <typename U>
+inline constexpr bool is_tuple1_v = is_tuple1<U>::value;
+}  // namespace _kleisli_detail
+
 // Bind: std::tuple<T> >>= (T -> std::tuple<U>) -> std::tuple<U>.
+// Constrained via SFINAE-friendly partial-specialization detector: the
+// Kleisli arrow's codomain must be a 1-tuple, ruling out accidental
+// carrier-changing binds (Copilot review on #632).
 export template <typename T, typename Func>
+  requires _kleisli_detail::is_tuple1_v<
+      std::remove_cvref_t<std::invoke_result_t<Func, T>>>
 constexpr auto operator>>=(const std::tuple<T>& t, Func&& f) {
   return std::forward<Func>(f)(std::get<0>(t));
 }
@@ -206,9 +226,11 @@ constexpr auto κ(MA const& ma, F&& f) {
  *   σ(wa, f) = φ(δ(wa), f)
  * This is the textbook co-Kleisli extension operation (extend/cobind).
  *
- * @tparam WA The comonadic type (e.g., Identity<T>; Maybe<T> on the
- *             Some-fragment per the @c kleisli__The_Maybe_Action_Engine
- *             concession)
+ * @tparam WA The comonadic type (e.g., @c std::tuple<T> as the
+ *             bona-fide Frobenius carrier per @c
+ *             kleisli__The_Tuple_Frobenius_Engine, or the identity-
+ *             arrow Identity).  Maybe is monad-only and intentionally
+ *             not a comonadic carrier here (#632).
  * @tparam F The function type to apply (typically W<A> → B)
  *
  * @param wa The comonadic value to extend

--- a/src/main/modules/dedekind/category/monad.cppm
+++ b/src/main/modules/dedekind/category/monad.cppm
@@ -49,7 +49,8 @@ namespace dedekind::category {
 
 /**
  * @brief Value-level alias for η (eta) with explicit hub tag dispatch.
- * @details Example: pure(maybe_hub, x), pure(identity_hub, x).
+ * @details Example: pure(maybe_hub, x), pure(identity_hub, x),
+ *          pure(tuple_hub, x).
  */
 export template <typename HubTag, typename A>
   requires IsDefaultHubTag<HubTag> &&

--- a/src/main/modules/dedekind/category/monad.cppm
+++ b/src/main/modules/dedekind/category/monad.cppm
@@ -49,8 +49,7 @@ namespace dedekind::category {
 
 /**
  * @brief Value-level alias for η (eta) with explicit hub tag dispatch.
- * @details Example: pure(maybe_hub, x), pure(identity_hub, x), pure(box_hub,
- * x).
+ * @details Example: pure(maybe_hub, x), pure(identity_hub, x).
  */
 export template <typename HubTag, typename A>
   requires IsDefaultHubTag<HubTag> &&

--- a/src/main/modules/dedekind/category/morphism.cppm
+++ b/src/main/modules/dedekind/category/morphism.cppm
@@ -88,7 +88,7 @@ namespace dedekind::category {
 // Concrete instances of this pattern in the codebase:
 //   * @c Set<int> — the category whose objects are int values and
 //     whose morphisms are functions @c int @c → @c int.
-//   * @c Set<Box<int>> — a @b different category, same structural
+//   * @c Set<Maybe<int>> — a @b different category, same structural
 //     shape, distinct species.
 //   * @c Set<Path<int>> — a category whose objects are sequences
 //     @c ℕ @c → @c int.  Path<int> is an OBJECT in this category,
@@ -119,7 +119,7 @@ namespace dedekind::category {
 //
 //   * @b F_obj: an action on objects, taking @c 𝒞.Species @c → @c 𝒟.Species.
 //     In code this is @c F::template @c Shape<U> (the type-constructor
-//     part: @c box_functor<T>::Shape<U> @c = @c Box<U>, etc.).
+//     part: @c maybe_functor<T>::Shape<U> @c = @c Maybe<U>, etc.).
 //   * @b F_mor: an action on morphisms, taking @c 𝒞.Arrow @c → @c 𝒟.Arrow,
 //     with @c F(g @c ∘ @c f) @c = @c F(g) @c ∘ @c F(f) and
 //     @c F(id_a) @c = @c id_{F(a)}.  In code this is @c F.φ(f) (the
@@ -135,7 +135,7 @@ namespace dedekind::category {
 //
 // In the architecture vocabulary below, functors are called @b hub
 // @b arrows: their endpoints are categories (the source / target
-// labels @c Σ_cat / @c Τ_cat that hub types like @c box_functor
+// labels @c Σ_cat / @c Τ_cat that hub types like @c maybe_functor
 // expose), so they sit "above" the spoke arrows that connect objects
 // within a single category.  The fish @c F @c >> @c G (sugar for
 // @c G @c ∘ @c F) at the hub level is functor composition; that

--- a/src/main/modules/dedekind/category/natural.cppm
+++ b/src/main/modules/dedekind/category/natural.cppm
@@ -138,6 +138,7 @@ constexpr Maybe<A> μ(maybe_hub_tag, Maybe<Maybe<A>> const& mma) {
  */
 // η: a → std::tuple<a>
 export template <typename A>
+  requires IsSpecies<std::decay_t<A>>
 constexpr std::tuple<std::decay_t<A>> η(tuple_hub_tag, A&& value) {
   return std::tuple<std::decay_t<A>>{std::forward<A>(value)};
 }

--- a/src/main/modules/dedekind/category/natural.cppm
+++ b/src/main/modules/dedekind/category/natural.cppm
@@ -59,6 +59,7 @@ module;
 #include <concepts>
 #include <functional>
 #include <optional>
+#include <tuple>  // std::tuple<T> — bona-fide Frobenius carrier (#632)
 
 export module dedekind.category:natural;
 
@@ -73,14 +74,17 @@ namespace dedekind::category {
 // Hub tags for textbook operator defaults without template-template dispatch.
 export struct maybe_hub_tag final {};
 export struct identity_hub_tag final {};
+export struct tuple_hub_tag final {};
 
 export inline constexpr maybe_hub_tag maybe_hub{};
 export inline constexpr identity_hub_tag identity_hub{};
+export inline constexpr tuple_hub_tag tuple_hub{};
 
 export template <typename Tag>
 concept IsDefaultHubTag =
     std::same_as<std::remove_cvref_t<Tag>, maybe_hub_tag> ||
-    std::same_as<std::remove_cvref_t<Tag>, identity_hub_tag>;
+    std::same_as<std::remove_cvref_t<Tag>, identity_hub_tag> ||
+    std::same_as<std::remove_cvref_t<Tag>, tuple_hub_tag>;
 
 /**
  * @brief The Maybe endofunctor T, implemented via std::optional.
@@ -114,39 +118,60 @@ constexpr Maybe<A> μ(maybe_hub_tag, Maybe<Maybe<A>> const& mma) {
   return mma.has_value() ? *mma : std::nullopt;
 }
 
-// Comonadic ε for Maybe.  Defined on the Some-fragment only:
-// ε(Some(x)) = x; ε(nullopt) is UB (dereferences a value-less
-// optional).  Same mathematical concession as the Box-as-trivial-
-// comonad vestigial path retired in #632 — the price of using
-// std-blessed std::optional as the carrier.
-template <typename A>
-constexpr A ε(Maybe<A> const& ma) {
-  return *ma;
-}
-
-export template <typename A>
-  requires IsSpecies<A>
-constexpr A ε(maybe_hub_tag, Maybe<A> const& ma) {
-  return *ma;
-}
+// (Maybe is a monad, not a comonad — counit on @c std::nullopt has no
+// honest answer.  The bona-fide Frobenius carrier in this codebase is
+// @c std::tuple<T> below; see the @c tuple_hub_tag block.)
 
 /**
- * @brief Comonadic duplicate (δ) for Maybe: Maybe<A> → Maybe<Maybe<A>>.
+ * @brief The std::tuple<T> Frobenius carrier.
  *
- * @details On the Some-fragment δ(Some(x)) = Some(Some(x)); on
- * @c nullopt the duplicate stays @c nullopt (the carrier propagates
- * the indecision rather than fabricating a Some).
+ * @details @c std::tuple<T> is a 1-tuple — it always has a single
+ * element, so the comonadic counit @c std::get<0> is total (no
+ * Some-fragment caveat) and the duplicate wraps once more cleanly.
+ * Combined with the textbook monadic structure (η as @c
+ * std::make_tuple, μ via @c std::get<0> on the inner tuple), this
+ * makes @c std::tuple<T> the project's bona-fide Frobenius witness
+ * — both Kleisli and co-Kleisli laws hold without concession.
+ *
+ * Replaces the vestigial @c Box-as-trivially-comonadic carrier
+ * retired in #632.
  */
+// η: a → std::tuple<a>
 template <typename A>
+constexpr std::tuple<std::decay_t<A>> η(tuple_hub_tag, A&& value) {
+  return std::tuple<std::decay_t<A>>{std::forward<A>(value)};
+}
+
+// μ: std::tuple<std::tuple<A>> → std::tuple<A>
+export template <typename A>
   requires IsSpecies<A>
-constexpr Maybe<Maybe<A>> δ(Maybe<A> const& ma) {
-  return ma.has_value() ? Maybe<Maybe<A>>{ma} : std::nullopt;
+constexpr std::tuple<A> μ(tuple_hub_tag, std::tuple<std::tuple<A>> const& tta) {
+  return std::get<0>(tta);
+}
+
+// ε: std::tuple<A> → A
+template <typename A>
+constexpr A ε(std::tuple<A> const& ta) {
+  return std::get<0>(ta);
 }
 
 export template <typename A>
   requires IsSpecies<A>
-constexpr Maybe<Maybe<A>> δ(maybe_hub_tag, Maybe<A> const& ma) {
-  return ma.has_value() ? Maybe<Maybe<A>>{ma} : std::nullopt;
+constexpr A ε(tuple_hub_tag, std::tuple<A> const& ta) {
+  return std::get<0>(ta);
+}
+
+// δ: std::tuple<A> → std::tuple<std::tuple<A>>
+template <typename A>
+  requires IsSpecies<A>
+constexpr std::tuple<std::tuple<A>> δ(std::tuple<A> const& ta) {
+  return std::tuple<std::tuple<A>>{ta};
+}
+
+export template <typename A>
+  requires IsSpecies<A>
+constexpr std::tuple<std::tuple<A>> δ(tuple_hub_tag, std::tuple<A> const& ta) {
+  return std::tuple<std::tuple<A>>{ta};
 }
 
 /**

--- a/src/main/modules/dedekind/category/natural.cppm
+++ b/src/main/modules/dedekind/category/natural.cppm
@@ -187,62 +187,6 @@ constexpr Identity<Identity<A>> δ(identity_hub_tag, Identity<A> const& ia) {
 }
 
 /**
- * @brief The Box endofunctor.
- * Reified 1-morphism that preserves both objects and arrows exactly.
- */
-// Monadic
-template <typename A>
-constexpr Box<std::decay_t<A>> η(A&& value) {
-  return {std::forward<A>(value)};
-}
-
-// Tagged defaults for Box hub.
-export template <typename A>
-  requires IsSpecies<std::decay_t<A>>
-constexpr Box<std::decay_t<A>> η(box_hub_tag, A&& value) {
-  return {std::forward<A>(value)};
-}
-
-/**
- * @brief μ for Box: flattens nested box context.
- * @details Box<Box<A>> -> Box<A>
- */
-template <typename A>
-  requires IsSpecies<A>
-constexpr Box<A> μ(Box<Box<A>> const& bba) {
-  return {bba.value.value};
-}
-
-export template <typename A>
-  requires IsSpecies<A>
-constexpr Box<A> μ(box_hub_tag, Box<Box<A>> const& bba) {
-  return {bba.value.value};
-}
-
-// Comonadic
-template <typename A>
-constexpr A ε(Box<A> const& ba) {
-  return ba.value;
-}
-
-export template <typename A>
-  requires IsSpecies<A>
-constexpr A ε(box_hub_tag, Box<A> const& ba) {
-  return ba.value;
-}
-
-template <typename A>
-constexpr Box<Box<A>> δ(Box<A> const& ba) {
-  return {ba};
-}
-
-export template <typename A>
-  requires IsSpecies<A>
-constexpr Box<Box<A>> δ(box_hub_tag, Box<A> const& ba) {
-  return {ba};
-}
-
-/**
  * @concept IsPreTransformation
  * @brief The raw family of components.
  */

--- a/src/main/modules/dedekind/category/natural.cppm
+++ b/src/main/modules/dedekind/category/natural.cppm
@@ -143,6 +143,16 @@ constexpr std::tuple<std::decay_t<A>> η(tuple_hub_tag, A&& value) {
 }
 
 // μ: std::tuple<std::tuple<A>> → std::tuple<A>
+//
+// Both untagged and tagged variants — the untagged form is what κ's body
+// invokes (κ(ma, f) = μ(φ(ma, f))).  Mirrors the Maybe and Identity
+// untagged-μ overloads above.
+template <typename A>
+  requires IsSpecies<A>
+constexpr std::tuple<A> μ(std::tuple<std::tuple<A>> const& tta) {
+  return std::get<0>(tta);
+}
+
 export template <typename A>
   requires IsSpecies<A>
 constexpr std::tuple<A> μ(tuple_hub_tag, std::tuple<std::tuple<A>> const& tta) {

--- a/src/main/modules/dedekind/category/natural.cppm
+++ b/src/main/modules/dedekind/category/natural.cppm
@@ -73,17 +73,14 @@ namespace dedekind::category {
 // Hub tags for textbook operator defaults without template-template dispatch.
 export struct maybe_hub_tag final {};
 export struct identity_hub_tag final {};
-export struct box_hub_tag final {};
 
 export inline constexpr maybe_hub_tag maybe_hub{};
 export inline constexpr identity_hub_tag identity_hub{};
-export inline constexpr box_hub_tag box_hub{};
 
 export template <typename Tag>
 concept IsDefaultHubTag =
     std::same_as<std::remove_cvref_t<Tag>, maybe_hub_tag> ||
-    std::same_as<std::remove_cvref_t<Tag>, identity_hub_tag> ||
-    std::same_as<std::remove_cvref_t<Tag>, box_hub_tag>;
+    std::same_as<std::remove_cvref_t<Tag>, identity_hub_tag>;
 
 /**
  * @brief The Maybe endofunctor T, implemented via std::optional.
@@ -115,6 +112,41 @@ export template <typename A>
   requires IsSpecies<A>
 constexpr Maybe<A> μ(maybe_hub_tag, Maybe<Maybe<A>> const& mma) {
   return mma.has_value() ? *mma : std::nullopt;
+}
+
+// Comonadic ε for Maybe.  Defined on the Some-fragment only:
+// ε(Some(x)) = x; ε(nullopt) is UB (dereferences a value-less
+// optional).  Same mathematical concession as the Box-as-trivial-
+// comonad vestigial path retired in #632 — the price of using
+// std-blessed std::optional as the carrier.
+template <typename A>
+constexpr A ε(Maybe<A> const& ma) {
+  return *ma;
+}
+
+export template <typename A>
+  requires IsSpecies<A>
+constexpr A ε(maybe_hub_tag, Maybe<A> const& ma) {
+  return *ma;
+}
+
+/**
+ * @brief Comonadic duplicate (δ) for Maybe: Maybe<A> → Maybe<Maybe<A>>.
+ *
+ * @details On the Some-fragment δ(Some(x)) = Some(Some(x)); on
+ * @c nullopt the duplicate stays @c nullopt (the carrier propagates
+ * the indecision rather than fabricating a Some).
+ */
+template <typename A>
+  requires IsSpecies<A>
+constexpr Maybe<Maybe<A>> δ(Maybe<A> const& ma) {
+  return ma.has_value() ? Maybe<Maybe<A>>{ma} : std::nullopt;
+}
+
+export template <typename A>
+  requires IsSpecies<A>
+constexpr Maybe<Maybe<A>> δ(maybe_hub_tag, Maybe<A> const& ma) {
+  return ma.has_value() ? Maybe<Maybe<A>>{ma} : std::nullopt;
 }
 
 /**

--- a/src/main/modules/dedekind/category/natural.cppm
+++ b/src/main/modules/dedekind/category/natural.cppm
@@ -137,7 +137,7 @@ constexpr Maybe<A> μ(maybe_hub_tag, Maybe<Maybe<A>> const& mma) {
  * retired in #632.
  */
 // η: a → std::tuple<a>
-template <typename A>
+export template <typename A>
 constexpr std::tuple<std::decay_t<A>> η(tuple_hub_tag, A&& value) {
   return std::tuple<std::decay_t<A>>{std::forward<A>(value)};
 }

--- a/src/main/modules/dedekind/linear_algebra/vec2.cppm
+++ b/src/main/modules/dedekind/linear_algebra/vec2.cppm
@@ -311,7 +311,7 @@ constexpr Covec2V<T> Vec2V<T>::transpose() const {
  *  lifts elementwise to an arrow @c Vec2V<T>→Vec2V<T> (resp.\ Covec).
  *  The hub types below own that lift and witness
  *  @c dedekind::category::IsFunctor for each shape.  They mirror
- *  @c dedekind::category::box_functor / @c maybe_functor in pattern.
+ *  @c dedekind::category::maybe_functor in pattern.
  */
 export template <typename T>
   requires std::regular<T> && dedekind::algebra::HasRingOperators<T>

--- a/src/main/modules/dedekind/numbers/rational.cppm
+++ b/src/main/modules/dedekind/numbers/rational.cppm
@@ -363,7 +363,7 @@ static_assert((Rational<default_integer>(default_integer{2}, default_integer{3})
 // (Real<Q>, Complex<R>) and value_type (Dual<F>, IsTangentBundle).
 // The dedekind.category:functor partition meanwhile establishes the
 // canonical convention --- Σ_cat / Τ_cat for source/target category
-// and Shape<U> for the on-objects action (cf. box_functor<T> at
+// and Shape<U> for the on-objects action (cf. maybe_functor<T> at
 // src/main/modules/dedekind/category/functor.cppm).  Unifying the carrier-side
 // projections with the :functor convention is NEW-A trait-registry
 // work and tracked under #498; this static_assert is the smallest

--- a/src/main/modules/dedekind/sequences/path.cppm
+++ b/src/main/modules/dedekind/sequences/path.cppm
@@ -535,11 +535,11 @@ namespace dedekind::category {
  * Kleisli witness registry (@c unit_witness / @c counit_witness /
  * @c IsKleisliExtension / @c IsCoKleisliExtension / @c IsFrobenius).
  * Named @c path_functor for naming-convention parity with the sibling
- * @c box_functor / @c maybe_functor / @c vec2_functor /
- * @c matrix2x2_functor Hubs in other partitions.
+ * @c maybe_functor / @c vec2_functor / @c matrix2x2_functor Hubs in
+ * other partitions.
  *
  * @section path__Functor_Limitation
- * Unlike @c box_functor / @c maybe_functor — which DO satisfy
+ * Unlike @c maybe_functor — which DOES satisfy
  * @c dedekind::category::IsFunctor — @c path_functor deliberately
  * does NOT.  Reason: @c Path<T> is itself an Arrow at the type level
  * (carries @c Domain @c = @c std::size_t and @c Codomain @c = @c T,

--- a/src/test/cpp/modules/dedekind/category/functor_test.cpp
+++ b/src/test/cpp/modules/dedekind/category/functor_test.cpp
@@ -11,7 +11,6 @@ TEST_CASE("Category: Functor Concepts", "[category][functor]") {
 
   STATIC_CHECK(IsFunctor<identity_functor<IntCat>>);
   STATIC_CHECK(IsEndofunctor<identity_functor<IntCat>>);
-  STATIC_CHECK(IsFunctor<box_functor<int>>);
   STATIC_CHECK(IsFunctor<maybe_functor<int>>);
   STATIC_CHECK(IsFunctor<trace_functor<int>>);
   STATIC_CHECK(IsSpokeArrow<decltype(plus_one)>);
@@ -27,17 +26,6 @@ TEST_CASE("Category: Functor hub action", "[category][functor][hub-action]") {
     STATIC_CHECK(IsArrow<decltype(lifted)>);
     CHECK(lifted(41) == 42);
     CHECK(lifted(-2) == -1);
-  }
-
-  SECTION("Box functor lifts codomain into Box<T>") {
-    box_functor<int> boxf;
-    auto plus_one = arrow([](int x) { return x + 1; });
-
-    auto lifted = boxf.φ(plus_one);
-
-    STATIC_CHECK(IsArrow<decltype(lifted)>);
-    CHECK(lifted(Box<int>{41}) == Box<int>{42});
-    CHECK(lifted(Box<int>{-2}) == Box<int>{-1});
   }
 
   SECTION("Maybe functor short-circuits empty inputs") {

--- a/src/test/cpp/modules/dedekind/category/kleisli_test.cpp
+++ b/src/test/cpp/modules/dedekind/category/kleisli_test.cpp
@@ -1,67 +1,77 @@
 #include <catch2/catch_test_macros.hpp>
 #include <concepts>
 #include <optional>
+#include <tuple>
 
 import dedekind.category;
 
 using namespace dedekind::category;
 
 TEST_CASE("Category: Kleisli Extension Concepts", "[category][kleisli]") {
+  // Maybe is a monad (Kleisli extension only); std::tuple<T> is the
+  // bona-fide Frobenius carrier (both Kleisli and co-Kleisli, no
+  // Some-fragment concession).
   STATIC_CHECK(IsKleisliExtension<maybe_functor<int>, int, int>);
-  STATIC_CHECK(IsCoKleisliExtension<maybe_functor<int>, int, int>);
-  STATIC_CHECK(IsFrobenius<maybe_functor<int>, int, int>);
+  STATIC_CHECK(IsKleisliExtension<tuple_functor<int>, int, int>);
+  STATIC_CHECK(IsCoKleisliExtension<tuple_functor<int>, int, int>);
+  STATIC_CHECK(IsFrobenius<tuple_functor<int>, int, int>);
 }
 
-TEST_CASE("Category: Maybe Frobenius structure",
+TEST_CASE("Category: Tuple Frobenius structure",
           "[category][kleisli][frobenius]") {
-  // Some-fragment witnesses: Maybe is mathematically a monad, not a
-  // true comonad (counit on nullopt has no honest answer).  These
-  // tests exercise Maybe on Some-values where the comonadic surface
-  // is well-defined; see :kleisli's kleisli__The_Maybe_Action_Engine
-  // section for the wider concession.
-  Maybe<int> value{9};
+  std::tuple<int> value{9};
 
   SECTION("Unit followed by counit returns the original value") {
-    auto wrapped = unit_witness<maybe_functor<int>, int>{}(*value);
-    auto raw = counit_witness<maybe_functor<int>, int>{}(wrapped);
-    CHECK(raw == *value);
+    auto wrapped = unit_witness<tuple_functor<int>, int>{}(std::get<0>(value));
+    auto raw = counit_witness<tuple_functor<int>, int>{}(wrapped);
+    CHECK(raw == std::get<0>(value));
   }
 
   SECTION("Kleisli right unit law: κ(ma, η) = ma") {
-    auto result = κ(value, unit_witness<maybe_functor<int>, int>{});
+    auto result = κ(value, unit_witness<tuple_functor<int>, int>{});
     CHECK(result == value);
   }
 
   SECTION("Co-Kleisli right counit law: σ(wa, ε) = wa") {
-    auto result = σ(value, counit_witness<maybe_functor<int>, int>{});
+    auto result = σ(value, counit_witness<tuple_functor<int>, int>{});
     CHECK(result == value);
   }
 
   SECTION("Bind then extract agrees with direct function result") {
-    auto f = [](int x) { return Maybe<int>{x * 3}; };
+    auto f = [](int x) { return std::tuple<int>{x * 3}; };
     auto via_bind = κ(value, f);
-    CHECK(counit_witness<maybe_functor<int>, int>{}(via_bind) ==
-          counit_witness<maybe_functor<int>, int>{}(f(*value)));
+    CHECK(counit_witness<tuple_functor<int>, int>{}(via_bind) ==
+          counit_witness<tuple_functor<int>, int>{}(f(std::get<0>(value))));
   }
 
   SECTION("Extend then extract agrees with direct co-Kleisli result") {
-    auto g = [](Maybe<int> b) { return *b + 4; };
+    auto g = [](std::tuple<int> b) { return std::get<0>(b) + 4; };
     auto via_extend = σ(value, g);
-    CHECK(counit_witness<maybe_functor<int>, int>{}(via_extend) == g(value));
+    CHECK(counit_witness<tuple_functor<int>, int>{}(via_extend) == g(value));
   }
 }
 
-TEST_CASE("Category: Maybe Bind and Extend", "[category][kleisli]") {
+TEST_CASE("Category: Tuple Bind and Extend", "[category][kleisli]") {
+  std::tuple<int> value{21};
+
+  SECTION("Bind (>>=) chains in-context computations") {
+    auto doubled = value >>= [](int x) { return std::tuple<int>{x * 2}; };
+    CHECK(doubled == std::tuple<int>{42});
+  }
+
+  SECTION("Extend (<<=) samples context to build new context") {
+    auto summarized = value <<=
+        [](std::tuple<int> b) { return std::get<0>(b) + 1; };
+    CHECK(summarized == std::tuple<int>{22});
+  }
+}
+
+TEST_CASE("Category: Maybe Bind", "[category][kleisli]") {
   Maybe<int> value{21};
 
   SECTION("Bind (>>=) chains in-context computations") {
     auto doubled = value >>= [](int x) { return Maybe<int>{x * 2}; };
     CHECK(doubled == Maybe<int>{42});
-  }
-
-  SECTION("Extend (<<=) samples context to build new context") {
-    auto summarized = value <<= [](Maybe<int> b) { return *b + 1; };
-    CHECK(summarized == Maybe<int>{22});
   }
 }
 
@@ -83,16 +93,18 @@ TEST_CASE("Category: Kleisli κ (kappa) extension",
 
 TEST_CASE("Category: Co-Kleisli σ (sigma) extend",
           "[category][kleisli][sigma]") {
-  Maybe<int> value{7};
+  std::tuple<int> value{7};
 
   SECTION("σ applies co-Kleisli arrow to comonadic value") {
-    auto result = σ(value, [](Maybe<int> b) { return *b + 3; });
-    CHECK(result == Maybe<int>{10});
+    auto result =
+        σ(value, [](std::tuple<int> b) { return std::get<0>(b) + 3; });
+    CHECK(result == std::tuple<int>{10});
   }
 
   SECTION("σ chains through δ duplication") {
-    auto extracted = σ(value, [](Maybe<int> b) { return *b * 2; });
-    CHECK(extracted == Maybe<int>{14});
+    auto extracted =
+        σ(value, [](std::tuple<int> b) { return std::get<0>(b) * 2; });
+    CHECK(extracted == std::tuple<int>{14});
   }
 }
 
@@ -141,33 +153,35 @@ TEST_CASE("Category: Fish alias operator>> for bind",
 
 TEST_CASE("Category: Co-Kleisli cobind operator<<=",
           "[category][kleisli][cobind]") {
-  Maybe<int> value{8};
+  std::tuple<int> value{8};
 
   SECTION("Comonadic extend with <<= operator") {
-    auto result = value <<= [](Maybe<int> b) { return *b - 2; };
-    CHECK(result == Maybe<int>{6});
+    auto result = value <<=
+        [](std::tuple<int> b) { return std::get<0>(b) - 2; };
+    CHECK(result == std::tuple<int>{6});
   }
 
   SECTION("Chaining multiple coextends") {
-    auto result = (value <<= [](Maybe<int> b) { return *b / 2; }) <<=
-        [](Maybe<int> b) { return *b + 3; };
-    CHECK(result == Maybe<int>{7});
+    auto result =
+        (value <<= [](std::tuple<int> b) { return std::get<0>(b) / 2; }) <<=
+        [](std::tuple<int> b) { return std::get<0>(b) + 3; };
+    CHECK(result == std::tuple<int>{7});
   }
 }
 
 TEST_CASE("Category: Fish alias operator<< for cobind",
           "[category][kleisli][cobind][fish-alias]") {
-  Maybe<int> value{8};
+  std::tuple<int> value{8};
 
   SECTION("Value-level upstream fish aliases cobind") {
-    auto result = value << [](Maybe<int> b) { return *b - 2; };
-    CHECK(result == Maybe<int>{6});
+    auto result = value << [](std::tuple<int> b) { return std::get<0>(b) - 2; };
+    CHECK(result == std::tuple<int>{6});
   }
 
   SECTION("Fish alias supports left-associative cobind chains") {
-    auto result = value << [](Maybe<int> b) { return *b / 2; }
-                        << [](Maybe<int> b) { return *b + 3; };
-    CHECK(result == Maybe<int>{7});
+    auto result = value << [](std::tuple<int> b) { return std::get<0>(b) / 2; }
+                        << [](std::tuple<int> b) { return std::get<0>(b) + 3; };
+    CHECK(result == std::tuple<int>{7});
   }
 }
 
@@ -178,10 +192,11 @@ TEST_CASE("Category: Named Kleisli aliases", "[category][kleisli][aliases]") {
     CHECK(result == Maybe<int>{10});
   }
 
-  SECTION("extend aliases σ for Maybe") {
-    Maybe<int> value{6};
-    auto result = extend(value, [](Maybe<int> b) { return *b * 3; });
-    CHECK(result == Maybe<int>{18});
+  SECTION("extend aliases σ for std::tuple") {
+    std::tuple<int> value{6};
+    auto result =
+        extend(value, [](std::tuple<int> b) { return std::get<0>(b) * 3; });
+    CHECK(result == std::tuple<int>{18});
   }
 
   SECTION("bind aliases κ for Maybe/optional") {
@@ -202,16 +217,16 @@ TEST_CASE("Category: Named Kleisli aliases", "[category][kleisli][aliases]") {
     CHECK(bind(maybe_hub, empty, plus_two) == std::nullopt);
   }
 
-  SECTION("bind and extend with maybe_hub on Some-fragment") {
-    Maybe<int> value{6};
+  SECTION("bind and extend with tuple_hub use default Frobenius routes") {
+    std::tuple<int> value{6};
 
     auto bound =
-        bind(maybe_hub, value, [](int x) { return Maybe<int>{x + 4}; });
-    CHECK(bound == Maybe<int>{10});
+        bind(tuple_hub, value, [](int x) { return std::tuple<int>{x + 4}; });
+    CHECK(bound == std::tuple<int>{10});
 
-    auto extended =
-        extend(maybe_hub, value, [](Maybe<int> b) { return *b * 3; });
-    CHECK(extended == Maybe<int>{18});
+    auto extended = extend(
+        tuple_hub, value, [](std::tuple<int> b) { return std::get<0>(b) * 3; });
+    CHECK(extended == std::tuple<int>{18});
   }
 }
 
@@ -229,9 +244,12 @@ TEST_CASE(
     STATIC_CHECK(HasKleisliBindOperators<Maybe<int>, MaybeBind>);
   }
 
-  SECTION("HasComonadicExtendOperators: Maybe<int> + co-Kleisli arrow fires") {
-    using MaybeCoBind = decltype([](Maybe<int> b) { return *b * 2; });
-    STATIC_CHECK(HasComonadicExtendOperators<Maybe<int>, MaybeCoBind>);
+  SECTION(
+      "HasComonadicExtendOperators: std::tuple<int> + co-Kleisli "
+      "arrow fires") {
+    using TupleCoBind =
+        decltype([](std::tuple<int> b) { return std::get<0>(b) * 2; });
+    STATIC_CHECK(HasComonadicExtendOperators<std::tuple<int>, TupleCoBind>);
   }
 
   SECTION(

--- a/src/test/cpp/modules/dedekind/category/kleisli_test.cpp
+++ b/src/test/cpp/modules/dedekind/category/kleisli_test.cpp
@@ -1,175 +1,187 @@
 #include <catch2/catch_test_macros.hpp>
 #include <concepts>
+#include <optional>
 
 import dedekind.category;
 
 using namespace dedekind::category;
 
 TEST_CASE("Category: Kleisli Extension Concepts", "[category][kleisli]") {
-  STATIC_CHECK(IsKleisliExtension<box_functor<int>, int, int>);
-  STATIC_CHECK(IsCoKleisliExtension<box_functor<int>, int, int>);
-  STATIC_CHECK(IsFrobenius<box_functor<int>, int, int>);
+  STATIC_CHECK(IsKleisliExtension<maybe_functor<int>, int, int>);
+  STATIC_CHECK(IsCoKleisliExtension<maybe_functor<int>, int, int>);
+  STATIC_CHECK(IsFrobenius<maybe_functor<int>, int, int>);
 }
 
-TEST_CASE("Category: Box Frobenius structure",
+TEST_CASE("Category: Maybe Frobenius structure",
           "[category][kleisli][frobenius]") {
-  Box<int> value{9};
+  // Some-fragment witnesses: Maybe is mathematically a monad, not a
+  // true comonad (counit on nullopt has no honest answer).  These
+  // tests exercise Maybe on Some-values where the comonadic surface
+  // is well-defined; see :kleisli's kleisli__The_Maybe_Action_Engine
+  // section for the wider concession.
+  Maybe<int> value{9};
 
   SECTION("Unit followed by counit returns the original value") {
-    auto boxed = unit_witness<box_functor<int>, int>{}(value.value);
-    auto raw = counit_witness<box_functor<int>, int>{}(boxed);
-    CHECK(raw == value.value);
+    auto wrapped = unit_witness<maybe_functor<int>, int>{}(*value);
+    auto raw = counit_witness<maybe_functor<int>, int>{}(wrapped);
+    CHECK(raw == *value);
   }
 
   SECTION("Kleisli right unit law: κ(ma, η) = ma") {
-    auto result = κ(value, unit_witness<box_functor<int>, int>{});
+    auto result = κ(value, unit_witness<maybe_functor<int>, int>{});
     CHECK(result == value);
   }
 
   SECTION("Co-Kleisli right counit law: σ(wa, ε) = wa") {
-    auto result = σ(value, counit_witness<box_functor<int>, int>{});
+    auto result = σ(value, counit_witness<maybe_functor<int>, int>{});
     CHECK(result == value);
   }
 
   SECTION("Bind then extract agrees with direct function result") {
-    auto f = [](int x) { return Box<int>{x * 3}; };
+    auto f = [](int x) { return Maybe<int>{x * 3}; };
     auto via_bind = κ(value, f);
-    CHECK(counit_witness<box_functor<int>, int>{}(via_bind) ==
-          counit_witness<box_functor<int>, int>{}(f(value.value)));
+    CHECK(counit_witness<maybe_functor<int>, int>{}(via_bind) ==
+          counit_witness<maybe_functor<int>, int>{}(f(*value)));
   }
 
   SECTION("Extend then extract agrees with direct co-Kleisli result") {
-    auto g = [](Box<int> b) { return b.value + 4; };
+    auto g = [](Maybe<int> b) { return *b + 4; };
     auto via_extend = σ(value, g);
-    CHECK(counit_witness<box_functor<int>, int>{}(via_extend) == g(value));
+    CHECK(counit_witness<maybe_functor<int>, int>{}(via_extend) == g(value));
   }
 }
 
-TEST_CASE("Category: Box Bind and Extend", "[category][kleisli]") {
-  Box<int> value{21};
+TEST_CASE("Category: Maybe Bind and Extend", "[category][kleisli]") {
+  Maybe<int> value{21};
 
   SECTION("Bind (>>=) chains in-context computations") {
-    auto doubled = value >>= [](int x) { return Box<int>{x * 2}; };
-    CHECK(doubled == Box<int>{42});
+    auto doubled = value >>= [](int x) { return Maybe<int>{x * 2}; };
+    CHECK(doubled == Maybe<int>{42});
   }
 
   SECTION("Extend (<<=) samples context to build new context") {
-    auto summarized = value <<= [](Box<int> b) { return b.value + 1; };
-    CHECK(summarized == Box<int>{22});
+    auto summarized = value <<= [](Maybe<int> b) { return *b + 1; };
+    CHECK(summarized == Maybe<int>{22});
   }
 }
 
 TEST_CASE("Category: Kleisli κ (kappa) extension",
           "[category][kleisli][kappa]") {
-  Box<int> value{10};
+  Maybe<int> value{10};
 
-  SECTION("κ applies Kleisli arrow to boxed value") {
-    auto result = κ(value, [](int x) { return Box<int>{x * 2}; });
-    CHECK(result == Box<int>{20});
+  SECTION("κ applies Kleisli arrow to monadic value") {
+    auto result = κ(value, [](int x) { return Maybe<int>{x * 2}; });
+    CHECK(result == Maybe<int>{20});
   }
 
   SECTION("κ chains multiple Kleisli extensions") {
-    auto step1 = κ(value, [](int x) { return Box<int>{x + 5}; });
-    auto step2 = κ(step1, [](int x) { return Box<int>{x * 2}; });
-    CHECK(step2 == Box<int>{30});
+    auto step1 = κ(value, [](int x) { return Maybe<int>{x + 5}; });
+    auto step2 = κ(step1, [](int x) { return Maybe<int>{x * 2}; });
+    CHECK(step2 == Maybe<int>{30});
   }
 }
 
 TEST_CASE("Category: Co-Kleisli σ (sigma) extend",
           "[category][kleisli][sigma]") {
-  Box<int> value{7};
+  Maybe<int> value{7};
 
   SECTION("σ applies co-Kleisli arrow to comonadic value") {
-    auto result = σ(value, [](Box<int> b) { return b.value + 3; });
-    CHECK(result == Box<int>{10});
+    auto result = σ(value, [](Maybe<int> b) { return *b + 3; });
+    CHECK(result == Maybe<int>{10});
   }
 
   SECTION("σ chains through δ duplication") {
-    auto extracted = σ(value, [](Box<int> b) { return b.value * 2; });
-    CHECK(extracted == Box<int>{14});
+    auto extracted = σ(value, [](Maybe<int> b) { return *b * 2; });
+    CHECK(extracted == Maybe<int>{14});
   }
 }
 
 TEST_CASE("Category: Kleisli bind operator>>=", "[category][kleisli][bind]") {
-  Box<int> value{5};
+  Maybe<int> value{5};
 
   SECTION("Monadic bind with >>= operator") {
-    auto result = value >>= [](int x) { return Box<int>{x + 10}; };
-    CHECK(result == Box<int>{15});
+    auto result = value >>= [](int x) { return Maybe<int>{x + 10}; };
+    CHECK(result == Maybe<int>{15});
   }
 
   SECTION("Chaining multiple binds") {
-    auto result = (value >>= [](int x) { return Box<int>{x * 2}; }) >>=
-        [](int x) { return Box<int>{x + 1}; };
-    CHECK(result == Box<int>{11});
+    auto result = (value >>= [](int x) { return Maybe<int>{x * 2}; }) >>=
+        [](int x) { return Maybe<int>{x + 1}; };
+    CHECK(result == Maybe<int>{11});
   }
 
   SECTION("Bind preserves container structure") {
-    Box<int> initial{3};
-    auto final = initial >>= [](int x) { return Box<int>{x * x}; };
-    CHECK(final.value == 9);
+    Maybe<int> initial{3};
+    auto final = initial >>= [](int x) { return Maybe<int>{x * x}; };
+    CHECK(*final == 9);
+  }
+
+  SECTION("Bind on nullopt propagates the empty case") {
+    Maybe<int> empty{std::nullopt};
+    auto result = empty >>= [](int x) { return Maybe<int>{x + 10}; };
+    CHECK(result == std::nullopt);
   }
 }
 
 TEST_CASE("Category: Fish alias operator>> for bind",
           "[category][kleisli][bind][fish-alias]") {
-  Box<int> value{5};
+  Maybe<int> value{5};
 
   SECTION("Value-level fish aliases bind") {
-    auto result = value >> [](int x) { return Box<int>{x + 10}; };
-    CHECK(result == Box<int>{15});
+    auto result = value >> [](int x) { return Maybe<int>{x + 10}; };
+    CHECK(result == Maybe<int>{15});
   }
 
   SECTION("Fish alias supports left-associative bind chains") {
-    auto result = value >> [](int x) { return Box<int>{x * 2}; } >>
-                  [](int x) { return Box<int>{x + 1}; };
-    CHECK(result == Box<int>{11});
+    auto result = value >> [](int x) { return Maybe<int>{x * 2}; } >>
+                  [](int x) { return Maybe<int>{x + 1}; };
+    CHECK(result == Maybe<int>{11});
   }
 }
 
 TEST_CASE("Category: Co-Kleisli cobind operator<<=",
           "[category][kleisli][cobind]") {
-  Box<int> value{8};
+  Maybe<int> value{8};
 
   SECTION("Comonadic extend with <<= operator") {
-    auto result = value <<= [](Box<int> b) { return b.value - 2; };
-    CHECK(result == Box<int>{6});
+    auto result = value <<= [](Maybe<int> b) { return *b - 2; };
+    CHECK(result == Maybe<int>{6});
   }
 
   SECTION("Chaining multiple coextends") {
-    auto result = (value <<= [](Box<int> b) { return b.value / 2; }) <<=
-        [](Box<int> b) { return b.value + 3; };
-    CHECK(result == Box<int>{7});
+    auto result = (value <<= [](Maybe<int> b) { return *b / 2; }) <<=
+        [](Maybe<int> b) { return *b + 3; };
+    CHECK(result == Maybe<int>{7});
   }
 }
 
 TEST_CASE("Category: Fish alias operator<< for cobind",
           "[category][kleisli][cobind][fish-alias]") {
-  Box<int> value{8};
+  Maybe<int> value{8};
 
   SECTION("Value-level upstream fish aliases cobind") {
-    auto result = value << [](Box<int> b) { return b.value - 2; };
-    CHECK(result == Box<int>{6});
+    auto result = value << [](Maybe<int> b) { return *b - 2; };
+    CHECK(result == Maybe<int>{6});
   }
 
   SECTION("Fish alias supports left-associative cobind chains") {
-    auto result = value << [](Box<int> b) { return b.value / 2; }
-                        << [](Box<int> b) { return b.value + 3; };
-    CHECK(result == Box<int>{7});
+    auto result = value << [](Maybe<int> b) { return *b / 2; }
+                        << [](Maybe<int> b) { return *b + 3; };
+    CHECK(result == Maybe<int>{7});
   }
 }
 
 TEST_CASE("Category: Named Kleisli aliases", "[category][kleisli][aliases]") {
-  SECTION("bind aliases κ for Box") {
-    Box<int> value{6};
-    auto result = bind(value, [](int x) { return Box<int>{x + 4}; });
-    CHECK(result == Box<int>{10});
+  SECTION("bind aliases κ for Maybe") {
+    Maybe<int> value{6};
+    auto result = bind(value, [](int x) { return Maybe<int>{x + 4}; });
+    CHECK(result == Maybe<int>{10});
   }
 
-  SECTION("extend aliases σ for Box") {
-    Box<int> value{6};
-    auto result = extend(value, [](Box<int> b) { return b.value * 3; });
-    CHECK(result == Box<int>{18});
+  SECTION("extend aliases σ for Maybe") {
+    Maybe<int> value{6};
+    auto result = extend(value, [](Maybe<int> b) { return *b * 3; });
+    CHECK(result == Maybe<int>{18});
   }
 
   SECTION("bind aliases κ for Maybe/optional") {
@@ -190,15 +202,16 @@ TEST_CASE("Category: Named Kleisli aliases", "[category][kleisli][aliases]") {
     CHECK(bind(maybe_hub, empty, plus_two) == std::nullopt);
   }
 
-  SECTION("bind and extend with box_hub use default textbook routes") {
-    Box<int> value{6};
+  SECTION("bind and extend with maybe_hub on Some-fragment") {
+    Maybe<int> value{6};
 
-    auto bound = bind(box_hub, value, [](int x) { return Box<int>{x + 4}; });
-    CHECK(bound == Box<int>{10});
+    auto bound =
+        bind(maybe_hub, value, [](int x) { return Maybe<int>{x + 4}; });
+    CHECK(bound == Maybe<int>{10});
 
     auto extended =
-        extend(box_hub, value, [](Box<int> b) { return b.value * 3; });
-    CHECK(extended == Box<int>{18});
+        extend(maybe_hub, value, [](Maybe<int> b) { return *b * 3; });
+    CHECK(extended == Maybe<int>{18});
   }
 }
 
@@ -210,20 +223,20 @@ TEST_CASE(
   // operator surfaces they support.  These are operator-shape concepts:
   // they pin syntactic availability, not the equational laws (which are
   // pinned by IsArrow / IsMonad / IsComonad in their own partitions).
-  using BoxBind = decltype([](int x) { return Box<int>{x + 1}; });
+  using MaybeBind = decltype([](int x) { return Maybe<int>{x + 1}; });
 
-  SECTION("HasKleisliBindOperators: Box<int> + Kleisli arrow fires") {
-    STATIC_CHECK(HasKleisliBindOperators<Box<int>, BoxBind>);
+  SECTION("HasKleisliBindOperators: Maybe<int> + Kleisli arrow fires") {
+    STATIC_CHECK(HasKleisliBindOperators<Maybe<int>, MaybeBind>);
   }
 
-  SECTION("HasComonadicExtendOperators: Box<int> + co-Kleisli arrow fires") {
-    using BoxCoBind = decltype([](Box<int> b) { return b.value * 2; });
-    STATIC_CHECK(HasComonadicExtendOperators<Box<int>, BoxCoBind>);
+  SECTION("HasComonadicExtendOperators: Maybe<int> + co-Kleisli arrow fires") {
+    using MaybeCoBind = decltype([](Maybe<int> b) { return *b * 2; });
+    STATIC_CHECK(HasComonadicExtendOperators<Maybe<int>, MaybeCoBind>);
   }
 
   SECTION(
       "HasKleisliBindOperators negative: bare int + bind-arrow does NOT "
       "fire (no Kleisli operator surface on a non-monadic carrier)") {
-    STATIC_CHECK(!HasKleisliBindOperators<int, BoxBind>);
+    STATIC_CHECK(!HasKleisliBindOperators<int, MaybeBind>);
   }
 }

--- a/src/test/cpp/modules/dedekind/category/monad_test.cpp
+++ b/src/test/cpp/modules/dedekind/category/monad_test.cpp
@@ -1,5 +1,6 @@
 #include <catch2/catch_test_macros.hpp>
 #include <concepts>
+#include <tuple>
 
 import dedekind.category;
 
@@ -73,15 +74,22 @@ TEST_CASE("Category: Monad textbook aliases", "[category][monad][aliases]") {
     CHECK(j(8) == 8);
   }
 
-  SECTION("pure, join, extract, duplicate route through Maybe defaults") {
-    // Maybe is a monad, not a true comonad; extract / duplicate are
-    // well-defined only on the Some-fragment.  See
-    // :natural's η/μ/ε/δ block for the concession.
+  SECTION("pure, join route through Maybe defaults (monad only)") {
+    // Maybe is a monad, not a comonad — extract / duplicate live on
+    // the Frobenius carrier std::tuple<T>, not on Maybe.
     CHECK(pure(maybe_hub, 2) == Maybe<int>{2});
     CHECK(join(maybe_hub, Maybe<Maybe<int>>{Maybe<int>{6}}) == Maybe<int>{6});
-    CHECK(extract(maybe_hub, Maybe<int>{9}) == 9);
-    CHECK(duplicate(maybe_hub, Maybe<int>{9}) ==
-          Maybe<Maybe<int>>{Maybe<int>{9}});
+  }
+
+  SECTION("pure, join, extract, duplicate route through tuple defaults") {
+    // std::tuple<T> is the project's bona-fide Frobenius carrier
+    // per #632 — both monad and comonad laws hold without concession.
+    CHECK(pure(tuple_hub, 2) == std::tuple<int>{2});
+    CHECK(join(tuple_hub, std::tuple<std::tuple<int>>{std::tuple<int>{6}}) ==
+          std::tuple<int>{6});
+    CHECK(extract(tuple_hub, std::tuple<int>{9}) == 9);
+    CHECK(duplicate(tuple_hub, std::tuple<int>{9}) ==
+          std::tuple<std::tuple<int>>{std::tuple<int>{9}});
   }
 }
 

--- a/src/test/cpp/modules/dedekind/category/monad_test.cpp
+++ b/src/test/cpp/modules/dedekind/category/monad_test.cpp
@@ -73,11 +73,15 @@ TEST_CASE("Category: Monad textbook aliases", "[category][monad][aliases]") {
     CHECK(j(8) == 8);
   }
 
-  SECTION("pure, join, extract, duplicate route through Box defaults") {
-    CHECK(pure(box_hub, 2) == Box<int>{2});
-    CHECK(join(box_hub, Box<Box<int>>{{6}}) == Box<int>{6});
-    CHECK(extract(box_hub, Box<int>{9}) == 9);
-    CHECK(duplicate(box_hub, Box<int>{9}) == Box<Box<int>>{{9}});
+  SECTION("pure, join, extract, duplicate route through Maybe defaults") {
+    // Maybe is a monad, not a true comonad; extract / duplicate are
+    // well-defined only on the Some-fragment.  See
+    // :natural's η/μ/ε/δ block for the concession.
+    CHECK(pure(maybe_hub, 2) == Maybe<int>{2});
+    CHECK(join(maybe_hub, Maybe<Maybe<int>>{Maybe<int>{6}}) == Maybe<int>{6});
+    CHECK(extract(maybe_hub, Maybe<int>{9}) == 9);
+    CHECK(duplicate(maybe_hub, Maybe<int>{9}) ==
+          Maybe<Maybe<int>>{Maybe<int>{9}});
   }
 }
 

--- a/src/test/cpp/modules/dedekind/category/natural_test.cpp
+++ b/src/test/cpp/modules/dedekind/category/natural_test.cpp
@@ -1,5 +1,6 @@
 #include <catch2/catch_test_macros.hpp>
 #include <concepts>
+#include <tuple>
 
 import dedekind.category;
 
@@ -63,18 +64,29 @@ TEST_CASE("Category: Natural textbook operator defaults",
     CHECK(duplicated(id<int>())(9) == 9);
   }
 
-  SECTION("Maybe hub supports η, μ, ε, δ defaults (Some-fragment)") {
-    // Maybe is mathematically a monad, not a true comonad; the
-    // comonadic ε / δ defaults are well-defined only on the
-    // Some-fragment of Maybe<T> (counit on nullopt has no honest
-    // answer).  See :natural's η/μ/ε/δ block for the concession.
+  SECTION("Maybe hub supports monadic η, μ defaults") {
+    // Maybe is mathematically a monad, not a comonad — counit on
+    // nullopt has no honest answer.  The bona-fide Frobenius carrier
+    // is std::tuple<T> (next SECTION); Maybe stays monad-only here.
     auto injected = η(maybe_hub, 4);
     CHECK(injected == Maybe<int>{4});
 
     Maybe<Maybe<int>> nested{Maybe<int>{17}};
     CHECK(μ(maybe_hub, nested) == Maybe<int>{17});
+  }
 
-    CHECK(ε(maybe_hub, Maybe<int>{19}) == 19);
-    CHECK(δ(maybe_hub, Maybe<int>{19}) == Maybe<Maybe<int>>{Maybe<int>{19}});
+  SECTION("Tuple hub supports η, μ, ε, δ defaults (Frobenius)") {
+    // std::tuple<T> is the project's bona-fide Frobenius (= monad +
+    // comonad) carrier per #632.  The 1-tuple always has a single
+    // element, so std::get<0> is total — no Some-fragment caveat.
+    auto injected = η(tuple_hub, 4);
+    CHECK(injected == std::tuple<int>{4});
+
+    std::tuple<std::tuple<int>> nested{std::tuple<int>{17}};
+    CHECK(μ(tuple_hub, nested) == std::tuple<int>{17});
+
+    CHECK(ε(tuple_hub, std::tuple<int>{19}) == 19);
+    CHECK(δ(tuple_hub, std::tuple<int>{19}) ==
+          std::tuple<std::tuple<int>>{std::tuple<int>{19}});
   }
 }

--- a/src/test/cpp/modules/dedekind/category/natural_test.cpp
+++ b/src/test/cpp/modules/dedekind/category/natural_test.cpp
@@ -63,14 +63,18 @@ TEST_CASE("Category: Natural textbook operator defaults",
     CHECK(duplicated(id<int>())(9) == 9);
   }
 
-  SECTION("Box hub supports η, μ, ε, δ defaults") {
-    auto injected = η(box_hub, 4);
-    CHECK(injected == Box<int>{4});
+  SECTION("Maybe hub supports η, μ, ε, δ defaults (Some-fragment)") {
+    // Maybe is mathematically a monad, not a true comonad; the
+    // comonadic ε / δ defaults are well-defined only on the
+    // Some-fragment of Maybe<T> (counit on nullopt has no honest
+    // answer).  See :natural's η/μ/ε/δ block for the concession.
+    auto injected = η(maybe_hub, 4);
+    CHECK(injected == Maybe<int>{4});
 
-    Box<Box<int>> nested{{17}};
-    CHECK(μ(box_hub, nested) == Box<int>{17});
+    Maybe<Maybe<int>> nested{Maybe<int>{17}};
+    CHECK(μ(maybe_hub, nested) == Maybe<int>{17});
 
-    CHECK(ε(box_hub, Box<int>{19}) == 19);
-    CHECK(δ(box_hub, Box<int>{19}) == Box<Box<int>>{{19}});
+    CHECK(ε(maybe_hub, Maybe<int>{19}) == 19);
+    CHECK(δ(maybe_hub, Maybe<int>{19}) == Maybe<Maybe<int>>{Maybe<int>{19}});
   }
 }


### PR DESCRIPTION
## Summary

Retires the vestigial `Box<T>` type / `box_functor<T>` / `box_hub_tag` from `dedekind.category` and reorganises the monad / comonad / Frobenius surface across two std-blessed carriers, each playing a clean structural role:

- **`Maybe<T>` = `std::optional<T>` — monad only.** `>>=` (bind), `unit_witness<maybe_functor<T>, T>`, `η` / `μ`.  No comonadic surface; counit on `nullopt` has no honest answer.
- **`std::tuple<T>` (1-tuple) — bona-fide Frobenius (monad + comonad).** `>>=`, `<<=`, `unit_witness<tuple_functor<T>, T>`, `counit_witness<tuple_functor<T>, T>`, `η` / `μ` / `ε` / `δ`, `φ` overload, and the new `tuple_functor<T>` Hub in `:functor`.  `std::get<0>` is total — no Some-fragment caveat.

Replaces the pre-PR `Box`, which was carrying both monadic AND comonadic roles by virtue of always having a value.  The split lands the two roles on two std-blessed carriers, with the comonadic side on the carrier that genuinely supports it and the monadic-only side on `Maybe`.

## Why this shape

Discussed during the PR's iteration cycle:

1. **Initial direction (early commits):** Box → Maybe with Some-fragment comonadic concession on Maybe. Mathematically sketchy — Maybe isn't a comonad, and counit on `nullopt` had to either UB or fabricate a default.
2. **Calibration:** identified that the comonadic side could move to a genuinely-comonadic carrier rather than being hacked onto Maybe.  Shortlisted `Identity` (project-internal) and `std::tuple<T>` (std-blessed).  `Identity<T>` in this codebase is the identity arrow, not a value-wrapper, so the Frobenius witnesses (which need a `.value`-style projection) don't fit it directly.
3. **Resolution:** `std::tuple<T>` carries the Frobenius role.  std-blessed, always has a single element, `std::get<0>` is total, no caveats.  Maybe stays monadic-only — clean.

## Source changes

### Additions

- `:functor` — new `tuple_functor<T>` Hub with `Shape<U> = std::tuple<U>`; `IsFunctor` witness pinned.
- `:functor` — exported `Maybe<T>` alias (was internal pre-PR; needed for downstream test usage).
- `:functor` — `φ` overload for `std::tuple<T>` (mirrors the existing Maybe / Identity overloads).
- `:natural` — new `tuple_hub_tag` / `tuple_hub` exports; `IsDefaultHubTag` disjunction widened.
- `:natural` — `η` / `μ` / `ε` / `δ` for `std::tuple<A>` (untagged + tagged).
- `:kleisli` — `>>=` and `<<=` for `std::tuple<T>`; `unit_witness<tuple_functor<T>, T>` and `counit_witness<tuple_functor<T>, T>` specialisations.
- `:kleisli` — `>>=` for `Maybe<T>` (monadic only); `unit_witness<maybe_functor<T>, T>`.

### Removals

- `:functor` — `Box<T>` struct, `box_functor<T>`, `IsFunctor<box_functor<int>>` witness, `φ` overload for `Box<A>`.
- `:natural` — `box_hub_tag` / `box_hub` exports; `η` / `μ` / `ε` / `δ` overloads for `Box`.
- `:kleisli` — `>>=` / `<<=` for `Box<T>`; `unit_witness<box_functor<T>, T>` / `counit_witness<box_functor<T>, T>`; the `box_hub_tag` Kleisli-arrow witnesses.
- (No comonadic Maybe surface — Maybe is a monad, not a comonad.)

### Doc cleanups

- `:functor` / `:kleisli` / `:morphism` / `:monad` — doxygen-comment Box references rewritten to point at `Maybe` / `tuple_functor` / `Identity` analogs.
- `:sequences:path` / `:linear_algebra:vec2` / `:numbers:rational` — removed `box_functor` cross-references in favour of `maybe_functor` / `tuple_functor`.
- `docs/paper/paper.tex` — locks in the three-slot grammar (algebra HAS-A underlying set; set HAS-A ambient + classifier; ambient IS-A small category) as paper-side target architecture (post-#629 lift).

### Tests

- `kleisli_test.cpp` — comonadic / Frobenius / `σ` / `<<=` / `IsCoKleisliExtension` / `IsFrobenius` SECTIONs now exercise `std::tuple<int>` via `tuple_functor`. Monadic SECTIONs (`>>=`, κ, fish-alias bind) stay on `Maybe`.  `HasComonadicExtendOperators` now checks `std::tuple<int>`; the negative `HasKleisliBindOperators` on bare int stays.
- `natural_test.cpp` — Maybe hub SECTION shrinks to monadic η / μ; new tuple hub SECTION exercises full η / μ / ε / δ Frobenius.
- `monad_test.cpp` — Maybe hub SECTION shrinks to pure / join; new tuple hub SECTION exercises pure / join / extract / duplicate Frobenius.
- `functor_test.cpp` — drops the orphaned `box_functor` SECTION (the existing `maybe_functor` SECTION already covers the equivalent).

## CI history

- Iteration 1 (commit a5776af2): Frobenius carrier split landed.  Build failed: `Maybe` alias not exported; no `φ` overload for `std::tuple<T>` so κ / σ couldn't compose.
- Iteration 2 (commit d7ff7c99): added `export` to the `Maybe` alias; added `φ` for `std::tuple<T>` to functor.cppm alongside the existing Maybe / Identity overloads.

## Test plan

- [ ] CI build-and-deploy green (iteration 2 expected to clear)
- [x] Maybe-monad surface (>>=, unit_witness, η/μ) — exercised by `kleisli_test`, `natural_test`, `monad_test` (Maybe SECTIONs)
- [x] Tuple-Frobenius surface (>>=, <<=, unit/counit, η/μ/ε/δ) — exercised by the same suites' tuple SECTIONs

## Adjacent

- The mathematical concession is gone: Maybe is monadically clean (no UB hazard); `tuple_functor` is Frobenius-clean (no fragment caveat).
- The architectural target post-PR is the *carrier-role split* the codebase now reflects: monadic carriers and comonadic-Frobenius carriers can coexist as separate, structurally-honest types.  See #633 for the broader functor-vocabulary refactor (`IsFunctor` refinement quartet) this naturally feeds into.

🤖 Generated with [Claude Code](https://claude.com/claude-code)