### PR TITLE
feat(sets): #661 image(IsTerminalMorphism F, S) — terminal-codomain collapse

### DIFF
--- a/src/main/modules/dedekind/sets/singleton.cppm
+++ b/src/main/modules/dedekind/sets/singleton.cppm
@@ -328,6 +328,37 @@ constexpr auto image(
   return SingletonSet<U, L>{std::forward<F>(f)(s.pivot)};
 }
 
+/** @section singleton__Image_Terminal_Morphism (#661)
+ *  @brief Terminal-codomain-arrow collapse for @c image(F, S): when
+ *         @c F is an @c IsTerminalMorphism (@c F: @c T @c → @c One),
+ *         the image is structurally degenerate.
+ *  @details
+ *  - @c image(F, @c Ø<T, @c L>) → @c Ø<One, @c L> — empty source maps
+ *    to empty image.
+ *  - @c image(F, @c UniversalSet<T, @c L, @c C>) →
+ *    @c SingletonSet<One, @c L>{One{}} — inhabited source collapses
+ *    to the singleton on @c One.
+ *  - @c image(F, @c SingletonSet<T, @c L>) falls through to the
+ *    generic @c image(F, @c SingletonSet) above (correct: returns
+ *    @c SingletonSet<One, L>{F(pivot)} = @c SingletonSet<One, L>{One{}}).
+ *
+ *  Predicate-based @c Set<T, L, P> sources fall through to the
+ *  symbolic-fallback @c image() in @c :expressions (inhabitation
+ *  undecidable in general). */
+export template <typename L, typename T, typename C, typename F>
+  requires dedekind::category::IsTerminalMorphism<std::remove_cvref_t<F>> &&
+           std::same_as<dedekind::category::Dom<std::remove_cvref_t<F>>, T>
+constexpr auto image(F&&, const UniversalSet<T, L, C>&) {
+  return SingletonSet<dedekind::category::One, L>{dedekind::category::One{}};
+}
+
+export template <typename L, typename T, typename F>
+  requires dedekind::category::IsTerminalMorphism<std::remove_cvref_t<F>> &&
+           std::same_as<dedekind::category::Dom<std::remove_cvref_t<F>>, T>
+constexpr auto image(F&&, const Ø<T, L>&) {
+  return Ø<dedekind::category::One, L>{};
+}
+
 // Breadcrumbs for `image(f, SingletonSet)` live downstream in
 // `morphologies:archimedean` (the natural home for Peano-successor
 // witnesses).  The structural claims pinned there:

--- a/src/test/cpp/modules/dedekind/sets/boundaries_test.cpp
+++ b/src/test/cpp/modules/dedekind/sets/boundaries_test.cpp
@@ -121,3 +121,32 @@ TEST_CASE("Boundaries: The Algebra of Extremality", "[sets][boundaries]") {
                          SingletonSet<SignedExtensionalCardinal<>>>);
   }
 }
+
+TEST_CASE("image(IsTerminalMorphism F, S) — terminal-codomain collapse (#661)",
+          "[sets][image][terminal-morphism]") {
+  using dedekind::category::One;
+  const auto bang = dedekind::category::unit<int>();  // !: int → One
+
+  SECTION("UniversalSet source → SingletonSet<One> (inhabited collapse)") {
+    constexpr UniversalSet<int> universe;
+    const auto img = image(bang, universe);
+    STATIC_CHECK(std::same_as<std::remove_cvref_t<decltype(img)>,
+                              SingletonSet<One, ClassicalLogic>>);
+    CHECK(img(One{}));
+  }
+
+  SECTION("Ø source → Ø<One> (empty stays empty)") {
+    constexpr Ø<int> empty;
+    const auto img = image(bang, empty);
+    STATIC_CHECK(std::same_as<std::remove_cvref_t<decltype(img)>,
+                              Ø<One, ClassicalLogic>>);
+  }
+
+  SECTION("SingletonSet source → SingletonSet<One> via the generic overload") {
+    const auto s = singleton(7);
+    const auto img = image(bang, s);
+    STATIC_CHECK(std::same_as<std::remove_cvref_t<decltype(img)>,
+                              SingletonSet<One, ClassicalLogic>>);
+    CHECK(img(One{}));
+  }
+}


### PR DESCRIPTION
Closes #661.

Adds `image(F, S)` overloads for `F : T → One` (`IsTerminalMorphism`) on the two boundary set types:

| Source set | Result type | Reasoning |
|---|---|---|
| `UniversalSet<T, L, C>` | `SingletonSet<One, L>{One{}}` | inhabited source collapses to the singleton on One |
| `Ø<T, L>` | `Ø<One, L>{}` | empty source stays empty |
| `SingletonSet<T, L>` | (existing generic overload) → `SingletonSet<One, L>{F(pivot)} = SingletonSet<One, L>{One{}}` | no new code needed |

Predicate-based `Set<T, L, P>` sources fall through to the symbolic-fallback `image()` in `:expressions` (inhabitation undecidable in general — out of scope per the issue).

## Gate

Both new overloads use `dedekind::category::IsTerminalMorphism<std::remove_cvref_t<F>>`.  Wrapping in `remove_cvref_t` is necessary because the `:category:limit::IsTerminalMorphism` concept body uses `typename F::Domain` directly (no decay), so it fails on lvalue arrow types — `:category` stays strict per the project convention; the ergonomic decay lives in the `:sets`-side use site.

## Tests

In `boundaries_test.cpp` — new `TEST_CASE("image(IsTerminalMorphism F, S) — terminal-codomain collapse (#661)")` with three sections:
- `UniversalSet<int>` source → `SingletonSet<One, ClassicalLogic>{}` (type-level + runtime membership).
- `Ø<int>` source → `Ø<One, ClassicalLogic>{}` (type-level).
- `SingletonSet<int>` source → `SingletonSet<One, ClassicalLogic>{}` (covers the existing generic overload).

## Test plan

- [x] `make compile` — clean
- [x] `make test` — 15/15 test suites pass
- [x] Targeted: `./build/test_sets "[sets][image][terminal-morphism]"` → 5/5 assertions pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)