### PR TITLE
feat(sets): #660 — decidable image(F, ExtensionalSet) — #602 Layer 2 / Case B

### DIFF
--- a/src/main/modules/dedekind/sets/extensional.cppm
+++ b/src/main/modules/dedekind/sets/extensional.cppm
@@ -426,6 +426,41 @@ constexpr auto image(F&& f, std::set<T, Compare, Alloc>&& s) {
   }
 }
 
+/** @brief image(f, ExtensionalSet<T, L>) --- #602 Layer 2 / Case B
+ *         enumeration-decidable specialisation.
+ *
+ *  @details Exhaustive iteration is the decidability path here ---
+ *  unlike the F-side cases (iso / monic-with-retract), this overload
+ *  imposes @b no invertibility requirement on @c F.  Decidability is
+ *  inherited from the source set's extensionality: every element of
+ *  the source set is enumerable, every image is computed by direct
+ *  application, and the result lives in a finite extensional carrier
+ *  with classical-equality-based membership.
+ *
+ *  The result preserves the source's logic species @c L and is itself
+ *  an @c ExtensionalSet<U, L> (with default Hash / Equal policies on
+ *  the codomain type when @c U @c != @c T).
+ *
+ *  Sibling of @c image(f, std::unordered_set<T>) and @c image(f, std::set<T>)
+ *  above; this overload promotes the result to the project's wrapper
+ *  carrier rather than the bare std-container shape, keeping logic-
+ *  species information intact.  Together with the F-side specialisations
+ *  (iso #657, retract #659 / Case A), this completes the "low-hanging
+ *  fruit" Layer-2 decidability landscape from the #602 layering proposal.
+ */
+export template <typename T, typename L, typename Hash, typename Equal,
+                 typename F>
+  requires std::invocable<F&, const T&>
+constexpr auto image(F&& f, const ExtensionalSet<T, L, Hash, Equal>& s) {
+  using U = std::remove_cvref_t<std::invoke_result_t<F&, const T&>>;
+  ExtensionalSet<U, L> out;
+  out.elements.reserve(s.size());
+  for (const auto& x : s.elements) {
+    out.elements.insert(std::invoke(f, x));
+  }
+  return out;
+}
+
 /** @brief filter(p, std::unordered_set<T, Hash, Equal, Alloc>) — lvalue.
  *
  *  @details Filter is always endomorphic on the element type, so the

--- a/src/test/cpp/modules/dedekind/sets/extensional_test.cpp
+++ b/src/test/cpp/modules/dedekind/sets/extensional_test.cpp
@@ -132,3 +132,58 @@ TEST_CASE("Sets: image / filter on std-container carriers (#602, trivial)",
     CHECK_FALSE(evens_isset.χ(3));
   }
 }
+
+TEST_CASE(
+    "Dedekind Sets: image(F, ExtensionalSet<T, L>) — #602 Layer 2 / Case B",
+    "[sets][image][extensional][enumerated][layer2][602]") {
+  // Enumeration-decidable image: no invertibility requirement on F.
+  // Decidability comes from the source's extensionality --- iterate,
+  // fmap, collect.  The result is an ExtensionalSet<U, L>, preserving
+  // the source's logic species.
+
+  SECTION("Endomorphic image preserves Classical logic species") {
+    ExtensionalSet<int, dedekind::category::ClassicalLogic> S;
+    S.elements = {1, 2, 3, 4, 5};
+
+    auto img = image([](const int& x) { return x * 2; }, S);
+
+    STATIC_CHECK(std::same_as<typename decltype(img)::logic_species,
+                              dedekind::category::ClassicalLogic>);
+    STATIC_CHECK(std::same_as<typename decltype(img)::Domain, int>);
+    CHECK(img.size() == 5u);
+    CHECK(img.contains(2));
+    CHECK(img.contains(10));
+    CHECK_FALSE(img.contains(3));  // Odd, not in 2*{1..5}.
+  }
+
+  SECTION("Cross-carrier image (T → U) lands in ExtensionalSet<U, L>") {
+    ExtensionalSet<int, dedekind::category::ClassicalLogic> S;
+    S.elements = {-1, 0, 1};
+
+    // Map to bool: is the int non-negative?
+    auto img = image([](const int& x) { return x >= 0; }, S);
+
+    STATIC_CHECK(std::same_as<typename decltype(img)::Domain, bool>);
+    STATIC_CHECK(std::same_as<typename decltype(img)::logic_species,
+                              dedekind::category::ClassicalLogic>);
+    // {-1, 0, 1} → {false, true} after image.
+    CHECK(img.size() == 2u);
+    CHECK(img.contains(true));
+    CHECK(img.contains(false));
+  }
+
+  SECTION(
+      "Non-injective F collapses duplicates (decidability via set semantics)") {
+    ExtensionalSet<int, dedekind::category::ClassicalLogic> S;
+    S.elements = {-2, -1, 0, 1, 2};
+
+    // x ↦ |x| collapses {-2,2} → 2 and {-1,1} → 1.
+    auto img = image([](const int& x) { return x < 0 ? -x : x; }, S);
+
+    CHECK(img.size() == 3u);  // {0, 1, 2}
+    CHECK(img.contains(0));
+    CHECK(img.contains(1));
+    CHECK(img.contains(2));
+    CHECK_FALSE(img.contains(-1));
+  }
+}


### PR DESCRIPTION
## Summary

Closes #660 — third Layer-2 decidable specialisation past the F-side cases (iso #657 + retract #662). Switches the decidability source from the **F-side** (invertibility) to the **S-side** (enumeration).

## What lands

New `image(F, ExtensionalSet<T, L, Hash, Equal>)` overload in `:sets:extensional`:

- Iterates `s.elements` via begin/end, applies `F` to each, collects into a new `ExtensionalSet<U, L>` where `U = std::invoke_result_t<F&, const T&>`.
- Result preserves the source's logic species `L` (no demotion to `TernaryLogic`).
- Falls back to default `Hash` / `Equal` on the codomain when `U ≠ T`.
- **No invertibility requirement on F** — decidability comes from the source's extensionality + classical-equality semantics of `std::unordered_set`.

## Note on the sub-issue body

The issue body referenced `IsCompileTimeEnumerable<S>` as the gate. That concept was [retired](src/main/modules/dedekind/sets/computability.cppm#L25-L27) as redundant — `:sets:cardinality::IsExtensional` (and friends) is the canonical home for the enumerability axis post-2026-05-09. The concrete carrier `ExtensionalSet<T, L>` already satisfies `IsExtensional` and `IsEnumerated`; this overload targets it directly.

## Test plan

- [x] `test_sets` builds clean; Case B test passes (16 assertions in 1 case) on filter `[sets][image][extensional][enumerated][layer2][602]`.
- [x] Three witness sections:
  - Endomorphic (`int → int`): doubling preserves Classical L + size + contents.
  - Cross-carrier (`int → bool`): collapses `{-1,0,1}` to `{false,true}` via "is non-negative".
  - Non-injective: `|·|` collapses `{-2,-1,0,1,2}` to `{0,1,2}` via set deduplication.
- [ ] CI green on `build-and-deploy` and CodeQL.

## #602 Layer 2 status after this slice

| Case | F-side gate | S-side gate | Status |
|---|---|---|---|
| Iso | `IsIsomorphism<F>` | any | ✅ #657 merged |
| A — Retract | `IsRetractableArrow<F>` | any | ✅ #662 merged |
| **B — Enumerable** | any `IsArrow<F>` | `ExtensionalSet<T, L>` | **THIS PR** |
| C — Terminal codomain | `IsTerminalMorphism<F>` | any | open #661 |
| (general fallback) | `IsArrow<F>` only | any | already in place — honest always-Unknown |

With this PR the three "low-hanging fruit" Layer-2 paths are covered. Case C (#661) is the optional small-bonus slice; the deeper general solution provably doesn't exist (many F are not invertible).

## References

- Parent: #602 (Layer 2).
- Pattern source: existing `image(F, std::unordered_set<T>)` overloads in `:sets:extensional`.
- Sibling sub-tasks: #657 (iso, merged), #659 (retract, merged as #662), #661 (terminal codomain).
