### PR TITLE
Review tests for boundary sets.

### DIFF
--- a/src/main/modules/dedekind/sets/boundaries.cppm
+++ b/src/main/modules/dedekind/sets/boundaries.cppm
@@ -44,6 +44,7 @@ module;
 #include <compare>
 #include <concepts>
 #include <functional>
+#include <utility>  // std::pair (Ø × S cartesian-product return type)
 #include <limits>
 
 export module dedekind.sets:boundaries;
@@ -176,10 +177,28 @@ struct Ø final {
   constexpr auto operator^(const S& s) const {
     return s;
   }
+
+  /** @brief Ø × S = Ø<pair<T, S::Ambient>, L> — empty annihilates the
+   *         cartesian product on the @b left.  Carrier widens to the
+   *         pair type so the result is type-correct as a set of pairs. */
+  template <typename S>
+    requires(IsSet<S>)
+  constexpr auto operator*(const S&) const {
+    return Ø<std::pair<T, typename S::Ambient>, L>{};
+  }
 };
 
 template <typename T, typename L>
 inline const Ø<T, L> Ø<T, L>::χ{};
+
+/** @brief S × Ø = Ø<pair<S::Ambient, T2>, L> — empty annihilates the
+ *         cartesian product on the @b right.  Symmetric companion to
+ *         @c Ø::operator*; carrier widens to the pair type. */
+export template <typename S, typename T2, typename L>
+  requires(IsSet<S> && !std::same_as<S, Ø<typename S::Ambient, L>>)
+constexpr auto operator*(const S&, const Ø<T2, L>&) {
+  return Ø<std::pair<typename S::Ambient, T2>, L>{};
+}
 
 /**
  * @struct UniversalSet

--- a/src/main/modules/dedekind/sets/boundaries.cppm
+++ b/src/main/modules/dedekind/sets/boundaries.cppm
@@ -44,8 +44,8 @@ module;
 #include <compare>
 #include <concepts>
 #include <functional>
-#include <utility>  // std::pair (Ø × S cartesian-product return type)
 #include <limits>
+#include <utility>  // std::pair (Ø × S cartesian-product return type)
 
 export module dedekind.sets:boundaries;
 

--- a/src/test/cpp/modules/dedekind/sets/boundaries_test.cpp
+++ b/src/test/cpp/modules/dedekind/sets/boundaries_test.cpp
@@ -56,10 +56,12 @@ TEST_CASE("Boundaries: The Algebra of Extremality", "[sets][boundaries]") {
     constexpr auto s = ι<int>(42);
 
     INFO("In a Union, the Void is the Identity: ∅ | S = S.");
-    STATIC_REQUIRE(std::is_same_v<decltype(null | s), std::remove_cvref_t<decltype(s)>>);
+    STATIC_REQUIRE(
+        std::is_same_v<decltype(null | s), std::remove_cvref_t<decltype(s)>>);
     STATIC_REQUIRE((null | s) == s);
     INFO("In an Intersection, the Universe is the Identity: Ω & S = S.");
-    STATIC_REQUIRE(std::is_same_v<decltype(universe & s), std::remove_cvref_t<decltype(s)>>);
+    STATIC_REQUIRE(std::is_same_v<decltype(universe & s),
+                                  std::remove_cvref_t<decltype(s)>>);
     STATIC_REQUIRE((universe & s) == s);
   }
 

--- a/src/test/cpp/modules/dedekind/sets/boundaries_test.cpp
+++ b/src/test/cpp/modules/dedekind/sets/boundaries_test.cpp
@@ -53,15 +53,13 @@ TEST_CASE("Boundaries: The Algebra of Extremality", "[sets][boundaries]") {
   }
 
   SECTION("Aha! 2: The Law of Identity") {
-    auto s = ι<size_t>(42);
+    constexpr auto s = ι<size_t>(42);
 
     INFO("In a Union, the Void is the Identity: ∅ | S = S.");
     STATIC_REQUIRE(std::is_same_v<decltype(null | s), decltype(s)>);
-    // Compiles in non-static mode. Apparently missing constexptr?
     STATIC_REQUIRE((null | s) == s);
-    INFO("n an Intersection, the Universe is the Identity: Ω & S = S.");
+    INFO("In an Intersection, the Universe is the Identity: Ω & S = S.");
     STATIC_REQUIRE(std::is_same_v<decltype(universe & s), decltype(s)>);
-    // Compiles in non-static mode. Apparently missing constexptr?
     STATIC_REQUIRE((universe & s) == s);
   }
 

--- a/src/test/cpp/modules/dedekind/sets/boundaries_test.cpp
+++ b/src/test/cpp/modules/dedekind/sets/boundaries_test.cpp
@@ -113,6 +113,13 @@ TEST_CASE("Boundaries: The Algebra of Extremality", "[sets][boundaries]") {
     CHECK(std::is_same_v<decltype(universe & s),
                          SingletonSet<SignedExtensionalCardinal<>>>);
   }
+
+  SECTION("Cartesian Product") {
+    INFO("The empty set is a fixed point of the cartesian product.");
+    STATIC_CHECK(null * null == null);
+    STATIC_CHECK(universe * null == null);
+    STATIC_CHECK(null * universe == null);
+  }
 }
 
 TEST_CASE("image(IsTerminalMorphism F, S) — terminal-codomain collapse (#661)",

--- a/src/test/cpp/modules/dedekind/sets/boundaries_test.cpp
+++ b/src/test/cpp/modules/dedekind/sets/boundaries_test.cpp
@@ -122,14 +122,13 @@ TEST_CASE("Boundaries: The Algebra of Extremality", "[sets][boundaries]") {
     // type because the cartesian product is type-correct as a set
     // of pairs.
     INFO("Ø × Ø = Ø<pair>");
-    STATIC_CHECK(std::is_same_v<decltype(null * null),
-                                Ø<std::pair<int, int>>>);
+    STATIC_CHECK(std::is_same_v<decltype(null * null), Ø<std::pair<int, int>>>);
     INFO("Ω × Ø = Ø<pair>");
-    STATIC_CHECK(std::is_same_v<decltype(universe * null),
-                                Ø<std::pair<int, int>>>);
+    STATIC_CHECK(
+        std::is_same_v<decltype(universe * null), Ø<std::pair<int, int>>>);
     INFO("Ø × Ω = Ø<pair>");
-    STATIC_CHECK(std::is_same_v<decltype(null * universe),
-                                Ø<std::pair<int, int>>>);
+    STATIC_CHECK(
+        std::is_same_v<decltype(null * universe), Ø<std::pair<int, int>>>);
   }
 }
 

--- a/src/test/cpp/modules/dedekind/sets/boundaries_test.cpp
+++ b/src/test/cpp/modules/dedekind/sets/boundaries_test.cpp
@@ -8,19 +8,17 @@ using namespace dedekind::sets;
 
 TEST_CASE("Level 1 Final Proof: The Mereology Highway",
           "[ontology][mereology][highway]") {
+  Ø<int> empty;
   SECTION("2. Initial Object Proof") {
-    Ø<int> empty;
-    static_assert(dedekind::category::IsSet<decltype(ambient_set<int>(empty))>);
+    static_assert(IsSet<decltype(ambient_set<int>(empty))>);
   }
 
   SECTION("3. The Extreme Bounds (0 and 1)") {
-    Ø<int> empty;
     UniversalSet<int> universe;
 
     // Verify these are valid sets over the active logic species.
-    static_assert(dedekind::category::IsSet<decltype(ambient_set<int>(empty))>);
-    static_assert(
-        dedekind::category::IsSet<decltype(ambient_set<int>(universe))>);
+    static_assert(IsSet<decltype(ambient_set<int>(empty))>);
+    static_assert(IsSet<decltype(ambient_set<int>(universe))>);
 
     // Verify the Logical Truth across species
     REQUIRE(empty(42) == false);
@@ -40,37 +38,32 @@ TEST_CASE("Level 1 Final Proof: The Mereology Highway",
 }
 
 TEST_CASE("Boundaries: The Algebra of Extremality", "[sets][boundaries]") {
-  // Use SignedExtensionalCardinal<> directly as the carrier for the
-  // boundary identities (post-#559 ℤ slice migration; the prior local
-  // alias `using ℤ = int` is no longer referenced after the type-site
-  // sweep replaced ℤ with the carrier name in the body).
-
   // The Identities: Ø and Ω as the "North and South Poles"
-  constexpr Ø<SignedExtensionalCardinal<>> null;
-  constexpr UniversalSet<SignedExtensionalCardinal<>> universe;
+  constexpr Ø<int> null;
+  constexpr UniversalSet<int> universe;
 
   SECTION("Aha! 1: The Law of Absorption (Annihilation)") {
     /**
      * In a Union, the Universe is the Annihilator: Ω | S = Ω.
      * In an Intersection, the Void is the Annihilator: ∅ & S = ∅.
      */
-    static_assert(std::is_same_v<decltype((universe | null)),
-                                 UniversalSet<SignedExtensionalCardinal<>>>);
-    static_assert(std::is_same_v<decltype((null & universe)),
-                                 Ø<SignedExtensionalCardinal<>>>);
+    static_assert(
+        std::is_same_v<decltype((universe | null)), UniversalSet<int>>);
+    static_assert(std::is_same_v<decltype((null & universe)), Ø<int>>);
   }
 
-  // SECTION("Aha! 2: The Law of Identity") {
-  //   /**
-  //    * In a Union, the Void is the Identity: ∅ | S = S.
-  //    * In an Intersection, the Universe is the Identity: Ω & S = S.
-  //    */
-  //   // Let's use a Singleton to prove it preserves the specific "Body"
-  //   constexpr SingletonSet<ℤ>{42} s;
+  SECTION("Aha! 2: The Law of Identity") {
+    auto s = ι<size_t>(42);
 
-  //   static_assert(std::is_same_v<decltype(null | s), SingletonSet<ℤ>>);
-  //   static_assert(std::is_same_v<decltype(universe & s), SingletonSet<ℤ>>);
-  // }
+    INFO("In a Union, the Void is the Identity: ∅ | S = S.");
+    STATIC_REQUIRE(std::is_same_v<decltype(null | s), decltype(s)>);
+    // Compiles in non-static mode. Apparently missing constexptr?
+    STATIC_REQUIRE((null | s) == s);
+    INFO("n an Intersection, the Universe is the Identity: Ω & S = S.");
+    STATIC_REQUIRE(std::is_same_v<decltype(universe & s), decltype(s)>);
+    // Compiles in non-static mode. Apparently missing constexptr?
+    STATIC_REQUIRE((universe & s) == s);
+  }
 
   SECTION("Aha! 3: The Involution of the Remainder") {
     /**

--- a/src/test/cpp/modules/dedekind/sets/boundaries_test.cpp
+++ b/src/test/cpp/modules/dedekind/sets/boundaries_test.cpp
@@ -56,10 +56,10 @@ TEST_CASE("Boundaries: The Algebra of Extremality", "[sets][boundaries]") {
     constexpr auto s = ι<int>(42);
 
     INFO("In a Union, the Void is the Identity: ∅ | S = S.");
-    STATIC_REQUIRE(std::is_same_v<decltype(null | s), decltype(s)>);
+    STATIC_REQUIRE(std::is_same_v<decltype(null | s), std::remove_cvref_t<decltype(s)>>);
     STATIC_REQUIRE((null | s) == s);
     INFO("In an Intersection, the Universe is the Identity: Ω & S = S.");
-    STATIC_REQUIRE(std::is_same_v<decltype(universe & s), decltype(s)>);
+    STATIC_REQUIRE(std::is_same_v<decltype(universe & s), std::remove_cvref_t<decltype(s)>>);
     STATIC_REQUIRE((universe & s) == s);
   }
 

--- a/src/test/cpp/modules/dedekind/sets/boundaries_test.cpp
+++ b/src/test/cpp/modules/dedekind/sets/boundaries_test.cpp
@@ -53,7 +53,7 @@ TEST_CASE("Boundaries: The Algebra of Extremality", "[sets][boundaries]") {
   }
 
   SECTION("Aha! 2: The Law of Identity") {
-    constexpr auto s = ι<size_t>(42);
+    constexpr auto s = ι<int>(42);
 
     INFO("In a Union, the Void is the Identity: ∅ | S = S.");
     STATIC_REQUIRE(std::is_same_v<decltype(null | s), decltype(s)>);

--- a/src/test/cpp/modules/dedekind/sets/boundaries_test.cpp
+++ b/src/test/cpp/modules/dedekind/sets/boundaries_test.cpp
@@ -115,10 +115,21 @@ TEST_CASE("Boundaries: The Algebra of Extremality", "[sets][boundaries]") {
   }
 
   SECTION("Cartesian Product") {
-    INFO("The empty set is a fixed point of the cartesian product.");
-    STATIC_CHECK(null * null == null);
-    STATIC_CHECK(universe * null == null);
-    STATIC_CHECK(null * universe == null);
+    // The empty set annihilates the cartesian product on either side.
+    // Type-level claim only (cross-type Ø<T> == Ø<U> equality lives
+    // in #685's equality-matrix scope and would be needed for the
+    // value-level `== null` reading).  Carrier widens to the pair
+    // type because the cartesian product is type-correct as a set
+    // of pairs.
+    INFO("Ø × Ø = Ø<pair>");
+    STATIC_CHECK(std::is_same_v<decltype(null * null),
+                                Ø<std::pair<int, int>>>);
+    INFO("Ω × Ø = Ø<pair>");
+    STATIC_CHECK(std::is_same_v<decltype(universe * null),
+                                Ø<std::pair<int, int>>>);
+    INFO("Ø × Ω = Ø<pair>");
+    STATIC_CHECK(std::is_same_v<decltype(null * universe),
+                                Ø<std::pair<int, int>>>);
   }
 }
 


### PR DESCRIPTION
Partial fulfillment of #681 — exercising the boundary sets (`Ø`, `UniversalSet`) on textbook lattice-of-sets identities and finding which ones the DSL can prove today vs which need follow-up.

## What lands

**Test-side** ([`boundaries_test.cpp`](src/test/cpp/modules/dedekind/sets/boundaries_test.cpp)):
- **Aha! 2 — Law of Identity.** `∅ | S = S` and `Ω & S = S`, witnessed both type-level (`STATIC_REQUIRE std::is_same_v`) and value-level (`STATIC_REQUIRE (… == s)`).
- **Aha! 3 — Involution of the Remainder.** `!!S = S` via `Complement<Complement<S>>` collapse on both `Ø` and `UniversalSet`.
- **Cartesian Product on `Ø`.** Type-level: `Ø × Ø`, `Ω × Ø`, `Ø × Ω` all reduce to `Ø<pair<…>>` — empty annihilates the product.

**Main-side** ([`boundaries.cppm`](src/main/modules/dedekind/sets/boundaries.cppm)):
- Member `Ø<T,L>::operator*(S)` — empty-annihilation on the left.
- Free `operator*(S, Ø<T2,L>)` — empty-annihilation on the right (constrained to disambiguate from the member).
- Carrier widens to the pair type, matching the set-of-pairs codomain of `×`.

## What's deferred

`null * null == null` value-level reading needs cross-type `Ø<T> == Ø<U>` equality (already partially present at [boundaries.cppm:132](src/main/modules/dedekind/sets/boundaries.cppm#L132) but not exercised on `Ø<pair<…>>`); tracked under #685's equality-matrix scope. Type-level form chosen here to keep intent unambiguous.

## Net

+57 / -28 across 2 files. Build green (15/15 suites pass locally; CI green).