### PR TITLE
docs(paper): #456 — tikz-cd rank progression scalar → vector → matrix

### DIFF
--- a/docs/paper/paper.tex
+++ b/docs/paper/paper.tex
@@ -1351,9 +1351,9 @@ T \arrow[r, "\mathrm{Free}_n", hook] \& V_n(T) = T^n \arrow[r, "\mathrm{End}_T",
                                                   \arrow[l, shift right=2, "\mathrm{row}_i / \mathrm{col}_j"', dashed]
 \end{tikzcd}
 \caption{The rank progression scalar $\to$ vector $\to$ matrix as a commuting diagram (Table~\ref{tab:rosetta-rank}).
-Forward arrows (solid, $\hookrightarrow$) are total morphisms: $\mathrm{Free}_n$ embeds the scalar $T$ as a $1$-tuple (or, equivalently, lifts to a $1{\times}1$ matrix via the composite $\mathrm{End}_T \circ \mathrm{Free}_n$); $\mathrm{End}_T$ promotes a free module $V_n(T)$ to its endomorphism ring $M_n(T)$.
-Reverse arrows (dashed) are not categorical inverses: $\pi_i : V_n \to T$ projects to a single coordinate (a left inverse of $\mathrm{Free}_n$ only on the $i$-th axis), and $\mathrm{row}_i / \mathrm{col}_j : M_n \to V_n$ extracts a row or column (a basis-dependent reduction, not a quotient).
-The diagram commutes on data: the composite $T \hookrightarrow V_n \hookrightarrow M_n$ agrees with the direct scalar-as-$1{\times}1$-matrix embedding, and reductions through the dashed arrows recover scalars from matrices in the basis-aligned subcases.
+Forward arrows (solid, $\hookrightarrow$) are total morphisms: $\mathrm{Free}_n$ is the free-module-of-rank-$n$ construction $T \mapsto V_n(T) = T^n$ (\textbf{P} in the HSP sense; Burris--Sankappanavar §II.10); $\mathrm{End}_T$ is the endomorphism-ring construction $V_n(T) \mapsto M_n(T) = \mathrm{End}_T(V_n)$ (internal hom in $\mathbf{Mod}_R$; Mac Lane CWM §VII).
+Reverse arrows (dashed) are not categorical inverses: $\pi_i : V_n \to T$ projects to a single coordinate (a left inverse of $\mathrm{Free}_n$ only along the $i$-th axis), and $\mathrm{row}_i / \mathrm{col}_j : M_n \to V_n$ extracts a row or column (a basis-dependent reduction, not a quotient).
+The rank ladder reads left-to-right: the only path scalar~$\to$~matrix is the forward composite $T \hookrightarrow V_n \hookrightarrow M_n$; the dashed arrows recover the lower rung from the higher one in the basis-aligned subcases.
 In the codebase the three vertices are inhabited by \cppinline{T}, \cppinline{Vec2V<T>}, and \cppinline{Matrix2x2V<T>} at $n = 2$ (Table~\ref{tab:rosetta-rank}); higher ranks ship through the combinators \texttt{DirectSum} / \texttt{BlockUpperTriangular} / \texttt{Kronecker} (\#368).}
 \label{fig:rank-progression}
 \end{figure}

--- a/docs/paper/paper.tex
+++ b/docs/paper/paper.tex
@@ -1342,6 +1342,22 @@ $M_n(T) = \mathrm{End}_T(V_n)$ & internal hom in $\mathbf{Mod}_R$ (\emph{not} HS
 \end{tabular}
 \end{table}
 
+\begin{figure}[htbp]
+\centering
+\begin{tikzcd}[column sep=5em, row sep=4em, ampersand replacement=\&]
+T \arrow[r, "\mathrm{Free}_n", hook] \& V_n(T) = T^n \arrow[r, "\mathrm{End}_T", hook]
+                                                  \arrow[l, shift right=2, "\pi_i"', dashed]
+\& M_n(T) = \mathrm{End}_T(V_n)
+                                                  \arrow[l, shift right=2, "\mathrm{row}_i / \mathrm{col}_j"', dashed]
+\end{tikzcd}
+\caption{The rank progression scalar $\to$ vector $\to$ matrix as a commuting diagram (Table~\ref{tab:rosetta-rank}).
+Forward arrows (solid, $\hookrightarrow$) are total morphisms: $\mathrm{Free}_n$ embeds the scalar $T$ as a $1$-tuple (or, equivalently, lifts to a $1{\times}1$ matrix via the composite $\mathrm{End}_T \circ \mathrm{Free}_n$); $\mathrm{End}_T$ promotes a free module $V_n(T)$ to its endomorphism ring $M_n(T)$.
+Reverse arrows (dashed) are not categorical inverses: $\pi_i : V_n \to T$ projects to a single coordinate (a left inverse of $\mathrm{Free}_n$ only on the $i$-th axis), and $\mathrm{row}_i / \mathrm{col}_j : M_n \to V_n$ extracts a row or column (a basis-dependent reduction, not a quotient).
+The diagram commutes on data: the composite $T \hookrightarrow V_n \hookrightarrow M_n$ agrees with the direct scalar-as-$1{\times}1$-matrix embedding, and reductions through the dashed arrows recover scalars from matrices in the basis-aligned subcases.
+In the codebase the three vertices are inhabited by \cppinline{T}, \cppinline{Vec2V<T>}, and \cppinline{Matrix2x2V<T>} at $n = 2$ (Table~\ref{tab:rosetta-rank}); higher ranks ship through the combinators \texttt{DirectSum} / \texttt{BlockUpperTriangular} / \texttt{Kronecker} (\#368).}
+\label{fig:rank-progression}
+\end{figure}
+
 \begin{table}[htbp]
 \centering
 \caption{\textbf{Quotient-axis rosetta ($\mathfrak{Q}$) — all rows


### PR DESCRIPTION
## Summary

- Closes #456 (q3-low-corr-high-causal).
- Third sibling figure to #453 (PR #652 comprehension triangle, **merged**) and #454 (PR #654 type-directed collapse, in flight). Same Pierce-style commuting-diagram pattern.
- Sits right after the rank-rosetta `\ref{tab:rosetta-rank}` in §5 Algebraic Lattice, where the scalar / vector / matrix vocabulary lives.

## What the figure shows

```
  T  ──Free_n──→  V_n(T)  ──End_T──→  M_n(T)
      ←──π_i──            ←─row/col──
```

- **Forward arrows** (solid, `↪`): total morphisms — `Free_n` embeds the scalar as a 1-tuple; `End_T` promotes the free module to its endomorphism ring.
- **Reverse arrows** (dashed): basis-dependent reductions, **not categorical inverses** — `π_i` projects to one coordinate, `row_i`/`col_j` extract by basis. Spelled out in the caption so readers don't mistake them for left inverses.

## Codebase wire-up

The three vertices are inhabited by `T`, `Vec2V<T>`, and `Matrix2x2V<T>` at n=2 (per Table 1's rank rosetta). Higher ranks ship via the combinators `DirectSum` / `BlockUpperTriangular` / `Kronecker` (issue #368).

## Test plan

- [x] Local single-pass `lualatex -halt-on-error` builds clean (55 pages — no float overflow, same count as before).
- [ ] CI paper build green on `build-and-deploy`.

## References

- Sibling figures: PR #652 (#453, merged), PR #654 (#454).
- Insertion site: `[paper.tex:1343 → 1370]`, immediately after Table~`tab:rosetta-rank` in §5 Algebraic Lattice.
- Rank rosetta data: Burris–Sankappanavar §II.10 (`Free_n` = HSP-P), Mac Lane CWM §VII (`End_T` = internal hom in `Mod_R`).
