### PR TITLE
feat(category, numbers): #633 — IsEmbeddingFunctor / IsQuotientFunctor textbook modifiers; 5 embedding witnesses for #602 layer-1

### DIFF
--- a/src/main/modules/dedekind/category/functor.cppm
+++ b/src/main/modules/dedekind/category/functor.cppm
@@ -855,12 +855,28 @@ inline constexpr bool is_embedding_functor_v = false;
  * @c IsMonicArrow check is the mechanical verification that the
  * arrow's monic registration is also in place.
  *
+ * @b Opt-in @b semantics (#641 review note): the type-system gate
+ * here is @c IsArrow @c + @c IsMonicArrow @c + the @c
+ * is_embedding_functor_v trait.  It does @b not require the bare
+ * @c IsFunctor concept (which today carries the container-flavoured
+ * @c Shape<U> requirement, see @c functor__Two_Intuition_Pumps), so
+ * bare spoke arrows can register as @c IsEmbeddingFunctor witnesses
+ * without first satisfying @c IsFunctor.  This is intentional: the
+ * carrier-lattice @c embed_*_*_ family @b are functors @c Set<source>
+ * @c → @c Set<codomain> at the Mac Lane §I.3 level, but they're
+ * presented in the codebase as bare arrows rather than as @c IsFunctor
+ * witnesses with @c Σ_cat / @c Τ_cat slots.  The @c
+ * is_embedding_functor_v trait is the engineer's commitment to the
+ * functorial reading; once the deferred @c IsFunctor refactor lands
+ * (drop the @c Shape<U> requirement, per #633's "Implementation
+ * sequence"), this concept will be tightened to require @c IsFunctor.
+ *
  * @b Concrete @b witnesses (registered in @c :numbers and adjacent
  * partitions): @c embed_𝔹_ℕ_ (@c bool @c ↪ @c Cardinality), @c
  * embed_𝔹_𝕂3_ (@c bool @c ↪ @c TernaryLogic::Ω), @c embed_uint_ℕ_
  * (@c unsigned @c ↪ @c Cardinality), @c embed_sint_ℤ_ (@c int @c ↪
  * @c SignedCardinality), @c embed_ℤ_ℚ (machine_integer @c ↪ @c
- * Rational<I>).  Each is an arrow with @c IsMonomorphism / @c
+ * Rational<I>).  Each is an arrow with @c IsMonicArrow / @c
  * IsInjective + a registered @c is_embedding_functor_v specialisation
  * pinning the functor-level structural claim.
  *

--- a/src/main/modules/dedekind/category/functor.cppm
+++ b/src/main/modules/dedekind/category/functor.cppm
@@ -846,10 +846,14 @@ inline constexpr bool is_embedding_functor_v = false;
  *        @em on @em objects (Mac Lane CWM §IV.4 strong reading; the
  *        Yoneda-embedding flavour).
  *
- * @details Trait-registered via @c is_embedding_functor_v --- the
- * engineer asserts the categorical content (fully faithful +
- * injective-on-objects) at the carrier site; this concept gates on
- * the engineer's claim.
+ * @details Embeddings are @b monic in the categorical sense.  This
+ * concept therefore @b mechanically @b requires @c IsMonicArrow as
+ * the textbook structural prerequisite (in addition to the
+ * engineer-asserted @c is_embedding_functor_v trait that pins the
+ * stronger fully-faithful + injective-on-objects claim).  The trait
+ * is the engineer's commitment to the Mac Lane §IV.4 reading; the
+ * @c IsMonicArrow check is the mechanical verification that the
+ * arrow's monic registration is also in place.
  *
  * @b Concrete @b witnesses (registered in @c :numbers and adjacent
  * partitions): @c embed_𝔹_ℕ_ (@c bool @c ↪ @c Cardinality), @c
@@ -865,7 +869,8 @@ inline constexpr bool is_embedding_functor_v = false;
  * consumer earns them.
  */
 export template <typename F>
-concept IsEmbeddingFunctor = IsArrow<F> && is_embedding_functor_v<F>;
+concept IsEmbeddingFunctor =
+    IsArrow<F> && IsMonicArrow<F> && is_embedding_functor_v<F>;
 
 /**
  * @brief Trait registry for the @ref IsQuotientFunctor concept.
@@ -890,13 +895,22 @@ inline constexpr bool is_quotient_functor_v = false;
  * @brief A functor that is a regular epi / coequalizer presentation
  *        (Borceux @em Handbook §4.3).
  *
- * @details Trait-registered via @c is_quotient_functor_v.
- * Categorically dual to @c IsEmbeddingFunctor: where embeddings
- * are fully-faithful-monic, quotients are coequalizer-epi.
+ * @details Quotients are @b epic in the categorical sense.  This
+ * concept therefore @b mechanically @b requires @c IsEpicArrow as
+ * the textbook structural prerequisite (in addition to the
+ * engineer-asserted @c is_quotient_functor_v trait that pins the
+ * stronger regular-epi / coequalizer reading).  Categorically dual
+ * to @c IsEmbeddingFunctor: where embeddings are fully-faithful-
+ * monic, quotients are coequalizer-epi.
+ *
  * No concrete witnesses today --- the slot is reserved for the
- * (A, F) anchor and #602's carrier-lattice quotient half.
+ * (A, F) anchor and #602's carrier-lattice quotient half.  When
+ * witnesses land, each registration site needs @b both the
+ * @c is_quotient_functor_v specialisation @b and the underlying
+ * @c is_epic_arrow_v specialisation.
  */
 export template <typename F>
-concept IsQuotientFunctor = IsArrow<F> && is_quotient_functor_v<F>;
+concept IsQuotientFunctor =
+    IsArrow<F> && IsEpicArrow<F> && is_quotient_functor_v<F>;
 
 }  // namespace dedekind::category

--- a/src/main/modules/dedekind/category/functor.cppm
+++ b/src/main/modules/dedekind/category/functor.cppm
@@ -756,117 +756,82 @@ constexpr auto φ(Identity<A> const& id, F&& f)
 // — the propagation only meaningfully applies to declared HSP /
 // free-algebra carriers).
 
-/** @section functor__The_Refinement_Quartet (#633)
+/** @section functor__Textbook_Modifiers (#633)
  *
- * @details Beyond the container-style @c IsFunctor pinned above, the
- * project's universal-algebra and (A, F)-anchor commitments call for
- * a richer functor vocabulary covering the @em algebraic-set intuition
- * (functors as structure-preserving maps between named categories,
- * with the further structural split between embeddings (monic) and
- * quotients (epi)).  The refinement quartet below names these slots:
+ * @details Textbook CT (Mac Lane @em CWM; Borceux @em Handbook) names
+ * functors by their @em adjective modifiers, not by polymorphism /
+ * non-polymorphism umbrellas.  The project already carries the
+ * textbook-canonical modifiers as separate concepts:
  *
- * @code
- *   IsFunctor                  (general — Mac Lane CWM §I.3; currently
- *   │                           equivalent to IsContainerFunctor in this
- *   │                           partition pending the target-vector refactor
- *   │                           tracked at #633)
- *   ├── IsContainerFunctor     (polymorphic / type-constructor flavour;
- *   │                           Maybe, std::tuple, Identity, ...)
- *   └── IsSpecificFunctor      (between two specific named categories;
- *       │                       embeddings, quotients, forgetful, Σ-algebras-
- *       │                       as-functors)
- *       ├── IsEmbeddingFunctor (monic specific functor; fully faithful +
- *       │                       injective on objects — Mac Lane CWM §IV.4)
- *       └── IsQuotientFunctor  (epi specific functor; regular epi /
- *                               coequalizer presentation — Borceux §4.3)
- * @endcode
+ *   - @c IsEndofunctor (Mac Lane §I.3; @c F @c : @c 𝒞 @c → @c 𝒞)
+ *     --- defined above in this partition.
+ *   - @c IsFreeFunctor (Mac Lane §IV.3; left adjoint to forgetful)
+ *     --- defined in @c :adjunction.
+ *   - @c IsForgetfulFunctor (Mac Lane §IV; right adjoint to free)
+ *     --- defined in @c :adjunction.
  *
- * Two intuition pumps live here side-by-side (cf. #633 body):
- *   - @b Container @b reading (Haskell-tutorial flavour): functor as a
- *     polymorphic type-constructor.  @c IsContainerFunctor pins this.
- *   - @b Algebraic-set @b reading (universal-algebra flavour): functor as
- *     a structure-preserving map between two specific named categories.
- *     @c IsSpecificFunctor pins this; @c IsEmbeddingFunctor / @c
- *     IsQuotientFunctor refine to the monic / epi cases.
+ * The two modifiers below complete the monic / epi pair the
+ * carrier-lattice and (A, F) anchor work need:
  *
- * The leaf concepts (@c IsEmbeddingFunctor / @c IsQuotientFunctor) are
- * @em engineer-asserted via trait registration --- @c
- * is_embedding_functor_v<F> / @c is_quotient_functor_v<F> --- mirroring
- * the @c is_monic_arrow_v / @c is_epic_arrow_v pattern in @c :morphism.
- * The categorical content (full faithfulness + injectivity on objects;
- * coequalizer of two parallel functors) is the engineer's claim,
- * type-checked at registration sites.
+ *   - @c IsEmbeddingFunctor (Mac Lane CWM §IV.4; fully faithful +
+ *     injective on objects --- the Yoneda-embedding flavour).
+ *     Concrete witnesses: the @c embed_*_*_ family.
+ *   - @c IsQuotientFunctor (Borceux @em Handbook §4.3; regular epi
+ *     / coequalizer presentation).  Slot reserved for the (A, F)
+ *     anchor's Σ-algebras-as-functors @c T_Σ @c → @c Ddk (algebras
+ *     arise as quotients of free algebras --- Burris-Sankappanavar
+ *     §II.10) and #602's carrier-lattice @c Frac / @c Cplx / @c
+ *     Dual quotient half.
  *
- * @section functor__Quartet_Intended_Refactor
+ * Both are @em engineer-asserted via trait registration ---
+ * @c is_embedding_functor_v<F> / @c is_quotient_functor_v<F> ---
+ * mirroring the @c is_monic_arrow_v / @c is_epic_arrow_v pattern in
+ * @c :morphism.  The categorical content (fully faithful +
+ * injectivity on objects for embeddings; coequalizer of two parallel
+ * functors for quotients) is the engineer's claim, type-checked at
+ * the registration site.
  *
- * The target-vector intent (per #633) is to refactor @c IsFunctor itself
- * to the @em general Mac Lane §I.3 definition (no polymorphic-@c
- * Shape<U> requirement) and lift the polymorphic / type-constructor
- * commitment into @c IsContainerFunctor.  That refactor is @b deferred
- * here: this slice lands the additive quartet (siblings + refinements
- * of the current container-flavoured @c IsFunctor), so the (A, F)
- * anchor work and #602's per-arrow embedding lifts have the structural
- * concept anchor available.  The @c IsFunctor / @c IsContainerFunctor
- * split lands as a follow-up slice that sweeps consumers; absent
- * regression risk, @c IsContainerFunctor is currently defined as @c
- * IsFunctor (the witnesses coincide).
+ * Weaker reading variants (@c IsFaithfulFunctor on its own,
+ * @c IsFullFunctor on its own, @c IsEpiFunctor without the regular-
+ * epi strengthening, @c IsEssentiallySurjectiveFunctor, ...) land
+ * flat as separate concepts when a consumer earns them; there's no
+ * umbrella distinction in textbook CT.
+ *
+ * @section functor__Two_Intuition_Pumps
+ *
+ * Two reading registers live side-by-side in CT (cf. #633 body),
+ * but they are @b not separate type-system concepts:
+ *
+ *   - @b Container / Hask-endofunctor flavour: functor as polymorphic
+ *     type-constructor.  Examples in this partition: @c maybe_functor,
+ *     @c tuple_functor, @c identity_functor.  Type-system witness:
+ *     these all satisfy @c IsFunctor with @c Σ_cat @c = @c Τ_cat ---
+ *     i.e.\ they are @em endofunctors (which is the textbook name).
+ *   - @b Algebraic-set / structural-CT flavour: functor as a
+ *     structure-preserving map between two specific named categories,
+ *     with further modifiers for monic / epi / faithful / full / etc.
+ *     The carrier-lattice embeddings are @c IsEmbeddingFunctor
+ *     witnesses; future quotient projections will be @c
+ *     IsQuotientFunctor witnesses.
+ *
+ * The two intuitions are unified at the @c IsFunctor level (Mac Lane
+ * §I.3): a functor is a structure-preserving map between two
+ * categories, full stop.  Polymorphic / non-polymorphic is a
+ * presentation choice for how F is given, not a structural CT
+ * property; textbook CT therefore does not name umbrella concepts
+ * "@c IsContainerFunctor" / "@c IsSpecificFunctor".  This project
+ * follows the textbook reading: no umbrella concepts, only the
+ * textbook-canonical adjective modifiers.
  */
-
-/**
- * @concept IsContainerFunctor
- * @brief @ref IsFunctor specialised to the container / type-constructor
- *        flavour --- a polymorphic functor parameterised by element
- *        type via @c F::template Shape<U>.
- *
- * @details Currently equivalent to @c IsFunctor (which already pins
- * the @c Shape<U> requirement).  The split into a weaker general @c
- * IsFunctor and a stronger @c IsContainerFunctor is queued as a
- * follow-up slice (see @c functor__Quartet_Intended_Refactor); this
- * sibling alias gives consumers a forward-compatible name to gate on
- * when they specifically want the container flavour.
- *
- * Witnesses: @c maybe_functor<T>, @c tuple_functor<T>, @c
- * identity_functor<Cat>, @c composite_functor<F, G>, @c
- * trace_functor<T>.
- */
-export template <typename F>
-concept IsContainerFunctor = IsFunctor<F>;
-
-/**
- * @concept IsSpecificFunctor
- * @brief A structure-preserving map between two specific named small
- *        categories @c Σ and @c Τ --- the @em algebraic-set intuition
- *        pump (universal-algebra flavour).
- *
- * @details Gates on @c F being an @c IsArrow, @c Σ and @c Τ being @c
- * IsSmallCategory, and @c F's @c Dom / @c Cod matching the species
- * types of @c Σ / @c Τ.  Covers any of:
- *   - @b monic @b specific @b functors (the carrier-lattice
- *     embeddings; refined by @c IsEmbeddingFunctor below);
- *   - @b epi @b specific @b functors (Σ-algebras-as-functors @c T_Σ
- *     @c → @c Ddk; @c Frac / @c Cplx / @c Dual at the carrier-lattice
- *     quotient level; refined by @c IsQuotientFunctor below);
- *   - "neither" specific functors (forgetful: @c Ring @c → @c AbGrp,
- *     @c AbGrp @c → @c Set, the @c embed_*_*_ family at intermediate
- *     ranks).
- *
- * Mac Lane CWM §I.3 (functors) + §IV (forgetful / free as paradigmatic
- * specific functors).
- */
-export template <typename F, typename Σ, typename Τ>
-concept IsSpecificFunctor =
-    IsArrow<F> && IsSmallCategory<Σ> && IsSmallCategory<Τ> &&
-    std::same_as<Dom<F>, typename Σ::Species> &&
-    std::same_as<Cod<F>, typename Τ::Species>;
 
 /**
  * @brief Trait registry for the @ref IsEmbeddingFunctor concept.
- * @details Engineer-asserted opt-in: a specific functor is an
- *          embedding (fully faithful + injective on objects --- Mac
- *          Lane CWM §IV.4, the Yoneda-embedding flavour) iff the
- *          engineer specialises this trait to @c true at the
- *          functor's declaration site.  Mirrors @c is_monic_arrow_v
- *          in @c :morphism: the categorical claim is the engineer's,
+ * @details Engineer-asserted opt-in: a functor is an embedding
+ *          (fully faithful + injective on objects --- Mac Lane CWM
+ *          §IV.4, the Yoneda-embedding flavour) iff the engineer
+ *          specialises this trait to @c true at the functor's
+ *          declaration site.  Mirrors @c is_monic_arrow_v in
+ *          @c :morphism: the categorical claim is the engineer's,
  *          type-checked at the registration site.
  *
  *          Default @c false.  Specialise @b at @b the @b carrier @b
@@ -877,14 +842,14 @@ inline constexpr bool is_embedding_functor_v = false;
 
 /**
  * @concept IsEmbeddingFunctor
- * @brief A specific functor that is @em fully @em faithful @c + @em
- *        injective @em on @em objects (Mac Lane CWM §IV.4 strong
- *        reading; the Yoneda-embedding flavour).
+ * @brief A functor that is @em fully @em faithful @c + @em injective
+ *        @em on @em objects (Mac Lane CWM §IV.4 strong reading; the
+ *        Yoneda-embedding flavour).
  *
- * @details The monic refinement of @c IsSpecificFunctor.  Trait-
- * registered via @c is_embedding_functor_v --- the engineer asserts
- * the categorical content (fully faithful + injective-on-objects)
- * at the carrier site; this concept gates on the engineer's claim.
+ * @details Trait-registered via @c is_embedding_functor_v --- the
+ * engineer asserts the categorical content (fully faithful +
+ * injective-on-objects) at the carrier site; this concept gates on
+ * the engineer's claim.
  *
  * @b Concrete @b witnesses (registered in @c :numbers and adjacent
  * partitions): @c embed_𝔹_ℕ_ (@c bool @c ↪ @c Cardinality), @c
@@ -904,10 +869,10 @@ concept IsEmbeddingFunctor = IsArrow<F> && is_embedding_functor_v<F>;
 
 /**
  * @brief Trait registry for the @ref IsQuotientFunctor concept.
- * @details Engineer-asserted opt-in: a specific functor is a quotient
- *          (regular epi / coequalizer presentation in @c [Σ, @c Τ] ---
- *          Borceux @em Handbook §4.3) iff the engineer specialises
- *          this trait to @c true at the functor's declaration site.
+ * @details Engineer-asserted opt-in: a functor is a quotient
+ *          (regular epi / coequalizer presentation --- Borceux
+ *          @em Handbook §4.3) iff the engineer specialises this
+ *          trait to @c true at the functor's declaration site.
  *          Same shape as @c is_embedding_functor_v above.
  *
  *          Default @c false.  Concrete witnesses populate when the
@@ -922,15 +887,14 @@ inline constexpr bool is_quotient_functor_v = false;
 
 /**
  * @concept IsQuotientFunctor
- * @brief A specific functor that is a regular epi / coequalizer
- *        presentation in @c [Σ, @c Τ] (Borceux @em Handbook §4.3).
+ * @brief A functor that is a regular epi / coequalizer presentation
+ *        (Borceux @em Handbook §4.3).
  *
- * @details The epi refinement of @c IsSpecificFunctor.  Trait-
- * registered via @c is_quotient_functor_v.  Categorically dual to
- * @c IsEmbeddingFunctor: where embeddings are fully-faithful-monic,
- * quotients are coequalizer-epi.  No concrete witnesses today ---
- * the slot is reserved for the (A, F) anchor and #602's
- * carrier-lattice quotient half.
+ * @details Trait-registered via @c is_quotient_functor_v.
+ * Categorically dual to @c IsEmbeddingFunctor: where embeddings
+ * are fully-faithful-monic, quotients are coequalizer-epi.
+ * No concrete witnesses today --- the slot is reserved for the
+ * (A, F) anchor and #602's carrier-lattice quotient half.
  */
 export template <typename F>
 concept IsQuotientFunctor = IsArrow<F> && is_quotient_functor_v<F>;

--- a/src/main/modules/dedekind/category/functor.cppm
+++ b/src/main/modules/dedekind/category/functor.cppm
@@ -756,4 +756,183 @@ constexpr auto φ(Identity<A> const& id, F&& f)
 // — the propagation only meaningfully applies to declared HSP /
 // free-algebra carriers).
 
+/** @section functor__The_Refinement_Quartet (#633)
+ *
+ * @details Beyond the container-style @c IsFunctor pinned above, the
+ * project's universal-algebra and (A, F)-anchor commitments call for
+ * a richer functor vocabulary covering the @em algebraic-set intuition
+ * (functors as structure-preserving maps between named categories,
+ * with the further structural split between embeddings (monic) and
+ * quotients (epi)).  The refinement quartet below names these slots:
+ *
+ * @code
+ *   IsFunctor                  (general — Mac Lane CWM §I.3; currently
+ *   │                           equivalent to IsContainerFunctor in this
+ *   │                           partition pending the target-vector refactor
+ *   │                           tracked at #633)
+ *   ├── IsContainerFunctor     (polymorphic / type-constructor flavour;
+ *   │                           Maybe, std::tuple, Identity, ...)
+ *   └── IsSpecificFunctor      (between two specific named categories;
+ *       │                       embeddings, quotients, forgetful, Σ-algebras-
+ *       │                       as-functors)
+ *       ├── IsEmbeddingFunctor (monic specific functor; fully faithful +
+ *       │                       injective on objects — Mac Lane CWM §IV.4)
+ *       └── IsQuotientFunctor  (epi specific functor; regular epi /
+ *                               coequalizer presentation — Borceux §4.3)
+ * @endcode
+ *
+ * Two intuition pumps live here side-by-side (cf. #633 body):
+ *   - @b Container @b reading (Haskell-tutorial flavour): functor as a
+ *     polymorphic type-constructor.  @c IsContainerFunctor pins this.
+ *   - @b Algebraic-set @b reading (universal-algebra flavour): functor as
+ *     a structure-preserving map between two specific named categories.
+ *     @c IsSpecificFunctor pins this; @c IsEmbeddingFunctor / @c
+ *     IsQuotientFunctor refine to the monic / epi cases.
+ *
+ * The leaf concepts (@c IsEmbeddingFunctor / @c IsQuotientFunctor) are
+ * @em engineer-asserted via trait registration --- @c
+ * is_embedding_functor_v<F> / @c is_quotient_functor_v<F> --- mirroring
+ * the @c is_monic_arrow_v / @c is_epic_arrow_v pattern in @c :morphism.
+ * The categorical content (full faithfulness + injectivity on objects;
+ * coequalizer of two parallel functors) is the engineer's claim,
+ * type-checked at registration sites.
+ *
+ * @section functor__Quartet_Intended_Refactor
+ *
+ * The target-vector intent (per #633) is to refactor @c IsFunctor itself
+ * to the @em general Mac Lane §I.3 definition (no polymorphic-@c
+ * Shape<U> requirement) and lift the polymorphic / type-constructor
+ * commitment into @c IsContainerFunctor.  That refactor is @b deferred
+ * here: this slice lands the additive quartet (siblings + refinements
+ * of the current container-flavoured @c IsFunctor), so the (A, F)
+ * anchor work and #602's per-arrow embedding lifts have the structural
+ * concept anchor available.  The @c IsFunctor / @c IsContainerFunctor
+ * split lands as a follow-up slice that sweeps consumers; absent
+ * regression risk, @c IsContainerFunctor is currently defined as @c
+ * IsFunctor (the witnesses coincide).
+ */
+
+/**
+ * @concept IsContainerFunctor
+ * @brief @ref IsFunctor specialised to the container / type-constructor
+ *        flavour --- a polymorphic functor parameterised by element
+ *        type via @c F::template Shape<U>.
+ *
+ * @details Currently equivalent to @c IsFunctor (which already pins
+ * the @c Shape<U> requirement).  The split into a weaker general @c
+ * IsFunctor and a stronger @c IsContainerFunctor is queued as a
+ * follow-up slice (see @c functor__Quartet_Intended_Refactor); this
+ * sibling alias gives consumers a forward-compatible name to gate on
+ * when they specifically want the container flavour.
+ *
+ * Witnesses: @c maybe_functor<T>, @c tuple_functor<T>, @c
+ * identity_functor<Cat>, @c composite_functor<F, G>, @c
+ * trace_functor<T>.
+ */
+export template <typename F>
+concept IsContainerFunctor = IsFunctor<F>;
+
+/**
+ * @concept IsSpecificFunctor
+ * @brief A structure-preserving map between two specific named small
+ *        categories @c Σ and @c Τ --- the @em algebraic-set intuition
+ *        pump (universal-algebra flavour).
+ *
+ * @details Gates on @c F being an @c IsArrow, @c Σ and @c Τ being @c
+ * IsSmallCategory, and @c F's @c Dom / @c Cod matching the species
+ * types of @c Σ / @c Τ.  Covers any of:
+ *   - @b monic @b specific @b functors (the carrier-lattice
+ *     embeddings; refined by @c IsEmbeddingFunctor below);
+ *   - @b epi @b specific @b functors (Σ-algebras-as-functors @c T_Σ
+ *     @c → @c Ddk; @c Frac / @c Cplx / @c Dual at the carrier-lattice
+ *     quotient level; refined by @c IsQuotientFunctor below);
+ *   - "neither" specific functors (forgetful: @c Ring @c → @c AbGrp,
+ *     @c AbGrp @c → @c Set, the @c embed_*_*_ family at intermediate
+ *     ranks).
+ *
+ * Mac Lane CWM §I.3 (functors) + §IV (forgetful / free as paradigmatic
+ * specific functors).
+ */
+export template <typename F, typename Σ, typename Τ>
+concept IsSpecificFunctor =
+    IsArrow<F> && IsSmallCategory<Σ> && IsSmallCategory<Τ> &&
+    std::same_as<Dom<F>, typename Σ::Species> &&
+    std::same_as<Cod<F>, typename Τ::Species>;
+
+/**
+ * @brief Trait registry for the @ref IsEmbeddingFunctor concept.
+ * @details Engineer-asserted opt-in: a specific functor is an
+ *          embedding (fully faithful + injective on objects --- Mac
+ *          Lane CWM §IV.4, the Yoneda-embedding flavour) iff the
+ *          engineer specialises this trait to @c true at the
+ *          functor's declaration site.  Mirrors @c is_monic_arrow_v
+ *          in @c :morphism: the categorical claim is the engineer's,
+ *          type-checked at the registration site.
+ *
+ *          Default @c false.  Specialise @b at @b the @b carrier @b
+ *          site (e.g. in @c :numbers:natural for @c embed_𝔹_ℕ_).
+ */
+export template <typename F>
+inline constexpr bool is_embedding_functor_v = false;
+
+/**
+ * @concept IsEmbeddingFunctor
+ * @brief A specific functor that is @em fully @em faithful @c + @em
+ *        injective @em on @em objects (Mac Lane CWM §IV.4 strong
+ *        reading; the Yoneda-embedding flavour).
+ *
+ * @details The monic refinement of @c IsSpecificFunctor.  Trait-
+ * registered via @c is_embedding_functor_v --- the engineer asserts
+ * the categorical content (fully faithful + injective-on-objects)
+ * at the carrier site; this concept gates on the engineer's claim.
+ *
+ * @b Concrete @b witnesses (registered in @c :numbers and adjacent
+ * partitions): @c embed_𝔹_ℕ_ (@c bool @c ↪ @c Cardinality), @c
+ * embed_𝔹_𝕂3_ (@c bool @c ↪ @c TernaryLogic::Ω), @c embed_uint_ℕ_
+ * (@c unsigned @c ↪ @c Cardinality), @c embed_sint_ℤ_ (@c int @c ↪
+ * @c SignedCardinality), @c embed_ℤ_ℚ (machine_integer @c ↪ @c
+ * Rational<I>).  Each is an arrow with @c IsMonomorphism / @c
+ * IsInjective + a registered @c is_embedding_functor_v specialisation
+ * pinning the functor-level structural claim.
+ *
+ * Weaker reading variants (@c IsFaithfulFunctor only, @c
+ * IsFullFunctor only) can be added as separate concepts when a
+ * consumer earns them.
+ */
+export template <typename F>
+concept IsEmbeddingFunctor = IsArrow<F> && is_embedding_functor_v<F>;
+
+/**
+ * @brief Trait registry for the @ref IsQuotientFunctor concept.
+ * @details Engineer-asserted opt-in: a specific functor is a quotient
+ *          (regular epi / coequalizer presentation in @c [Σ, @c Τ] ---
+ *          Borceux @em Handbook §4.3) iff the engineer specialises
+ *          this trait to @c true at the functor's declaration site.
+ *          Same shape as @c is_embedding_functor_v above.
+ *
+ *          Default @c false.  Concrete witnesses populate when the
+ *          (A, F) anchor work (#498) lands Σ-algebras as functors
+ *          @c T_Σ @c → @c Ddk (algebras arise as quotients of free
+ *          algebras --- Burris-Sankappanavar §II.10) and when the
+ *          carrier-lattice @c Frac / @c Cplx / @c Dual functors at
+ *          the strict-quotient reading land (#602 layer-1.5+).
+ */
+export template <typename F>
+inline constexpr bool is_quotient_functor_v = false;
+
+/**
+ * @concept IsQuotientFunctor
+ * @brief A specific functor that is a regular epi / coequalizer
+ *        presentation in @c [Σ, @c Τ] (Borceux @em Handbook §4.3).
+ *
+ * @details The epi refinement of @c IsSpecificFunctor.  Trait-
+ * registered via @c is_quotient_functor_v.  Categorically dual to
+ * @c IsEmbeddingFunctor: where embeddings are fully-faithful-monic,
+ * quotients are coequalizer-epi.  No concrete witnesses today ---
+ * the slot is reserved for the (A, F) anchor and #602's
+ * carrier-lattice quotient half.
+ */
+export template <typename F>
+concept IsQuotientFunctor = IsArrow<F> && is_quotient_functor_v<F>;
+
 }  // namespace dedekind::category

--- a/src/main/modules/dedekind/category/small.cppm
+++ b/src/main/modules/dedekind/category/small.cppm
@@ -230,7 +230,7 @@ inline constexpr bool is_associative_v<T, Op> = true;
  *        ∴  Concrete ⊆ LocSmall.
  *
  *        [Trans: "Concreteness gives locally-smallness for free: a faithful
- *        forgetful @c U @c : @c 𝒞 @c → @c Set monicly injects each Hom-set
+ *        forgetful @c U @c : @c 𝒞 @c → @c Set monically injects each Hom-set
  *        of @c 𝒞 into a function-set of @c Set, and a subset of a set is
  *        a set."]
  *       — Claude (Anthropic AI assistant), conversation log,

--- a/src/main/modules/dedekind/numbers/boolean.cppm
+++ b/src/main/modules/dedekind/numbers/boolean.cppm
@@ -360,4 +360,15 @@ inline constexpr bool
 static_assert(
     IsInjective<std::decay_t<decltype(dedekind::numbers::embed_𝔹_𝕂3_)>>,
     "embed_𝔹_𝕂3_ (𝔹 ↪ 𝕂3) is registered injective.");
+
+// IsEmbeddingFunctor witness (#633): @c embed_𝔹_𝕂3_ lifts the
+// two-element 𝔹 into the three-element 𝕂3 truth surface monicly
+// (False ↦ False, True ↦ True; the Unknown value is unreached).
+// Fully faithful + injective on objects per Mac Lane CWM §IV.4.
+template <>
+inline constexpr bool is_embedding_functor_v<
+    std::decay_t<decltype(dedekind::numbers::embed_𝔹_𝕂3_)>> = true;
+static_assert(
+    IsEmbeddingFunctor<std::decay_t<decltype(dedekind::numbers::embed_𝔹_𝕂3_)>>,
+    "embed_𝔹_𝕂3_ realises IsEmbeddingFunctor per #633's Mac Lane reading.");
 }  // namespace dedekind::category

--- a/src/main/modules/dedekind/numbers/boolean.cppm
+++ b/src/main/modules/dedekind/numbers/boolean.cppm
@@ -362,7 +362,7 @@ static_assert(
     "embed_𝔹_𝕂3_ (𝔹 ↪ 𝕂3) is registered injective.");
 
 // IsEmbeddingFunctor witness (#633): @c embed_𝔹_𝕂3_ lifts the
-// two-element 𝔹 into the three-element 𝕂3 truth surface monicly
+// two-element 𝔹 into the three-element 𝕂3 truth surface monically
 // (False ↦ False, True ↦ True; the Unknown value is unreached).
 // Fully faithful + injective on objects per Mac Lane CWM §IV.4.
 template <>

--- a/src/main/modules/dedekind/numbers/natural.cppm
+++ b/src/main/modules/dedekind/numbers/natural.cppm
@@ -494,4 +494,18 @@ inline constexpr bool
 static_assert(
     IsInjective<std::decay_t<decltype(dedekind::numbers::embed_𝔹_ℕ_)>>,
     "embed_𝔹_ℕ_ (𝔹 ↪ ℕ via Cardinality) is registered injective.");
+
+// IsEmbeddingFunctor witness (#633 refinement quartet): @c embed_𝔹_ℕ_ is
+// fully faithful (source is a discrete category, so faithfulness is
+// trivial) + injective on objects (the underlying function on the two
+// 𝔹-objects {false, true} maps to the two distinct Cardinality witnesses
+// {finite_cardinality(0), finite_cardinality(1)}).  Refines @c IsMonicArrow
+// at the functor level.
+template <>
+inline constexpr bool is_embedding_functor_v<
+    std::decay_t<decltype(dedekind::numbers::embed_𝔹_ℕ_)>> = true;
+static_assert(
+    IsEmbeddingFunctor<std::decay_t<decltype(dedekind::numbers::embed_𝔹_ℕ_)>>,
+    "embed_𝔹_ℕ_ realises IsEmbeddingFunctor: fully faithful + injective on "
+    "objects per #633's Mac Lane CWM §IV.4 reading.");
 }  // namespace dedekind::category

--- a/src/main/modules/dedekind/numbers/rational.cppm
+++ b/src/main/modules/dedekind/numbers/rational.cppm
@@ -924,6 +924,19 @@ static_assert(
     IsInjective<std::decay_t<decltype(dedekind::numbers::embed_ℤ_ℚ<>)>>,
     "embed_ℤ_ℚ (ℤ ↪ ℚ) is registered injective.");
 
+// IsEmbeddingFunctor witness (#633): @c embed_ℤ_ℚ is the canonical
+// field-of-fractions inclusion @c n @c ↦ @c n/1.  Fully faithful
+// (discrete machine-integer source) + injective on objects.  Pinned at
+// the default-template instantiation @c embed_ℤ_ℚ<> (= @c
+// embed_ℤ_ℚ<default_integer>); other carriers register at their
+// instantiation sites if needed.
+template <>
+inline constexpr bool is_embedding_functor_v<
+    std::decay_t<decltype(dedekind::numbers::embed_ℤ_ℚ<>)>> = true;
+static_assert(
+    IsEmbeddingFunctor<std::decay_t<decltype(dedekind::numbers::embed_ℤ_ℚ<>)>>,
+    "embed_ℤ_ℚ realises IsEmbeddingFunctor per #633's Mac Lane reading.");
+
 }  // namespace dedekind::category
 
 namespace dedekind::algebra {

--- a/src/main/modules/dedekind/numbers/sint.cppm
+++ b/src/main/modules/dedekind/numbers/sint.cppm
@@ -416,6 +416,18 @@ static_assert(
     "embed_sint_ℤ_ (int → SignedCardinality) is "
     "registered injective.");
 
+// IsEmbeddingFunctor witness (#633): @c embed_sint_ℤ_ is fully faithful
+// (discrete source) + injective on objects (sign-magnitude bijection
+// between machine signed values and the corresponding SignedCardinality
+// witnesses).
+template <>
+inline constexpr bool is_embedding_functor_v<
+    std::decay_t<decltype(dedekind::numbers::embed_sint_ℤ_)>> = true;
+static_assert(
+    IsEmbeddingFunctor<
+        std::decay_t<decltype(dedekind::numbers::embed_sint_ℤ_)>>,
+    "embed_sint_ℤ_ realises IsEmbeddingFunctor per #633's Mac Lane reading.");
+
 // ===========================================================================
 // Mazur-equivalence pilot (#591): @c std::signed_integral as @c ℤ for
 // inputs in @c [std::numeric_limits<S>::min(), @c

--- a/src/main/modules/dedekind/numbers/uint.cppm
+++ b/src/main/modules/dedekind/numbers/uint.cppm
@@ -470,6 +470,17 @@ static_assert(
     "embed_uint_ℕ_ (unsigned → Cardinality) is "
     "registered injective.");
 
+// IsEmbeddingFunctor witness (#633): @c embed_uint_ℕ_ is fully faithful
+// (discrete source) + injective on objects (machine unsigned values map
+// bijectively to their Cardinality witnesses in @c [0, 2^width)).
+template <>
+inline constexpr bool is_embedding_functor_v<
+    std::decay_t<decltype(dedekind::numbers::embed_uint_ℕ_)>> = true;
+static_assert(
+    IsEmbeddingFunctor<
+        std::decay_t<decltype(dedekind::numbers::embed_uint_ℕ_)>>,
+    "embed_uint_ℕ_ realises IsEmbeddingFunctor per #633's Mac Lane reading.");
+
 // ===========================================================================
 // Mazur-equivalence pilot (#591): @c std::unsigned_integral as @c ℕ for
 // inputs strictly less than @c 2^width.


### PR DESCRIPTION
## What this PR does

Adds two textbook-canonical functor-modifier concepts to `:functor` and registers the 5 layer-1 carrier-lattice embeddings as `IsEmbeddingFunctor` witnesses. Closes the functor-level gap that #602's per-arrow image lifts asked for.

## Scope after the textbook-name pass

Following user pushback on the first revision's `IsContainerFunctor` / `IsSpecificFunctor` umbrella concepts (Haskell-flavoured rather than textbook-CT), the PR now lands a minimal, textbook-canonical addition:

| Concept | Source | Status |
|---------|--------|--------|
| `IsFunctor` | Mac Lane CWM §I.3 | existing, unchanged |
| `IsEndofunctor` | Mac Lane CWM §I.3 (F: 𝒞 → 𝒞) | **existing, unchanged** in `:functor` |
| `IsFreeFunctor` | Mac Lane CWM §IV.3 | **existing, unchanged** in `:adjunction` |
| `IsForgetfulFunctor` | Mac Lane CWM §IV | **existing, unchanged** in `:adjunction` |
| **`IsEmbeddingFunctor`** | **Mac Lane CWM §IV.4** | **new in this PR** |
| **`IsQuotientFunctor`** | **Borceux *Handbook* §4.3** | **new in this PR** |

Both new concepts are trait-registered via `is_embedding_functor_v<F>` / `is_quotient_functor_v<F>`, mirroring the existing `is_monic_arrow_v` pattern.

## What's NOT in this PR (and why)

- No `IsContainerFunctor` umbrella — textbook CT doesn't carry the polymorphic-vs-non-polymorphic distinction; the Hask-endofunctor case is captured by the existing `IsEndofunctor`.
- No `IsSpecificFunctor` umbrella — every textbook functor is between two named categories; adjective modifiers refine, no umbrella needed.
- No refactor of `IsFunctor` itself (the polymorphic-`Shape<U>` requirement stays) — deferred per #633's "Implementation sequence" out-of-scope note; would sweep ~55 consumer sites and is non-blocking for #602 support.

## IsEmbeddingFunctor witnesses (5 sites — directly supports #602's layer 1)

| Site | Arrow | Categorical content |
|------|-------|---------------------|
| `:numbers:natural` | `embed_𝔹_ℕ_` | `bool ↪ Cardinality` |
| `:numbers:boolean` | `embed_𝔹_𝕂3_` | `bool ↪ TernaryLogic::Ω` |
| `:numbers:uint` | `embed_uint_ℕ_` | `unsigned ↪ Cardinality` |
| `:numbers:sint` | `embed_sint_ℤ_` | `int ↪ SignedCardinality` |
| `:numbers:rational` | `embed_ℤ_ℚ<>` | `machine_integer ↪ Rational<I>` |

Each registration mirrors the existing `is_monic_arrow_v` specialization at the same site; pinned with a follow-on `static_assert(IsEmbeddingFunctor<...>)`. The categorical content (fully faithful + injective on objects per Mac Lane CWM §IV.4) is the engineer's assertion, type-checked at the registration site.

## Connection to #602

#602's Layer 1 has been adding per-arrow image lifts (`embed_𝔹_ℕ`, `embed_𝔹_𝕂3`, `embed_uint_ℕ`, `embed_sint_ℤ`, `Frac`) — each pinned via `IsImageOf<result, F>` at the per-arrow site. The 5 `IsEmbeddingFunctor` registrations here close the **functor-level** structural gap: each per-arrow lift in #602 now has a sister functor-level claim pinning the monic side of the epi+mono factorization at the categorical level. The `IsQuotientFunctor` slot is reserved for the future quotient half (true `Frac` on pair-sets, `Cplx`, `Dual`).

## Documentation

`:functor` partition header gets a new `functor__Textbook_Modifiers` section explaining the textbook CT discipline (modifiers, not umbrellas) and pointing at the existing concepts (`IsEndofunctor`, `IsFreeFunctor`, `IsForgetfulFunctor`) alongside the new ones. A `functor__Two_Intuition_Pumps` subsection acknowledges the container-vs-algebraic-set reading-registers explicitly noting they are *not* separate type-system concepts.

## Sweep

- 1 `.cppm` in `:category` (`:functor`, +91 lines after the textbook-name pass: docstring + 2 new concepts + 2 traits)
- 5 `.cppm` in `:numbers` (one `is_embedding_functor_v` specialisation + `static_assert` per site)
- 0 changes to existing `IsFunctor` consumers — net additive

## Test plan

- [ ] CI build-and-deploy green.
- [ ] CodeQL green.
- [ ] codecov green (concepts are compile-time).
- [ ] No semantic change for existing functors.

Local clean build: `dedekind_category`, `dedekind_sets`, `dedekind_algebra`, `dedekind_sequences`, `dedekind_order`, `test_category` all compile clean. `dedekind_numbers` blocked by the pre-existing libc++ variant-`==` quirk in `embed_sint_ℤ`; CI authoritative.

🤖 Generated with [Claude Code](https://claude.com/claude-code)