### PR TITLE
feat(category): #664 morphism vocabulary — IsMonotone / IsAntiMonotone / IsOrderIsomorphism / IsOrderAntiIsomorphism in :posetal

### DIFF
--- a/src/main/modules/dedekind/algebra/boolean.cppm
+++ b/src/main/modules/dedekind/algebra/boolean.cppm
@@ -276,8 +276,8 @@ static_assert(
 // ≤ @c true to @c False @c ≤ @c True — order is preserved.
 template <>
 inline constexpr bool is_monotone_v<
-    std::decay_t<decltype(dedekind::algebra::embed_𝔹_𝕂3_)>,
-    std::less_equal<>> = true;
+    std::decay_t<decltype(dedekind::algebra::embed_𝔹_𝕂3_)>, std::less_equal<>> =
+    true;
 static_assert(
     IsMonotone<std::decay_t<decltype(dedekind::algebra::embed_𝔹_𝕂3_)>>,
     "embed_𝔹_𝕂3_ (𝔹 ↪ 𝕂3) is monotone — preserves the Boolean order "

--- a/src/main/modules/dedekind/algebra/boolean.cppm
+++ b/src/main/modules/dedekind/algebra/boolean.cppm
@@ -268,4 +268,18 @@ inline constexpr bool is_embedding_functor_v<
 static_assert(
     IsEmbeddingFunctor<std::decay_t<decltype(dedekind::algebra::embed_𝔹_𝕂3_)>>,
     "embed_𝔹_𝕂3_ realises IsEmbeddingFunctor per #633's Mac Lane reading.");
+
+// IsMonotone witness (#664 morphism vocabulary): @c false @c ↦ @c False
+// (@c -1), @c true @c ↦ @c True (@c 1).  Under the canonical Kleene order
+// @c False @c < @c Unknown @c < @c True (which @c std::less_equal lifts
+// to the underlying @c int-valued enum), the embedding sends @c false @c
+// ≤ @c true to @c False @c ≤ @c True — order is preserved.
+template <>
+inline constexpr bool is_monotone_v<
+    std::decay_t<decltype(dedekind::algebra::embed_𝔹_𝕂3_)>,
+    std::less_equal<>> = true;
+static_assert(
+    IsMonotone<std::decay_t<decltype(dedekind::algebra::embed_𝔹_𝕂3_)>>,
+    "embed_𝔹_𝕂3_ (𝔹 ↪ 𝕂3) is monotone — preserves the Boolean order "
+    "under the canonical Kleene three-value order.");
 }  // namespace dedekind::category

--- a/src/main/modules/dedekind/category/posetal.cppm
+++ b/src/main/modules/dedekind/category/posetal.cppm
@@ -405,8 +405,7 @@ concept IsOrderIsomorphism = IsBijectiveArrow<F> && IsMonotone<F, Op>;
  *          ordered field flips the halfspace's direction.
  */
 export template <typename F, typename Op = std::less_equal<>>
-concept IsOrderAntiIsomorphism =
-    IsBijectiveArrow<F> && IsAntiMonotone<F, Op>;
+concept IsOrderAntiIsomorphism = IsBijectiveArrow<F> && IsAntiMonotone<F, Op>;
 
 // Identity arrows are monotone under any relation: id(x) = x, so
 // Op(x, y) ⇒ Op(id(x), id(y)) holds trivially.

--- a/src/main/modules/dedekind/category/posetal.cppm
+++ b/src/main/modules/dedekind/category/posetal.cppm
@@ -50,6 +50,8 @@ export module dedekind.category:posetal;
 
 import :logic;
 import :mereology;
+import :morphism;  // IsArrow / IsBijectiveArrow / Identity (gates for
+                   // IsMonotone / IsAntiMonotone / IsOrderIsomorphism)
 
 namespace dedekind::category {
 
@@ -298,5 +300,125 @@ static_assert(
         &p1, &p2, &p3,
         arrow_drill_down_min<const std::ranges::min_max_result<int>*>),
     "Opt-in operator-> drill-down must preserve posetal path semantics.");
+
+// ---------------------------------------------------------------------------
+// Order-aware morphism classes (#664 acceptance criteria, 2026-05-14).
+//
+// Sibling vocabulary to @c :morphism's @c IsMonicArrow / @c IsEpicArrow /
+// @c IsBijectiveArrow: those are the order-FREE morphism classes (injective /
+// surjective / bijective predicates on a single arrow @c F).  The classes
+// below add the order-AWARE classes (monotone / anti-monotone / order-
+// isomorphism / order-anti-isomorphism), parameterised by the ambient
+// order relation @c Op.  Per Mac Lane CWM ("the arrows are just the
+// instances of the order relation"), monotone maps are the arrows between
+// posetal categories — this is their natural home.
+//
+// Pattern: same as @c :morphism's @c is_monic_arrow_v / @c IsMonicArrow
+// pair — an opt-in trait that defaults to @c false plus a concept that
+// gates on @c IsArrow @c && the trait.  White-list witnesses where the
+// proof is reachable at landing time; downstream partitions late-bind
+// additional proofs by adding their own trait specialisations.  No wrapper
+// structs (Juliet posture): the trait carries the structural claim
+// without an extra type.
+//
+// User's mnemonic ("iso / mono => enabling"): order-isos enable clean
+// halfspace-pivot transport (result is again a halfspace); monos-without-
+// inverse enable image-with-witness transport (halfspace + witness, e.g.\
+// @c AffineImageOfHalfspace on the ℤ ring-retract).  The vocabulary below
+// names the enabling shapes so scout-algebra pipes can dispatch on them
+// rather than on per-slice positive/negative branching.
+// ---------------------------------------------------------------------------
+
+/**
+ * @brief User-declared monotonicity witness for an arrow type @c F
+ *        with respect to the ambient order relation @c Op.
+ *
+ * @details Monotonicity cannot be verified at compile time in general
+ *          (it quantifies over all input pairs); users specialise this
+ *          to @c true to declare that @c F preserves the order @c Op
+ *          (∀ @c x, @c y: @c Op(x, @c y) @c ⇒ @c Op(F(x), @c F(y))).
+ *          The compiler trusts the declaration; the public review
+ *          process is the audit trail.  Mirrors @c is_monic_arrow_v
+ *          in @c :morphism (same opt-in pattern).
+ *
+ *          Default relation @c std::less_equal<> matches the partition
+ *          convention (see partition header).
+ */
+export template <typename F, typename Op = std::less_equal<>>
+inline constexpr bool is_monotone_v = false;
+
+/**
+ * @concept IsMonotone
+ * @brief An arrow @c F declared to be @b order-preserving with respect
+ *        to the ambient order relation @c Op.
+ *
+ * @details ∀ @c x, @c y in @c Dom<F>: @c Op(x, @c y) @c ⇒ @c
+ *          Op(F(x), @c F(y)).  Per Mac Lane, this is the canonical
+ *          shape of an arrow between posetal categories.
+ */
+export template <typename F, typename Op = std::less_equal<>>
+concept IsMonotone = IsArrow<F> && is_monotone_v<F, Op>;
+
+/**
+ * @brief User-declared anti-monotonicity witness for an arrow type
+ *        @c F with respect to the ambient order relation @c Op.
+ *
+ * @details ∀ @c x, @c y: @c Op(x, @c y) @c ⇒ @c Op(F(y), @c F(x))
+ *          (order @b reversed).  Mirrors @c is_monotone_v; same
+ *          opt-in trait pattern.  Composition rule (audit-trail
+ *          property): @c IsAntiMonotone @c ∘ @c IsAntiMonotone @c =
+ *          @c IsMonotone (two flips cancel).
+ */
+export template <typename F, typename Op = std::less_equal<>>
+inline constexpr bool is_antimonotone_v = false;
+
+/**
+ * @concept IsAntiMonotone
+ * @brief An arrow @c F declared to be @b order-reversing with respect
+ *        to the ambient order relation @c Op.
+ */
+export template <typename F, typename Op = std::less_equal<>>
+concept IsAntiMonotone = IsArrow<F> && is_antimonotone_v<F, Op>;
+
+/**
+ * @concept IsOrderIsomorphism
+ * @brief An arrow that is both an order-preserving map and a bijection.
+ *
+ * @details Composes the categorical bijection certificate
+ *          (@c :morphism::IsBijectiveArrow @c = @c IsMonicArrow @c &&
+ *          @c IsEpicArrow) with the order-preservation trait above.
+ *          This is the textbook "enabling" class for clean halfspace-
+ *          pivot transport in @c :algebra:scout_algebra: the image of
+ *          a halfspace under an order-iso is again a halfspace.
+ */
+export template <typename F, typename Op = std::less_equal<>>
+concept IsOrderIsomorphism = IsBijectiveArrow<F> && IsMonotone<F, Op>;
+
+/**
+ * @concept IsOrderAntiIsomorphism
+ * @brief An arrow that is both an order-reversing map and a bijection.
+ *
+ * @details Composes @c IsBijectiveArrow with @c IsAntiMonotone.  Under
+ *          this class, halfspace-pivot transport remains clean but the
+ *          direction (Upward / Downward) is @b flipped — the structural
+ *          reason multiplicative scaling by a negative scalar on an
+ *          ordered field flips the halfspace's direction.
+ */
+export template <typename F, typename Op = std::less_equal<>>
+concept IsOrderAntiIsomorphism =
+    IsBijectiveArrow<F> && IsAntiMonotone<F, Op>;
+
+// Identity arrows are monotone under any relation: id(x) = x, so
+// Op(x, y) ⇒ Op(id(x), id(y)) holds trivially.
+template <typename T, typename Op>
+inline constexpr bool is_monotone_v<Identity<T>, Op> = true;
+
+// Identity arrows are therefore order-isomorphisms (they are bijective
+// via the @c :morphism registration AND monotone via the above).
+static_assert(IsMonotone<Identity<int>>,
+              "Identity must be recognised as a monotone arrow.");
+static_assert(IsOrderIsomorphism<Identity<int>>,
+              "Identity must be recognised as an order-isomorphism "
+              "(bijection + monotone).");
 
 }  // namespace dedekind::category

--- a/src/main/modules/dedekind/morphologies/sint.cppm
+++ b/src/main/modules/dedekind/morphologies/sint.cppm
@@ -474,6 +474,17 @@ static_assert(
     IsEmbeddingFunctor<std::decay_t<decltype(embed_sint_ℤ_)>>,
     "embed_sint_ℤ_ realises IsEmbeddingFunctor per #633's Mac Lane reading.");
 
+// IsMonotone witness (#664 morphism vocabulary): the canonical inclusion
+// @c int @c → @c SignedCardinality preserves order — the embedding takes
+// @c k to @c finite_signed_cardinality(k), and @c SignedCardinality's
+// @c <=> agrees with the machine @c int order on the finite fragment.
+template <>
+inline constexpr bool is_monotone_v<std::decay_t<decltype(embed_sint_ℤ_)>,
+                                    std::less_equal<>> = true;
+static_assert(IsMonotone<std::decay_t<decltype(embed_sint_ℤ_)>>,
+              "embed_sint_ℤ_ (int → SignedCardinality) is monotone — "
+              "the canonical inclusion preserves the numeric order.");
+
 // ===========================================================================
 // Mazur-equivalence pilot (#591): @c std::signed_integral as @c ℤ for
 // inputs in @c [std::numeric_limits<S>::min(), @c

--- a/src/main/modules/dedekind/morphologies/sint.cppm
+++ b/src/main/modules/dedekind/morphologies/sint.cppm
@@ -479,8 +479,9 @@ static_assert(
 // @c k to @c finite_signed_cardinality(k), and @c SignedCardinality's
 // @c <=> agrees with the machine @c int order on the finite fragment.
 template <>
-inline constexpr bool is_monotone_v<std::decay_t<decltype(embed_sint_ℤ_)>,
-                                    std::less_equal<>> = true;
+inline constexpr bool
+    is_monotone_v<std::decay_t<decltype(embed_sint_ℤ_)>, std::less_equal<>> =
+        true;
 static_assert(IsMonotone<std::decay_t<decltype(embed_sint_ℤ_)>>,
               "embed_sint_ℤ_ (int → SignedCardinality) is monotone — "
               "the canonical inclusion preserves the numeric order.");

--- a/src/main/modules/dedekind/morphologies/uint.cppm
+++ b/src/main/modules/dedekind/morphologies/uint.cppm
@@ -488,6 +488,18 @@ static_assert(
     IsEmbeddingFunctor<std::decay_t<decltype(embed_uint_ℕ_)>>,
     "embed_uint_ℕ_ realises IsEmbeddingFunctor per #633's Mac Lane reading.");
 
+// IsMonotone witness (#664 morphism vocabulary): the canonical inclusion
+// @c unsigned @c → @c Cardinality preserves order — both carriers are
+// totally ordered and the embedding sends @c k to @c finite_cardinality(k),
+// which is comparable to other finite cardinalities via the same numeric
+// magnitude.
+template <>
+inline constexpr bool is_monotone_v<std::decay_t<decltype(embed_uint_ℕ_)>,
+                                    std::less_equal<>> = true;
+static_assert(IsMonotone<std::decay_t<decltype(embed_uint_ℕ_)>>,
+              "embed_uint_ℕ_ (unsigned → Cardinality) is monotone — "
+              "the canonical inclusion preserves the numeric order.");
+
 // ===========================================================================
 // Mazur-equivalence pilot (#591): @c std::unsigned_integral as @c ℕ for
 // inputs strictly less than @c 2^width.
@@ -543,4 +555,14 @@ inline constexpr bool is_monic_arrow_v<std::decay_t<decltype(embed_𝔹_uint_)>>
     true;
 static_assert(IsInjective<std::decay_t<decltype(embed_𝔹_uint_)>>,
               "embed_𝔹_uint_ (𝔹 ↪ ℕ) is registered injective.");
+
+// IsMonotone witness (#664 morphism vocabulary): @c false @c ↦ @c 0 and
+// @c true @c ↦ @c 1, which respects the canonical Boolean order
+// @c false @c ≤ @c true via the numeric order @c 0 @c ≤ @c 1.
+template <>
+inline constexpr bool is_monotone_v<std::decay_t<decltype(embed_𝔹_uint_)>,
+                                    std::less_equal<>> = true;
+static_assert(IsMonotone<std::decay_t<decltype(embed_𝔹_uint_)>>,
+              "embed_𝔹_uint_ (𝔹 ↪ ℕ) is monotone — preserves the "
+              "Boolean / numeric order.");
 }  // namespace dedekind::category

--- a/src/main/modules/dedekind/morphologies/uint.cppm
+++ b/src/main/modules/dedekind/morphologies/uint.cppm
@@ -494,8 +494,9 @@ static_assert(
 // which is comparable to other finite cardinalities via the same numeric
 // magnitude.
 template <>
-inline constexpr bool is_monotone_v<std::decay_t<decltype(embed_uint_ℕ_)>,
-                                    std::less_equal<>> = true;
+inline constexpr bool
+    is_monotone_v<std::decay_t<decltype(embed_uint_ℕ_)>, std::less_equal<>> =
+        true;
 static_assert(IsMonotone<std::decay_t<decltype(embed_uint_ℕ_)>>,
               "embed_uint_ℕ_ (unsigned → Cardinality) is monotone — "
               "the canonical inclusion preserves the numeric order.");
@@ -560,8 +561,9 @@ static_assert(IsInjective<std::decay_t<decltype(embed_𝔹_uint_)>>,
 // @c true @c ↦ @c 1, which respects the canonical Boolean order
 // @c false @c ≤ @c true via the numeric order @c 0 @c ≤ @c 1.
 template <>
-inline constexpr bool is_monotone_v<std::decay_t<decltype(embed_𝔹_uint_)>,
-                                    std::less_equal<>> = true;
+inline constexpr bool
+    is_monotone_v<std::decay_t<decltype(embed_𝔹_uint_)>, std::less_equal<>> =
+        true;
 static_assert(IsMonotone<std::decay_t<decltype(embed_𝔹_uint_)>>,
               "embed_𝔹_uint_ (𝔹 ↪ ℕ) is monotone — preserves the "
               "Boolean / numeric order.");

--- a/src/main/modules/dedekind/numbers/natural.cppm
+++ b/src/main/modules/dedekind/numbers/natural.cppm
@@ -454,4 +454,17 @@ static_assert(
     IsEmbeddingFunctor<std::decay_t<decltype(dedekind::numbers::embed_𝔹_ℕ_)>>,
     "embed_𝔹_ℕ_ realises IsEmbeddingFunctor: fully faithful + injective on "
     "objects per #633's Mac Lane CWM §IV.4 reading.");
+
+// IsMonotone witness (#664 morphism vocabulary): @c false @c ↦
+// @c finite_cardinality(0), @c true @c ↦ @c finite_cardinality(1); the
+// embedding preserves the canonical Boolean order under @c
+// Cardinality 's @c <=>.
+template <>
+inline constexpr bool is_monotone_v<
+    std::decay_t<decltype(dedekind::numbers::embed_𝔹_ℕ_)>,
+    std::less_equal<>> = true;
+static_assert(
+    IsMonotone<std::decay_t<decltype(dedekind::numbers::embed_𝔹_ℕ_)>>,
+    "embed_𝔹_ℕ_ (𝔹 ↪ ℕ via Cardinality) is monotone — preserves the "
+    "Boolean / cardinality order.");
 }  // namespace dedekind::category

--- a/src/main/modules/dedekind/numbers/natural.cppm
+++ b/src/main/modules/dedekind/numbers/natural.cppm
@@ -461,10 +461,9 @@ static_assert(
 // Cardinality 's @c <=>.
 template <>
 inline constexpr bool is_monotone_v<
-    std::decay_t<decltype(dedekind::numbers::embed_𝔹_ℕ_)>,
-    std::less_equal<>> = true;
-static_assert(
-    IsMonotone<std::decay_t<decltype(dedekind::numbers::embed_𝔹_ℕ_)>>,
-    "embed_𝔹_ℕ_ (𝔹 ↪ ℕ via Cardinality) is monotone — preserves the "
-    "Boolean / cardinality order.");
+    std::decay_t<decltype(dedekind::numbers::embed_𝔹_ℕ_)>, std::less_equal<>> =
+    true;
+static_assert(IsMonotone<std::decay_t<decltype(dedekind::numbers::embed_𝔹_ℕ_)>>,
+              "embed_𝔹_ℕ_ (𝔹 ↪ ℕ via Cardinality) is monotone — preserves the "
+              "Boolean / cardinality order.");
 }  // namespace dedekind::category

--- a/src/main/modules/dedekind/sets/cardinality.cppm
+++ b/src/main/modules/dedekind/sets/cardinality.cppm
@@ -2390,8 +2390,8 @@ static_assert(IsInjective<std::decay_t<decltype(lift_ℕ_ℤ_)>>,
 // with the same numeric magnitude, and @c SignedCardinality 's @c <=>
 // agrees with @c Cardinality 's on the common fragment.
 template <>
-inline constexpr bool is_monotone_v<std::decay_t<decltype(lift_ℕ_ℤ_)>,
-                                    std::less_equal<>> = true;
+inline constexpr bool
+    is_monotone_v<std::decay_t<decltype(lift_ℕ_ℤ_)>, std::less_equal<>> = true;
 static_assert(IsMonotone<std::decay_t<decltype(lift_ℕ_ℤ_)>>,
               "lift_ℕ_ℤ_ (Cardinality → SignedCardinality) is monotone — "
               "the variant-layer ℕ ↪ ℤ embedding preserves order.");
@@ -2406,8 +2406,9 @@ static_assert(IsInjective<std::decay_t<decltype(embed_𝕂3_ℤ_)>>,
 // @c Unknown @c ↦ @c 0, @c True @c ↦ @c 1, which respects the canonical
 // Kleene three-value order @c False @c < @c Unknown @c < @c True.
 template <>
-inline constexpr bool is_monotone_v<std::decay_t<decltype(embed_𝕂3_ℤ_)>,
-                                    std::less_equal<>> = true;
+inline constexpr bool
+    is_monotone_v<std::decay_t<decltype(embed_𝕂3_ℤ_)>, std::less_equal<>> =
+        true;
 static_assert(IsMonotone<std::decay_t<decltype(embed_𝕂3_ℤ_)>>,
               "embed_𝕂3_ℤ_ (𝕂3 → ℤ) is monotone — preserves the Kleene "
               "three-value order through the canonical embedding.");

--- a/src/main/modules/dedekind/sets/cardinality.cppm
+++ b/src/main/modules/dedekind/sets/cardinality.cppm
@@ -2384,11 +2384,33 @@ static_assert(IsInjective<std::decay_t<decltype(lift_ℕ_ℤ_)>>,
               "lift_ℕ_ℤ_ (variant-layer ℕ ↪ ℤ; Grothendieck-construction unit) "
               "is registered injective.");
 
+// IsMonotone witness (#664 morphism vocabulary): the variant-layer
+// canonical inclusion @c Cardinality @c → @c SignedCardinality preserves
+// order — non-negative cardinals lift to non-negative signed cardinals
+// with the same numeric magnitude, and @c SignedCardinality 's @c <=>
+// agrees with @c Cardinality 's on the common fragment.
+template <>
+inline constexpr bool is_monotone_v<std::decay_t<decltype(lift_ℕ_ℤ_)>,
+                                    std::less_equal<>> = true;
+static_assert(IsMonotone<std::decay_t<decltype(lift_ℕ_ℤ_)>>,
+              "lift_ℕ_ℤ_ (Cardinality → SignedCardinality) is monotone — "
+              "the variant-layer ℕ ↪ ℤ embedding preserves order.");
+
 template <>
 inline constexpr bool is_monic_arrow_v<std::decay_t<decltype(embed_𝕂3_ℤ_)>> =
     true;
 static_assert(IsInjective<std::decay_t<decltype(embed_𝕂3_ℤ_)>>,
               "embed_𝕂3_ℤ_ (𝕂3 → ℤ) is registered injective.");
+
+// IsMonotone witness (#664 morphism vocabulary): @c False @c ↦ @c -1,
+// @c Unknown @c ↦ @c 0, @c True @c ↦ @c 1, which respects the canonical
+// Kleene three-value order @c False @c < @c Unknown @c < @c True.
+template <>
+inline constexpr bool is_monotone_v<std::decay_t<decltype(embed_𝕂3_ℤ_)>,
+                                    std::less_equal<>> = true;
+static_assert(IsMonotone<std::decay_t<decltype(embed_𝕂3_ℤ_)>>,
+              "embed_𝕂3_ℤ_ (𝕂3 → ℤ) is monotone — preserves the Kleene "
+              "three-value order through the canonical embedding.");
 
 // ---------------------------------------------------------------------------
 // Carrier-lattice lift unification (#455): existential-proof

--- a/src/test/cpp/modules/dedekind/category/posetal_test.cpp
+++ b/src/test/cpp/modules/dedekind/category/posetal_test.cpp
@@ -1,6 +1,8 @@
 /** @file test/cpp/modules/dedekind/category/posetal_test.cpp */
 #include <algorithm>
 #include <catch2/catch_test_macros.hpp>
+#include <functional>  // std::less_equal (default order relation for the
+                       // IsMonotone family below)
 
 import dedekind.category;
 
@@ -74,5 +76,63 @@ TEST_CASE("Posetal: textbook default relation", "[category][posetal][order]") {
 
     CHECK(join(x, meet(y, z)) == meet(join(x, y), join(x, z)));
     CHECK(meet(x, join(y, z)) == join(meet(x, y), meet(x, z)));
+  }
+}
+
+// ===========================================================================
+// Order-aware morphism vocabulary (#664 acceptance criteria).
+//
+// Confirms the new concepts behave as advertised:
+//   * default trait state is @c false (Honest stance: no claim is the safe
+//     claim);
+//   * @c Identity registers monotone (and therefore order-iso, since it is
+//     also bijective via @c :morphism);
+//   * the synonym pair @c IsBijective / @c IsBijectiveArrow agrees with
+//     the new order-iso concepts on the Identity arrow.
+// Per-arrow witnesses on the @c embed_* family are exercised in their
+// home partitions' static_asserts (e.g.\ @c morphologies/uint.cppm and
+// @c sint.cppm; @c sets/cardinality.cppm) so the test surface here stays
+// upstream-of-numbers and the @c :category test layer doesn't reach
+// across the module DAG.
+// ===========================================================================
+
+TEST_CASE("Posetal: order-aware morphism vocabulary defaults (#664)",
+          "[category][posetal][morphism][monotone][negative]") {
+  SECTION("is_monotone_v / is_antimonotone_v default to false") {
+    STATIC_CHECK(!is_monotone_v<int, std::less_equal<>>);
+    STATIC_CHECK(!is_antimonotone_v<int, std::less_equal<>>);
+  }
+
+  SECTION("IsMonotone / IsAntiMonotone gate on IsArrow + the trait") {
+    // Non-arrow types refuse the concept even if the trait were set —
+    // the @c IsArrow gate is structural.
+    STATIC_CHECK(!IsMonotone<int>);
+    STATIC_CHECK(!IsAntiMonotone<int>);
+  }
+}
+
+TEST_CASE("Posetal: Identity is the canonical monotone witness (#664)",
+          "[category][posetal][morphism][monotone][identity]") {
+  SECTION("Identity is monotone under the default <= relation") {
+    STATIC_CHECK(IsMonotone<Identity<int>>);
+    STATIC_CHECK(IsMonotone<Identity<int>, std::less_equal<>>);
+  }
+
+  SECTION("Identity is bijective via :morphism") {
+    // Sanity: the existing @c IsBijective registration on Identity is
+    // load-bearing for the IsOrderIsomorphism composition below.
+    STATIC_CHECK(IsBijectiveArrow<Identity<int>>);
+    STATIC_CHECK(IsBijective<Identity<int>>);
+  }
+
+  SECTION("Identity is therefore an order-isomorphism (composed concept)") {
+    // The composition IsBijectiveArrow && IsMonotone fires for free once
+    // both ingredients hold — no separate is_order_iso_v opt-in needed.
+    STATIC_CHECK(IsOrderIsomorphism<Identity<int>>);
+  }
+
+  SECTION("Identity is NOT anti-monotone (it preserves order, not reverses)") {
+    STATIC_CHECK(!IsAntiMonotone<Identity<int>>);
+    STATIC_CHECK(!IsOrderAntiIsomorphism<Identity<int>>);
   }
 }


### PR DESCRIPTION
Closes part of #664 — the morphism-level concept acceptance criteria (2026-05-14 revision).

## Summary

Lands the order-aware morphism vocabulary called out in #664: predicates on arrows that name the textbook morphism classes the scout-algebra DSL's per-slice pipes are concretely realising. Per the user's mnemonic **"iso / mono => enabling"** — order-isos enable clean halfspace-pivot transport (halfspace → halfspace); mono-without-inverse enables image-with-witness transport (`AffineImageOfHalfspace` on the ℤ ring-retract).

## Partition split

| Concept | Home | Status |
|---|---|---|
| `IsBijection<f>` | `:category:morphism` | **Already covered** by existing `IsBijective<F>` / `IsBijectiveArrow<F>` (composes `is_monic_arrow_v && is_epic_arrow_v`); no new code. |
| `IsMonotone<F, Op>` | `:category:posetal` | **New** — opt-in trait `is_monotone_v<F, Op>` defaults to `false`; concept gates on `IsArrow<F> && trait`. |
| `IsAntiMonotone<F, Op>` | `:category:posetal` | **New** — order-reversing sibling. |
| `IsOrderIsomorphism<F, Op>` | `:category:posetal` | **New** — `IsBijectiveArrow<F> && IsMonotone<F, Op>` (free composition). |
| `IsOrderAntiIsomorphism<F, Op>` | `:category:posetal` | **New** — `IsBijectiveArrow<F> && IsAntiMonotone<F, Op>`. |

Per `:posetal`'s own header (Mac Lane CWM: "the arrows are just the instances of the order relation"), monotone maps are the canonical arrows between posetal categories — their natural home. `:equivalence` was considered and rejected: that partition is about equivalence *relations on a single carrier* (Mazur's "equal up to ~"); our concepts are predicates on arrows.

## Juliet posture (load-bearing)

- **No wrapper structs** (no `Monotone<F>` / `OrderIso<F>` etc.).
- **No new carriers**.
- Mirrors the existing `:morphism::is_monic_arrow_v / IsMonicArrow` machinery: a `concept IsX = IsArrow<F> && registered_trait_v<...>` definition plus per-arrow `template <> inline constexpr bool is_x_v<...> = true;` opt-in registrations.

## White-listed witnesses

Per #664's acceptance criteria, Sollbruchstellen-style landing is explicitly fine — register the obvious witnesses now, leave the rest for downstream partitions to late-bind. Witnesses in this PR (all order-preserving inclusions between totally-ordered carriers; trait reg sits next to the existing `is_monic_arrow_v` reg for each arrow):

- `Identity<T>` — `IsMonotone` for any relation, therefore `IsOrderIsomorphism` (free composition with the existing `IsBijectiveArrow<Identity<T>>`).
- `embed_uint_ℕ_`, `embed_𝔹_uint_` (`morphologies/uint.cppm`)
- `embed_sint_ℤ_` (`morphologies/sint.cppm`)
- `lift_ℕ_ℤ_`, `embed_𝕂3_ℤ_` (`sets/cardinality.cppm`)
- `embed_𝔹_𝕂3_` (`algebra/boolean.cppm`)
- `embed_𝔹_ℕ_` (`numbers/natural.cppm`)

**Anti-monotone has no witness in this PR** intentionally — the obvious anti-monotone arrows in the codebase (negative-scalar scaling, negation) currently surface as scout-algebra DSL operators on `GroupScout` / `BoundScout` types, which do not satisfy `IsArrow` yet. Registering them belongs with a follow-up that promotes scout types to `IsArrow` (separate scope).

## Tests

Extends `posetal_test.cpp` with:
- default-`false` traits + `IsArrow` gating;
- `Identity` as monotone / order-iso / NOT anti-monotone / NOT order-anti-iso;
- Synonym agreement (`IsBijective` ≡ `IsBijectiveArrow` on `Identity`).

Per-arrow witnesses on the `embed_*` family are static-asserted in their home partitions (in-line cross-partition assertion convention).

## What does NOT land

- Scout-arrow witnesses (translation, multiplicative scaling, negation) — blocked on scout types not being `IsArrow`; follow-up.
- Canonical witness `Set{bound<2> * in<ℤ> + bound<1> | (in<ℤ> > bound<5>)}` — still blocked by ring-retract + additive-shift composition (would need `AffineImageOfHalfspace` to carry an offset `B`); separately tracked under #664.

## Test plan

- [x] `make compile` — clean
- [x] `make test` — 15/15 test suites pass
- [x] `make format` — clean (pre-push hook reformatted 6 sites; folded into `bc5dca8a`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)