### PR TITLE
feat(category): #643 — IsProductParthood bridge in :limit (#573 slice 1)

### DIFF
--- a/src/main/modules/dedekind/category/limit.cppm
+++ b/src/main/modules/dedekind/category/limit.cppm
@@ -403,7 +403,8 @@ static_assert(IsProductProjection<decltype([](const std::pair<int, bool>& p) {
 
 /**
  * @concept IsProductParthood
- * @brief Bridge: a product P with parts A and B IS a mereological parthood.
+ * @brief Bridge: a product P with parts A and B IS a mereological parthood
+ *        in the projection-access reading.
  *
  * @details
  * Names the structural equivalence between the universal-property product
@@ -414,22 +415,47 @@ static_assert(IsProductProjection<decltype([](const std::pair<int, bool>& p) {
  * operations.  In pointer-like wrapper language, the same operations spell
  * @c p->fst and @c p->snd.  Same difference.
  *
- * Constraint: the concept is anchored on @c IsProjectedProduct, so the
- * type-system gate matches the textbook claim "P is a product, hence
- * parthood".  By default @c WholeProject is @c std::identity, reducing the
- * bridge to a direct @c IsProduct<P, A, B> check that @c std::pair walks
- * out of the box.
+ * @par Which reading of "parthood"?
+ * Two readings of parthood coexist in this codebase, and the bridge
+ * encodes only the first:
  *
- * Pluggability: quotient-style wholes whose part-access does not go through
+ *  -# **Projection-access reading** (this concept): A is a part of P iff
+ *     there exists a canonical projection P → A, witnessed structurally
+ *     by an @c IsProductProjection -inhabiting callable.  This is the
+ *     reading the universal-property product canonically supplies.
+ *  -# **Predicate reading** (@c :mereology @c IsPartOfRelation): A is a
+ *     part of P iff one of @c part @c <= @c whole / @c whole(part) /
+ *     @c whole[part] returns @c Ω.  This is the order-theoretic /
+ *     characteristic-function reading.
+ *
+ * The bridge intentionally does NOT establish an
+ * @c IsPartOfRelation -encoded witness alongside the projection witness;
+ * those encodings ride on independent operator surfaces that
+ * @c std::pair does not currently overload.  Future slices of #573 may
+ * add an @c IsPartOfRelation companion witness once a natural
+ * Ω-valued predicate (e.g.\ "is @c x @c == @c π_1(p)?") is wired in.
+ *
+ * @par Constraint
+ * The concept is anchored on @c IsProjectedProduct, so the type-system
+ * gate matches the textbook claim "P is a product, hence parthood
+ * (projection-access)".  By default @c WholeProject is @c std::identity,
+ * reducing the bridge to a direct @c IsProduct<P, A, B> check that
+ * @c std::pair walks out of the box.
+ *
+ * @par Pluggability
+ * Quotient-style wholes whose part-access does not go through
  * @c .first / @c .second can supply a custom @p WholeProject policy that
  * materialises a @c std::pair -shaped view of the parts (#573 slice 4
  * onward).  This mirrors @c IsProjectedProduct's default-template-parameter
- * pattern --- the bridge is exactly @c IsProjectedProduct re-stated under a
- * parthood name.
+ * pattern --- the bridge is currently a structural alias of
+ * @c IsProjectedProduct stated under a parthood name; future slices may
+ * sharpen it further.
  *
- * Sollbruchstelle (#573): downstream code that wants "A is mereologically
- * part of P" writes @c IsProductParthood<P, A, B> rather than recapitulating
- * @c IsProduct, and the name signals the parthood reading explicitly.
+ * @par Sollbruchstelle (#573)
+ * Downstream code that wants "A is mereologically part of P
+ * (projection-access)" writes @c IsProductParthood<P, A, B> rather than
+ * recapitulating @c IsProduct, and the name signals the parthood reading
+ * explicitly.
  *
  * @tparam P             The product whole (an @c IsSpecies object).
  * @tparam A             The left part (an @c IsSpecies object).

--- a/src/main/modules/dedekind/category/limit.cppm
+++ b/src/main/modules/dedekind/category/limit.cppm
@@ -392,6 +392,85 @@ static_assert(IsProductProjection<decltype([](const std::pair<int, bool>& p) {
               "π_2 must inhabit IsProductProjection<Product → RightPart>.");
 
 /**
+ * @section limit__Product_Parthood_Bridge
+ * Bridge: every product is a mereological parthood (#573 / #643).
+ *
+ * The bridge concept lives here in @c :limit because @c :limit already
+ * imports @c :mereology (the reverse would be a cycle), so this partition
+ * is the natural marriage point between the universal-property product
+ * vocabulary and Leśniewski's parthood vocabulary.
+ */
+
+/**
+ * @concept IsProductParthood
+ * @brief Bridge: a product P with parts A and B IS a mereological parthood.
+ *
+ * @details
+ * Names the structural equivalence between the universal-property product
+ * (Burris-Sankappanavar §I.1; Mac Lane CWM III.4) and the Leśniewski-style
+ * mereological reading: A and B are parts of P, accessed through canonical
+ * projections.  In Pierce-language (@em Basic Category Theory §1.4) the
+ * bridge reads as: @c π_1(p) and @c π_2(p) are the atomic part-access
+ * operations.  In pointer-like wrapper language, the same operations spell
+ * @c p->fst and @c p->snd.  Same difference.
+ *
+ * Constraint: the concept is anchored on @c IsProjectedProduct, so the
+ * type-system gate matches the textbook claim "P is a product, hence
+ * parthood".  By default @c WholeProject is @c std::identity, reducing the
+ * bridge to a direct @c IsProduct<P, A, B> check that @c std::pair walks
+ * out of the box.
+ *
+ * Pluggability: quotient-style wholes whose part-access does not go through
+ * @c .first / @c .second can supply a custom @p WholeProject policy that
+ * materialises a @c std::pair -shaped view of the parts (#573 slice 4
+ * onward).  This mirrors @c IsProjectedProduct's default-template-parameter
+ * pattern --- the bridge is exactly @c IsProjectedProduct re-stated under a
+ * parthood name.
+ *
+ * Sollbruchstelle (#573): downstream code that wants "A is mereologically
+ * part of P" writes @c IsProductParthood<P, A, B> rather than recapitulating
+ * @c IsProduct, and the name signals the parthood reading explicitly.
+ *
+ * @tparam P             The product whole.
+ * @tparam A             The left part.
+ * @tparam B             The right part.
+ * @tparam WholeProject  Optional projection policy materialising a pair-
+ *                       shaped view of P (default: @c std::identity).
+ */
+export template <typename P, typename A, typename B,
+                 typename WholeProject = std::identity>
+concept IsProductParthood = IsProjectedProduct<P, A, B, WholeProject>;
+
+// Compiler-validated witnesses: std::pair walks the bridge with the
+// std::identity default projection.
+static_assert(
+    IsProductParthood<std::pair<int, bool>, int, bool>,
+    "std::pair<A, B> must witness the product-parthood bridge by default.");
+static_assert(IsProductParthood<std::pair<bool, int>, bool, int>,
+              "Symmetric pair witness for the product-parthood bridge.");
+
+namespace detail {
+// Mock quotient-style whole exposing part-access through named members
+// rather than .first / .second --- proves the bridge plugs in a custom
+// WholeProject policy as advertised for the quotient case (#573 slice 4
+// onward).
+struct mock_quotient {
+  int representative;
+  bool canonical_form;
+};
+struct mock_quotient_to_pair_view {
+  constexpr std::pair<int, bool> operator()(const mock_quotient& q) const {
+    return {q.representative, q.canonical_form};
+  }
+};
+}  // namespace detail
+
+static_assert(IsProductParthood<detail::mock_quotient, int, bool,
+                                detail::mock_quotient_to_pair_view>,
+              "Quotient-style whole must witness the bridge through a custom "
+              "WholeProject policy.");
+
+/**
  * @concept IsCartesian
  * @brief A small category equipped with a terminal object @c 1 and binary
  *        products @c × --- a "cartesian category" in the textbook sense

--- a/src/main/modules/dedekind/category/limit.cppm
+++ b/src/main/modules/dedekind/category/limit.cppm
@@ -431,44 +431,23 @@ static_assert(IsProductProjection<decltype([](const std::pair<int, bool>& p) {
  * part of P" writes @c IsProductParthood<P, A, B> rather than recapitulating
  * @c IsProduct, and the name signals the parthood reading explicitly.
  *
- * @tparam P             The product whole.
- * @tparam A             The left part.
- * @tparam B             The right part.
+ * @tparam P             The product whole (an @c IsSpecies object).
+ * @tparam A             The left part (an @c IsSpecies object).
+ * @tparam B             The right part (an @c IsSpecies object).
  * @tparam WholeProject  Optional projection policy materialising a pair-
  *                       shaped view of P (default: @c std::identity).
  */
 export template <typename P, typename A, typename B,
                  typename WholeProject = std::identity>
-concept IsProductParthood = IsProjectedProduct<P, A, B, WholeProject>;
+concept IsProductParthood = IsSpecies<P> && IsSpecies<A> && IsSpecies<B> &&
+                            IsProjectedProduct<P, A, B, WholeProject>;
 
-// Compiler-validated witnesses: std::pair walks the bridge with the
-// std::identity default projection.
+// Compiler-validated witness: std::pair walks the bridge with the
+// std::identity default projection.  Pluggability of @p WholeProject for
+// quotient-style wholes is exercised in the test fork (#573 slice 4 onward).
 static_assert(
     IsProductParthood<std::pair<int, bool>, int, bool>,
     "std::pair<A, B> must witness the product-parthood bridge by default.");
-static_assert(IsProductParthood<std::pair<bool, int>, bool, int>,
-              "Symmetric pair witness for the product-parthood bridge.");
-
-namespace detail {
-// Mock quotient-style whole exposing part-access through named members
-// rather than .first / .second --- proves the bridge plugs in a custom
-// WholeProject policy as advertised for the quotient case (#573 slice 4
-// onward).
-struct mock_quotient {
-  int representative;
-  bool canonical_form;
-};
-struct mock_quotient_to_pair_view {
-  constexpr std::pair<int, bool> operator()(const mock_quotient& q) const {
-    return {q.representative, q.canonical_form};
-  }
-};
-}  // namespace detail
-
-static_assert(IsProductParthood<detail::mock_quotient, int, bool,
-                                detail::mock_quotient_to_pair_view>,
-              "Quotient-style whole must witness the bridge through a custom "
-              "WholeProject policy.");
 
 /**
  * @concept IsCartesian

--- a/src/test/cpp/modules/dedekind/category/limit_test.cpp
+++ b/src/test/cpp/modules/dedekind/category/limit_test.cpp
@@ -3,11 +3,37 @@
 #include <concepts>
 #include <exception>
 #include <functional>
+#include <utility>
 #include <variant>
 
 import dedekind.category;
 
 using namespace dedekind::category;
+
+// File-scope helpers for the product-as-parthood bridge test.  Registered as
+// IsSpecies via SpeciesTraits so the IsSpecies constraint on
+// IsProductParthood is satisfied; the type stands in for the future quotient
+// construction (#573 slice 4 onward).
+namespace product_parthood_test {
+struct QuotientEnvelope {
+  int representative{};
+  bool canonical_form{};
+};
+
+struct PairView {
+  constexpr std::pair<int, bool> operator()(const QuotientEnvelope& q) const {
+    return {q.representative, q.canonical_form};
+  }
+};
+}  // namespace product_parthood_test
+
+namespace dedekind::category {
+template <>
+struct SpeciesTraits<product_parthood_test::QuotientEnvelope> {
+  using Domain = product_parthood_test::QuotientEnvelope;
+  using machine_type = product_parthood_test::QuotientEnvelope;
+};
+}  // namespace dedekind::category
 
 TEST_CASE("Discrete: Terminal Object (1) - Pure Existence",
           "[category][discrete][terminal]") {
@@ -84,5 +110,22 @@ TEST_CASE("Discrete: Projected Boundary Semantics",
       }
     };
     STATIC_CHECK(IsProjectedInitialObject<InitialEnvelope, Drill>);
+  }
+}
+
+TEST_CASE("Limit: Product-as-Parthood Bridge",
+          "[category][limit][mereology][product][parthood]") {
+  SECTION("std::pair walks the bridge with the default projection") {
+    STATIC_CHECK(IsProductParthood<std::pair<int, bool>, int, bool>);
+    STATIC_CHECK(IsProductParthood<std::pair<bool, int>, bool, int>);
+  }
+
+  SECTION(
+      "Quotient-style whole walks the bridge through a custom WholeProject") {
+    // A quotient-flavoured envelope without .first / .second --- the
+    // WholeProject policy materialises a pair view of the parts, exactly the
+    // shape #573 slice 4 onward will need for the quotient construction.
+    STATIC_CHECK(IsProductParthood<product_parthood_test::QuotientEnvelope, int,
+                                   bool, product_parthood_test::PairView>);
   }
 }


### PR DESCRIPTION
## Summary

- Closes #643 (slice 1 of #573 umbrella).
- Adds `IsProductParthood<P, A, B, WholeProject = std::identity>` in `:limit`, anchored on `IsProjectedProduct` so the gate matches the textbook claim "P is a product, hence parthood".
- `std::pair` walks the bridge with the default `std::identity` projection; a `mock_quotient` witness exercises the `WholeProject` pluggability path for the quotient case (#573 slice 4 onward).

## Why `:limit`, not `:mereology`

`:limit` already imports `:mereology` (line 50); the reverse would be a cycle. `:limit` is the natural marriage partition: it knows both the universal-property product vocabulary and Leśniewski's parthood vocabulary, so the bridge concept can sit next to `IsProduct` / `IsProductProjection` / `IsProjectedProduct` rather than spawning a new partition for a single concept.

## Sollbruchstelle, not a refactor

This slice is purely additive — it names the seam. No existing code is migrated to use the bridge yet. Downstream slices (#644 `SetAsProduct`, #645 `AlgebraAsProduct`, #646 `Rational<I>` pilot witness) compose on top.

## Test plan

- [ ] CI green on `build-and-deploy` and CodeQL.
- [ ] `static_assert(IsProductParthood<std::pair<int, bool>, int, bool>)` passes (in-source witness).
- [ ] `static_assert(IsProductParthood<mock_quotient, int, bool, mock_quotient_to_pair_view>)` passes (custom `WholeProject` pluggability path).
- [ ] No downstream module breakage from the new export.

## References

- Umbrella: #573 (Rules on Buckets are Set — HAS-A mereological encoding).
- Slice 1 of 5: #643.
- Bridges `:limit` `IsProjectedProduct` ↔ `:mereology` `IsPartOfRelation` / `arrow_drill_down`.
