### PR TITLE
feat(numbers, algebra): #646 — slice 4 pilot witness on Rational<I> (#573 umbrella)

### DIFF
--- a/src/main/modules/dedekind/numbers/rational.cppm
+++ b/src/main/modules/dedekind/numbers/rational.cppm
@@ -549,6 +549,20 @@ static_assert(
     "ℚ's underlying carrier IS Rational<default_integer> — the textbook "
     "universe-over-carrier reading.");
 
+// #573 slice 4 pilot witness: ℚ walks SetAsProduct.  The universe value
+// is a UniversalSet over Rational<default_integer> --- its Ambient is the
+// underlying species, its χ is the always-True classifier.  Names the
+// (Underlying, Classifier) product reading of the ambient rational set
+// concretely on the canonical pilot carrier.
+static_assert(
+    dedekind::category::SetAsProduct<std::remove_cvref_t<decltype(ℚ)>,
+                                     Rational<default_integer>,
+                                     std::remove_cvref_t<decltype(ℚ.χ)>>,
+    "#573 slice 4: ℚ must witness SetAsProduct over "
+    "(Rational<default_integer>, "
+    "χ-type).  The universe value is a UniversalSet whose Ambient matches the "
+    "rational carrier and whose χ is recoverable as a typed member.");
+
 /** @brief The predicate-set value (instance of @c RationalSet),
  *         retained for set-builder DSL usage like @c Set{q @c % @c Q}
  *         where @c q @c = @c var<ℚ> ranges over rationals.

--- a/src/test/cpp/modules/dedekind/numbers/rational_as_product_test.cpp
+++ b/src/test/cpp/modules/dedekind/numbers/rational_as_product_test.cpp
@@ -1,0 +1,77 @@
+/** @file test/cpp/modules/dedekind/numbers/rational_as_product_test.cpp
+ *
+ *  Pilot witness tests for the #573 product-as-parthood seams on the
+ *  canonical Rational<I> carrier (slice 4 / #646).
+ *
+ *  Two halves:
+ *
+ *    - @c SetAsProduct: the @e set-level witness is in main code (a
+ *      static_assert at the ℚ definition site in rational.cppm, since
+ *      ℚ = UniversalSet<Rational<default_integer>> already walks
+ *      IsSetObject without adapters).
+ *    - @c AlgebraAsProduct: the @e algebra-level witness lives here in
+ *      the test fork, via a thin @c rational_view<I> wrapper that
+ *      exposes Rational<I> through the HasCarrier mereology arms
+ *      (predicate-style part-of + arrow_drill_down).  Same pattern as
+ *      slice 3's @c BoolAlgebraView (#651).
+ */
+#include <catch2/catch_test_macros.hpp>
+#include <functional>
+#include <type_traits>
+
+import dedekind.algebra;
+import dedekind.category;
+import dedekind.numbers;
+import dedekind.sets;
+
+using namespace dedekind::algebra;
+using namespace dedekind::category;
+using namespace dedekind::numbers;
+
+// File-scope thin Rational view wrapper.  Real-shaped (not mock-shaped):
+// wraps a single Rational<I> value and exposes both mereology arms
+// HasCarrier asks for --- predicate-style part-of (whole(part) iff
+// equal) and operator->() drill-down to recover the wrapped Rational
+// through arrow_drill_down.  Same shape as
+// _has_carrier_witness::algebra_view<T> in :algebra:universal, scoped
+// here so the test does not poke at the main module's internal
+// namespace.
+namespace rational_as_product_test {
+template <typename I>
+struct RationalView {
+  Rational<I> value;
+  constexpr bool operator()(const Rational<I>& part) const noexcept {
+    return part == value;
+  }
+  constexpr const Rational<I>* operator->() const noexcept { return &value; }
+  friend constexpr bool operator==(const RationalView&,
+                                   const RationalView&) = default;
+};
+}  // namespace rational_as_product_test
+
+TEST_CASE(
+    "Numbers: AlgebraAsProduct pilot witness on Rational<I> (#573 slice 4)",
+    "[numbers][rational][algebra][product][parthood]") {
+  using I = default_integer;
+  using View = rational_as_product_test::RationalView<I>;
+
+  // ℚ is the universal set object over Rational<I>; its Ambient matches
+  // the carrier type the algebra-side HasCarrier reads.
+  using QuniverseT = std::remove_cvref_t<decltype(ℚ)>;
+
+  SECTION("AlgebraAsProduct: Rational view walks the (Set, Operations) pair") {
+    // The two field operations are the standard textbook ones, picked at
+    // the carrier-type level so HasCarrier's IsAlgebra arm closes.
+    STATIC_CHECK(AlgebraAsProduct<View, QuniverseT, std::plus<Rational<I>>,
+                                  std::multiplies<Rational<I>>>);
+  }
+
+  SECTION("closure tier (no Ops): set-level shape without operation closure") {
+    // With no Ops, AlgebraAsProduct reduces to its closure-tier shape:
+    // IsSetObject<ℚ-type, Rational<I>> still holds AND HasCarrier's
+    // no-Ops form (std::regular + IsPartOfRelation + arrow_drill_down)
+    // still holds on the View.  Only the per-operation closure
+    // requirements simplify away.
+    STATIC_CHECK(AlgebraAsProduct<View, QuniverseT>);
+  }
+}

--- a/src/test/cpp/modules/dedekind/numbers/rational_as_product_test.cpp
+++ b/src/test/cpp/modules/dedekind/numbers/rational_as_product_test.cpp
@@ -10,7 +10,7 @@
  *      ℚ = UniversalSet<Rational<default_integer>> already walks
  *      IsSetObject without adapters).
  *    - @c AlgebraAsProduct: the @e algebra-level witness lives here in
- *      the test fork, via a thin @c rational_view<I> wrapper that
+ *      the test fork, via a thin @c RationalView<I> wrapper that
  *      exposes Rational<I> through the HasCarrier mereology arms
  *      (predicate-style part-of + arrow_drill_down).  Same pattern as
  *      slice 3's @c BoolAlgebraView (#651).


### PR DESCRIPTION
## Summary

- Closes #646 (slice 4 of #573 umbrella — the **pilot witness**).
- First slice where a #573 Sollbruchstelle actually breaks: a real named-carrier type (`Rational<I>`) walks across both new seams.

## Two halves

### 1. `SetAsProduct` — main code (rational.cppm)

`ℚ = UniversalSet<Rational<default_integer>>` already walks `IsSetObject` without adapters (Ambient = rational species, χ = always-True classifier). One static_assert at the ℚ definition site witnesses `SetAsProduct<decltype(ℚ), Rational<default_integer>, decltype(ℚ.χ)>`.

### 2. `AlgebraAsProduct` — test fork (rational_as_product_test.cpp)

Thin file-scope `RationalView<I>` wrapper exposes `Rational<I>` through `HasCarrier`'s mereology arms (predicate-style part-of via `operator()`, `arrow_drill_down` via `operator->()`). Same pattern as slice 3's `BoolAlgebraView` (PR #651) — real-shaped, not mock-shaped. Witnesses `AlgebraAsProduct` at both the operations tier (F = +, *) and the closure tier (no Ops).

## What this closes architecturally

With this slice, the nested-product spine `algebra → set → underlying` is mechanically certified on the canonical rational carrier from the numeric tower:

```
Rational<I>   ──HasCarrier/AlgebraAsProduct──→   ℚ (set)
ℚ             ──SetAsProduct──────────────────→  Rational<I> (underlying) × χ-type (classifier)
```

The load-bearing claim of the #573 umbrella — "HAS-A := mereological parthood via product-as-parthood" — now has a concrete witness on a real, named, numeric carrier.

## Test plan

- [x] `rational.cppm` compiles clean in isolation locally.
- [ ] `test_numbers` blocked locally by the pre-existing libc++ `variant operator==` clang-resolution quirk in `:sint` (CI-only blocker; main is green on the same revision — see `feedback_optimistic_concurrency`).
- [ ] CI green on `build-and-deploy` and CodeQL.
- [ ] No downstream breakage.

## References

- Umbrella: #573.
- Predecessors: PR #648 (slice 1), PR #650 (slice 2), PR #651 (slice 3).
- Sibling in flight: PR #653 (slice 5 paper §3.1 footnote).
- Related: PR #654 (#454 paper figure).
- Pattern precedent: `_has_carrier_witness::algebra_view<T>` in :algebra:universal; `BoolAlgebraView` in algebra_as_product_test.cpp.
