### PR TITLE
feat(scout_algebra): #664 Slice 4 — affine composition (m*x + b) on fields

### DIFF
--- a/src/main/modules/dedekind/algebra/scout_algebra.cppm
+++ b/src/main/modules/dedekind/algebra/scout_algebra.cppm
@@ -33,17 +33,26 @@
  *    @c IsAbelianGroup<T, @c std::multiplies<T>> (i.e.\ a field
  *    carrier, gated on PR #674's @c IsField cert) --- produces
  *    @c GroupScout<T, @c std::multiplies<T>, @c k, @c BoundScout<T>>.
+ *  - @c operator+(GroupScout, @c Bound<k>) and
+ *    @c operator*(GroupScout, @c Bound<k>) (Slice 4): @b composition
+ *    factories lifting the above to a @c GroupScout LHS, so the
+ *    canonical @b affine syntax @c (in<T> @c * @c bound<m>) @c + @c
+ *    bound<k> = @c λx.\,m*x @c + @c k compiles.  Two-layer composition
+ *    today (one BoundScout-inner leaf); deeper composition is a
+ *    follow-up.
  *
  * The comprehension pipe @c GroupScout::operator|(Halfspace) performs
  * @b halfspace-pivot @b transport.  The additive pipe shifts the
  * source pivot by the scout's @c Element along the additive group
  * action.  The multiplicative pipe (Slice 3) scales the source pivot,
  * preserves direction when @c k > 0, flips direction when @c k < 0,
- * and Honest-Rejects @c k = 0 (collapsing-halfspace case).  Both
- * yield a @c Comprehension that Set CTAD picks up and resolves to a
- * @c Set with the transported halfspace as predicate.  No Set CTAD
- * changes needed; the existing @c Comprehension path in
- * @c :sets:expressions is the consumer.
+ * and Honest-Rejects @c k = 0 (collapsing-halfspace case).  Slice 4's
+ * @b composition pipes recurse: inner-first transport, then outer's
+ * pipe on top, with the same direction-flip rules.  All yield a
+ * @c Comprehension that Set CTAD picks up and resolves to a @c Set
+ * with the transported halfspace as predicate.  No Set CTAD changes
+ * needed; the existing @c Comprehension path in @c :sets:expressions
+ * is the consumer.
  *
  * @section scout_algebra__Honest_Rejection
  *
@@ -66,9 +75,11 @@
  *    (e.g.\ @c Rational{1,k}) into the resulting scout's @c Element,
  *    which forces @c T to be a structural NTTP carrier ---
  *    incompatible with the variant-carrier ℚ today.  Follow-up.
- *  - Composition of scouts beyond a single @c BoundScout inner
- *    (e.g.\ @c bound<2> @c * @c in<ℤ> @c + @c bound<1> --- where the
- *    inner of the outer @c + is itself a @c GroupScout) (follow-up).
+ *  - Deeper composition (3+ layers --- e.g.\ @c ((x @c + @c 1) @c *
+ *    @c 2) @c + @c 3) is not yet enabled: the Slice-4 composition
+ *    pipes assume a 2-layer @c GroupScout-of-@c BoundScout chain.
+ *    Lifting to recursive composition would require the recursive
+ *    case to also accept @c GroupScout-of-@c GroupScout as @c Inner.
  *
  * @copyright 2026 The Dedekind Authors
  * Licensed under the Apache License, Version 2.0.
@@ -405,6 +416,109 @@ struct GroupScout {
           Inner::ambient, NewHalfspace{}};
     }
   }
+
+  /**
+   * @brief Comprehension pipe (composition): @c GroupScout @c |
+   *        @c Halfspace when @c Inner is itself a @c GroupScout ---
+   *        recursive halfspace-pivot transport across a composed
+   *        affine map @c λx.\,f(g(x)) (#664 Slice 4).
+   *
+   * @details
+   * Composition reads inside-out: @c (@c m @c * @c x @c ) @c + @c b
+   * = @c λx.\,b @c + @c (m @c * @c x) is the outer @c GroupScout
+   * (@c Op @c = @c std::plus, @c Element @c = @c b) wrapping the
+   * inner @c GroupScout (@c Op @c = @c std::multiplies,
+   * @c Element @c = @c m).  Halfspace transport applies the @b inner
+   * transport first (it's the inside of the function composition),
+   * then this scout's transport on top.  The result is the same
+   * @c Comprehension shape the base pipes produce; the recursion
+   * terminates at a @c BoundScout-inner leaf via the base-case
+   * overload above.
+   *
+   * The new pivot, direction, and strictness are extracted from
+   * @c Inner 's pipe result (@c Comprehension<..., InnerHalfspace>),
+   * then re-transported under @c std::plus<T> .  Mirrors the
+   * non-composed additive pipe's pivot arithmetic.
+   *
+   * @section Specialisation gate
+   *
+   * Outer is additive (@c Op @c = @c std::plus<T>) over an Inner that
+   * is a @c GroupScout (not a @c BoundScout).  The multiplicative-
+   * outer composition case (@c (@c x @c + @c b @c ) @c * @c m) is
+   * the dual overload below; the inner-leg recursion makes both
+   * cases compose freely.  Recursive composition (3+ layers) is not
+   * yet enabled (would require detecting @c Inner being a
+   * @c GroupScout-of-GroupScout); ship the 2-layer affine case first.
+   */
+  template <auto Pivot, dedekind::order::Direction D,
+            dedekind::order::Strictness S, typename L>
+    requires std::same_as<Op, std::plus<T>> && IsOrderedAdditiveGroup<T> &&
+             // Inner is a @c GroupScout (composition); has @c op_type
+             // and @c element, but not @c AmbientType / @c ambient ---
+             // the latter live on the @c BoundScout at the bottom of
+             // the chain.
+             requires {
+               typename Inner::op_type;
+               Inner::element;
+             }
+  constexpr auto operator|(
+      dedekind::order::Halfspace<T, Pivot, D, S, L> hs) const {
+    constexpr auto inner_comp = Inner{} | hs;
+    using InnerPredicate = std::remove_cvref_t<decltype(inner_comp.predicate)>;
+    constexpr auto new_pivot = InnerPredicate::pivot + Element;
+    using NewHalfspace =
+        dedekind::order::Halfspace<T, new_pivot, InnerPredicate::direction,
+                                   InnerPredicate::strictness, L>;
+    using AmbientType = std::remove_cvref_t<decltype(inner_comp.base)>;
+    return dedekind::sets::Comprehension<AmbientType, NewHalfspace>{
+        inner_comp.base, NewHalfspace{}};
+  }
+
+  /**
+   * @brief Comprehension pipe (composition, multiplicative outer):
+   *        @c (g(x)) @c * @c m where @c g is an inner scout.
+   *
+   * @details
+   * Multiplicative-outer twin of the composition pipe above.  Reads
+   * @c (@c x @c + @c b @c ) @c * @c m = @c λx.\,m @c * @c (x @c + @c b)
+   * --- inner additive shift, outer multiplicative scale.  Inner's
+   * pipe transports first; this scout multiplies the result's pivot
+   * by @c Element and flips direction if @c Element @c < @c 0
+   * (same direction-flip rule as the non-composed multiplicative
+   * pipe).  Honest-Rejects @c Element @c = @c 0.
+   */
+  template <auto Pivot, dedekind::order::Direction D,
+            dedekind::order::Strictness S, typename L>
+    requires std::same_as<Op, std::multiplies<T>> &&
+             IsOrderedMultiplicativeGroup<T> &&
+             (Element != decltype(Element){}) && requires {
+               typename Inner::op_type;
+               Inner::element;
+             }
+  constexpr auto operator|(
+      dedekind::order::Halfspace<T, Pivot, D, S, L> hs) const {
+    constexpr auto inner_comp = Inner{} | hs;
+    using InnerPredicate = std::remove_cvref_t<decltype(inner_comp.predicate)>;
+    constexpr auto new_pivot = Element * InnerPredicate::pivot;
+    using AmbientType = std::remove_cvref_t<decltype(inner_comp.base)>;
+    if constexpr (Element > decltype(Element){}) {
+      using NewHalfspace =
+          dedekind::order::Halfspace<T, new_pivot, InnerPredicate::direction,
+                                     InnerPredicate::strictness, L>;
+      return dedekind::sets::Comprehension<AmbientType, NewHalfspace>{
+          inner_comp.base, NewHalfspace{}};
+    } else {
+      constexpr auto flipped =
+          (InnerPredicate::direction == dedekind::order::Direction::Upward)
+              ? dedekind::order::Direction::Downward
+              : dedekind::order::Direction::Upward;
+      using NewHalfspace =
+          dedekind::order::Halfspace<T, new_pivot, flipped,
+                                     InnerPredicate::strictness, L>;
+      return dedekind::sets::Comprehension<AmbientType, NewHalfspace>{
+          inner_comp.base, NewHalfspace{}};
+    }
+  }
 };
 
 }  // namespace dedekind::algebra
@@ -507,6 +621,51 @@ constexpr auto operator*(BoundScout<Ambient>, dedekind::order::Bound<K>) {
   using T = typename BoundScout<Ambient>::T;
   return dedekind::algebra::GroupScout<T, std::multiplies<T>, K,
                                        BoundScout<Ambient>>{};
+}
+
+/**
+ * @brief Composition (additive outer): @c (g(x)) @c + @c bound<k> for
+ *        any @c GroupScout @c g(x) (#664 Slice 4).
+ *
+ * @details
+ * Lifts the @c operator+ factory from @c BoundScout to any
+ * @c GroupScout LHS, enabling the canonical @b affine syntax
+ * @c (in<ℚ> @c * @c bound<m>) @c + @c bound<k> = @c λx.\,m*x @c + @c k
+ * (or its multiplicative-outer twin below).  The result is a
+ * @c GroupScout with the LHS as @c Inner --- recursion handled by
+ * the composition pipe in @c GroupScout::operator|(Halfspace) above.
+ *
+ * Honest Rejection: writing @c (g(x)) @c + @c bound<k> on a non-
+ * additive-group carrier @c T fails at the same gate as the base
+ * factory (@c IsAbelianGroup<T, std::plus<T>>).
+ */
+export template <typename T, typename InnerOp, auto InnerElement,
+                 typename InnerInner, auto K>
+  requires dedekind::category::IsAbelianGroup<T, std::plus<T>> &&
+           std::convertible_to<decltype(K), T>
+constexpr auto operator+(
+    dedekind::algebra::GroupScout<T, InnerOp, InnerElement, InnerInner>,
+    dedekind::order::Bound<K>) {
+  return dedekind::algebra::GroupScout<
+      T, std::plus<T>, K,
+      dedekind::algebra::GroupScout<T, InnerOp, InnerElement, InnerInner>>{};
+}
+
+/**
+ * @brief Composition (multiplicative outer): @c (g(x)) @c * @c bound<k>
+ *        for any @c GroupScout @c g(x).  Multiplicative twin of the
+ *        additive composition factory above.
+ */
+export template <typename T, typename InnerOp, auto InnerElement,
+                 typename InnerInner, auto K>
+  requires dedekind::category::IsAbelianGroup<T, std::multiplies<T>> &&
+           std::convertible_to<decltype(K), T>
+constexpr auto operator*(
+    dedekind::algebra::GroupScout<T, InnerOp, InnerElement, InnerInner>,
+    dedekind::order::Bound<K>) {
+  return dedekind::algebra::GroupScout<
+      T, std::multiplies<T>, K,
+      dedekind::algebra::GroupScout<T, InnerOp, InnerElement, InnerInner>>{};
 }
 
 }  // namespace dedekind::sets

--- a/src/main/modules/dedekind/algebra/scout_algebra.cppm
+++ b/src/main/modules/dedekind/algebra/scout_algebra.cppm
@@ -37,9 +37,11 @@
  *    @c operator*(GroupScout, @c Bound<k>) (Slice 4): @b composition
  *    factories lifting the above to a @c GroupScout LHS, so the
  *    canonical @b affine syntax @c (in<T> @c * @c bound<m>) @c + @c
- *    bound<k> = @c λx.\,m*x @c + @c k compiles.  Two-layer composition
- *    today (one BoundScout-inner leaf); deeper composition is a
- *    follow-up.
+ *    bound<k> = @c λx.\,m*x @c + @c k compiles.  Composition is
+ *    @b recursive: nesting any depth of @c GroupScout layers (e.g.\
+ *    @c ((x @c + @c 1) @c * @c 2) @c + @c 3) constructs and pipes
+ *    correctly --- each recursive pipe call defers to @c Inner{} @c |
+ *    @c hs, which terminates at the @c BoundScout base case.
  *
  * The comprehension pipe @c GroupScout::operator|(Halfspace) performs
  * @b halfspace-pivot @b transport.  The additive pipe shifts the
@@ -75,11 +77,10 @@
  *    (e.g.\ @c Rational{1,k}) into the resulting scout's @c Element,
  *    which forces @c T to be a structural NTTP carrier ---
  *    incompatible with the variant-carrier ℚ today.  Follow-up.
- *  - Deeper composition (3+ layers --- e.g.\ @c ((x @c + @c 1) @c *
- *    @c 2) @c + @c 3) is not yet enabled: the Slice-4 composition
- *    pipes assume a 2-layer @c GroupScout-of-@c BoundScout chain.
- *    Lifting to recursive composition would require the recursive
- *    case to also accept @c GroupScout-of-@c GroupScout as @c Inner.
+ *  - (No further composition-depth limitation: the Slice-4 recursive
+ *    pipes handle 2-layer @b and deeper nesting through the same
+ *    @c Inner{} @c | @c hs recursion.  Pinned by the 3-layer test in
+ *    @c q_scout_algebra_test.cpp.)
  *
  * @copyright 2026 The Dedekind Authors
  * Licensed under the Apache License, Version 2.0.
@@ -446,9 +447,10 @@ struct GroupScout {
    * is a @c GroupScout (not a @c BoundScout).  The multiplicative-
    * outer composition case (@c (@c x @c + @c b @c ) @c * @c m) is
    * the dual overload below; the inner-leg recursion makes both
-   * cases compose freely.  Recursive composition (3+ layers) is not
-   * yet enabled (would require detecting @c Inner being a
-   * @c GroupScout-of-GroupScout); ship the 2-layer affine case first.
+   * cases compose freely.  Deeper composition (3+ layers, e.g.\
+   * @c ((x @c + @c 1) @c * @c 2) @c + @c 3) works through the same
+   * @c Inner{} @c | @c hs recursion; the @c requires-clause matches
+   * any @c GroupScout @c Inner, not just @c GroupScout-of-@c BoundScout.
    */
   template <auto Pivot, dedekind::order::Direction D,
             dedekind::order::Strictness S, typename L>

--- a/src/test/cpp/modules/dedekind/numbers/q_scout_algebra_test.cpp
+++ b/src/test/cpp/modules/dedekind/numbers/q_scout_algebra_test.cpp
@@ -96,6 +96,83 @@ TEST_CASE("ℚ: negative-scalar scaling flips direction (#664 Slice 3)",
 }
 
 // ---------------------------------------------------------------------------
+// Scout-algebra: affine composition `(m * x) + b` (#664 Slice 4).
+// The canonical affine form: inner multiplicative scale, outer
+// additive shift.  Halfspace transport applies the inner pipe first,
+// then the outer pipe on the result.
+// ---------------------------------------------------------------------------
+
+TEST_CASE(
+    "ℚ: affine composition (m * x) + b transports correctly (#664 Slice 4)",
+    "[numbers][rational][scout_algebra][slice4]") {
+  constexpr auto x = dedekind::sets::element<ℚ>;
+  // {x ∈ ℚ | x > 5} pushed through λx. 2·x + 1.
+  //   Inner *2:  pivot 5 → 10, direction Upward preserved.
+  //   Outer +1:  pivot 10 → 11, direction Upward preserved.
+  // Final: {y ∈ ℚ | y > 11}.
+  constexpr auto S = dedekind::sets::Set{x * dedekind::order::bound<2> +
+                                             dedekind::order::bound<1> |
+                                         (x > dedekind::order::bound<5>)};
+
+  using SetL = typename dedekind::sets::NaturalLogic<
+      std::remove_cvref_t<decltype(ℚ)>>::type;
+  using ExpectedPredicate =
+      dedekind::order::Halfspace<Rational<default_integer>, 11,
+                                 dedekind::order::Direction::Upward,
+                                 dedekind::order::Strictness::Strict>;
+  using ExpectedSet =
+      dedekind::sets::Set<Rational<default_integer>, SetL, ExpectedPredicate>;
+  STATIC_CHECK(std::same_as<std::remove_cvref_t<decltype(S)>, ExpectedSet>);
+}
+
+TEST_CASE(
+    "ℚ: affine composition (x + b) * m transports correctly (#664 Slice 4)",
+    "[numbers][rational][scout_algebra][slice4]") {
+  constexpr auto x = dedekind::sets::element<ℚ>;
+  // {x ∈ ℚ | x > 5} pushed through λx. 2·(x + 3) = 2x + 6.
+  //   Inner +3:  pivot 5 → 8, direction Upward preserved.
+  //   Outer *2:  pivot 8 → 16, direction Upward preserved.
+  // Final: {y ∈ ℚ | y > 16}.
+  constexpr auto S = dedekind::sets::Set{
+      (x + dedekind::order::bound<3>)*dedekind::order::bound<2> |
+      (x > dedekind::order::bound<5>)};
+
+  using SetL = typename dedekind::sets::NaturalLogic<
+      std::remove_cvref_t<decltype(ℚ)>>::type;
+  using ExpectedPredicate =
+      dedekind::order::Halfspace<Rational<default_integer>, 16,
+                                 dedekind::order::Direction::Upward,
+                                 dedekind::order::Strictness::Strict>;
+  using ExpectedSet =
+      dedekind::sets::Set<Rational<default_integer>, SetL, ExpectedPredicate>;
+  STATIC_CHECK(std::same_as<std::remove_cvref_t<decltype(S)>, ExpectedSet>);
+}
+
+TEST_CASE(
+    "ℚ: affine composition with negative outer scaling flips direction "
+    "(#664 Slice 4)",
+    "[numbers][rational][scout_algebra][slice4]") {
+  constexpr auto x = dedekind::sets::element<ℚ>;
+  // {x ∈ ℚ | x > 5} pushed through λx. (-2)·(x + 3) = -2x - 6.
+  //   Inner +3:  pivot 5 → 8, direction Upward.
+  //   Outer *(-2): pivot 8 → -16, direction FLIPPED to Downward.
+  // Final: {y ∈ ℚ | y < -16}.
+  constexpr auto S = dedekind::sets::Set{
+      (x + dedekind::order::bound<3>)*dedekind::order::bound<-2> |
+      (x > dedekind::order::bound<5>)};
+
+  using SetL = typename dedekind::sets::NaturalLogic<
+      std::remove_cvref_t<decltype(ℚ)>>::type;
+  using ExpectedPredicate =
+      dedekind::order::Halfspace<Rational<default_integer>, -16,
+                                 dedekind::order::Direction::Downward,
+                                 dedekind::order::Strictness::Strict>;
+  using ExpectedSet =
+      dedekind::sets::Set<Rational<default_integer>, SetL, ExpectedPredicate>;
+  STATIC_CHECK(std::same_as<std::remove_cvref_t<decltype(S)>, ExpectedSet>);
+}
+
+// ---------------------------------------------------------------------------
 // Honest Rejection: @c k_E = 0 scaling.  Scaling by zero collapses the
 // scout function to the constant map @c x @c ↦ @c 0; the image is the
 // singleton @c {0} (or @c ∅), not a halfspace, so the pivot-transport

--- a/src/test/cpp/modules/dedekind/numbers/q_scout_algebra_test.cpp
+++ b/src/test/cpp/modules/dedekind/numbers/q_scout_algebra_test.cpp
@@ -149,6 +149,34 @@ TEST_CASE(
 }
 
 TEST_CASE(
+    "ℚ: 3-layer composition ((x + a) * b) + c transports correctly "
+    "(#664 Slice 4)",
+    "[numbers][rational][scout_algebra][slice4]") {
+  constexpr auto x = dedekind::sets::element<ℚ>;
+  // {x ∈ ℚ | x > 5} pushed through λx. ((x + 1) * 2) + 3 = 2x + 5.
+  //   Innermost +1: pivot 5 → 6.
+  //   Middle *2:   pivot 6 → 12.
+  //   Outermost +3: pivot 12 → 15.
+  // The recursive composition pipe handles depth >2 automatically ---
+  // each layer's pipe calls Inner{} | hs which recurses down to the
+  // BoundScout base case.
+  constexpr auto S = dedekind::sets::Set{
+      ((x + dedekind::order::bound<1>)*dedekind::order::bound<
+          2>)+dedekind::order::bound<3> |
+      (x > dedekind::order::bound<5>)};
+
+  using SetL = typename dedekind::sets::NaturalLogic<
+      std::remove_cvref_t<decltype(ℚ)>>::type;
+  using ExpectedPredicate =
+      dedekind::order::Halfspace<Rational<default_integer>, 15,
+                                 dedekind::order::Direction::Upward,
+                                 dedekind::order::Strictness::Strict>;
+  using ExpectedSet =
+      dedekind::sets::Set<Rational<default_integer>, SetL, ExpectedPredicate>;
+  STATIC_CHECK(std::same_as<std::remove_cvref_t<decltype(S)>, ExpectedSet>);
+}
+
+TEST_CASE(
     "ℚ: affine composition with negative outer scaling flips direction "
     "(#664 Slice 4)",
     "[numbers][rational][scout_algebra][slice4]") {


### PR DESCRIPTION
## Summary

Lifts the in-line scout-algebra surface from single transformations to **affine composition**. ℚ now supports the canonical `(in<ℚ> * bound<m>) + bound<k>` form (and its dual `(in<ℚ> + bound<b>) * bound<m>`) at the type level — halfspace pivot transports inner-first, then outer's pipe applies on top. **Composition is recursive: nesting any depth works** (verified by a 3-layer witness). Direction-flip rules compose correctly with the inner result.

This is the third slice closing the issue-#664 surface (Slice 2 / PR #668: additive translation; Slice 3 / PR #677: multiplicative scaling on fields; this PR adds composition).

## New surface (in `:algebra:scout_algebra`)

- `GroupScout::operator|(Halfspace)` **recursive overloads** — additive and multiplicative outer over a `GroupScout` inner. Recursion terminates at the `BoundScout`-inner base case (the existing Slice 2 / Slice 3 pipes).
- **Composition factories** in `dedekind::sets`:
  - `operator+(GroupScout<T, *, M, Inner>, Bound<K>)` produces `GroupScout<T, +, K, GroupScout<...>>`.
  - `operator*(GroupScout<T, +, B, Inner>, Bound<K>)` produces `GroupScout<T, *, K, GroupScout<...>>`.

Both the factories and the pipes match *any* `GroupScout` `Inner`, not just `GroupScout`-of-`BoundScout`, so deeper composition works through the same recursion.

## Four witness TEST_CASEs (`numbers/q_scout_algebra_test`)

| Form | Source pivot | Stages | Result |
|---|---|---|---|
| `(m * x) + b`, m=2, b=1 | 5, Upward, Strict | 5 → 10 → 11 | pivot 11 |
| `(x + b) * m`, b=3, m=2 | 5, Upward, Strict | 5 → 8 → 16 | pivot 16 |
| `((x + a) * b) + c`, a=1, b=2, c=3 | 5, Upward, Strict | 5 → 6 → 12 → 15 | pivot 15 (3-layer) |
| `(x + b) * (-m)`, b=3, m=-2 | 5, Upward, Strict | 5 → 8 → -16, **direction flipped** | pivot -16, Downward |

## Documented out-of-scope (header)

No composition-depth limitation — the recursive pipes handle arbitrary nesting through `Inner{} | hs` until the `BoundScout` base case fires.

## Issue #664 remaining items

Per the [2026-05-13 status comment](https://github.com/vincentk/dedekind/issues/664#issuecomment-4440255432):

- **Ring-retract scaling on ℤ** — the issue's canonical witness `Set{bound<2> * in<ℤ> + bound<1> | in<ℤ> > bound<5>}` still needs retract+divisibility machinery on Comprehension (not yet built).
- **Division on fields** — blocked by structural-NTTP wall (#675).
- **Stand-alone negation factory** `-in<T>`.

## Norm deviation

Per the 2026-05-13 negative-net-by-default norm, this slice nets **net-positive (+~280 / -19)** — a documented deviation. Genuine new-surface PR with no obvious deletion target; the composition path now opens space for adjacent chiselling downstream.

## Concept-search pass

Ran per the procedural rule: the recursive pipes introduce new template overloads on existing concepts (`Op = std::plus` / `Op = std::multiplies`), no new concept-level surface. The composition factories use the same `IsAbelianGroup<T, +>` / `IsAbelianGroup<T, *>` gates as the base factories. No upstream-concept replacement opportunities surfaced.

## Test plan

- [x] `make compile` clean
- [x] `make test` 15/15 binaries pass (four new TEST_CASEs incl. 3-layer)
- [x] `(m * x) + b` form produces correct pivot 11 (2*5 + 1)
- [x] `(x + b) * m` form produces correct pivot 16 (2*(5+3))
- [x] 3-layer `((x+1)*2)+3` produces correct pivot 15
- [x] Negative outer scaling flips direction
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)