### PR TITLE
refactor(sets, algebra, paper): #623 — IsArrow gate; slogan maturation to "Rules on Buckets are Set"

### DIFF
--- a/docs/paper/paper.tex
+++ b/docs/paper/paper.tex
@@ -122,7 +122,7 @@
 \newcommand{\bind}{\mathbin{>\!\!>\mkern-6.7mu=}}
 
 % --- Document Metadata ---
-\title{Sets Are Rules, Not Buckets:\\
+\title{Rules on Buckets are Set:\\
   Intensional Programming in C++23 via \texttt{dedekind}\thanks{%
     Draft intended for submission to \emph{Programming}~\cite{programming_journal},
     the journal for programming-related research.
@@ -868,9 +868,9 @@ itemised in the carrier-rosetta tables in
 the universal property that defines them, not by the storage
 scheme they happen to use.}
 
-\subsection{The Comprehension View: Sets Are Rules, Not Buckets}
+\subsection{The Comprehension View: Rules on Buckets are Set}
 
-Here is the move. A set is not a bucket. A set is a rule:
+Here is the move. A set is a rule on a bucket:
 \[
   S = \{x \in A \mid P(x)\}.
 \]
@@ -3117,7 +3117,7 @@ The second pillar.  Sets as predicates over an ambient species (the
 Comprehension View), and the symbolic composition of set operations
 under the subobject classifier $\Omega$.  Where §\ref{sec:axiomatic}
 fixes the substrate, the sets layer reifies its first concrete
-inhabitants — sets that are rules, not buckets.  The sequence-layer
+inhabitants --- rules on buckets are set.  The sequence-layer
 counterpart (functions $\mathbb{N} \to T$ as infinite-dimensional
 vectors, sharing the same intensional posture) extends this pillar
 in a sibling slice.

--- a/docs/paper/paper.tex
+++ b/docs/paper/paper.tex
@@ -3117,7 +3117,7 @@ The second pillar.  Sets as predicates over an ambient species (the
 Comprehension View), and the symbolic composition of set operations
 under the subobject classifier $\Omega$.  Where §\ref{sec:axiomatic}
 fixes the substrate, the sets layer reifies its first concrete
-inhabitants --- rules on buckets are set.  The sequence-layer
+inhabitants --- \emph{Rules on Buckets are Set}.  The sequence-layer
 counterpart (functions $\mathbb{N} \to T$ as infinite-dimensional
 vectors, sharing the same intensional posture) extends this pillar
 in a sibling slice.

--- a/docs/paper/submission/README.md
+++ b/docs/paper/submission/README.md
@@ -1,6 +1,6 @@
 # Submission package
 
-Submission-portal metadata for *Sets Are Rules, Not Buckets*
+Submission-portal metadata for *Rules on Buckets are Set*
 (target: the journal *Programming*).  These artefacts are *not*
 part of the paper proper; they live here so they are tracked
 alongside the paper and travel with it.

--- a/docs/paper/submission/cover_letter.md
+++ b/docs/paper/submission/cover_letter.md
@@ -2,7 +2,7 @@
 
 Dear Editors,
 
-We submit *Sets Are Rules, Not Buckets* for consideration in
+We submit *Rules on Buckets are Set* for consideration in
 *Programming*.  The paper introduces the `dedekind` library, which
 leverages C++23's concepts and non-type template parameters to
 embed formal categorical structures into the type system at

--- a/src/main/modules/dedekind/algebra/universal.cppm
+++ b/src/main/modules/dedekind/algebra/universal.cppm
@@ -156,8 +156,16 @@ concept IsAlgebra = std::regular<T> && (... && IsOpOn<T, Ops>);
 //             (the F; set-level ops like complement / | / & live on X
 //              itself, not in Ops, so they're never confused with F).
 //
+// Gated by @c IsArrow on @c X (#623): under the project's current
+// set-as-characteristic-morphism encoding, a "set" @b is its @c χ :
+// @c T @c → @c Ω --- so @c IsArrow<X> implies @c typename @c X::Domain
+// is well-formed.  Gating at the concept level shortens diagnostics
+// on mis-use compared to the inlined @c requires @c { @c typename @c
+// X::Domain; @c } pattern.  If the encoding later decouples sets
+// from arrows, the gate is the natural site to revisit.
 export template <typename X, typename... Ops>
-concept IsAlgebraOnSet = IsAlgebra<typename X::Domain, Ops...>;
+concept IsAlgebraOnSet =
+    dedekind::category::IsArrow<X> && IsAlgebra<typename X::Domain, Ops...>;
 
 // ---------------------------------------------------------------------------
 // IsTotalAlgebra: the totality-tier anchor between :universal and :total

--- a/src/main/modules/dedekind/optimization/optimization.cppm
+++ b/src/main/modules/dedekind/optimization/optimization.cppm
@@ -17,7 +17,7 @@
  * This realises the paper's thesis in a sharpened form: the feasible
  * polytope is a set-as-predicate, its finite vertex set is enumerated
  * structurally, and the objective's ordering collapses the candidate set
- * to a singleton optimum. "Sets are rules, not buckets" specialised to
+ * to a singleton optimum.  "Rules on buckets are set" specialised to
  * convex programming.
  *
  * @note "Modellbildung ist die halbe Miete."

--- a/src/main/modules/dedekind/optimization/optimization.cppm
+++ b/src/main/modules/dedekind/optimization/optimization.cppm
@@ -17,7 +17,7 @@
  * This realises the paper's thesis in a sharpened form: the feasible
  * polytope is a set-as-predicate, its finite vertex set is enumerated
  * structurally, and the objective's ordering collapses the candidate set
- * to a singleton optimum.  "Rules on buckets are set" specialised to
+ * to a singleton optimum.  "Rules on Buckets are Set" specialised to
  * convex programming.
  *
  * @note "Modellbildung ist die halbe Miete."

--- a/src/main/modules/dedekind/sets/expressions.cppm
+++ b/src/main/modules/dedekind/sets/expressions.cppm
@@ -79,11 +79,13 @@ struct Comprehension {
   static constexpr bool is_idempotent_v = true;
 };
 
-// @c BoundScout forward declaration, gated by @c HasUnderlyingCarrier
-// (from @c :category:species) on @c decltype(Ambient) per #623 so
-// callers passing a value whose type lacks @c ::Domain hit a single
-// diagnostic at the declaration site rather than a cascade of
-// template-instantiation errors inside @c BoundScout's body.
+// @c BoundScout forward declaration, gated by @c IsArrow (from
+// @c :category:morphism) on @c decltype(Ambient) per #623 so callers
+// passing a value whose type lacks @c ::Domain hit a single diagnostic
+// at the declaration site rather than a cascade of template-instantiation
+// errors inside @c BoundScout's body.  The textbook justification for
+// the @c IsArrow gate (a set IS its characteristic morphism under the
+// current encoding) is in the longer comment on @c element below.
 
 /** @brief Forward declaration of @c BoundScout (post-#551), needed by
  *  @c MembershipBinding<S>::operator| below for the bool-truthy

--- a/src/main/modules/dedekind/sets/expressions.cppm
+++ b/src/main/modules/dedekind/sets/expressions.cppm
@@ -79,10 +79,17 @@ struct Comprehension {
   static constexpr bool is_idempotent_v = true;
 };
 
+// @c BoundScout forward declaration, gated by @c HasUnderlyingCarrier
+// (from @c :category:species) on @c decltype(Ambient) per #623 so
+// callers passing a value whose type lacks @c ::Domain hit a single
+// diagnostic at the declaration site rather than a cascade of
+// template-instantiation errors inside @c BoundScout's body.
+
 /** @brief Forward declaration of @c BoundScout (post-#551), needed by
  *  @c MembershipBinding<S>::operator| below for the bool-truthy
  *  specialisation. */
 export template <auto Ambient>
+  requires dedekind::category::IsArrow<std::remove_cvref_t<decltype(Ambient)>>
 struct BoundScout;
 
 /** @brief Boolean equality predicate for compile-time pruning over 𝔹.
@@ -161,6 +168,7 @@ struct MembershipBinding {
  * AmbientType::Domain below).
  */
 export template <auto Ambient>
+  requires dedekind::category::IsArrow<std::remove_cvref_t<decltype(Ambient)>>
 struct BoundScout {
   using AmbientType = std::remove_cvref_t<decltype(Ambient)>;
   using T = typename AmbientType::Domain;
@@ -207,8 +215,18 @@ struct BoundScout {
  *  ambient value.  Companion to @c Ω<T>: spell @c element<Ω<T>> to
  *  get a scout that ranges over the universal predicate at carrier
  *  @c T.  */
+// Gated by @c IsArrow (#623): the @c BoundScout instantiation requires
+// @c decltype(Ambient)::Domain.  Under the project's @b current encoding
+// a "set" @b is its characteristic morphism @c χ : @c T @c → @c Ω
+// (ETCS reading), so any IsArrow has @c ::Domain, and the project's
+// set-as-predicate carriers (@c Ω<T>, @c UniversalSet<T, L, C>, @c
+// Subobject<A, χ>) all satisfy @c IsArrow via their @c χ --- no need
+// for a project-specific @c HasUnderlyingCarrier concept.  If the
+// encoding later decouples sets from arrows (e.g. sets as
+// non-characteristic carriers), the gate is the natural site to
+// revisit.
 export template <auto Ambient>
-//  requires IsSet<Ambient>
+  requires dedekind::category::IsArrow<std::remove_cvref_t<decltype(Ambient)>>
 inline constexpr BoundScout<Ambient> element{};
 
 /** @brief Soft alias @c in<Ambient> for @c element<Ambient> (#603) ---
@@ -237,6 +255,7 @@ inline constexpr BoundScout<Ambient> element{};
  *  in the @c sets DSL idiomatically route through @c S.contains(x) on
  *  the set value itself, sidestepping the conflict. */
 export template <auto Ambient>
+  requires dedekind::category::IsArrow<std::remove_cvref_t<decltype(Ambient)>>
 inline constexpr BoundScout<Ambient> const& in = element<Ambient>;
 
 // True-alias witness: @c in<A> and @c element<A> are the same object


### PR DESCRIPTION
## What this PR does

Two related architectural moves landing in one slice — both cashing out the **IS-A → HAS-A maturation** of the project's set encoding (discussed in the conversation thread that produced this PR).

### (1) `#623` — IsArrow gate

User pushback on the issue body's `HasUnderlyingCarrier` proposal: `IsArrow` already requires `::Domain`, and under the project's current encoding a "set" *is* its characteristic morphism `χ: T → Ω`, so set-as-predicate carriers (`Ω<T>`, `UniversalSet<T, L, C>`, `Subobject<A, χ>`) already satisfy `IsArrow`. Per the textbook-factoring principle (`feedback_textbook_factoring_principle`), no need to invent a new concept when an existing textbook-canonical one does the job.

Gated:

- `BoundScout<auto Ambient>` (forward + definition) on `IsArrow<std::remove_cvref_t<decltype(Ambient)>>`
- `element<auto Ambient>` on the same
- `in<auto Ambient>` on the same
- `IsAlgebraOnSet<X, Ops...>` on `IsArrow<X>` (replaces the inlined `typename X::Domain` access with the named concept)

Each docstring carries the **"for now" hedge**: the IsArrow gate works under the *current* set-as-characteristic-morphism encoding; if the encoding later decouples sets from arrows (the HAS-A target where `IsSet := IsSubobject` and the set HAS-A χ as a member rather than IS its χ), the gate is the natural site to revisit.

### (2) Slogan maturation: *"Sets are rules, not buckets"* → *"Rules on Buckets are Set"*

The original slogan encoded two claims: (a) anti-bucket (rejects naive collection-of-elements), (b) sets-are-rules (the IS-A bootstrap shortcut where set ≡ χ). As the codebase has matured, the HAS-A reading has emerged: a set HAS-A characteristic morphism; it isn't its χ. The new slogan compresses both maturity points into a pun:

> **Rules on Buckets are Set.**

- **Reading 1 (math, noun):** a rule-on-a-bucket gives you a *set* (textbook subobject = χ over an ambient).
- **Reading 2 (idiom, past participle):** the structural commitment is fixed / decided / type-checked (echoes `feedback_type_check_as_safety_boundary`).
- The bucket is no longer rejected — it's *included* as the underlying carrier; the rule sits on top.
- HAS-A relationship encoded in the preposition "on" (a rule without a bucket isn't a set).

Maturation arc across three vintages:

| Vintage | Slogan | Encoding |
|---------|--------|----------|
| Original | "Sets are rules, not buckets." | IS-A (sets ≡ χ); buckets rejected |
| Transitional | "Sets aren't buckets, but they have rules." | HAS-A; still distances from bucket |
| **Mature** | **"Rules on Buckets are Set."** | Composition; bucket *included* as the carrier; pun does the work |

## Sweep across the repo

- `paper.tex` — title (`\title{...}`), §3.2 subsection title, §3 body prose
- `submission/README.md` — submission metadata reference
- `submission/cover_letter.md` — editor-facing cover letter
- `optimization.cppm` — LP showcase header comment
- `sets/expressions.cppm` — IsArrow gate + commentary (per #623)
- `algebra/universal.cppm` — IsArrow gate on `IsAlgebraOnSet` (per #623)

## Test plan

- [ ] CI build-and-deploy green.
- [ ] CodeQL green.
- [ ] codecov green.
- [ ] Paper compiles clean (single-pass `lualatex -halt-on-error`).

Local clean build: `dedekind_sets`, `dedekind_algebra`, `dedekind_category`, `test_category` all compile clean. `dedekind_numbers` blocked by the pre-existing libc++ variant-`==` quirk in `embed_sint_ℤ`; CI authoritative.

🤖 Generated with [Claude Code](https://claude.com/claude-code)