### PR TITLE
feat(category, sets): #644 — SetAsProduct seam (#573 slice 2)

### DIFF
--- a/src/main/modules/dedekind/category/concrete.cppm
+++ b/src/main/modules/dedekind/category/concrete.cppm
@@ -86,6 +86,50 @@ concept IsSetObject = IsSubobject<S, A> && requires {
 };
 
 /**
+ * @concept SetAsProduct
+ * @brief Set := (Underlying, Classifier) read as a product, in the
+ *        projection-access sense.
+ *
+ * @details
+ * Names the @em product reading of a set object explicitly --- a set is a
+ * pair of (i) its underlying ambient species @p Underlying, accessed
+ * type-level via @c S::Ambient, and (ii) its characteristic morphism
+ * @p Classifier, accessed value-level via the projector @c s.χ.  Sibling
+ * to @c IsSetObject, which names the @em predicate reading "S is a
+ * subobject of A".  The two readings carve the same surface from
+ * different angles.
+ *
+ * @par Why this concept exists (#573 / #644 --- Sollbruchstelle)
+ * The user's framing for the HAS-A maturation: "a set should be a product
+ * in the @c :cartesian sense of an underlying and predicates."  This
+ * concept names that seam.  It refines @c IsSetObject by adding a typed
+ * obligation that the classifier projects to @p Classifier --- a
+ * structural witness that the (Underlying, Classifier) decomposition is
+ * recoverable.  Downstream slices (#573 slice 3 @c AlgebraAsProduct,
+ * slice 4 pilot witness) compose on this name.
+ *
+ * @par Relation to @c IsProductParthood
+ * The bridge concept @c IsProductParthood in @c :limit asserts the
+ * structural product-as-parthood reading uniformly via
+ * @c IsProjectedProduct.  @c SetAsProduct is the set-level specialisation,
+ * but the asymmetry "Underlying is a type, Classifier is a value" makes
+ * a direct @c IsProductParthood composition awkward at this slice ---
+ * the parts are accessed through different kinds of projectors
+ * (type-level @c ::Ambient vs.\ value-level @c .χ).  The concepts are
+ * logical siblings, not typed dependencies; future slices may unify the
+ * projector vocabulary once a natural meeting point emerges.
+ *
+ * @tparam S           The set object.
+ * @tparam Underlying  The ambient species (an @c IsSpecies object).
+ * @tparam Classifier  The characteristic-morphism type projected from
+ *                     @c s.χ.
+ */
+export template <typename S, typename Underlying, typename Classifier>
+concept SetAsProduct = IsSetObject<S, Underlying> && requires(const S& s) {
+  { s.χ } -> std::convertible_to<Classifier>;
+};
+
+/**
  * @concept IsConcrete
  * @brief A small category @c C is @em concrete when its objects are
  *        themselves sets --- equivalently, when there is a faithful functor

--- a/src/main/modules/dedekind/category/concrete.cppm
+++ b/src/main/modules/dedekind/category/concrete.cppm
@@ -126,7 +126,10 @@ concept IsSetObject = IsSubobject<S, A> && requires {
  */
 export template <typename S, typename Underlying, typename Classifier>
 concept SetAsProduct = IsSetObject<S, Underlying> && requires(const S& s) {
-  { s.χ } -> std::convertible_to<Classifier>;
+  // Match the projected type of s.χ exactly (after stripping cv-ref) so
+  // the seam captures the structural identity rather than relying on
+  // implicit conversions.  Per PR #650 review.
+  requires std::same_as<std::remove_cvref_t<decltype(s.χ)>, Classifier>;
 };
 
 /**

--- a/src/test/cpp/modules/dedekind/sets/set_as_product_test.cpp
+++ b/src/test/cpp/modules/dedekind/sets/set_as_product_test.cpp
@@ -3,13 +3,15 @@
  *  Witness tests for the @c SetAsProduct seam (#573 slice 2 / #644).
  *
  *  The concept itself lives in @c :category:concrete next to
- *  @c IsSetObject (predicate reading), but its witness uses
- *  @c classify<T>(...) from @c :sets:expressions, which is downstream of
- *  @c :category in the module DAG.  Per the project's DAG-tests rule
- *  (@c feedback_module_dag_tests), the witness test belongs at the
- *  @c :sets layer where both the concept and the witness are visible.
+ *  @c IsSetObject (predicate reading).  The witness uses
+ *  @c classify<T>(...) from @c :category:topoi (available through the
+ *  @c dedekind.category umbrella) to materialise a @c Subobject<A, χ>
+ *  test target; the @c :sets layer is the natural home for the test
+ *  fork so future witnesses using the @c :sets:expressions DSL
+ *  (@c element<...>, @c in<...>, named carriers) can sit alongside.
  */
 #include <catch2/catch_test_macros.hpp>
+#include <type_traits>
 
 import dedekind.category;
 import dedekind.sets;
@@ -19,22 +21,23 @@ using namespace dedekind::sets;
 
 TEST_CASE("Concrete: SetAsProduct seam — Set := (Underlying, Classifier)",
           "[category][concrete][sets][product][parthood]") {
-  // A canonical set object materialised through :sets:expressions:
-  // classify<T>(predicate) builds a Set<T, L, P> whose Ambient is T and
-  // whose χ is the predicate.  The natural witness for the
+  // classify<T>(predicate) (from :category:topoi) materialises a
+  // Subobject<A, χ> whose Ambient is T and whose χ is the rule-arrow
+  // built from the predicate.  This is the natural test target for the
   // (Underlying, Classifier) reading.
   const auto s_even = classify<int>([](const int& x) { return x % 2 == 0; });
+
+  using ChiType = std::remove_cvref_t<decltype(s_even.χ)>;
 
   SECTION("set object witnesses both readings (predicate and product)") {
     // Predicate reading (sibling): S is a subobject of int.
     STATIC_CHECK(IsSetObject<decltype(s_even), int>);
-    // Product reading (this slice): S decomposes as (int, decltype(χ)).
-    STATIC_CHECK(SetAsProduct<decltype(s_even), int, decltype(s_even.χ)>);
+    // Product reading (this slice): S decomposes as (int, χ-type).
+    STATIC_CHECK(SetAsProduct<decltype(s_even), int, ChiType>);
   }
 
   SECTION("Underlying must match S::Ambient") {
     // A wrong Underlying must not satisfy the concept.
-    STATIC_CHECK_FALSE(
-        SetAsProduct<decltype(s_even), bool, decltype(s_even.χ)>);
+    STATIC_CHECK_FALSE(SetAsProduct<decltype(s_even), bool, ChiType>);
   }
 }

--- a/src/test/cpp/modules/dedekind/sets/set_as_product_test.cpp
+++ b/src/test/cpp/modules/dedekind/sets/set_as_product_test.cpp
@@ -1,0 +1,40 @@
+/** @file test/cpp/modules/dedekind/sets/set_as_product_test.cpp
+ *
+ *  Witness tests for the @c SetAsProduct seam (#573 slice 2 / #644).
+ *
+ *  The concept itself lives in @c :category:concrete next to
+ *  @c IsSetObject (predicate reading), but its witness uses
+ *  @c classify<T>(...) from @c :sets:expressions, which is downstream of
+ *  @c :category in the module DAG.  Per the project's DAG-tests rule
+ *  (@c feedback_module_dag_tests), the witness test belongs at the
+ *  @c :sets layer where both the concept and the witness are visible.
+ */
+#include <catch2/catch_test_macros.hpp>
+
+import dedekind.category;
+import dedekind.sets;
+
+using namespace dedekind::category;
+using namespace dedekind::sets;
+
+TEST_CASE("Concrete: SetAsProduct seam — Set := (Underlying, Classifier)",
+          "[category][concrete][sets][product][parthood]") {
+  // A canonical set object materialised through :sets:expressions:
+  // classify<T>(predicate) builds a Set<T, L, P> whose Ambient is T and
+  // whose χ is the predicate.  The natural witness for the
+  // (Underlying, Classifier) reading.
+  const auto s_even = classify<int>([](const int& x) { return x % 2 == 0; });
+
+  SECTION("set object witnesses both readings (predicate and product)") {
+    // Predicate reading (sibling): S is a subobject of int.
+    STATIC_CHECK(IsSetObject<decltype(s_even), int>);
+    // Product reading (this slice): S decomposes as (int, decltype(χ)).
+    STATIC_CHECK(SetAsProduct<decltype(s_even), int, decltype(s_even.χ)>);
+  }
+
+  SECTION("Underlying must match S::Ambient") {
+    // A wrong Underlying must not satisfy the concept.
+    STATIC_CHECK_FALSE(
+        SetAsProduct<decltype(s_even), bool, decltype(s_even.χ)>);
+  }
+}


### PR DESCRIPTION
## Summary

- Closes #644 (slice 2 of #573 umbrella).
- Adds `SetAsProduct<S, Underlying, Classifier>` in `:category:concrete`, sibling to existing `IsSetObject<S, A>`.
- Witness test in the `:sets` test layer (DAG-tests rule — the witness `classify<T>(predicate)` is in `:sets:expressions`, downstream of `:category`).
- Sollbruchstelle: names the (Underlying, Classifier) decomposition seam without forcing existing types to refactor.

## Architectural read-off

The two sibling readings of a set object now have names side by side:

| Concept | Reading | Encoded as |
|---|---|---|
| `IsSetObject<S, A>` | predicate ("S is a subobject of A via χ") | `IsSubobject<S, A> + S::Ambient == A` |
| `SetAsProduct<S, U, C>` | product ("S = (Underlying U, Classifier C)") | `IsSetObject<S, U> + .χ projects to C` |

The user's framing from the #573 thread: "a set should be a product in the `:cartesian` sense of an underlying and predicates." This concept names that seam.

## Why not direct `IsProductParthood` composition

Slice 1's `IsProductParthood<P, A, B>` asserts a uniform structural-projection product via `IsProjectedProduct`. The set case is asymmetric: Underlying is accessed type-level (`S::Ambient`), Classifier is accessed value-level (`s.χ`). Forcing `IsProductParthood` composition would require materialising the Underlying as a value (e.g. a universal set on `Ambient`), which is heavier than this slice should carry. The two concepts are logical siblings rather than typed dependencies; a future slice can unify the projector vocabulary if a natural meeting point emerges.

## Test plan

- [x] `test_sets` builds clean; `SetAsProduct` test passes (3 assertions in 1 test case) on filter `[category][concrete][sets][product][parthood]`.
- [ ] CI green on `build-and-deploy` and CodeQL.
- [ ] No downstream breakage from the new export.

## References

- Umbrella: #573.
- Predecessor: PR #648 (slice 1 — `IsProductParthood` bridge in `:limit`).
- Sibling concept: `IsSetObject` at [concrete.cppm:83](src/main/modules/dedekind/category/concrete.cppm#L83).
- Witness construction: `classify<T>` in `:sets:expressions`.
