### PR TITLE
docs(paper): #647 — §3.1 names SetAsProduct / AlgebraAsProduct (#573 slice 5)

### DIFF
--- a/docs/paper/paper.tex
+++ b/docs/paper/paper.tex
@@ -653,6 +653,7 @@ The architecture converges on a small grammar worth naming explicitly as target 
 The HAS-A reading is the same shape at both upper layers, but the kind of ``has'' differs --- an algebra carries behavioural structure (functions with axioms governing them), a set carries shape-only structure (the $\chi$ is the \cppinline{IsSubobject} contract's anchor, with the actual decision living in the predicate's \cppinline{operator()}).
 Three slots, mapped onto the codebase: the IS-A category lives in \texttt{category:cartesian}; the set HAS-A in \texttt{category:etcs}; the algebra HAS-A in \texttt{algebra:universal}.
 Every concept the project ships fits one of the three.
+The two HAS-A layers are reified at the type level by a pair of sibling concepts in the spirit of product-as-parthood (Le\'sniewski mereology composed with the universal-property product; \texttt{category:mereology} + \texttt{category:limit}): \cppinline{SetAsProduct<S, Underlying, Classifier>} in \texttt{category:concrete} names the set HAS-A as the (\textsc{Underlying}, \textsc{Classifier}) pair, and \cppinline{AlgebraAsProduct<A, Set, Ops...>} in \texttt{algebra:universal} names the algebra HAS-A as the (\textsc{Set}, \textsc{Operations}) pair, composing on the element-level \cppinline{HasCarrier<Algebra, Carrier, Ops...>} sibling that has been in this partition since the \cppinline{(A, F)} read-off was first encoded.
 
 % Source excerpt from dedekind.algebra:universal.
 \begin{listing}[ht]


### PR DESCRIPTION
## Summary

- Closes #647 (slice 5 of #573 umbrella).
- One-sentence addition at the end of §3.1's HAS-A canonicalisation paragraph naming the type-level reification of the HAS-A posture:
  - `SetAsProduct<S, Underlying, Classifier>` in `:category:concrete` (slice 2, merged in PR #650) — the set HAS-A as the (Underlying, Classifier) pair.
  - `AlgebraAsProduct<A, Set, Ops...>` in `:algebra:universal` (slice 3, in flight on PR #651) — the algebra HAS-A as the (Set, Operations) pair, composing on element-level `HasCarrier`.

Together with the §1 footnote on "carrier" already in place (landed via PR #571), this closes the prose ↔ encoding loop tracked in the #573 umbrella.

## Why slice 5 fires now

- Slice 1 (`IsProductParthood` bridge, `:limit`) merged in PR #648.
- Slice 2 (`SetAsProduct`, `:category:concrete`) merged in PR #650 — concept is now a live reference.
- Slice 3 (`AlgebraAsProduct`, `:algebra:universal`) in flight on PR #651 — referenceable now; will be live once that PR merges.

Forward-reference to slice 3 in the prose is benign: a code-companion paper can name in-flight concepts; the references resolve when the PR merges.

## Test plan

- [x] Local single-pass `lualatex -halt-on-error` builds clean (55 pages).
- [ ] CI paper build green on `build-and-deploy`.
- [ ] No figures, listings, or table content touched.

## References

- Umbrella: #573.
- Predecessors: PR #648 (slice 1), PR #650 (slice 2), PR #651 (slice 3, in flight).
- Paper §3.1 HAS-A canonicalisation paragraph at [paper.tex:652](docs/paper/paper.tex#L652).
- §1 footnote already done in PR #571.
