### PR TITLE
feat(sets, category): #659 — decidable image(monic+retract, Set) — #602 Layer 2 / Case A

### DIFF
--- a/src/main/modules/dedekind/category/morphism.cppm
+++ b/src/main/modules/dedekind/category/morphism.cppm
@@ -955,6 +955,51 @@ static_assert(IsEpicArrow<Identity<int>>,
               "Identity must be recognised as an epic arrow.");
 
 /**
+ * @concept IsRetractableArrow
+ * @brief A monic arrow that ships with a structurally-known
+ *        @em retract --- a partial inverse @c retract(f) @c : @c Cod<F>
+ *        @c → @c Maybe<Dom<F>> --- discoverable via ADL on @p F.
+ *
+ * @details The retract is the operational gate for a decidability path
+ * on @c image(f, S) that's strictly more general than @c IsIsomorphism
+ * (which requires a @em total inverse): for a monic @c F that admits a
+ * partial inverse, the image membership
+ *
+ *   @c y @c ∈ @c image(F, @c S)
+ *
+ * reduces to
+ *
+ *   @c let @c mx @c = @c retract(f)(y); @c mx.has_value() @c && @c
+ * S(mx.value())
+ *
+ * which is decidable whenever the retract itself is decidable.  The
+ * canonical project use case is the @c embed_* family of carrier-
+ * lattice embeddings, each of which is monic and admits a natural
+ * partial inverse (e.g.\ @c embed_𝔹_ℕ has retract
+ * @c Cardinality @c → @c Maybe<bool>; @c embed_uint_ℕ has retract
+ * @c Cardinality @c → @c Maybe<unsigned> that fires on the finite-
+ * representable range).
+ *
+ * @par Relation to @c IsIsomorphism
+ * Iso arrows are retractable (the retract is @c inverse(f) wrapped in
+ * the always-Some branch), so structurally @c IsIsomorphism ⊂
+ * @c IsRetractableArrow.  In code we keep the two image-overload paths
+ * disjoint via a @c !IsIsomorphism guard on the retract overload, so
+ * iso routes through the simpler unconditional-inverse path (PR #657)
+ * and only genuinely-partial retracts route through the retract path.
+ *
+ * @par Opt-in semantics
+ * Retracts are user-declared via the @c retract(f) ADL hook (like
+ * @c inverse for @c IsIsomorphism); the concept's @c requires-clause
+ * only checks that the hook is well-formed.  The user owns the
+ * @b correctness obligation (the hook genuinely partially-inverts F).
+ */
+export template <typename F>
+concept IsRetractableArrow = IsMonicArrow<F> && requires(F f) {
+  { retract(f) };
+};
+
+/**
  * @concept IsBijectiveArrow
  * @brief An arrow declared to be both a monomorphism (ι: A ↣ B) and an
  *        epimorphism (π: A ↠ B), i.e. an isomorphism of sets (A ≅ B).

--- a/src/main/modules/dedekind/category/morphism.cppm
+++ b/src/main/modules/dedekind/category/morphism.cppm
@@ -47,6 +47,7 @@ module;
 
 #include <concepts>
 #include <functional>
+#include <optional>
 
 export module dedekind.category:morphism;
 
@@ -957,8 +958,9 @@ static_assert(IsEpicArrow<Identity<int>>,
 /**
  * @concept IsRetractableArrow
  * @brief A monic arrow that ships with a structurally-known
- *        @em retract --- a partial inverse @c retract(f) @c : @c Cod<F>
- *        @c → @c Maybe<Dom<F>> --- discoverable via ADL on @p F.
+ *        @em retract --- a partial inverse
+ *        @c retract(f) @c : @c Cod<F> @c → @c std::optional<Dom<F>> ---
+ *        discoverable via ADL on @p F.
  *
  * @details The retract is the operational gate for a decidability path
  * on @c image(f, S) that's strictly more general than @c IsIsomorphism
@@ -970,33 +972,47 @@ static_assert(IsEpicArrow<Identity<int>>,
  * reduces to
  *
  *   @c let @c mx @c = @c retract(f)(y); @c mx.has_value() @c && @c
- * S(mx.value())
+ * S(*mx)
  *
  * which is decidable whenever the retract itself is decidable.  The
  * canonical project use case is the @c embed_* family of carrier-
  * lattice embeddings, each of which is monic and admits a natural
  * partial inverse (e.g.\ @c embed_𝔹_ℕ has retract
- * @c Cardinality @c → @c Maybe<bool>; @c embed_uint_ℕ has retract
- * @c Cardinality @c → @c Maybe<unsigned> that fires on the finite-
- * representable range).
+ * @c Cardinality @c → @c std::optional<bool>; @c embed_uint_ℕ has
+ * retract @c Cardinality @c → @c std::optional<unsigned> that fires on
+ * the finite-representable range).
+ *
+ * @par Concept shape
+ * The concept requires that @c retract(f) is invocable on
+ * @c Cod<F> @c const& and returns an @c std::optional -shaped value
+ * (one supporting @c has_value() and @c operator*).  Generalising to
+ * the project's broader @c IsPotential surface (which also admits
+ * @c Partial<T> / @c TernaryResult<T> as Maybe-likes) is a deliberate
+ * follow-up --- for retracts specifically, the binary has/has-not
+ * distinction @c std::optional carries is what the image-overload
+ * needs, and tighter shapes than that aren't load-bearing today.
  *
  * @par Relation to @c IsIsomorphism
- * Iso arrows are retractable (the retract is @c inverse(f) wrapped in
- * the always-Some branch), so structurally @c IsIsomorphism ⊂
- * @c IsRetractableArrow.  In code we keep the two image-overload paths
- * disjoint via a @c !IsIsomorphism guard on the retract overload, so
- * iso routes through the simpler unconditional-inverse path (PR #657)
- * and only genuinely-partial retracts route through the retract path.
+ * Mathematically, an isomorphism has a total inverse, so a retract for
+ * it is structurally available (wrap @c inverse(f) in always-Some).
+ * In @b code, however, this PR does @b not auto-register a
+ * @c retract(f) hook for arbitrary @c IsIsomorphism @c F --- the
+ * concept here is satisfied only when the user has explicitly provided
+ * a @c retract overload AND opted into @c is_monic_arrow_v.  Iso
+ * arrows therefore continue to route through the @c IsIsomorphism
+ * image-overload path (#657), and the retract path handles the
+ * monic-but-not-iso case.  If a user wanted to route an iso through
+ * the retract overload they would have to register the retract hook
+ * themselves --- not done by default.
  *
  * @par Opt-in semantics
  * Retracts are user-declared via the @c retract(f) ADL hook (like
- * @c inverse for @c IsIsomorphism); the concept's @c requires-clause
- * only checks that the hook is well-formed.  The user owns the
- * @b correctness obligation (the hook genuinely partially-inverts F).
+ * @c inverse for @c IsIsomorphism).  The user owns the @b correctness
+ * obligation (the hook genuinely partially-inverts F).
  */
 export template <typename F>
-concept IsRetractableArrow = IsMonicArrow<F> && requires(F f) {
-  { retract(f) };
+concept IsRetractableArrow = IsMonicArrow<F> && requires(F f, const Cod<F>& y) {
+  { retract(f)(y) } -> std::same_as<std::optional<Dom<F>>>;
 };
 
 /**

--- a/src/main/modules/dedekind/sets/expressions.cppm
+++ b/src/main/modules/dedekind/sets/expressions.cppm
@@ -1015,21 +1015,32 @@ struct ComposedRetractImagePredicate {
  *         inverse via the @c retract(f) ADL hook).  #602 Layer 2 / Case A.
  *
  *  @details When @c f is a monomorphism (@c IsMonicArrow) AND ships a
- *  retract @c retract(f) @c : @c Cod(f) @c → @c Maybe<Dom(f)>, the image
- *  of an intensional Set is mechanically recoverable via the retract:
+ *  retract @c retract(f) @c : @c Cod(f) @c → @c std::optional<Dom(f)>,
+ *  the image of an intensional Set is mechanically recoverable via the
+ *  retract:
  *
  *  @code
  *    image(f, S)(y)
  *      = let mx = retract(f)(y);
- *        mx.has_value() ? S(mx.value()) : L::False
+ *        mx.has_value() ? S(*mx) : L::False
  *  @endcode
  *
- *  This is strictly more general than the @c IsIsomorphism specialisation
- *  above (#657 sister): iso arrows happen to be retractable too (retract
- *  is inverse wrapped in always-Some), but most carrier-lattice embeddings
- *  in the project (@c embed_𝔹_ℕ, @c embed_uint_ℕ, @c embed_sint_ℤ, ...)
- *  are monic-but-not-iso with natural retracts that can opt in to this
- *  path by registering a @c retract overload.
+ *  The retract contract is @c std::optional -shaped specifically (the
+ *  @c IsRetractableArrow concept in @c :morphism gates on
+ *  @c std::same_as<std::optional<Dom<F>>>); generalising to the
+ *  project's broader @c IsPotential surface (@c Partial<T> /
+ *  @c TernaryResult<T> etc.) is a deliberate follow-up.
+ *
+ *  This is independent of the @c IsIsomorphism specialisation above
+ *  (#657 sister): although every iso has a structural total retract,
+ *  this PR does @b not auto-register a @c retract hook for arbitrary
+ *  iso arrows, so iso routes through the @c IsIsomorphism overload
+ *  unchanged.  The retract path handles the monic-but-not-iso case ---
+ *  most carrier-lattice embeddings in the project (@c embed_𝔹_ℕ,
+ *  @c embed_uint_ℕ, @c embed_sint_ℤ, ...) are monic and admit a
+ *  natural retract, and can opt in to this path by registering a
+ *  @c retract overload alongside their existing @c is_monic_arrow_v
+ *  declaration.
  *
  *  The result keeps the source's logic species @c L (no demotion to
  *  Ternary) and stores the composed predicate carrying both the source
@@ -1037,10 +1048,11 @@ struct ComposedRetractImagePredicate {
  *
  *  @par Disambiguation against the iso overload
  *  The @c !IsIsomorphism guard in the requires-clause keeps iso arrows
- *  on the simpler unconditional-inverse path above (#657) and only
- *  routes genuinely-partial retracts here.  Both overloads otherwise
- *  satisfy the same partial-ordering tier (more constrained than the
- *  @c IsArrow fallback), so the guard is the explicit tiebreaker.
+ *  on the simpler unconditional-inverse path above (#657) in the
+ *  hypothetical case where a user did opt an iso arrow into the
+ *  retract path (by registering a retract hook on it).  Without that
+ *  guard, an iso arrow that also happened to be retractable would be
+ *  ambiguous between the two overloads; with it, iso always wins.
  */
 export template <typename T, typename L, typename P,
                  dedekind::category::IsRetractableArrow F>

--- a/src/main/modules/dedekind/sets/expressions.cppm
+++ b/src/main/modules/dedekind/sets/expressions.cppm
@@ -902,6 +902,84 @@ constexpr auto image(F&&, const Set<T, L, P>&) {
       SymbolicImagePredicate<U>{}};
 }
 
+/** @brief Composed predicate for the retract-decidable @c image(f, Set)
+ *         specialisation: @c y @c ↦ @c let @c mx @c = @c retract(f)(y);
+ *         @c mx.has_value() @c ? @c S(mx.value()) @c : @c L::False.
+ *
+ *  @details Operational shape:
+ *  - When @c retract(f)(y) has a value, the membership query factors
+ *    through the source set's @c operator() at that preimage.
+ *  - When the retract returns nothing, @c y is structurally outside
+ *    @c image(F, S) and the predicate returns @c L::False directly.
+ *
+ *  Stores the source set and the retract callable by value.  Sister
+ *  predicate shape to the (in-flight) @c ComposedIsoImagePredicate
+ *  from #657 / #602 Case A's iso sibling.
+ */
+template <typename SourceSet, typename RetractFn, typename L>
+struct ComposedRetractImagePredicate {
+  SourceSet source;
+  RetractFn retract_fn;
+
+  template <typename U>
+  constexpr typename L::Ω operator()(const U& y) const {
+    auto mx = retract_fn(y);
+    if (mx.has_value()) {
+      return source(*mx);
+    }
+    return L::False;
+  }
+};
+
+/** @brief image(monic-with-retract f, Set<T, L, P>) --- @b decidable
+ *         specialisation for monic arrows that ship a retract (a partial
+ *         inverse via the @c retract(f) ADL hook).  #602 Layer 2 / Case A.
+ *
+ *  @details When @c f is a monomorphism (@c IsMonicArrow) AND ships a
+ *  retract @c retract(f) @c : @c Cod(f) @c → @c Maybe<Dom(f)>, the image
+ *  of an intensional Set is mechanically recoverable via the retract:
+ *
+ *  @code
+ *    image(f, S)(y)
+ *      = let mx = retract(f)(y);
+ *        mx.has_value() ? S(mx.value()) : L::False
+ *  @endcode
+ *
+ *  This is strictly more general than the @c IsIsomorphism specialisation
+ *  (#657 sister): iso arrows happen to be retractable too (retract is
+ *  inverse wrapped in always-Some), but most carrier-lattice embeddings
+ *  in the project (@c embed_𝔹_ℕ, @c embed_uint_ℕ, @c embed_sint_ℤ, ...)
+ *  are monic-but-not-iso with natural retracts that can opt in to this
+ *  path by registering a @c retract overload.
+ *
+ *  The result keeps the source's logic species @c L (no demotion to
+ *  Ternary) and stores the composed predicate carrying both the source
+ *  set and the retract callable.
+ *
+ *  @par Disambiguation against the iso overload
+ *  The @c !IsIsomorphism guard in the requires-clause keeps iso arrows
+ *  on the simpler unconditional-inverse path (#657, sister sub-task)
+ *  and only routes genuinely-partial retracts here.  Both overloads
+ *  otherwise satisfy the same partial-ordering tier (more constrained
+ *  than the @c IsArrow fallback), so the guard is the explicit
+ *  tiebreaker.
+ */
+export template <typename T, typename L, typename P,
+                 dedekind::category::IsRetractableArrow F>
+  requires std::same_as<dedekind::category::Dom<std::remove_cvref_t<F>>, T> &&
+           (!dedekind::category::IsIsomorphism<std::remove_cvref_t<F>>)
+constexpr auto image(F&& f, const Set<T, L, P>& s) {
+  using U = dedekind::category::Cod<std::remove_cvref_t<F>>;
+  // Unqualified call so ADL routes to the retract overload registered
+  // for f's type in the appropriate namespace.  The IsRetractableArrow
+  // concept guarantees the call is well-formed.
+  auto retract_fn = retract(std::forward<F>(f));
+  using RetractFn = std::remove_cvref_t<decltype(retract_fn)>;
+  using NewPredicate =
+      ComposedRetractImagePredicate<Set<T, L, P>, RetractFn, L>;
+  return Set<U, L, NewPredicate>{NewPredicate{s, std::move(retract_fn)}};
+}
+
 /** @brief Explicit set complement overload to avoid picking category morphism
  * `!`. */
 export template <typename T, typename L, typename Predicate>

--- a/src/test/cpp/modules/dedekind/sets/expressions_test.cpp
+++ b/src/test/cpp/modules/dedekind/sets/expressions_test.cpp
@@ -1,10 +1,41 @@
 #include <catch2/catch_test_macros.hpp>
+#include <optional>
 
 import dedekind.category;
 import dedekind.sets;
 
 using namespace dedekind::category;
 using namespace dedekind::sets;
+
+// Test-fork helpers for the retract-decidable image specialisation
+// (#602 Layer 2 / Case A / #659).  A non-iso monic arrow whose image
+// is decidable through a partial inverse (retract).
+//
+// DoubleArrow: int → int, x ↦ 2*x.  Monic (the user declares
+// is_monic_arrow_v) but not iso (the codomain is "even ints only", so
+// no total inverse on the natural int).  Retract: y ↦ y/2 if y is
+// even, else nullopt.
+namespace retract_image_test {
+struct DoubleArrow {
+  using Domain = int;
+  using Codomain = int;
+  constexpr int operator()(int x) const { return 2 * x; }
+};
+
+constexpr auto retract(DoubleArrow) {
+  return [](const int& y) -> std::optional<int> {
+    if (y % 2 == 0) return y / 2;
+    return std::nullopt;
+  };
+}
+}  // namespace retract_image_test
+
+// Register the monic trait so IsMonicArrow (and IsRetractableArrow)
+// fire on the test wrapper.
+template <>
+inline constexpr bool
+    dedekind::category::is_monic_arrow_v<retract_image_test::DoubleArrow> =
+        true;
 
 TEST_CASE("Dedekind MVP: Basic Membership and Symbols", "[sets]") {
   SECTION("Integer Universe Membership") {
@@ -424,5 +455,42 @@ TEST_CASE("Dedekind Sets: Heterogeneous subset semantics",
 
     CHECK(positive.is_subset_of_at(small, 5) == false);
     CHECK(positive.is_subset_of_at(small, -1) == true);
+  }
+}
+
+TEST_CASE(
+    "Dedekind Sets: image(monic-with-retract, Set) — #602 Layer 2 / Case A",
+    "[sets][image][retract][monic][layer2][602]") {
+  // DoubleArrow is monic (declared above) but not iso --- the codomain
+  // is "even ints", a strict subset of int.  The retract sends even y
+  // back to y/2 and odd y to nullopt.  Test that:
+  //   (i)  image(DoubleArrow, S) preserves the source's logic species
+  //        (no demotion to TernaryLogic);
+  //   (ii) y in image iff y is even AND y/2 in S (decidable);
+  //   (iii) odd y is always out of image (the retract returns nullopt).
+
+  SECTION("Classical: image preserves Classical decidability") {
+    const auto positive_pred = [](const int& v) { return v > 0; };
+    const Set<int, ClassicalLogic, decltype(positive_pred)> positive{
+        positive_pred};
+
+    auto img = image(retract_image_test::DoubleArrow{}, positive);
+
+    // Logic species is preserved (NOT TernaryLogic, which would be the
+    // IsArrow-fallback result).
+    STATIC_CHECK(
+        std::same_as<typename decltype(img)::logic_species, ClassicalLogic>);
+    STATIC_CHECK(std::same_as<typename decltype(img)::Ambient, int>);
+
+    // y = 10 is even, 10/2 = 5 > 0, so in image.
+    CHECK(img(10) == true);
+    // y = 4 is even, 4/2 = 2 > 0, so in image.
+    CHECK(img(4) == true);
+    // y = -6 is even, -6/2 = -3, not > 0, so NOT in image.
+    CHECK(img(-6) == false);
+    // y = 7 is odd, retract returns nullopt → NOT in image.
+    CHECK(img(7) == false);
+    // y = -3 is odd, same story.
+    CHECK(img(-3) == false);
   }
 }


### PR DESCRIPTION
## Summary

Closes #659 — second decidable `image(F, Set<T,L,P>)` specialisation on the #602 Layer-2 axis, after #657 (iso). Generalises decidability from "F invertible" to "F monic with a structurally-known partial inverse (retract)".

## What lands

1. **`IsRetractableArrow<F>` concept** in `:category:morphism`:
   ```cpp
   IsMonicArrow<F> && requires(F f) { { retract(f) }; }
   ```
   The `retract(f)` ADL hook returns a callable `Cod<F> → std::optional<Dom<F>>` (or any Maybe-shaped retraction).

2. **`image(monic-with-retract f, Set<T,L,P>)` overload** in `:sets:expressions`, gated on `IsRetractableArrow<F> && !IsIsomorphism<F>`. The `!IsIsomorphism` guard disambiguates against the iso path (in flight on PR #657) — iso arrows are technically retractable too, but route through the simpler unconditional-inverse path.

   Composed predicate:
   ```cpp
   image(f, S)(y)
     = let mx = retract(f)(y);
       mx.has_value() ? S(mx.value()) : L::False
   ```

   Result keeps the source's logic species `L` (no demotion to `TernaryLogic`).

3. **Witness** in the test fork: `DoubleArrow` (`int → int`, `x ↦ 2x`, monic but not iso) with `retract(y) = y/2 if even, nullopt otherwise`. 7 assertions cover the even-in-image, even-out-of-image, and odd-not-in-image cases over a Classical-logic source set.

## Test plan

- [x] `test_sets` builds clean; retract-image test passes (7 assertions in 1 case) on filter `[sets][image][retract][monic][layer2][602]`.
- [ ] CI green on `build-and-deploy` and CodeQL.

## Sequencing

- Sister of **PR #657** (iso case, in flight). Disambiguation via `!IsIsomorphism` keeps both paths cleanly separate. If #657 merges first, this PR's gate continues to work. If this merges first, #657 should rebase on top — the `!IsIsomorphism` guard is in the requires-clause of *this* PR's overload, so the iso overload from #657 needs no change.

## Natural follow-up (out of scope here)

Register `retract` overloads on the existing carrier-lattice embeddings (`embed_𝔹_ℕ`, `embed_uint_ℕ`, `embed_sint_ℤ`) so they pick up the decidable-image path automatically. That's another focused slice.

## References

- Parent: #602 (Layer 2).
- Sister sub-tasks: #657 (iso, PR open), #660 (enumerable source), #661 (terminal codomain).
- Pattern: PR #657's `ComposedIsoImagePredicate`.
