### PR TITLE
feat(sets, category): #602 layer 2 — decidable image(iso, Set) specialisation

### DIFF
--- a/src/main/modules/dedekind/category/morphism.cppm
+++ b/src/main/modules/dedekind/category/morphism.cppm
@@ -854,7 +854,7 @@ concept IsIsomorphism = IsArrow<F> && requires(F f) {
 };
 
 /** @brief The structural inverse of an Identity is itself. */
-template <typename T>
+export template <typename T>
 [[nodiscard]] constexpr auto inverse(Identity<T> id) noexcept {
   return id;
 }
@@ -868,7 +868,7 @@ static_assert(IsIsomorphism<Identity<bool>>,
               "Identity must be a self-inverse isomorphism.");
 
 /** @brief The structural inverse of Negation is itself (Involutive). */
-template <typename A, typename B, typename Impl>
+export template <typename A, typename B, typename Impl>
   requires std::same_as<Impl, std::negate<A>>
 [[nodiscard]] constexpr auto inverse(Morphism<A, B, Impl> f) noexcept {
   return f;  // Negate is its own inverse

--- a/src/main/modules/dedekind/sets/expressions.cppm
+++ b/src/main/modules/dedekind/sets/expressions.cppm
@@ -907,16 +907,19 @@ constexpr auto image(F&&, const Set<T, L, P>&) {
  *         is the source set's characteristic and @c f^{-1} is the
  *         iso's inverse.
  *
- *  @details Captures (i) the source set @c S by value so the closure is
- *  default-constructible-style and constexpr-friendly, and (ii) the
- *  inverse arrow @c FInv by value.  The Set's @c operator() already
- *  performs @c lift_logic<L> on the inner result, and @c S.operator()
- *  on the unwrapped @c x returns @c L::Ω directly, so the composition
- *  preserves the source logic species without going through Ternary.
+ *  @details Captures (i) the source set @c S by value and (ii) the
+ *  inverse arrow @c FInv by value, so the closure is self-contained
+ *  and constexpr-friendly at the call site.  Not default-constructible
+ *  in general --- @c Set<T,L,P> stores a @c Predicate by value and has
+ *  no default constructor, so callers must always supply both
+ *  components to the in-class aggregate initialiser.  The Set's
+ *  @c operator() already performs @c lift_logic<L> on the inner
+ *  result, and @c S.operator() on the unwrapped @c x returns @c L::Ω
+ *  directly, so the composition preserves the source logic species
+ *  without going through Ternary.
  *
  *  @c SourceSet is the @c Set<T,L,P> instantiation; @c FInv is the
- *  type returned by @c inverse(f) for the iso @c f.  Both are stored
- *  by value to keep the composed predicate self-contained.
+ *  type returned by @c inverse(f) for the iso @c f.
  */
 template <typename SourceSet, typename FInv>
 struct ComposedIsoImagePredicate {
@@ -964,10 +967,12 @@ export template <typename T, typename L, typename P,
   requires std::same_as<dedekind::category::Dom<std::remove_cvref_t<F>>, T>
 constexpr auto image(F&& f, const Set<T, L, P>& s) {
   using U = dedekind::category::Cod<std::remove_cvref_t<F>>;
-  // Unqualified call so ADL routes to the inverse overload for f's type
-  // (e.g.\ Identity<T>, TaggedNegate) in dedekind::category, even though
-  // the individual inverse overloads are non-exported.  The IsIsomorphism
-  // concept guarantees the call is well-formed.
+  // Unqualified call so ADL routes to the inverse overload for f's
+  // type (e.g.\ Identity<T>, TaggedNegate) in dedekind::category.
+  // This PR exports the relevant inverse overloads (a small boy-scout
+  // edit in :morphism, see commit history); the unqualified shape is
+  // what the IsIsomorphism concept itself uses, and matches the
+  // codebase's ADL-hook style for partial categorical primitives.
   auto f_inv = inverse(std::forward<F>(f));
   using FInv = std::remove_cvref_t<decltype(f_inv)>;
   using NewPredicate = ComposedIsoImagePredicate<Set<T, L, P>, FInv>;

--- a/src/main/modules/dedekind/sets/expressions.cppm
+++ b/src/main/modules/dedekind/sets/expressions.cppm
@@ -902,6 +902,78 @@ constexpr auto image(F&&, const Set<T, L, P>&) {
       SymbolicImagePredicate<U>{}};
 }
 
+/** @brief Composed predicate for the iso-decidable @c image(f, Set)
+ *         specialisation below: @c y @c ↦ @c S(f^{-1}(y)) where @c S
+ *         is the source set's characteristic and @c f^{-1} is the
+ *         iso's inverse.
+ *
+ *  @details Captures (i) the source set @c S by value so the closure is
+ *  default-constructible-style and constexpr-friendly, and (ii) the
+ *  inverse arrow @c FInv by value.  The Set's @c operator() already
+ *  performs @c lift_logic<L> on the inner result, and @c S.operator()
+ *  on the unwrapped @c x returns @c L::Ω directly, so the composition
+ *  preserves the source logic species without going through Ternary.
+ *
+ *  @c SourceSet is the @c Set<T,L,P> instantiation; @c FInv is the
+ *  type returned by @c inverse(f) for the iso @c f.  Both are stored
+ *  by value to keep the composed predicate self-contained.
+ */
+template <typename SourceSet, typename FInv>
+struct ComposedIsoImagePredicate {
+  SourceSet source;
+  FInv f_inverse;
+
+  template <typename U>
+  constexpr auto operator()(const U& y) const {
+    return source(f_inverse(y));
+  }
+};
+
+/** @brief image(iso f, Set<T, L, P>) — @b decidable specialisation for
+ *         isomorphism arrows (#602 Layer 2 entry).
+ *
+ *  @details When @c f admits an inverse @c f^{-1} (the @c IsIsomorphism
+ *  gate), the image of an intensional Set under @c f is mechanically
+ *  recoverable via predicate composition:
+ *
+ *  @code
+ *    image(f, S) = { y ∈ Cod(f) | S(f^{-1}(y)) }
+ *  @endcode
+ *
+ *  The result is a @c Set<U, L, ComposedIsoImagePredicate<...>> --- the
+ *  same logic species @c L as the source (no demotion to Ternary), and
+ *  a composed predicate that evaluates membership through the inverse.
+ *  This is strictly stronger than the @c IsArrow fallback above, which
+ *  honestly returns the always-Unknown @c SymbolicImagePredicate; iso
+ *  arrows preserve decidability of the image because the existential
+ *  @c ∃x ∈ T. P(x) ∧ y == f(x) reduces to a single test @c P(f^{-1}(y)).
+ *
+ *  Overload resolution picks this specialisation over the @c IsArrow
+ *  one by partial-ordering (@c IsIsomorphism subsumes @c IsArrow).
+ *
+ *  @section expressions__Image_Iso_Layer2_Anchor
+ *
+ *  Layer-2 entry from the @c #602 layering proposal: the
+ *  "predicate-set with iso" path that the Layer-1 overload's docstring
+ *  flagged as the natural strengthening.  Layer-2 will continue with
+ *  weaker partial-inverse gates (monic-with-inverse, Kleisli-bind
+ *  generalisation, etc.) over follow-up slices.
+ */
+export template <typename T, typename L, typename P,
+                 dedekind::category::IsIsomorphism F>
+  requires std::same_as<dedekind::category::Dom<std::remove_cvref_t<F>>, T>
+constexpr auto image(F&& f, const Set<T, L, P>& s) {
+  using U = dedekind::category::Cod<std::remove_cvref_t<F>>;
+  // Unqualified call so ADL routes to the inverse overload for f's type
+  // (e.g.\ Identity<T>, TaggedNegate) in dedekind::category, even though
+  // the individual inverse overloads are non-exported.  The IsIsomorphism
+  // concept guarantees the call is well-formed.
+  auto f_inv = inverse(std::forward<F>(f));
+  using FInv = std::remove_cvref_t<decltype(f_inv)>;
+  using NewPredicate = ComposedIsoImagePredicate<Set<T, L, P>, FInv>;
+  return Set<U, L, NewPredicate>{NewPredicate{s, std::move(f_inv)}};
+}
+
 /** @brief Explicit set complement overload to avoid picking category morphism
  * `!`. */
 export template <typename T, typename L, typename Predicate>

--- a/src/test/cpp/modules/dedekind/sets/expressions_test.cpp
+++ b/src/test/cpp/modules/dedekind/sets/expressions_test.cpp
@@ -426,3 +426,48 @@ TEST_CASE("Dedekind Sets: Heterogeneous subset semantics",
     CHECK(positive.is_subset_of_at(small, -1) == true);
   }
 }
+
+TEST_CASE(
+    "Dedekind Sets: image(iso f, Set<T, L, P>) — #602 Layer 2 decidable "
+    "specialisation",
+    "[sets][image][iso][layer2][602]") {
+  // Identity<int> is an isomorphism (inverse = self).  The image of an
+  // intensional Set<int> under the identity iso must be (i) on the same
+  // ambient int, (ii) on the same logic species (no demotion to Ternary
+  // as the generic IsArrow fallback would), and (iii) decidable point-
+  // wise --- membership query lifts through the inverse (here = the
+  // identity), so the image preserves the source's truth table exactly.
+
+  SECTION("Identity iso preserves classical decidability") {
+    const auto positive_pred = [](const int& v) { return v > 0; };
+    const Set<int, ClassicalLogic, decltype(positive_pred)> positive{
+        positive_pred};
+
+    auto img = image(Identity<int>{}, positive);
+
+    // The image's logic species is the source's (ClassicalLogic),
+    // NOT TernaryLogic (which would be the IsArrow-fallback result).
+    STATIC_CHECK(
+        std::same_as<typename decltype(img)::logic_species, ClassicalLogic>);
+    // Ambient is preserved.
+    STATIC_CHECK(std::same_as<typename decltype(img)::Ambient, int>);
+    // Decidable: same truth values as the source through the identity.
+    CHECK(img(5) == true);
+    CHECK(img(-1) == false);
+    CHECK(img(0) == false);
+  }
+
+  SECTION("Identity iso on a ternary-logic source preserves Ternary") {
+    auto x = element<ℕ>;
+    const auto gt_zero = Set{x | (x > 0u)};
+    static_assert(
+        std::same_as<typename decltype(gt_zero)::logic_species, TernaryLogic>);
+
+    auto img = image(Identity<Cardinality>{}, gt_zero);
+
+    STATIC_CHECK(
+        std::same_as<typename decltype(img)::logic_species, TernaryLogic>);
+    CHECK(img(5u) == Ternary::True);
+    CHECK(img(0u) == Ternary::False);
+  }
+}


### PR DESCRIPTION
## Summary

First **Layer 2** slice of #602 (`image(f, S)` framework — decidable specialisations).

The Layer-1 `image(F, Set<T,L,P>)` overload in `:sets:expressions` returns the always-Unknown `SymbolicImagePredicate` when `F` is a generic `IsArrow` — honest about the undecidability of `∃x ∈ S. y == f(x)` on transfinite carriers without further structure. The Layer-1 docstring already flagged the natural strengthening: *"IsMonicArrow<F> would be the natural strengthening for the decidable-specialisation path (layer 2)"*. This PR ships the **iso half** of that strengthening.

## What lands

```cpp
image(iso f, Set<T, L, P> s)
  = Set<U, L, ComposedIsoImagePredicate>
  where the new predicate sends  y ↦ s(f^{-1}(y))
```

- New `ComposedIsoImagePredicate<Source, FInv>` struct: composes the source set's `operator()` with the inverse arrow.
- New `image(F&& f, const Set<T,L,P>& s)` overload constrained on `IsIsomorphism<F>`. Preferred by C++23 partial ordering over the `IsArrow` fallback (subsumption).
- Two `inverse()` overloads in `:category:morphism` (`Identity<T>` and `Morphism<A,B,std::negate<A>>`) are now `export`ed so ADL can find them from importing modules — they were free functions in `dedekind::category` but not exported, which made `IsIsomorphism`'s `inverse(f)` gate unreachable from `:sets:expressions`.

## What's earned over the fallback

1. **No demotion to Ternary**: result keeps the source's `logic_species` `L` (Classical stays Classical), since iso preserves decidability.
2. **Decidable membership**: queries fire at the carrier through `s(f^{-1}(y))`, returning the original `L::Ω` truth value.

## Test plan

- [x] `test_sets` builds clean; iso-image test passes (8 assertions in 1 case) on filter `[sets][image][iso][layer2][602]`.
- [x] Witness 1: `image(Identity<int>, Set<int, ClassicalLogic, ...>)` preserves Classical, evaluates source predicate through identity.
- [x] Witness 2: `image(Identity<Cardinality>, Set<ℕ, TernaryLogic, ...>)` preserves Ternary at the Cardinality ambient.
- [ ] CI green on `build-and-deploy` and CodeQL.

## Next Layer-2 slices (out of scope here)

- `image(monic f with registered partial inverse, Set)` — generalises beyond iso to the partial-inverse case (e.g.\ `embed_*` arrows that are injective with a `Maybe`-typed retraction).
- Kleisli-bind generalisation `S >>= g` for `g: T → Set<U>`.
- Sequence-mediated image for `IsCompileTimeEnumerable` sets (the powerset-monad bind through `List → Set` natural transformation).

## References

- Parent: #602.
- Layer-1 docstring with the "natural strengthening" pointer: [expressions.cppm:894](src/main/modules/dedekind/sets/expressions.cppm#L894).
- `IsIsomorphism` definition: [morphism.cppm:847](src/main/modules/dedekind/category/morphism.cppm#L847).
- Existing per-shape `image(F, S)` overloads (Layer 1): `singleton.cppm`, `extensional.cppm`, `expressions.cppm` (generic fallback).
