### PR TITLE
feat(scout_algebra): #664 Slice B (canonical witness) — outer + over inner ring-retract on ℤ folds into `AffineImageOfHalfspace<T, M, B, SrcHS>`

### DIFF
--- a/src/main/modules/dedekind/algebra/scout_algebra.cppm
+++ b/src/main/modules/dedekind/algebra/scout_algebra.cppm
@@ -657,9 +657,8 @@ struct GroupScout {
     using InnerPredicate = std::remove_cvref_t<decltype(inner_comp.predicate)>;
     constexpr auto new_offset = InnerPredicate::offset + Element;
     using SrcHalfspace = typename InnerPredicate::source_halfspace_type;
-    using NewPredicate =
-        AffineImageOfHalfspace<T, InnerPredicate::multiplier, new_offset,
-                               SrcHalfspace>;
+    using NewPredicate = AffineImageOfHalfspace<T, InnerPredicate::multiplier,
+                                                new_offset, SrcHalfspace>;
     using AmbientType = std::remove_cvref_t<decltype(inner_comp.base)>;
     return dedekind::sets::Comprehension<AmbientType, NewPredicate>{
         inner_comp.base, NewPredicate{}};

--- a/src/main/modules/dedekind/algebra/scout_algebra.cppm
+++ b/src/main/modules/dedekind/algebra/scout_algebra.cppm
@@ -326,6 +326,19 @@ concept HasHalfspaceShape = requires {
   P::direction;
   P::strictness;
 };
+
+// Sibling probe for the @c AffineImageOfHalfspace shape.  Used in the
+// Slice-B canonical-witness composition pipe to detect when the inner
+// scout's pipe produced an affine-image predicate (the Slice-5 ring-
+// retract output) rather than a plain @c Halfspace --- the two
+// composition routes are structurally distinct and the requires-
+// clauses dispatch on shape.
+template <typename P>
+concept HasAffineImageShape = requires {
+  P::multiplier;
+  P::offset;
+  typename P::source_halfspace_type;
+};
 }  // namespace detail
 
 // Forward declaration of @c AffineImageOfHalfspace --- the ring-retract
@@ -334,7 +347,16 @@ concept HasHalfspaceShape = requires {
 // which depends only on the @c :order:halfspace types already
 // imported.  The forward declaration here is enough for two-phase
 // name lookup inside @c GroupScout's ring-retract pipe to bind.
-export template <typename T, auto M, typename SourceHalfspace>
+//
+// Slice-5-canonical extension (post-PR #664-Slice-B): a fourth NTTP
+// @c B carries the additive offset of the affine map @f$y = M @c * x +
+// B@f$.  The pre-extension form @c AffineImageOfHalfspace<T, M, SrcHS>
+// is now @c AffineImageOfHalfspace<T, M, /*B=*/T-typed-zero, SrcHS>; the
+// Slice-5 ring-retract pipe instantiates it that way (no offset), and a
+// new composition pipe folds outer additive shifts into the offset so
+// the canonical witness @c Set{bound<2> @c * @c in<ℤ> @c + @c bound<1>
+// @c | @c (in<ℤ> @c > @c bound<5>)} reaches a single predicate.
+export template <typename T, auto M, auto B, typename SourceHalfspace>
 struct AffineImageOfHalfspace;
 
 /**
@@ -583,6 +605,67 @@ struct GroupScout {
   }
 
   /**
+   * @brief Comprehension pipe (canonical-witness composition, #664
+   *        Slice B): outer additive shift @c (@c f(x) @c ) @c + @c K
+   *        over an inner ring-retract scaling @c f(x) @c = @c M
+   *        @c * @c g(x) @c + @c B_inner.
+   *
+   * @details
+   * The canonical-witness shape: @c Set{bound<M> @c * @c in<ℤ> @c +
+   * @c bound<K> @c | @c (in<ℤ> @c ⋈ @c bound<p>)} on @c ℤ.  Inner
+   * ring-retract produces @c AffineImageOfHalfspace<T, M, B_inner,
+   * SrcHS>; outer additive shift by @c Element folds into the offset:
+   *
+   * @code
+   *   inner:        x ↦ M @c * @c x @c + @c B_inner
+   *   outer shift:  y ↦ y @c + @c Element
+   *   composed:     x ↦ M @c * @c x @c + @c (B_inner @c + @c Element)
+   * @endcode
+   *
+   * Membership of @c z in the composed image: @c (z @c - @c B_new)
+   * is divisible by @c M AND @c src((z @c - @c B_new) @c / @c M),
+   * with @c B_new @c = @c B_inner @c + @c Element.  The result type
+   * is again @c AffineImageOfHalfspace --- the divisibility witness
+   * doesn't collapse under additive shift (the divisor stays @c M).
+   *
+   * Dispatch: shape-detected via @c detail::HasAffineImageShape on
+   * the inner pipe's predicate type, which is the sibling probe to
+   * @c HasHalfspaceShape used by the standard additive-composition
+   * pipe above.  The two pipes are mutually exclusive (a predicate
+   * exposes @b either @c pivot @b or @c multiplier, never both), so
+   * the requires-clauses partition cleanly without overload
+   * ambiguity.
+   */
+  template <auto Pivot, dedekind::order::Direction D,
+            dedekind::order::Strictness S, typename L>
+    requires std::same_as<Op, std::plus<T>> && IsOrderedAdditiveGroup<T> &&
+             requires {
+               typename Inner::op_type;
+               Inner::element;
+             } &&
+             // Inner's pipe produces an affine-image predicate (the
+             // Slice-5 ring-retract output).  Honest-Rejects the
+             // Slice-4 Halfspace case, which the sibling pipe above
+             // handles.
+             detail::HasAffineImageShape<std::remove_cvref_t<
+                 decltype((Inner{} | std::declval<dedekind::order::Halfspace<
+                                         T, Pivot, D, S, L>>())
+                              .predicate)>>
+  constexpr auto operator|(
+      dedekind::order::Halfspace<T, Pivot, D, S, L> hs) const {
+    constexpr auto inner_comp = Inner{} | hs;
+    using InnerPredicate = std::remove_cvref_t<decltype(inner_comp.predicate)>;
+    constexpr auto new_offset = InnerPredicate::offset + Element;
+    using SrcHalfspace = typename InnerPredicate::source_halfspace_type;
+    using NewPredicate =
+        AffineImageOfHalfspace<T, InnerPredicate::multiplier, new_offset,
+                               SrcHalfspace>;
+    using AmbientType = std::remove_cvref_t<decltype(inner_comp.base)>;
+    return dedekind::sets::Comprehension<AmbientType, NewPredicate>{
+        inner_comp.base, NewPredicate{}};
+  }
+
+  /**
    * @brief Comprehension pipe (composition, multiplicative outer):
    *        @c (g(x)) @c * @c m where @c g is an inner scout.
    *
@@ -679,7 +762,14 @@ struct GroupScout {
   constexpr auto operator|(
       dedekind::order::Halfspace<T, Pivot, D, S, L>) const {
     using SourceHalfspace = dedekind::order::Halfspace<T, Pivot, D, S, L>;
-    using ResultPredicate = AffineImageOfHalfspace<T, Element, SourceHalfspace>;
+    // Slice-5 base case: no outer additive shift, so the affine
+    // offset @c B is zero.  Slice-B's outer-shift composition pipe
+    // (below) folds non-zero offsets in by accumulating @c B_inner
+    // @c + @c K when an outer @c + @c bound<K> wraps an inner
+    // ring-retract.
+    using ResultPredicate =
+        AffineImageOfHalfspace<T, Element, decltype(Element){0},
+                               SourceHalfspace>;
     using AmbientType = typename Inner::AmbientType;
     return dedekind::sets::Comprehension<AmbientType, ResultPredicate>{
         Inner::ambient, ResultPredicate{}};
@@ -688,18 +778,22 @@ struct GroupScout {
 
 /**
  * @brief Image of a source halfspace under the affine map @f$y = M
- *        \cdot x@f$ on a commutative ring carrier (#664 Slice 5
- *        ring-retract scaling).
+ *        \cdot x + B@f$ on a commutative ring carrier (#664 Slice 5
+ *        ring-retract scaling + Slice-B canonical-witness extension).
  *
  * @details
  * Membership of @c y in the image is the conjunction of two
- * decidable checks:
+ * decidable checks (after the affine inversion @c y @c ↦ @c (y @c -
+ * @c B) @c / @c M):
  *
- *   (1) @b Divisibility @c M @c | @c y --- there exists an integer
- *       @c x with @c M*x @c = @c y; on a ring carrier this is
- *       computable as @c (y @c % @c M) @c == @c 0.
- *   (2) @b Source @b predicate @c source(y/M) --- the (unique
- *       modulo sign) preimage satisfies the source halfspace.
+ *   (1) @b Divisibility @c M @c | @c (y @c - @c B) --- there exists
+ *       an integer @c x with @c M*x @c = @c y @c - @c B; on a ring
+ *       carrier this is computable as @c ((y @c - @c B) @c % @c M)
+ *       @c == @c 0 (or the identity-based form used in the body
+ *       below, which propagates correctly through variant sentinels).
+ *   (2) @b Source @b predicate @c source((y @c - @c B) @c / @c M)
+ *       --- the (unique modulo sign) preimage satisfies the source
+ *       halfspace.
  *
  * On a field (@c ℚ) the divisibility check is vacuous (every @c y
  * has a preimage); the @c !IsOrderedMultiplicativeGroup<T> gate at
@@ -708,34 +802,52 @@ struct GroupScout {
  * @c Halfspace, which folds at compile time without the
  * runtime modular check.
  *
+ * @b Slice-B @b canonical @b witness: the offset @c B carries the
+ * outer additive shift folded into the predicate by the
+ * @c GroupScout<T, std::plus<T>, K, AffineImageInner> composition
+ * pipe below.  The pre-extension Slice-5 form (no outer shift) sets
+ * @c B @c = @c 0; the composition pipe accumulates @c B_new @c =
+ * @c B_inner @c + @c K.
+ *
  * @tparam T               Carrier (ordered commutative ring).
  * @tparam M               Affine multiplier (NTTP, @c != @c 0).
+ * @tparam B               Affine offset (NTTP; @c 0 in the base
+ *                         Slice-5 ring-retract pipe; non-zero only
+ *                         when the canonical-witness composition
+ *                         folds an outer additive shift in).
  * @tparam SourceHalfspace Source halfspace type.
  */
-export template <typename T, auto M, typename SourceHalfspace>
+export template <typename T, auto M, auto B, typename SourceHalfspace>
 struct AffineImageOfHalfspace {
   using Domain = T;
   using Codomain = typename SourceHalfspace::Codomain;
   using logic_species = typename SourceHalfspace::logic_species;
   using cardinality_type = dedekind::sets::ℵ_0;
+  using source_halfspace_type = SourceHalfspace;
+  static constexpr auto multiplier = M;
+  static constexpr auto offset = B;
 
   constexpr Codomain operator()(const T& y) const {
     using L = logic_species;
     const T m_in_t = T{M};
-    // Divisibility-via-identity: @c y @c in @c image @c iff there
-    // exists @c x with @c M*x @c = @c y, i.e.\ @c M @c * @c (y/M)
-    // @c == @c y.  This formulation is preferred over the modular
-    // @c y @c % @c M @c == @c 0 form because it propagates correctly
-    // through variant sentinels (@c \pm @c \aleph_0, @c NaZ) on the
-    // saturating ℤ proxy @c SignedCardinality: @c \pm @c \aleph_0
-    // @c / @c m @c = @c \pm @c \aleph_0 and @c m @c * @c \pm @c
-    // \aleph_0 @c = @c \pm @c \aleph_0, so the identity holds at
-    // the sentinel and the predicate correctly defers to the
-    // source halfspace's sentinel-handling.  (The modular form would
-    // return @c NaZ for sentinel mod, mis-rejecting sentinels that
-    // are actually in the image.)
-    const T x_preimage = y / m_in_t;
-    if (!((m_in_t * x_preimage) == y)) {
+    const T b_in_t = T{B};
+    // Invert the affine map @c y @c = @c M*x @c + @c B by computing
+    // @c y_minus_b @c = @c y @c - @c B and then the preimage
+    // @c x @c = @c y_minus_b @c / @c M.  Divisibility-via-identity:
+    // @c y @c in @c image @c iff @c M @c * @c (y_minus_b @c / @c M)
+    // @c == @c y_minus_b.  This formulation is preferred over the
+    // modular @c y_minus_b @c % @c M @c == @c 0 form because it
+    // propagates correctly through variant sentinels (@c \pm @c
+    // \aleph_0, @c NaZ) on the saturating ℤ proxy @c
+    // SignedCardinality: @c \pm @c \aleph_0 @c / @c m @c = @c \pm @c
+    // \aleph_0 and @c m @c * @c \pm @c \aleph_0 @c = @c \pm @c
+    // \aleph_0, so the identity holds at the sentinel and the
+    // predicate correctly defers to the source halfspace's sentinel-
+    // handling.  (The modular form would return @c NaZ for sentinel
+    // mod, mis-rejecting sentinels that are actually in the image.)
+    const T y_minus_b = y - b_in_t;
+    const T x_preimage = y_minus_b / m_in_t;
+    if (!((m_in_t * x_preimage) == y_minus_b)) {
       return L::False;  // No preimage --- y not in image.
     }
     return SourceHalfspace{}(x_preimage);

--- a/src/test/cpp/modules/dedekind/numbers/z_scout_algebra_test.cpp
+++ b/src/test/cpp/modules/dedekind/numbers/z_scout_algebra_test.cpp
@@ -169,10 +169,9 @@ TEST_CASE(
     "[numbers][integer][scout_algebra][canonical-witness]") {
   constexpr auto x = dedekind::sets::element<ℤ>;
   // The canonical-witness form straight out of the issue body.
-  constexpr auto S =
-      dedekind::sets::Set{x * dedekind::order::bound<2> +
-                              dedekind::order::bound<1> |
-                          (x > dedekind::order::bound<5>)};
+  constexpr auto S = dedekind::sets::Set{x * dedekind::order::bound<2> +
+                                             dedekind::order::bound<1> |
+                                         (x > dedekind::order::bound<5>)};
 
   using SetL = typename dedekind::sets::NaturalLogic<
       std::remove_cvref_t<decltype(ℤ)>>::type;

--- a/src/test/cpp/modules/dedekind/numbers/z_scout_algebra_test.cpp
+++ b/src/test/cpp/modules/dedekind/numbers/z_scout_algebra_test.cpp
@@ -111,7 +111,7 @@ TEST_CASE(
                                  dedekind::order::Direction::Upward,
                                  dedekind::order::Strictness::Strict>;
   using ExpectedPredicate = dedekind::algebra::AffineImageOfHalfspace<
-      dedekind::sets::SignedCardinality, 2, SourceHalfspace>;
+      dedekind::sets::SignedCardinality, /*M=*/2, /*B=*/0, SourceHalfspace>;
   using ExpectedSet = dedekind::sets::Set<dedekind::sets::SignedCardinality,
                                           SetL, ExpectedPredicate>;
   STATIC_CHECK(std::same_as<std::remove_cvref_t<decltype(S)>, ExpectedSet>);
@@ -143,4 +143,69 @@ TEST_CASE(
   CHECK(S(pos_inf) == L::True);
   CHECK(S(neg_inf) == L::False);
   CHECK(S(naz) == L::False);
+}
+
+// ---------------------------------------------------------------------------
+// Canonical witness (#664 Slice B): ring-retract scaling composed with
+// outer additive shift on ℤ.
+//
+// The §First-slice example from the issue:
+//
+//   constexpr auto S = Set{bound<2> * in<ℤ> + bound<1> | in<ℤ> > bound<5>};
+//   // S = {2n + 1 | n ∈ ℤ, n > 5} = {13, 15, 17, ...}
+//
+// Inner ring-retract `bound<2> * in<ℤ>` produces an
+// AffineImageOfHalfspace<ℤ, 2, 0, src_hs>; the outer additive shift
+// `+ bound<1>` is detected by the new composition pipe and folded into
+// the offset, yielding AffineImageOfHalfspace<ℤ, 2, 1, src_hs> --- the
+// canonical singly-typed predicate the issue's anti-cheat property
+// demands.
+// ---------------------------------------------------------------------------
+
+TEST_CASE(
+    "ℤ: canonical witness Set{bound<2> * in<ℤ> + bound<1> | in<ℤ> > bound<5>} "
+    "folds to a single AffineImageOfHalfspace predicate (#664 canonical "
+    "witness / Slice B)",
+    "[numbers][integer][scout_algebra][canonical-witness]") {
+  constexpr auto x = dedekind::sets::element<ℤ>;
+  // The canonical-witness form straight out of the issue body.
+  constexpr auto S =
+      dedekind::sets::Set{x * dedekind::order::bound<2> +
+                              dedekind::order::bound<1> |
+                          (x > dedekind::order::bound<5>)};
+
+  using SetL = typename dedekind::sets::NaturalLogic<
+      std::remove_cvref_t<decltype(ℤ)>>::type;
+  using SourceHalfspace =
+      dedekind::order::Halfspace<dedekind::sets::SignedCardinality, 5,
+                                 dedekind::order::Direction::Upward,
+                                 dedekind::order::Strictness::Strict>;
+  using ExpectedPredicate = dedekind::algebra::AffineImageOfHalfspace<
+      dedekind::sets::SignedCardinality, /*M=*/2, /*B=*/1, SourceHalfspace>;
+  using ExpectedSet = dedekind::sets::Set<dedekind::sets::SignedCardinality,
+                                          SetL, ExpectedPredicate>;
+  STATIC_CHECK(std::same_as<std::remove_cvref_t<decltype(S)>, ExpectedSet>);
+
+  // Membership behaviour: S = {13, 15, 17, ...}.
+  using L = SetL;
+  // Positive cases: 2*n + 1 for n > 5, i.e.\ n ∈ {6, 7, 8, ...} →
+  // S = {13, 15, 17, ...}.
+  CHECK(S(dedekind::sets::finite_signed_cardinality(13)) == L::True);
+  CHECK(S(dedekind::sets::finite_signed_cardinality(15)) == L::True);
+  CHECK(S(dedekind::sets::finite_signed_cardinality(17)) == L::True);
+  // Source-predicate fails: 11 = 2*5 + 1, but 5 is NOT > 5.
+  CHECK(S(dedekind::sets::finite_signed_cardinality(11)) == L::False);
+  // Divisibility-after-offset fails: 14 - 1 = 13 is odd, so no integer
+  // preimage exists.
+  CHECK(S(dedekind::sets::finite_signed_cardinality(14)) == L::False);
+  // Both fail (12: 12 - 1 = 11 odd; no preimage).
+  CHECK(S(dedekind::sets::finite_signed_cardinality(12)) == L::False);
+  // Sentinel behaviour: same propagation as Slice 5 (additive shift
+  // doesn't change sentinel logic --- +ℵ_0 ± 1 = +ℵ_0, etc.).
+  constexpr auto pos_inf =
+      dedekind::sets::SignedCardinality{dedekind::sets::PositiveInfinity{}};
+  constexpr auto neg_inf =
+      dedekind::sets::SignedCardinality{dedekind::sets::NegativeInfinity{}};
+  CHECK(S(pos_inf) == L::True);
+  CHECK(S(neg_inf) == L::False);
 }


### PR DESCRIPTION
**Closes #664.**

Lands the original §First-slice canonical witness from issue #664:

```cpp
constexpr auto S = Set{bound<2> * in<ℤ> + bound<1> | in<ℤ> > bound<5>};
// S = {2n + 1 | n ∈ ℤ, n > 5} = {13, 15, 17, ...}
```

Previously the inner `bound<2> * in<ℤ>` ring-retract pipe produced `AffineImageOfHalfspace<T, M, SrcHS>` (no `pivot` / `direction` / `strictness` members), so the outer `+ bound<1>` additive-composition pipe's `HasHalfspaceShape` requires-clause Honest-Rejected — the canonical-witness form did not compile.

## Structural extension

- **`AffineImageOfHalfspace` gains a fourth NTTP `B`** carrying the additive offset of the affine map `y = M·x + B`. Predicate body inverts the full affine map (subtract `B`, then divide by `M`; identity-based divisibility check on `y − B`). Sentinel propagation unchanged.
- **Two new exposures**: `source_halfspace_type` typedef + `multiplier` / `offset` static members. Make the outer-composition pipe shape-dispatchable.
- **New `detail::HasAffineImageShape<P>`** sibling probe to `HasHalfspaceShape`. The two probes partition cleanly — a predicate exposes either `pivot` or `multiplier`, never both — so the composition-pipe overloads have no ambiguity.
- **New composition pipe** on `GroupScout<T, std::plus<T>, K, Inner>` triggers when `Inner`'s pipe produces an `AffineImageOfHalfspace`. Folds the outer additive shift into the predicate's offset: `B_new = B_inner + K`. Result type stays `AffineImageOfHalfspace` (the divisibility witness doesn't collapse under additive shift — the divisor stays `M`).

Composition:

```
inner:        x ↦ M·x + B_inner
outer shift:  y ↦ y + K
composed:     x ↦ M·x + (B_inner + K)
```

## Existing call sites

- Slice-5 ring-retract pipe now instantiates with `B = 0` explicitly (no-op shift); behaviour and tests unchanged.

## Tests

- Slice-5 test updated to the new 4-arg signature.
- New canonical-witness `TEST_CASE` in `z_scout_algebra_test` exercises:
  - **type-level**: `S` reduces to a single `AffineImageOfHalfspace<ℤ, 2, 1, src_hs>` (STATIC_CHECK on the composed Set type).
  - **membership (positive)**: 13, 15, 17 → True.
  - **membership (negative)**: 11 → source-pred fails (5 not > 5); 12, 14 → divisibility after offset fails (12−1=11 odd; 14−1=13 odd).
  - **sentinels**: +ℵ_0 → True; -ℵ_0 → False (additive shift doesn't change sentinel logic).

All 9 assertions pass; full suite 15/15 green.

## Test plan

- [x] `make compile` — clean
- [x] `make test` — 15/15 test suites pass
- [x] `./build/test_numbers "[canonical-witness]"` — 9/9 assertions pass
- [x] `make format` — clean (pre-push hook reformatted; folded into `aedcdb68`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
