### PR TITLE
refactor(category, paper): #635 — pin the size-axis vocabulary across :small / :etcs / paper §2.3

### DIFF
--- a/docs/paper/paper.tex
+++ b/docs/paper/paper.tex
@@ -623,7 +623,7 @@ Each step adds one structural commitment, and each commitment is reified as an e
 
 \begin{table}[htbp]
 \centering
-\caption{\textbf{The chain $\mathbf{Cat} \to \mathbf{Ddk}$ as named refinement steps.}  Each row adds one structural commitment over the previous; each is cashed out by an existing C++23 partition / concept.  The chain is approximately linear at the granularity shown; the honest reading is more lattice-shaped, with concreteness (objects \emph{are} sets) sitting orthogonally to the CCC and topos refinements rather than strictly downstream of them.}
+\caption{\textbf{The chain $\mathbf{Cat} \to \mathbf{Ddk}$ as named refinement steps.}  Each row adds one structural commitment over the previous; each is cashed out by an existing C++23 partition / concept.  Steps 0--6 are internal to category theory; step 7 is the move out of pure CT into the C++ realisation.  The chain is approximately linear at the granularity shown; the honest reading is more lattice-shaped, with concreteness (step 6) and the size axis (step 1) sitting orthogonally to the CCC and topos refinements (steps 2--4) rather than strictly downstream of them.}
 \label{tbl:cat-to-ddk}
 \small
 \begin{tabular}{@{}c l l l@{}}
@@ -636,12 +636,14 @@ Each step adds one structural commitment, and each commitment is reified as an e
 3 & exponentials $B^A$                           & \cppinline{:cartesian} / \cppinline{IsExponential}      & CCC                            \\
 4 & subobject classifier $\Omega$                & \cppinline{:topoi} / \cppinline{IsSubobject}, \cppinline{IsTopos} & elementary topos      \\
 5 & ETCS axioms (well-pointedness, NNO, choice)  & \cppinline{:etcs}                                       & Set-modeling topos             \\
-6 & C++ Juliet binding (carriers as concrete C++ types) & \cppinline{:cartesian::Ddk}                      & $\mathbf{Ddk}$                 \\
+6 & concreteness (objects \emph{are} sets; faithful $U: \mathcal{C} \to \mathbf{Set}$) & \cppinline{:etcs} / \cppinline{IsSetObject}, \cppinline{Subobject} & concrete Set-model \\
+\midrule
+7 & C++ Juliet binding (carriers as concrete C++ types) & \cppinline{:cartesian::Ddk}                      & $\mathbf{Ddk}$                 \\
 \bottomrule
 \end{tabular}
 \end{table}
 
-The locally-small-not-small slot --- the textbook home of $\mathbf{Cat}$ itself, $\mathbf{Set}$, $\mathbf{Alg}(\Sigma)$, $\mathbf{Top}$ --- branches off this chain at step~1 and is intentionally not navigated by the project today\footnote{Reifying \cppinline{IsLocallySmallCategory} as a sibling concept would require a higher-kinded $\mathrm{Hom}\langle A, B \rangle$ slot whose template-template machinery the codebase otherwise keeps at arm's length; deferred until a load-bearing consumer surfaces.  The architectural slot is named in the \cppinline{:small} docstring without a concept stub.}.
+The locally-small-not-small slot --- the textbook home of $\mathbf{Cat}$ itself, $\mathbf{Set}$, $\mathbf{Alg}(\Sigma)$, $\mathbf{Top}$ --- branches off this chain at step~1 and is intentionally not navigated by the project today; the architectural intent and reasons for deferring \cppinline{IsLocallySmallCategory} live in the \cppinline{:small} docstring (\texttt{small\_\_The\_Locally\_Small\_Slot}).
 
 The algebraic structure each carrier provides (per \cppinline{IsAlgebraOnSet}, Listing~\ref{lst:algebra:universal}) lives \emph{inside} this CCC.
 The operations are arrows in $\mathbf{Ddk}$; axioms are equations between such arrows; the forgetful arrows the project ships ($\mathbf{Ring} \to \mathbf{AbGrp} \to \mathbf{Set}$, together with the \texttt{embed\_*\_*\_} family) drop operations as they move between carriers.

--- a/docs/paper/paper.tex
+++ b/docs/paper/paper.tex
@@ -617,6 +617,32 @@ $\mathbf{Ddk}$ is itself a cartesian closed category.
 Products are \cppinline{std::pair}, exponentials are \cppinline{std::function}, the terminal is \cppinline{std::monostate} --- the same constructions C++ programmers reach for daily.
 The \cppinline{IsCartesianClosed<Set<T>>} witness in \texttt{category:cartesian} is the moment these constructions are agreed-upon to be looked at categorically: the Juliet posture made concrete.
 
+\paragraph{From $\mathbf{Cat}$ to $\mathbf{Ddk}$ in named refinement steps.}
+The construction is not a single jump from the bare metacategory $\mathbf{Cat}$ to the project's specific instance $\mathbf{Ddk}$.
+Each step adds one structural commitment, and each commitment is reified as an existing C++23 partition or concept, so the chain is reproducible by reading the partition DAG (Table~\ref{tbl:cat-to-ddk}).
+
+\begin{table}[htbp]
+\centering
+\caption{\textbf{The chain $\mathbf{Cat} \to \mathbf{Ddk}$ as named refinement steps.}  Each row adds one structural commitment over the previous; each is cashed out by an existing C++23 partition / concept.  The chain is approximately linear at the granularity shown; the honest reading is more lattice-shaped, with concreteness (objects \emph{are} sets) sitting orthogonally to the CCC and topos refinements rather than strictly downstream of them.}
+\label{tbl:cat-to-ddk}
+\small
+\begin{tabular}{@{}c l l l@{}}
+\toprule
+\textbf{\#} & \textbf{Refinement added} & \textbf{Partition / concept} & \textbf{Net structure} \\
+\midrule
+0 & (bare category axioms)                       & ---                                                    & category                       \\
+1 & smallness                                    & \cppinline{:small} / \cppinline{IsSmallCategory}        & small category                 \\
+2 & terminal $1$, binary products $\times$       & \cppinline{:cartesian} / \cppinline{IsTerminal}, \cppinline{IsProduct} & finitely complete \\
+3 & exponentials $B^A$                           & \cppinline{:cartesian} / \cppinline{IsExponential}      & CCC                            \\
+4 & subobject classifier $\Omega$                & \cppinline{:topoi} / \cppinline{IsSubobject}, \cppinline{IsTopos} & elementary topos      \\
+5 & ETCS axioms (well-pointedness, NNO, choice)  & \cppinline{:etcs}                                       & Set-modeling topos             \\
+6 & C++ Juliet binding (carriers as concrete C++ types) & \cppinline{:cartesian::Ddk}                      & $\mathbf{Ddk}$                 \\
+\bottomrule
+\end{tabular}
+\end{table}
+
+The locally-small-not-small slot --- the textbook home of $\mathbf{Cat}$ itself, $\mathbf{Set}$, $\mathbf{Alg}(\Sigma)$, $\mathbf{Top}$ --- branches off this chain at step~1 and is intentionally not navigated by the project today\footnote{Reifying \cppinline{IsLocallySmallCategory} as a sibling concept would require a higher-kinded $\mathrm{Hom}\langle A, B \rangle$ slot whose template-template machinery the codebase otherwise keeps at arm's length; deferred until a load-bearing consumer surfaces.  The architectural slot is named in the \cppinline{:small} docstring without a concept stub.}.
+
 The algebraic structure each carrier provides (per \cppinline{IsAlgebraOnSet}, Listing~\ref{lst:algebra:universal}) lives \emph{inside} this CCC.
 The operations are arrows in $\mathbf{Ddk}$; axioms are equations between such arrows; the forgetful arrows the project ships ($\mathbf{Ring} \to \mathbf{AbGrp} \to \mathbf{Set}$, together with the \texttt{embed\_*\_*\_} family) drop operations as they move between carriers.
 Plain sets are the degenerate case where the operator tuple is empty.

--- a/src/main/modules/dedekind/category/cartesian.cppm
+++ b/src/main/modules/dedekind/category/cartesian.cppm
@@ -394,8 +394,8 @@ static_assert(!IsExponential<std::function<int(int)>, int, bool>,
 /**
  * @concept IsCartesianClosed
  * @brief A Category equipped with Terminal Objects, Products, and Exponentials.
- * @details This concept extends `IsCategory` to satisfy the three axioms of a
- * Cartesian Closed Category (CCC):
+ * @details This concept extends `IsSmallCategory` to satisfy the three axioms
+ * of a Cartesian Closed Category (CCC):
  * 1. **Terminal Object** — a unique sink `1` (represented by `One` /
  *    `std::monostate`).
  * 2. **Products** — for any two objects A, B, a product A × B exists
@@ -407,7 +407,7 @@ static_assert(!IsExponential<std::function<int(int)>, int, bool>,
  * the Dedekind topos (ETCS).
  */
 export template <typename Cat>
-concept IsCartesianClosed = IsCategory<Cat> && requires {
+concept IsCartesianClosed = IsSmallCategory<Cat> && requires {
   // 1. Terminal Object exists
   typename Cat::Terminal;
   requires IsTerminalObject<typename Cat::Terminal>;
@@ -438,7 +438,7 @@ struct SetId final {
 
   /**
    * @brief The explicit bridge to the Category's Arrow type.
-   * This satisfies the std::convertible_to constraint in IsCategory.
+   * This satisfies the std::convertible_to constraint in IsSmallCategory.
    */
   constexpr operator Morphism<T, T, std::function<T(T)>>() const {
     return Morphism<T, T, std::function<T(T)>>{
@@ -492,7 +492,7 @@ static_assert(IsCartesianClosed<CanonicalSetCCC<int>>,
  * @brief A Category Hub where the Species is a Categorical Product (std::pair).
  */
 export template <typename Cat>
-concept IsProductCategory = IsCategory<Cat> && requires {
+concept IsProductCategory = IsSmallCategory<Cat> && requires {
   /**
    * The species of this category must be a Product.
    * We extract A and B via the pair's internal aliases.

--- a/src/main/modules/dedekind/category/discrete.cppm
+++ b/src/main/modules/dedekind/category/discrete.cppm
@@ -114,7 +114,7 @@ static_assert(
  */
 export template <typename Cat>
 concept IsDiscreteCategory =
-    IsCategory<Cat> && std::same_as<typename Cat::Arrow, typename Cat::Id>;
+    IsSmallCategory<Cat> && std::same_as<typename Cat::Arrow, typename Cat::Id>;
 
 /**
  * @brief DiscreteCategory realization using the Identity Morphism.
@@ -140,8 +140,8 @@ using IntCat = DiscreteCategory<int>;
 // 2. Test: Does it satisfy the general Category contract?
 // This verifies: Arrow exists, id exists, and factory works.
 static_assert(
-    IsCategory<IntCat>,
-    "Verification Failed: DiscreteCategory<int> must satisfy IsCategory.");
+    IsSmallCategory<IntCat>,
+    "Verification Failed: DiscreteCategory<int> must satisfy IsSmallCategory.");
 
 // 3. Test: Does it satisfy the Discrete-specific property?
 // This verifies: Arrow type is identical to the Identity type.

--- a/src/main/modules/dedekind/category/etcs.cppm
+++ b/src/main/modules/dedekind/category/etcs.cppm
@@ -30,6 +30,26 @@
  * | **9. NNO (ℕ)**               | `SpeciesTraits<unsigned>`             |
  * | **10. Axiom of Choice** (asp.) | `meet` / `join` power-object lattice |
  *
+ * @section etcs__What_Concreteness_Pins
+ *
+ * @c :small establishes the @em cardinality reading of "small category":
+ * the collection of objects and the collection of arrows are each sets in
+ * the metatheory (forced by representing them as C++ types).  @c :etcs
+ * pins the complementary @em ontological reading: each object @b is
+ * a set, characterized structurally via the topos structure (terminal,
+ * products, exponentials, subobject classifier, NNO).  In the project's
+ * vocabulary this is the move from "objects are elements of a set"
+ * (@c :small, Reading 1) to "objects are sets" (@c :etcs, Reading 2 /
+ * @em concreteness; equivalently: faithful forgetful functor
+ * @c U @c : @c 𝒞 @c → @c Set).
+ *
+ * The two readings are independent: @c :small admits enum-style tag
+ * objects (small but not concrete); @c :etcs requires the topos
+ * structure that makes objects bona-fide sets.  Categories that satisfy
+ * both --- the small concrete categories --- are the @c IsCategory
+ * carriers whose @c Species is itself a set-typed carrier (@c Set<T>,
+ * the ETCS @c Subobject machinery).
+ *
  * @see Lawvere, F.W. (1964) "An Elementary Theory of the Category of Sets"
  * @see McLarty, C. (1993) "Numbers can be just what they have to"
  *

--- a/src/main/modules/dedekind/category/etcs.cppm
+++ b/src/main/modules/dedekind/category/etcs.cppm
@@ -46,7 +46,7 @@
  * The two readings are independent: @c :small admits enum-style tag
  * objects (small but not concrete); @c :etcs requires the topos
  * structure that makes objects bona-fide sets.  Categories that satisfy
- * both --- the small concrete categories --- are the @c IsCategory
+ * both --- the small concrete categories --- are the @c IsSmallCategory
  * carriers whose @c Species is itself a set-typed carrier (@c Set<T>,
  * the ETCS @c Subobject machinery).
  *
@@ -548,7 +548,7 @@ static_assert(
  * of the underlying-objects functor @c U @c : @c Cat @c → @c Set.  The
  * adjunction @c Disc @c ⊣ @c U lives between the @b meta-categories
  * @c Set and @c Cat.  This codebase encodes categories per-ambient
- * (one @c Species per @c IsCategory type), so the @b meta-categorical
+ * (one @c Species per @c IsSmallCategory type), so the @b meta-categorical
  * statement is one level above what the type system can express
  * directly --- there is no @c category_of_sets or @c
  * category_of_categories type whose @c Species ranges over all sets
@@ -577,7 +577,7 @@ using discrete_lift_t = DiscreteCategory<S>;
 
 // Witness that the lift produces a discrete category for the
 // representative @c IsSet-witnessing carrier from above.
-static_assert(IsCategory<discrete_lift_t<_isset_witness_t>>,
+static_assert(IsSmallCategory<discrete_lift_t<_isset_witness_t>>,
               "Set ↪ Cat lift: discrete_lift_t<S> satisfies the "
               "general Category contract.");
 static_assert(IsDiscreteCategory<discrete_lift_t<_isset_witness_t>>,

--- a/src/main/modules/dedekind/category/functor.cppm
+++ b/src/main/modules/dedekind/category/functor.cppm
@@ -106,10 +106,10 @@ namespace dedekind::category {
  * 2. Identity Law: F(id_c) = id_{F(c)}
  * 3. Composition Law: F(f >> g) = F(f) >> F(g)
  *
- * Because `IsCategory` in this project is single-species, the object witness
- * for `c` is always recovered by first forming the identity arrow `id_c(c)`.
- * Functorial object mapping is therefore observed indirectly through the spoke
- * `F(id_c(c))`, whose domain recovers the image object `F(c)`.
+ * Because `IsSmallCategory` in this project is single-species, the object
+ * witness for `c` is always recovered by first forming the identity arrow
+ * `id_c(c)`. Functorial object mapping is therefore observed indirectly through
+ * the spoke `F(id_c(c))`, whose domain recovers the image object `F(c)`.
  *
  * Canonical hub models provided in this partition are listed in
  * @ref IsFunctor_Models.
@@ -118,8 +118,8 @@ export template <typename F>
 concept IsFunctor = IsArrow<F> && requires {
   typename F::Σ_cat;
   typename F::Τ_cat;
-  requires IsCategory<typename F::Σ_cat>;
-  requires IsCategory<typename F::Τ_cat>;
+  requires IsSmallCategory<typename F::Σ_cat>;
+  requires IsSmallCategory<typename F::Τ_cat>;
 
   /**
    * 2. The Type Constructor (The Recipe)
@@ -650,7 +650,7 @@ static_assert(IsFunctor<trace_functor<int>>,
  * Concrete @ref IsFunctor model.
  */
 export template <typename Cat>
-  requires IsCategory<Cat>
+  requires IsSmallCategory<Cat>
 struct identity_functor {
   using ArrowKind = hub_arrow_tag;
   using Σ_cat = Cat;

--- a/src/main/modules/dedekind/category/morphism.cppm
+++ b/src/main/modules/dedekind/category/morphism.cppm
@@ -185,9 +185,9 @@ namespace dedekind::category {
 //     category): a spoke.
 //
 // The codebase realises this question structurally as
-// @c IsCategoryShape<Dom<T>>, defined further down.  @c IsCategoryShape
-// is the structural prefix of the full @c IsCategory in @c :small —
-// here we only need the shape to make the routing decision; the
+// @c IsSmallCategoryShape<Dom<T>>, defined further down.  @c
+// IsSmallCategoryShape is the structural prefix of the full @c IsSmallCategory
+// in @c :small — here we only need the shape to make the routing decision; the
 // behavioural axioms (composition closure, identity laws) are not
 // needed at this layer.
 //
@@ -201,7 +201,7 @@ namespace dedekind::category {
 // sequence is a function @c ℕ @c → @c T", which makes
 // @c IsArrow<Path<T>> trivially true even though @c Path<T> is an
 // @b object in @b Set, not a category.  The post-#525 form
-// @c !IsCategoryShape<Dom<T>> asks the right question and the
+// @c !IsSmallCategoryShape<Dom<T>> asks the right question and the
 // over-fire stops.
 //
 // @section Manual_Override
@@ -221,7 +221,7 @@ namespace dedekind::category {
  *
  * @details Currently @b reserved: @c IsSpokeArrow does not check for
  * @c ArrowKind @c = @c spoke_arrow_tag as an opt-in.  The structural
- * discriminator @c !IsCategoryShape<Dom<T>> already catches the typical
+ * discriminator @c !IsSmallCategoryShape<Dom<T>> already catches the typical
  * spoke case automatically, so no opt-in is needed in practice.  This
  * tag is kept as a parallel slot to @c hub_arrow_tag so a future opt-in
  * mechanism (e.g., for a type whose Domain is unusually category-shaped
@@ -316,25 +316,25 @@ export template <IsArrow F>
 using Cod = typename std::remove_cvref_t<F>::Codomain;
 
 /**
- * @concept IsCategoryShape
- * @brief Structural prefix of @c dedekind::category::IsCategory: a type
+ * @concept IsSmallCategoryShape
+ * @brief Structural prefix of @c dedekind::category::IsSmallCategory: a type
  *        carrying the identifying category-shaped aliases @c ::Arrow,
  *        @c ::Species, @c ::Id.
  *
- * @details The full @c IsCategory in @c :small refines this with
+ * @details The full @c IsSmallCategory in @c :small refines this with
  * behavioural checks (@c id_c factory, @c f @c >> @c g internal
  * closure, etc.).  At this layer we only need the structural test to
  * answer the question "is this thing a @b category" for purposes of
- * hub/spoke discrimination.  Full @c IsCategory cannot be referenced
+ * hub/spoke discrimination.  Full @c IsSmallCategory cannot be referenced
  * here because @c :small imports @c :morphism (cycle), and because
- * @c IsCategory recursively uses @c f @c >> @c g which is the very
+ * @c IsSmallCategory recursively uses @c f @c >> @c g which is the very
  * operator we are gating.  The structural prefix is the load-bearing
  * piece for routing — it identifies the @b argument-shape of a
  * functor (a thing taking a category, not an object), which is the
  * single distinction the hub/spoke split needs to make (#525).
  */
 export template <typename T>
-concept IsCategoryShape = requires {
+concept IsSmallCategoryShape = requires {
   typename std::remove_cvref_t<T>::Arrow;
   typename std::remove_cvref_t<T>::Species;
   typename std::remove_cvref_t<T>::Id;
@@ -347,7 +347,7 @@ concept IsCategoryShape = requires {
  * @details In the hub/spoke vocabulary, a "hub" arrow acts on
  *          categories as its objects: it is an arrow @b between
  *          categories, not within one.  Functors are the canonical
- *          example.  The @c IsCategoryShape prefix detects the
+ *          example.  The @c IsSmallCategoryShape prefix detects the
  *          identifying @c ::Arrow / @c ::Species / @c ::Id alias
  *          surface; the prior structural-proxy form
  *          (@c IsArrow<Dom<T>>) over-fired on object-level types
@@ -357,7 +357,7 @@ concept IsCategoryShape = requires {
  */
 export template <typename T>
 concept IsHubArrow =
-    IsArrow<T> && IsCategoryShape<Dom<T>> && IsCategoryShape<Cod<T>>;
+    IsArrow<T> && IsSmallCategoryShape<Dom<T>> && IsSmallCategoryShape<Cod<T>>;
 
 /**
  * @concept IsSpokeArrow
@@ -365,7 +365,7 @@ concept IsHubArrow =
  *        categories (#525 sharpening).
  * @details A "spoke" arrow connects ordinary species-level objects
  *          @b within a category.  The discriminator is "Domain is
- *          not a category-shaped thing" (@c !IsCategoryShape<Dom<T>>);
+ *          not a category-shaped thing" (@c !IsSmallCategoryShape<Dom<T>>);
  *          this is the formal expression of "this isn't a functor".
  *          Generic categorical composition in this partition is
  *          intentionally limited to spoke arrows so higher-order
@@ -375,7 +375,7 @@ concept IsHubArrow =
  * @section morphism__Spoke_Discriminator_Sharpening
  * Pre-#525 the discriminator read @c !IsArrow<Dom<T>> — a structural
  * proxy that worked coincidentally for functor-Hubs (whose Domain is
- * a @c IsCategory<C> witness, which trivially satisfies @c IsArrow
+ * a @c IsSmallCategory<C> witness, which trivially satisfies @c IsArrow
  * via @c Cat::Arrow), but over-fired on object-level carriers that
  * happen to expose @c Domain / @c Codomain aliases for unrelated
  * reasons.  The canonical example is @c Path<T>, which models the
@@ -383,7 +383,7 @@ concept IsHubArrow =
  * declaring @c Domain @c = @c std::size_t and a call operator —
  * making @c IsArrow<Path<T>> @b true at the type level even though
  * @c Path<T> is plainly an @b object (not a category-to-category
- * arrow).  The sharpened discriminator @c !IsCategoryShape<Dom<T>>
+ * arrow).  The sharpened discriminator @c !IsSmallCategoryShape<Dom<T>>
  * stops the over-fire while preserving the original intent: hub
  * arrows are arrows between categories.
  *
@@ -392,8 +392,8 @@ concept IsHubArrow =
  */
 export template <typename T>
 concept IsSpokeArrow =
-    IsArrow<T> && !IsCategoryShape<Dom<T>> && !IsCategoryShape<Cod<T>> &&
-    !requires {
+    IsArrow<T> && !IsSmallCategoryShape<Dom<T>> &&
+    !IsSmallCategoryShape<Cod<T>> && !requires {
       requires std::same_as<typename std::remove_cvref_t<T>::ArrowKind,
                             hub_arrow_tag>;
     };

--- a/src/main/modules/dedekind/category/natural.cppm
+++ b/src/main/modules/dedekind/category/natural.cppm
@@ -259,7 +259,7 @@ constexpr Identity<Identity<A>> δ(identity_hub_tag, Identity<A> const& ia) {
  * @brief The raw family of components.
  */
 export template <typename Α, typename CatS, typename CatT>
-concept IsPreTransformation = IsCategory<CatS> && IsCategory<CatT> &&
+concept IsPreTransformation = IsSmallCategory<CatS> && IsSmallCategory<CatT> &&
                               requires(Α α, typename CatS::Arrow::Domain c) {
                                 // The machine: takes an object in S, returns an
                                 // arrow in T

--- a/src/main/modules/dedekind/category/small.cppm
+++ b/src/main/modules/dedekind/category/small.cppm
@@ -121,6 +121,11 @@ inline constexpr bool is_associative_v<T, Op> = true;
  * `x` from that identity arrow, however, is not required by `IsCategory`; that
  * would need an additional guarantee that identity arrows carry or expose such
  * a witness.
+ * 
+ * I guess that in CT jargon, this concept boils down to defining categories
+ * which are
+ * a) small: every type that satisfies this concept is also a type constraint (a set boundary) in Cpp.
+ * b) monoidal: the fish operator is associative and has an identity.
  *
  * Axioms:
  * 1. Existence: For every arrow f, there exist unique identity arrows id_dom(f)

--- a/src/main/modules/dedekind/category/small.cppm
+++ b/src/main/modules/dedekind/category/small.cppm
@@ -103,7 +103,7 @@ template <typename T, typename Op>
 inline constexpr bool is_associative_v<T, Op> = true;
 
 /**
- * @concept IsCategory
+ * @concept IsSmallCategory
  * @brief A point-free, morphism-only reification of a Category.
  * @details In this structuralist approach, we bypass the traditional
  * object-morphism dichotomy. A category is defined solely by its arrows and
@@ -118,12 +118,12 @@ inline constexpr bool is_associative_v<T, Op> = true;
  * it gives a canonical type-/label-level representative of an object via the
  * identity arrow `Cat::id_c(x)`, allowing object-level reasoning to be
  * re-entered through composition. Recovering the original value-level label
- * `x` from that identity arrow, however, is not required by `IsCategory`; that
- * would need an additional guarantee that identity arrows carry or expose such
- * a witness.
+ * `x` from that identity arrow, however, is not required by `IsSmallCategory`;
+ * that would need an additional guarantee that identity arrows carry or expose
+ * such a witness.
  *
  * @section small__What_Smallness_Pins
- * In CT jargon, @c IsCategory pins exactly the @b smallness reading of
+ * In CT jargon, @c IsSmallCategory pins exactly the @b smallness reading of
  * "small category" --- the @em cardinality reading: the collection of
  * objects (the value-set of @c Species) and the collection of arrows
  * (the value-set of @c Arrow) are each sets in the metatheory.  This
@@ -131,7 +131,7 @@ inline constexpr bool is_associative_v<T, Op> = true;
  * form a set (not a proper class), so Ob(𝒞) and the total Hom-collection
  * are sets.
  *
- * @c IsCategory deliberately does @b not pin the second, ontological
+ * @c IsSmallCategory deliberately does @b not pin the second, ontological
  * reading of "small" --- @em concreteness --- under which each object
  * is itself a set (equivalently: there is a faithful forgetful functor
  * @c U @c : @c 𝒞 @c → @c Set).  Whether each object is a set or a tag
@@ -157,7 +157,7 @@ inline constexpr bool is_associative_v<T, Op> = true;
  * 3. Unitary: id_dom(f) >> f = f = f >> id_cod(f).
  */
 export template <typename Cat>
-concept IsCategory = requires {
+concept IsSmallCategory = requires {
   typename Cat::Arrow;
 
   // The 'label' type for objects in this category
@@ -192,7 +192,7 @@ concept IsCategory = requires {
 
   /**
    * @note External composition (Exo-composition)
-   * While not strictly required by the IsCategory concept, implementations
+   * While not strictly required by the IsSmallCategory concept, implementations
    * are encouraged to provide templated operator>> overloads to allow
    * composition with any external type satisfying IsArrow, provided
    * the Domain/Codomain plumbing is compatible.

--- a/src/main/modules/dedekind/category/small.cppm
+++ b/src/main/modules/dedekind/category/small.cppm
@@ -121,11 +121,34 @@ inline constexpr bool is_associative_v<T, Op> = true;
  * `x` from that identity arrow, however, is not required by `IsCategory`; that
  * would need an additional guarantee that identity arrows carry or expose such
  * a witness.
- * 
- * I guess that in CT jargon, this concept boils down to defining categories
- * which are
- * a) small: every type that satisfies this concept is also a type constraint (a set boundary) in Cpp.
- * b) monoidal: the fish operator is associative and has an identity.
+ *
+ * @section small__What_Smallness_Pins
+ * In CT jargon, @c IsCategory pins exactly the @b smallness reading of
+ * "small category" --- the @em cardinality reading: the collection of
+ * objects (the value-set of @c Species) and the collection of arrows
+ * (the value-set of @c Arrow) are each sets in the metatheory.  This
+ * is forced by representing both as C++ types: a C++ type's values
+ * form a set (not a proper class), so Ob(𝒞) and the total Hom-collection
+ * are sets.
+ *
+ * @c IsCategory deliberately does @b not pin the second, ontological
+ * reading of "small" --- @em concreteness --- under which each object
+ * is itself a set (equivalently: there is a faithful forgetful functor
+ * @c U @c : @c 𝒞 @c → @c Set).  Whether each object is a set or a tag
+ * depends on what @c Species is bound to at the call site
+ * (@c Set<T> binds to sets; an enum-style @c Species binds to tags).
+ * Concreteness as a structural commitment is layered downstream in
+ * @c :etcs --- the ETCS axiomatization of @c Set characterizes a
+ * topos in which objects @b are sets via the topos structure
+ * (terminal, products, exponentials, subobject classifier, NNO).
+ *
+ * Other refinements of "category" --- thin, discrete, locally-finite,
+ * intensional / extensional, lazy / strict --- are also intentionally
+ * out of scope here; they are named (or named-able) at downstream
+ * partitions where they have semantic content.  The intensional /
+ * extensional split in particular is reified at @c :sets:expressions
+ * (intensional, @c TernaryLogic) vs @c :sets:extensional (decidable
+ * membership), not at the category layer.
  *
  * Axioms:
  * 1. Existence: For every arrow f, there exist unique identity arrows id_dom(f)

--- a/src/main/modules/dedekind/category/small.cppm
+++ b/src/main/modules/dedekind/category/small.cppm
@@ -150,6 +150,40 @@ inline constexpr bool is_associative_v<T, Op> = true;
  * (intensional, @c TernaryLogic) vs @c :sets:extensional (decidable
  * membership), not at the category layer.
  *
+ * @section small__The_Locally_Small_Slot
+ * Standard CT distinguishes three slots along the size axis:
+ *
+ * | Concept                       | Object collection | Hom-sets    |
+ * |:------------------------------|:------------------|:------------|
+ * | (general) category            | proper class      | proper class|
+ * | @b locally @b small category  | proper class      | sets        |
+ * | @b small category             | set               | sets        |
+ *
+ * @c IsSmallCategory pins the third row (small).  The @b locally @b
+ * small slot --- where @c Set, @c Cpp (the category of C++ types),
+ * @c Top, and @c Alg(Σ) all live in standard CT --- is intentionally
+ * @b not given a sibling concept @c IsLocallySmallCategory in this
+ * codebase.  Two reasons:
+ *
+ *   1. @b No @b current @b consumer.  No site in the project today
+ *      requires a category whose object-collection is type-level
+ *      (a proper class) but whose Hom-collection is value-level (a
+ *      set).  The slot would be speculative API, and the project's
+ *      struct-creation posture is "burden of proof on adding a
+ *      concept, not on omitting one".
+ *   2. @b Implementation @b cost.  A faithful @c IsLocallySmallCategory
+ *      requires a higher-kinded @c Cat::template Hom<A, @c B> slot,
+ *      which is the same template-template territory the codebase
+ *      otherwise tries to keep at arm's length (in the @c IsFunctor
+ *      Hub/Spoke pattern, etc.).  Paying that complexity without a
+ *      load-bearing consumer would be the wrong trade.
+ *
+ * If a future slice introduces an honest @c Cpp-as-category or
+ * @c Alg(Σ)-as-category construction, that's the natural moment to
+ * reify the @c IsLocallySmallCategory slot --- with a real consumer
+ * to pressure-test the higher-kinded API shape rather than guessing
+ * it ahead of time.
+ *
  * Axioms:
  * 1. Existence: For every arrow f, there exist unique identity arrows id_dom(f)
  *    and id_cod(f).

--- a/src/main/modules/dedekind/sequences/path.cppm
+++ b/src/main/modules/dedekind/sequences/path.cppm
@@ -547,7 +547,7 @@ namespace dedekind::category {
  * makes @c Morphism<Path<T>, Path<T>, ...> fail @c IsSpokeArrow
  * (because @c Path<T> is an @c IsArrow domain), which in turn makes
  * @c Set<Path<T>>::operator>>(Arrow, Arrow) — needed by
- * @c IsCategory<Set<Path<T>>> — not resolve cleanly.  The standard
+ * @c IsSmallCategory<Set<Path<T>>> — not resolve cleanly.  The standard
  * Functor-on-Set machinery does not apply.  This is structural to
  * Path's "is itself an arrow" nature and not a defect to be papered
  * over.
@@ -612,7 +612,7 @@ static_assert(IsSequence<Path<int>>, "Path must satisfy the sequence concept.");
 // IsSpokeArrow discriminator read !IsArrow<Dom<T>> — but the
 // Morphism here has Dom = Path<int>, which IS an arrow, so the
 // proxy mis-classified Morphism<Path,Path,...> as NOT a SpokeArrow.
-// Post-#525 the discriminator reads !IsCategoryShape<Dom<T>>, which
+// Post-#525 the discriminator reads !IsSmallCategoryShape<Dom<T>>, which
 // returns false for Path<int> (it has no category-shape aliases),
 // so the Morphism IS a SpokeArrow.  This static_assert pins the fix
 // mechanically; if the discriminator ever regresses, it surfaces
@@ -626,7 +626,7 @@ using PathArrow = dedekind::category::CanonicalSetCCC<Path<int>>::Arrow;
 static_assert(dedekind::category::IsArrow<Path<int>>,
               "Path<int> is itself an IsArrow at the type level "
               "(Domain = size_t, Codomain = T, call operator).");
-static_assert(!dedekind::category::IsCategoryShape<Path<int>>,
+static_assert(!dedekind::category::IsSmallCategoryShape<Path<int>>,
               "Path<int> is NOT a category-shaped thing — it has no "
               "::Arrow / ::Species / ::Id aliases.  This is the "
               "distinction the #525 discriminator-sharpening makes.");

--- a/src/test/cpp/modules/dedekind/category/discrete_lift_test.cpp
+++ b/src/test/cpp/modules/dedekind/category/discrete_lift_test.cpp
@@ -35,10 +35,10 @@ TEST_CASE("discrete_lift_t produces a DiscreteCategory for any IsSet carrier",
   STATIC_CHECK(IsDiscreteCategory<discrete_lift_t<BoolTrueSet>>);
   STATIC_CHECK(IsDiscreteCategory<discrete_lift_t<UIntEvenSet>>);
 
-  // IsDiscreteCategory subsumes IsCategory; pin it for clarity.
-  STATIC_CHECK(IsCategory<discrete_lift_t<IntNonNegSet>>);
-  STATIC_CHECK(IsCategory<discrete_lift_t<BoolTrueSet>>);
-  STATIC_CHECK(IsCategory<discrete_lift_t<UIntEvenSet>>);
+  // IsDiscreteCategory subsumes IsSmallCategory; pin it for clarity.
+  STATIC_CHECK(IsSmallCategory<discrete_lift_t<IntNonNegSet>>);
+  STATIC_CHECK(IsSmallCategory<discrete_lift_t<BoolTrueSet>>);
+  STATIC_CHECK(IsSmallCategory<discrete_lift_t<UIntEvenSet>>);
 
   // The lift uses S itself, not S::Ambient — the static-type witness.
   STATIC_CHECK(std::same_as<discrete_lift_t<IntNonNegSet>,

--- a/src/test/cpp/modules/dedekind/numbers/discrete_lift_test.cpp
+++ b/src/test/cpp/modules/dedekind/numbers/discrete_lift_test.cpp
@@ -47,10 +47,10 @@ TEST_CASE("discrete_lift_t fires across the numeric tower",
   STATIC_CHECK(IsDiscreteCategory<discrete_lift_t<IntSubset>>);
   STATIC_CHECK(IsDiscreteCategory<discrete_lift_t<RationalSubset>>);
 
-  // IsCategory falls out of IsDiscreteCategory; pinned for clarity.
-  STATIC_CHECK(IsCategory<discrete_lift_t<NatSubset>>);
-  STATIC_CHECK(IsCategory<discrete_lift_t<IntSubset>>);
-  STATIC_CHECK(IsCategory<discrete_lift_t<RationalSubset>>);
+  // IsSmallCategory falls out of IsDiscreteCategory; pinned for clarity.
+  STATIC_CHECK(IsSmallCategory<discrete_lift_t<NatSubset>>);
+  STATIC_CHECK(IsSmallCategory<discrete_lift_t<IntSubset>>);
+  STATIC_CHECK(IsSmallCategory<discrete_lift_t<RationalSubset>>);
 }
 
 TEST_CASE("discrete_lift_t distinguishes refined subobjects of ℚ",


### PR DESCRIPTION
## What this PR does

A structural audit of the project's category-of-categories vocabulary, pinned across **docs, code, and paper** so the size-axis distinctions ("small", "locally small", "concrete") read coherently from any entry point.

The PR was opened as a Socratic question on the `IsCategory` concept and grew into the full audit as the conversation surfaced architectural commitments worth pinning explicitly.

## Four landed pieces

### 1. The two-reading docstring split (`:small` ↔ `:etcs`)

Standard CT distinguishes two senses of "small category":

1. **Reading 1 — smallness (cardinality):** Ob(𝒞) and the Hom-collection are sets in the metatheory.
2. **Reading 2 — concreteness (ontological):** each object *is* a set; equivalently, faithful `U: 𝒞 → Set`.

The two are independent (small-but-not-concrete: 𝟚, finite-state-machines-as-categories; concrete-but-not-small: Set itself).

This PR adds reciprocal cross-reference sections in both partition headers (`small__What_Smallness_Pins`, `etcs__What_Concreteness_Pins`):

- **`:category:small`** pins **Reading 1**. Forced by representing both `Species` and `Arrow` as C++ types: a C++ type's value-set is a set in the metatheory.
- **`:category:etcs`** pins **Reading 2**. The ETCS axiomatization characterizes a topos in which objects *are* sets via the topos structure (terminal, products, exponentials, subobject classifier, NNO).

### 2. `IsCategory` → `IsSmallCategory` rename

Hard rename (no deprecated alias per the project's experimental-API-breaks posture). Three reasons:

- **Convention compliance** — standard CT (Mac Lane, Pierce, Awodey) names "small category" explicitly when smallness is load-bearing.
- **Partition-concept symmetry** — the partition is named `:small`; the concept inside should agree.
- **Architectural headroom** — keeps `IsCategory` free for any future general-categories concept (e.g. `IsLocallySmallCategory` with a higher-kinded `Hom<A, B>` slot).

Sister concepts `IsFunctor` / `IsNaturalTransformation` are intentionally *not* renamed: a functor between small categories is still just a functor — CT doesn't have a "small functor" species; size is inherited from source / target categories.

Sweep: 8 `.cppm` in `:category` and `:sequences`, 2 `.cpp` in tests.

### 3. Locally-small slot named (no concept stub)

The `:small` docstring now carries a `small__The_Locally_Small_Slot` section pinning the size-axis table:

| Concept                       | Object collection | Hom-sets    |
|:------------------------------|:------------------|:------------|
| (general) category            | proper class      | proper class|
| **locally small** category    | proper class      | sets        |
| **small** category            | set               | sets        |

`IsSmallCategory` pins the third row. The locally-small slot — textbook home of `Set`, `Cpp`, `Top`, `Alg(Σ)` — is intentionally *not* given a sibling concept `IsLocallySmallCategory`:

- **No current consumer.** No site requires a category whose object-collection is type-level but whose Hom-collection is value-level.
- **Implementation cost.** A faithful `IsLocallySmallCategory` requires a higher-kinded `Cat::template Hom<A, B>` slot — template-template machinery the codebase otherwise keeps at arm's length.

If a future slice introduces an honest `Cpp`-as-category or `Alg(Σ)`-as-category construction, that's the natural moment to reify the slot — with a real consumer to pressure-test the higher-kinded API rather than guess it ahead of time.

### 4. Paper §2.3: Cat → Ddk refinement chain

A new paragraph + table in §2.3 ("A Common Ground") spells out the construction of `Ddk` as a sequence of *named* refinement steps from the bare metacategory `Cat`, rather than a single jump. **Steps 0–6 are internal to category theory; step 7 is the move out of pure CT into the C++ realisation.**

| # | Refinement added                                  | Partition / concept                                | Net structure       |
|---|---------------------------------------------------|----------------------------------------------------|---------------------|
| 0 | (bare category axioms)                            | —                                                  | category            |
| 1 | smallness                                         | `:small` / `IsSmallCategory`                       | small category      |
| 2 | terminal `1`, binary products `×`                 | `:cartesian` / `IsTerminal`, `IsProduct`           | finitely complete   |
| 3 | exponentials `B^A`                                | `:cartesian` / `IsExponential`                     | CCC                 |
| 4 | subobject classifier `Ω`                          | `:topoi` / `IsSubobject`, `IsTopos`                | elementary topos    |
| 5 | ETCS axioms (well-pointedness, NNO, choice)       | `:etcs`                                            | Set-modeling topos  |
| 6 | concreteness (objects *are* sets; faithful `U: 𝒞 → Set`) | `:etcs` / `IsSetObject`, `Subobject`-machinery | concrete Set-model |
| **7** | **C++ Juliet binding** (carriers as concrete C++ types) | `:cartesian::Ddk`                          | **Ddk**             |

Each row cashes out one structural commitment as an existing C++23 partition / concept, so the chain is reproducible by reading the partition DAG.

A footnote names the locally-small-not-small branch (the textbook home of `Cat`, `Set`, `Alg(Σ)`, `Top`) as a parallel path off step 1, and points at the `:small` docstring section `small__The_Locally_Small_Slot` for the architectural intent rather than re-stating it. The chain is presented as approximately linear; the caption flags the honest reading as lattice-shaped, with concreteness (step 6) and the size axis (step 1) sitting orthogonally to the CCC and topos refinements (steps 2–4) rather than strictly downstream of them.

Single-pass `lualatex -halt-on-error` compiles clean.

## What was deliberately *not* pinned

Other refinements of "category" — thin, discrete, locally-finite, intensional / extensional, lazy / strict — are intentionally out of scope at this layer. The intensional / extensional split in particular is reified at `:sets:expressions` (intensional, `TernaryLogic`) vs `:sets:extensional` (decidable membership), where it has actual semantic content. The category layer stays agnostic.

## Test plan

- [ ] CI build-and-deploy green.
- [ ] CodeQL green.
- [ ] codecov green.
- [ ] No semantic change — the sweep is a structural rename plus docstring/paper expansion. Concept rename is a non-breaking lift of the structural commitment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)