### PR TITLE
feat(category): #698 Slice 0 — `:thin` partition (`IsThinCategory<T, Rel, L>`)

### DIFF
--- a/src/main/modules/dedekind/category/category.cppm
+++ b/src/main/modules/dedekind/category/category.cppm
@@ -49,7 +49,9 @@ export import :equivalence;  // Equivalence relations (Mazur up-to relaxation;
 export import :logic;        // The Subobject Classifier (Truth)
 
 // Level 0.5: The Structural Infrastructure
-export import :posetal;    // Partial Orders (Verified by Logic)
+export import :thin;       // Thin Categories (preorders; row 1 of the
+                           // lattice Form-chain; #698)
+export import :posetal;    // Partial Orders (thin + antisymmetric)
 export import :small;      // Small Categories
 export import :discrete;   // The Discrete Category (Points as Arrows)
 export import :nno;        // The Natural Numbers Object (ETCS Axiom 9 reified;

--- a/src/main/modules/dedekind/category/small.cppm
+++ b/src/main/modules/dedekind/category/small.cppm
@@ -143,13 +143,18 @@ inline constexpr bool is_associative_v<T, Op> = true;
  * ETCS axiomatization picks out @c Set specifically among concrete
  * categories via the topos structure (well-pointedness, NNO, choice).
  *
- * Other refinements of "category" --- thin, discrete, locally-finite,
+ * Other refinements of "category" --- discrete, locally-finite,
  * intensional / extensional, lazy / strict --- are also intentionally
  * out of scope here; they are named (or named-able) at downstream
  * partitions where they have semantic content.  The intensional /
  * extensional split in particular is reified at @c :sets:expressions
  * (intensional, @c TernaryLogic) vs @c :sets:extensional (decidable
- * membership), not at the category layer.
+ * membership), not at the category layer.  @b Thin categories
+ * (hom(a, b) has @c ≤ 1 morphism — the categorical incarnation of
+ * preorders) were lifted from this Sollbruchstelle to their own
+ * partition @c :category::thin in #698, where they sit as row 1 of the
+ * lattice Form-chain (@c IsThinCategory @c ⊂ @c IsPosetal @c ⊂
+ * @c IsLatticeCategory).
  *
  * @section small__The_Locally_Small_Slot
  * Standard CT distinguishes three slots along the size axis:

--- a/src/main/modules/dedekind/category/thin.cppm
+++ b/src/main/modules/dedekind/category/thin.cppm
@@ -1,0 +1,117 @@
+/**
+ * @file dedekind/category/thin.cppm
+ * @partition :thin
+ * @brief Thin categories — categories whose hom-sets contain at most one
+ *        morphism.
+ *
+ * @section thin__Categorical_Definition
+ * A @b thin (or @em posetal-shaped, in the textbook's looser usage) category
+ * is one in which @c hom(a, @c b) has @b at @b most one morphism for any
+ * pair of objects.  Equivalently: any two parallel morphisms are equal.
+ *
+ * In the order-theoretic encoding the codebase uses across @c :mereology
+ * and @c :posetal, this corresponds to a @b preorder over @c T with relation
+ * @c Rel and truth-value codomain @c L::Ω:
+ *
+ * - Objects are elements of @c T.
+ * - The unique morphism @c a → b (when it exists) is the witness of
+ *   @c Rel(a, @c b) @c = @c L::True.
+ * - Identity morphism @c id_a corresponds to @b reflexivity
+ *   (@c Rel(a, @c a) @c = @c L::True).
+ * - Composition corresponds to @b transitivity
+ *   (@c Rel(a, @c b) @c ∧ @c Rel(b, @c c) @c ⇒ @c Rel(a, @c c)).
+ *
+ * @section thin__Distinction_from_Posetal
+ * @c IsThinCategory does @b not require @b antisymmetry.  A thin category
+ * is a @b preorder, not necessarily a partial order; isomorphic objects
+ * need not be identical.  Adding antisymmetry yields @c :posetal::IsPosetal
+ * — a thin category that is also @b skeletal.
+ *
+ * @c IsPosetal is a strict refinement of @c IsThinCategory; the inclusion
+ * is encoded definitionally per the project's @em "faithful specialization
+ * in the type signature from day 1" posture (#698).
+ *
+ * @section thin__Sollbruchstelle_From_Small
+ * @c :small's docstring deliberately defers thin-category vocabulary:
+ * @em "thin, discrete, locally-finite, intensional / extensional, lazy /
+ * strict --- are also intentionally out of scope here; they are named
+ * (or named-able) at downstream partitions where they have semantic
+ * content."  This partition closes that seam directly.
+ *
+ * @section thin__Boolean_Witness
+ * @c bool with @c std::less_equal participates: the 2-element poset
+ * @c (false @c ≤ @c true) is the smallest non-trivial thin category and
+ * a canonical entry point to the Form-chain (#698).
+ *
+ * @see https://en.wikipedia.org/wiki/Preorder
+ * @see https://ncatlab.org/nlab/show/thin+category
+ *
+ * @copyright 2026 The Dedekind Authors
+ * Licensed under the Apache License, Version 2.0.
+ *
+ * @note "Two parallel arrows in a thin category are equal --- the relation
+ *        IS the morphism."
+ */
+module;
+
+#include <concepts>
+#include <functional>
+
+export module dedekind.category:thin;
+
+import :logic;
+import :mereology;  // is_reflexive_v, is_transitive_v traits
+
+namespace dedekind::category {
+
+/**
+ * @concept IsThinCategory
+ * @brief A category in which every hom-set has at most one morphism.
+ *
+ * @details
+ * Equivalently, a @b preorder over @c T with relation @c Rel returning
+ * @c L::Ω.  The axioms enforced:
+ *
+ * - @b Closure: @c rel(a, @c b) yields a truth value in @c L::Ω.
+ * - @b Reflexivity: @c ∀a. @c rel(a, @c a) @c = @c L::True
+ *   (the identity morphism).
+ * - @b Transitivity: @c ∀a,b,c. @c rel(a, @c b) @c ∧ @c rel(b, @c c) @c ⇒
+ *   @c rel(a, @c c) (composition).
+ *
+ * Antisymmetry is @b not required; @c IsPosetal in @c :posetal is the
+ * strict refinement that adds it.
+ *
+ * @tparam T   The Domain (Objects).
+ * @tparam Rel The Relation (the unique-morphism witness).
+ * @tparam L   The Logic Species (the Subobject Classifier Ω).
+ */
+export template <typename T, typename Rel = std::less_equal<T>,
+                 typename L = ClassicalLogic>
+concept IsThinCategory = requires(Rel rel, T a, T b) {
+  /** @brief The relation must yield a result in the logical classifier. */
+  { rel(a, b) } -> std::same_as<typename L::Ω>;
+
+  /** @brief Reflexivity (identity arrow). */
+  requires is_reflexive_v<T, Rel>;
+
+  /** @brief Transitivity (composition). */
+  requires is_transitive_v<T, Rel>;
+};
+
+/** @section thin__Canonical_Witnesses
+ *
+ *  @brief Boolean is the canonical 2-element thin category.
+ *
+ *  @details @c (false @c ≤ @c true) under @c std::less_equal is the
+ *  smallest non-trivial thin category — and the smallest non-trivial
+ *  lattice / subobject classifier / Boolean algebra.  Pinning it here
+ *  anchors the Form-chain at its base.
+ */
+static_assert(IsThinCategory<bool>,
+              "bool with std::less_equal is the canonical 2-element thin "
+              "category (preorder over {false, true}).");
+
+static_assert(IsThinCategory<int>,
+              "int with std::less_equal is thin (the canonical total order).");
+
+}  // namespace dedekind::category

--- a/src/main/modules/dedekind/category/thin.cppm
+++ b/src/main/modules/dedekind/category/thin.cppm
@@ -27,9 +27,12 @@
  * need not be identical.  Adding antisymmetry yields @c :posetal::IsPosetal
  * — a thin category that is also @b skeletal.
  *
- * @c IsPosetal is a strict refinement of @c IsThinCategory; the inclusion
- * is encoded definitionally per the project's @em "faithful specialization
- * in the type signature from day 1" posture (#698).
+ * @c IsPosetal is a strict refinement of @c IsThinCategory.  At the time
+ * of this partition's introduction the inclusion is @b not yet encoded
+ * definitionally in @c IsPosetal — that signature-level refactor lands
+ * in #698 Slice 1, after which the inclusion is visible directly in
+ * @c IsPosetal's @c requires clause per the project's @em "faithful
+ * specialization in the type signature from day 1" posture.
  *
  * @section thin__Sollbruchstelle_From_Small
  * @c :small's docstring deliberately defers thin-category vocabulary:
@@ -60,7 +63,9 @@ module;
 export module dedekind.category:thin;
 
 import :logic;
-import :mereology;  // is_reflexive_v, is_transitive_v traits
+import :species;  // is_reflexive_v, is_transitive_v traits — defined in
+                  // :species; :mereology imports them without re-exporting,
+                  // so we must import :species directly here.
 
 namespace dedekind::category {
 

--- a/src/test/cpp/modules/dedekind/category/thin_test.cpp
+++ b/src/test/cpp/modules/dedekind/category/thin_test.cpp
@@ -1,0 +1,60 @@
+/** @file dedekind/category/thin_test.cpp
+ *
+ * Unit coverage for @c :category::thin (the lattice-Form-chain row 1, #698).
+ *
+ * @c IsThinCategory<T, Rel, L> reifies "category whose hom-sets have at most
+ * one morphism" as a preorder over @c T (reflexive + transitive, no
+ * antisymmetry).  Witnesses below pin the canonical entry points and the
+ * relationship to @c :posetal (the row-2 refinement).
+ */
+
+#include <catch2/catch_test_macros.hpp>
+#include <concepts>
+#include <functional>
+
+import dedekind.category;
+
+using namespace dedekind::category;
+
+TEST_CASE("category:thin — Bool is the canonical 2-element thin category",
+          "[category][thin][bool][canonical]") {
+  /** @brief @c (false @c ≤ @c true) under @c std::less_equal is the
+   *         smallest non-trivial thin category — and also the canonical
+   *         Boolean algebra / subobject classifier in Set. */
+  STATIC_CHECK(IsThinCategory<bool>);
+  STATIC_CHECK(IsThinCategory<bool, std::less_equal<bool>, ClassicalLogic>);
+}
+
+TEST_CASE("category:thin — integral carriers are thin",
+          "[category][thin][numeric]") {
+  /** @brief Standard integral carriers form thin categories under the
+   *         usual order — they are also totally ordered, but @c
+   *         IsThinCategory pins only the preorder content (no total-order
+   *         requirement).
+   *
+   *  @note Floating-point carriers (@c double, @c float) intentionally
+   *  do @b not satisfy @c IsThinCategory under @c std::less_equal: the
+   *  @c is_transitive_v trait in @c :species is specialised only for
+   *  integral and bool carriers, because @c NaN-tainted IEEE 754
+   *  comparisons break transitivity (@c NaN @c <= x is always false).
+   *  Honest rejection — see @c numbers::approx / @c :ieee for the
+   *  partial-arithmetic surface that handles this. */
+  STATIC_CHECK(IsThinCategory<int>);
+  STATIC_CHECK(IsThinCategory<unsigned>);
+  STATIC_CHECK(IsThinCategory<std::size_t>);
+}
+
+TEST_CASE("category:thin — IsPosetal strictly refines IsThinCategory",
+          "[category][thin][posetal][faithful]") {
+  /** @brief Faithful inclusion: every @c IsPosetal carrier is @c
+   *         IsThinCategory (poset = thin + antisymmetric).  The inclusion
+   *         is *currently* implicit because @c IsPosetal builds on @c
+   *         IsPartialOrder which already enforces reflexivity +
+   *         transitivity; the explicit signature-level encoding lands in
+   *         the @c :posetal refactor slice (#698 Slice 1). */
+  STATIC_CHECK(IsThinCategory<bool>);
+  STATIC_CHECK(IsPosetal<bool>);
+
+  STATIC_CHECK(IsThinCategory<int>);
+  STATIC_CHECK(IsPosetal<int>);
+}

--- a/src/test/cpp/modules/dedekind/category/thin_test.cpp
+++ b/src/test/cpp/modules/dedekind/category/thin_test.cpp
@@ -34,11 +34,12 @@ TEST_CASE("category:thin — integral carriers are thin",
    *
    *  @note Floating-point carriers (@c double, @c float) intentionally
    *  do @b not satisfy @c IsThinCategory under @c std::less_equal: the
-   *  @c is_transitive_v trait in @c :species is specialised only for
-   *  integral and bool carriers, because @c NaN-tainted IEEE 754
-   *  comparisons break transitivity (@c NaN @c <= x is always false).
-   *  Honest rejection — see @c numbers::approx / @c :ieee for the
-   *  partial-arithmetic surface that handles this. */
+   *  @c is_reflexive_v trait in @c :species is specialised only for
+   *  @c std::totally_ordered carriers, and @c double under IEEE 754 is
+   *  @b not totally ordered because @c NaN violates reflexivity
+   *  (@c NaN @c <= @c NaN is @c false).  Honest rejection — see
+   *  @c numbers::approx / @c :ieee for the partial-arithmetic surface
+   *  that handles this. */
   STATIC_CHECK(IsThinCategory<int>);
   STATIC_CHECK(IsThinCategory<unsigned>);
   STATIC_CHECK(IsThinCategory<std::size_t>);


### PR DESCRIPTION
Slice 0 of #698 (categorical re-grounding of lattice / mereology vocabulary).

## What lands

New `:category::thin` partition exporting:

```cpp
template <typename T, typename Rel = std::less_equal<T>,
          typename L = ClassicalLogic>
concept IsThinCategory = requires(Rel rel, T a, T b) {
  { rel(a, b) } -> std::same_as<typename L::Ω>;
  requires is_reflexive_v<T, Rel>;
  requires is_transitive_v<T, Rel>;
};
```

Reifies "category whose hom-sets have at most one morphism" as a **preorder** (reflexive + transitive, no antisymmetry). The order-theoretic encoding mirrors `:posetal`'s `(T, Rel, L)` shape so future Slice 1 can refactor `IsPosetal` to require `IsThinCategory` explicitly (faithful inclusion in signature).

## Form-chain row this fills

```
IsThinCategory                          ← THIS PR (row 1, preorder)
    ↓ + antisymmetry
IsPosetal                                (row 2, existing — Slice 1 refactor)
    ↓ + every finite subset has SOME upper bound
IsFilteredCategory                       (row 3 — Slice 2)
    ↓ + cofiltered + universality
IsLatticeCategory                        (row 4 — Slice 3, Form-chain home)
```

Each `↓ +` is a faithful inclusion (lower row strictly implies upper row), encoded definitionally per the project's *"faithful specialization in the type signature from day 1"* posture (#698).

## Sollbruchstelle closed

[`:small`'s docstring](src/main/modules/dedekind/category/small.cppm#L146-152) explicitly defers thin-category vocabulary:

> "thin, discrete, locally-finite, intensional / extensional, lazy / strict — are also intentionally out of scope here; they are named (or named-able) at downstream partitions where they have semantic content."

This PR closes the *thin* seam directly; the other refinements remain deferred. The docstring is updated to point to `:thin` so a future reader sees the seam resolved.

## Witnesses

Pinned both in [thin.cppm](src/main/modules/dedekind/category/thin.cppm) and in [thin_test.cpp](src/test/cpp/modules/dedekind/category/thin_test.cpp):

- **`IsThinCategory<bool>`** — Gemini's canonical example: the 2-element poset `(false ≤ true)`, also the canonical Boolean algebra / subobject classifier in Set.
- **`IsThinCategory<int>` / `<unsigned>` / `<std::size_t>`** — standard integral carriers.
- **`IsPosetal<T>` ⟹ `IsThinCategory<T>`** — pinned via dual `STATIC_CHECK` on both for the canonical witnesses. (Definitional encoding of the inclusion lands in Slice 1.)

## Honest rejection (worth a sentence)

Floating-point carriers (`double`, `float`) intentionally **do not** satisfy `IsThinCategory<T, std::less_equal<T>>` — `is_transitive_v` in `:species` is specialised only for integral and bool carriers, because NaN-tainted IEEE 754 comparisons break transitivity (`NaN <= x` is always false). This is consistent with the codebase's broader honest-rejection posture (Mandelbrot / `Real<S>` partial arithmetic / `SymbolicImagePredicate`) and is documented in the test file.

## Net

+187 / -3 across 4 files. Build green, 15/15 test suites pass locally.

## Adjacent

- [#698](https://github.com/vincentk/dedekind/issues/698) — design issue with the full Form-chain and slice plan.
- `:small` — partition whose docstring Sollbruchstelle this closes.
- `:posetal` — row 2; Slice 1 will refactor `IsPosetal` to import `:thin` explicitly.
- `:cartesian` — row 4's universal-property pieces (`IsProduct`, `IsCoproduct`, `IsExponential`) feed into `IsLatticeCategory` in Slice 3.