### PR TITLE
feat(category): #698 Slice 1 — IsPosetal definitionally requires IsThinCategory

### DIFF
--- a/src/main/modules/dedekind/category/posetal.cppm
+++ b/src/main/modules/dedekind/category/posetal.cppm
@@ -52,6 +52,8 @@ import :logic;
 import :mereology;
 import :morphism;  // IsArrow / IsBijectiveArrow / Identity (gates for
                    // IsMonotone / IsAntiMonotone / IsOrderIsomorphism)
+import :thin;      // IsThinCategory — the faithful row-1 inclusion that
+                   // IsPosetal explicitly imports per #698 Slice 1.
 
 namespace dedekind::category {
 
@@ -64,6 +66,14 @@ namespace dedekind::category {
  * By default, it assumes Classical (Boolean) logic, but it can be
  * parameterized to support intuitionistic or fuzzy relations.
  *
+ * @details
+ * @c IsPosetal is the strict refinement of @c IsThinCategory (#698 row 1):
+ * a posetal category is a thin category that is @b also @b skeletal
+ * (antisymmetric).  The faithful inclusion @c IsPosetal @c ⊊
+ * @c IsThinCategory is encoded definitionally in the signature per the
+ * project's @em "faithful specialization in the type signature from day
+ * one" posture (#698).
+ *
  * @tparam T   The Domain (Objects).
  * @tparam Rel The Relation (Morphisms).
  * @tparam L   The Logic Species (The Subobject Classifier).
@@ -71,6 +81,8 @@ namespace dedekind::category {
 export template <typename T, typename Rel = std::less_equal<T>,
                  typename L = ClassicalLogic>
 concept IsPosetal =
+    IsThinCategory<T, Rel, L> &&  // Faithful inclusion: every poset IS thin
+                                  // (preorder + antisymmetric); #698 Slice 1.
     IsPartialOrder<T, Rel, typename L::Ω> && requires(Rel rel, T a, T b) {
       // The relation must yield a result from the logical classifier
       { rel(a, b) } -> std::same_as<typename L::Ω>;


### PR DESCRIPTION
Slice 1 of #698. Depends on Slice 0 (#699) being merged first.

## What lands

`IsPosetal<T, Rel, L>` now explicitly imports and requires `IsThinCategory<T, Rel, L>` in its definition:

```cpp
export template <typename T, typename Rel = std::less_equal<T>,
                 typename L = ClassicalLogic>
concept IsPosetal =
    IsThinCategory<T, Rel, L> &&  // ← NEW: faithful inclusion in signature
    IsPartialOrder<T, Rel, typename L::Ω> && requires(Rel rel, T a, T b) {
      { rel(a, b) } -> std::same_as<typename L::Ω>;
    };
```

## Why

Per #698, the project's posture is **"faithful specialization in the type signature from day one"**. The inclusion `IsPosetal ⊊ IsThinCategory` was already true *logically* — `IsPartialOrder` enforces reflexive + transitive + antisymmetric, and `IsThinCategory` requires only reflexive + transitive. The change makes the inclusion visible in the signature: a reader now sees that posetal IS thin, with antisymmetry the only additional bit.

Net behavior: no change in which carriers satisfy `IsPosetal`. The signature carries the receipt.

## Net

+12 / -0 across 1 file. Foundational change; CI authoritative.

## Adjacent

- [#698](https://github.com/vincentk/dedekind/issues/698) — design issue.
- [#699](https://github.com/vincentk/dedekind/pull/699) — Slice 0 (`:thin` partition); merge prerequisite.