### PR TITLE
feat(algebra): #645 — AlgebraAsProduct seam (#573 slice 3)

### DIFF
--- a/src/main/modules/dedekind/algebra/universal.cppm
+++ b/src/main/modules/dedekind/algebra/universal.cppm
@@ -409,6 +409,69 @@ static_assert(
     "interpretation (idempotent ∧, involutive ⊕).");
 
 // ---------------------------------------------------------------------------
+// AlgebraAsProduct: set-level sibling of HasCarrier (#573 slice 3 / #645).
+// ---------------------------------------------------------------------------
+
+/**
+ * @concept AlgebraAsProduct
+ * @brief Set-level sibling of @c HasCarrier: an algebra is a product of
+ *        (set object, operations on the underlying type).
+ *
+ * @details
+ * Where element-level @c HasCarrier<Algebra, Carrier, Ops...> reads the
+ * carrier as a TYPE (e.g.\ @c int, @c bool, @c unsigned), this set-level
+ * concept reads the carrier as a SET OBJECT --- something with both an
+ * underlying species and a characteristic morphism @c χ.  In universal-
+ * algebra vocabulary (Burris--Sankappanavar §I.1): every algebra
+ * @c (A, @c F) is a pair of (carrier set @c A, operations @c F);
+ * element-level @c HasCarrier names the (A_type, F) reading, this
+ * set-level concept names the full (A_set, F) reading where A_set is
+ * the categorical set object carrying both the underlying type and the
+ * membership predicate.
+ *
+ * The two concepts are siblings, not replacements:
+ *   - @c HasCarrier:        the C++-idiomatic form ("algebra over @c int")
+ *   - @c AlgebraAsProduct:  the textbook-idiomatic form ("algebra over a set")
+ *
+ * Composition (read as @c &&-as-intersection):
+ *
+ * @code
+ *   AlgebraAsProduct<A, Set, Ops...>
+ *     := IsSetObject<Set, Set::Ambient>        (Set is a set object)
+ *      ∧ HasCarrier<A, Set::Ambient, Ops...>   (A has Set::Ambient as
+ *                                               carrier with these Ops)
+ * @endcode
+ *
+ * @par Sollbruchstelle (#573)
+ * Names the (Set, Operations) product reading of an algebra explicitly,
+ * complementing slice 2's @c SetAsProduct<Set, Underlying, Classifier>
+ * in @c :category:concrete.  Together they encode the nested-product
+ * structure  algebra → set → underlying  as typed obligations rather
+ * than naming conventions.  The pilot witness on a real named carrier
+ * (@c Rational<I>) ships in #573 slice 4 (#646).
+ *
+ * @tparam A    The algebra (whole).
+ * @tparam Set  The underlying set object (an @c IsSetObject; the left
+ *              part of the (Set, Operations) pair).
+ * @tparam Ops  The operations on @c Set::Ambient (the right part).
+ *
+ * @see @c HasCarrier above (element-level sibling, this partition).
+ * @see @c SetAsProduct (set-level sibling, @c :category:concrete; #644
+ *      slice 2).
+ * @see Burris \& Sankappanavar 1981 §I.1 (algebra @c (A, @c F) pair).
+ */
+export template <typename A, typename Set, typename... Ops>
+concept AlgebraAsProduct =
+    dedekind::category::IsSetObject<Set, typename Set::Ambient> &&
+    HasCarrier<A, typename Set::Ambient, Ops...>;
+
+// Pilot witness for AlgebraAsProduct ships in #573 slice 4 (#646) ---
+// see Rational<I>'s static_assert at its definition site.  Witnesses
+// using ad-hoc :sets:expressions classify<T>(...) constructions live in
+// the test fork (algebra/algebra_as_product_test.cpp) per the project's
+// "no mocks in main" guidance (PR #648 review).
+
+// ---------------------------------------------------------------------------
 // Phase 2: Homomorphisms — arrows between algebras (#506).
 // ---------------------------------------------------------------------------
 //

--- a/src/test/cpp/modules/dedekind/algebra/algebra_as_product_test.cpp
+++ b/src/test/cpp/modules/dedekind/algebra/algebra_as_product_test.cpp
@@ -52,8 +52,13 @@ TEST_CASE("Universal: AlgebraAsProduct seam — Algebra := (Set, Operations)",
   }
 
   SECTION("closure tier (no Ops): set-level shape without operation closure") {
-    // With no Ops, AlgebraAsProduct reduces to "Set is a set object AND A
-    // has Set::Ambient as a std::regular carrier with arrow_drill_down".
+    // With no Ops, AlgebraAsProduct reduces to the closure-tier shape:
+    // IsSetObject<Set, Set::Ambient> still holds (Set is a set object) AND
+    // HasCarrier<A, Set::Ambient> still holds at its no-Ops form ---
+    // std::regular<Set::Ambient> plus the IsPartOfRelation parthood witness
+    // and the arrow_drill_down projector.  Only the per-operation closure
+    // requirements on Ops simplify away; the mereology / parthood arms of
+    // HasCarrier do not.
     STATIC_CHECK(AlgebraAsProduct<algebra_as_product_test::BoolAlgebraView,
                                   decltype(bool_set)>);
   }

--- a/src/test/cpp/modules/dedekind/algebra/algebra_as_product_test.cpp
+++ b/src/test/cpp/modules/dedekind/algebra/algebra_as_product_test.cpp
@@ -1,0 +1,60 @@
+/** @file test/cpp/modules/dedekind/algebra/algebra_as_product_test.cpp
+ *
+ *  Witness test for the @c AlgebraAsProduct seam (#573 slice 3 / #645).
+ *
+ *  The concept lives in @c :algebra:universal next to element-level
+ *  @c HasCarrier; the witness composes a thin algebra-view wrapper
+ *  (real-shaped, not mock-shaped) with a @c :sets:expressions set object
+ *  via @c classify<T>(...).  Per @c feedback_module_dag_tests, this test
+ *  layer (@c :algebra) imports both @c :sets and @c :algebra, so the
+ *  composition is visible here.
+ */
+#include <catch2/catch_test_macros.hpp>
+#include <functional>
+
+import dedekind.algebra;
+import dedekind.category;
+import dedekind.sets;
+
+using namespace dedekind::algebra;
+using namespace dedekind::category;
+
+// File-scope thin algebra-view wrapper.  Wraps a single bool value and
+// exposes both mereology arms HasCarrier asks for: predicate-style
+// part-whole (whole(part) iff equal) and operator->() drill-down.  Same
+// shape as the internal _has_carrier_witness::algebra_view in
+// universal.cppm, but lives here so the test does not poke at the main
+// module's internal namespace.
+namespace algebra_as_product_test {
+struct BoolAlgebraView {
+  bool value;
+  constexpr bool operator()(const bool& part) const noexcept {
+    return part == value;
+  }
+  constexpr const bool* operator->() const noexcept { return &value; }
+  friend constexpr bool operator==(const BoolAlgebraView&,
+                                   const BoolAlgebraView&) = default;
+};
+}  // namespace algebra_as_product_test
+
+TEST_CASE("Universal: AlgebraAsProduct seam — Algebra := (Set, Operations)",
+          "[algebra][universal][product][parthood][sets]") {
+  // F_2 = (𝔹, ⊕, ∧) algebra view.  The set object is the universal bool
+  // set materialised via classify<bool>; its Ambient is bool, so the
+  // (Set, Operations) decomposition holds with the algebra-view as the
+  // whole and bool as the underlying carrier.
+  const auto bool_set = classify<bool>([](const bool&) { return true; });
+
+  SECTION("F_2 wrapped in a thin view witnesses AlgebraAsProduct") {
+    STATIC_CHECK(AlgebraAsProduct<algebra_as_product_test::BoolAlgebraView,
+                                  decltype(bool_set), std::bit_xor<bool>,
+                                  std::bit_and<bool>>);
+  }
+
+  SECTION("closure tier (no Ops): set-level shape without operation closure") {
+    // With no Ops, AlgebraAsProduct reduces to "Set is a set object AND A
+    // has Set::Ambient as a std::regular carrier with arrow_drill_down".
+    STATIC_CHECK(AlgebraAsProduct<algebra_as_product_test::BoolAlgebraView,
+                                  decltype(bool_set)>);
+  }
+}


### PR DESCRIPTION
## Summary

- Closes #645 (slice 3 of #573 umbrella).
- Adds `AlgebraAsProduct<A, Set, Ops...>` in `:algebra:universal`, sibling of existing element-level `HasCarrier`.
- Witness test in the `:algebra` test fork — thin file-scope algebra-view (real-shaped, not mock-shaped) composed with a `classify<bool>(...)` set object from `:topoi`.

## Architectural read-off

| Concept | Reading | Underlying as |
|---|---|---|
| `HasCarrier<Algebra, Carrier, Ops...>` (existing) | element-level / C++-idiomatic | TYPE (`int`, `bool`, `unsigned`) |
| `AlgebraAsProduct<A, Set, Ops...>` (this slice) | set-level / textbook (Burris–Sankappanavar §I.1) | SET OBJECT (with `.Ambient` + `χ`) |

The two are siblings, not replacements.  Composition:

```
AlgebraAsProduct<A, Set, Ops...>
  := IsSetObject<Set, Set::Ambient>        (Set is a set object)
   ∧ HasCarrier<A, Set::Ambient, Ops...>   (A has Set::Ambient as carrier)
```

Together with `SetAsProduct` from slice 2 (#644), the nested-product structure `algebra → set → underlying` is now encoded as typed obligations at every layer.

## Test plan

- [x] `test_algebra` builds clean; AlgebraAsProduct test passes (2 assertions in 1 test case) on filter `[algebra][universal][product][parthood][sets]`.
- [ ] CI green on `build-and-deploy` and CodeQL.
- [ ] No downstream breakage from the new export.

## Sequencing notes

- Independent of #650 (slice 2 / `SetAsProduct`) on the typed dependency surface — both concepts are siblings rather than typed dependencies.  Either can merge first.
- Pilot witness on a real named carrier (`Rational<I>`) ships in #573 slice 4 (#646), which will compose on both #650 and this slice.

## References

- Umbrella: #573.
- Sibling: #650 (slice 2 — `SetAsProduct` in `:category:concrete`).
- Element-level predecessor: existing `HasCarrier` at [algebra/universal.cppm:307](src/main/modules/dedekind/algebra/universal.cppm#L307).
- Textbook: Burris & Sankappanavar 1981 §I.1 (algebra (A, F) pair).
