### PR TITLE
feat(category): #698 Slice 2 — :filtered partition (IsFilteredCategory)

### DIFF
--- a/src/main/modules/dedekind/category/category.cppm
+++ b/src/main/modules/dedekind/category/category.cppm
@@ -52,6 +52,8 @@ export import :logic;        // The Subobject Classifier (Truth)
 export import :thin;       // Thin Categories (preorders; row 1 of the
                            // lattice Form-chain; #698)
 export import :posetal;    // Partial Orders (thin + antisymmetric)
+export import :filtered;   // Filtered Categories (thin + directed; row 3
+                           // of the lattice Form-chain; #698 Slice 2)
 export import :small;      // Small Categories
 export import :discrete;   // The Discrete Category (Points as Arrows)
 export import :nno;        // The Natural Numbers Object (ETCS Axiom 9 reified;

--- a/src/main/modules/dedekind/category/filtered.cppm
+++ b/src/main/modules/dedekind/category/filtered.cppm
@@ -1,0 +1,136 @@
+/**
+ * @file dedekind/category/filtered.cppm
+ * @partition :filtered
+ * @brief Filtered categories — categories whose finite diagrams have a
+ *        cocone.
+ *
+ * @section filtered__Categorical_Definition
+ * A @b filtered category is one in which every finite diagram has a
+ * @b cocone (an upper bound, in poset terms).  The standard textbook
+ * definition is three-fold:
+ *
+ * - The category is @b nonempty.
+ * - For every pair of objects @c (a, b), there exists an object @c c
+ *   and morphisms @c a @c → @c c, @c b @c → @c c (binary upper bound).
+ * - For every parallel pair @c f, @c g @c : @c a @c → b, there exists
+ *   @c h @c : @c b @c → @c c equalising them.
+ *
+ * @section filtered__Thin_Case
+ * In a thin category (hom-sets propositional), the third clause is
+ * automatic: parallel morphisms are equal by thinness, so any choice
+ * of @c h coequalises trivially.  Filtered then reduces to:
+ *
+ *   @b nonempty + ∀ a, b ∈ T. ∃ c ∈ T. Rel(a, c) ∧ Rel(b, c)
+ *
+ * By induction on finite-subset size, the binary case extends to
+ * arbitrary finite subsets — that's exactly the @b directedness
+ * axiom captured by @c :species::is_directed_v.
+ *
+ * @section filtered__Form_Chain_Row_3
+ * @c IsFilteredCategory is row 3 of the lattice Form-chain (#698):
+ *
+ * @code
+ *   IsThinCategory        (row 1, preorder)
+ *      ↓ + antisymmetry
+ *   IsPosetal             (row 2, poset)
+ *
+ *   IsThinCategory        (row 1, parallel branch)
+ *      ↓ + directedness
+ *   IsFilteredCategory    (row 3, this partition)
+ *
+ *   row 2 + row 3 + cofiltered + universality
+ *      ↓
+ *   IsLatticeCategory     (row 4, Form-chain home — Slice 3)
+ * @endcode
+ *
+ * Filtered cats are @b not refinements of posetal — they need only
+ * thin + directed, NOT antisymmetric.  The textbook example of a
+ * filtered non-poset is a preorder with two distinct maximal elements
+ * that are mutually @c ≤; under thin+directed it counts as filtered,
+ * but it is not a poset.
+ *
+ * @section filtered__Why_Filtered_Matters
+ * Filtered categories are the natural indexing shape for @b filtered
+ * @b colimits, which preserve finite limits.  In the context of
+ * @c :sets::mereology and the subobject classifier reading (#698):
+ *
+ * - @b Unrestricted-fusion mereology (Leśniewskian gunk-friendly
+ *   variants) needs arbitrary colimits in Sub(X) — these require
+ *   filtered cocompleteness of the ambient.
+ * - @b Filtered Ind-objects on Sub(X) name "limits of finite parts" —
+ *   the categorical machinery behind "arbitrary fusion".
+ *
+ * Whether the project ever needs this gunk-axis machinery is open;
+ * @c :filtered names the row regardless, so the @c IsLatticeCategory
+ * assembly in Slice 3 can encode the faithful inclusion
+ * @c IsLatticeCategory @c ⊊ @c IsFilteredCategory definitionally.
+ *
+ * @section filtered__Boolean_Witness
+ * @c bool with @c std::less_equal is filtered: @c true is the upper
+ * bound of every pair (and @c std::totally_ordered<bool> witnesses
+ * @c is_directed_v through the @c :species specialisation).  The
+ * 2-element thin category is also filtered.
+ *
+ * @see https://en.wikipedia.org/wiki/Filtered_category
+ * @see https://ncatlab.org/nlab/show/filtered+category
+ *
+ * @copyright 2026 The Dedekind Authors
+ * Licensed under the Apache License, Version 2.0.
+ *
+ * @note "Pas à pas, on va loin."  (Step by step, one goes far.)
+ *       — French proverb; here the steps are slices of #698.
+ */
+module;
+
+#include <concepts>
+#include <functional>
+
+export module dedekind.category:filtered;
+
+import :logic;
+import :species;  // is_directed_v, is_reflexive_v, is_transitive_v
+import :thin;     // IsThinCategory — the faithful row-1 inclusion
+
+namespace dedekind::category {
+
+/**
+ * @concept IsFilteredCategory
+ * @brief A thin category whose every finite subset of objects has an
+ *        upper bound (directedness).
+ *
+ * @details
+ * Faithful inclusion: @c IsFilteredCategory ⊊ @c IsThinCategory.  Every
+ * filtered category is thin (the relation IS the morphism, propositional
+ * hom-sets), but filtered additionally requires the directedness axiom:
+ *
+ *   ∀ a, b ∈ T. ∃ c ∈ T. Rel(a, c) ∧ Rel(b, c).
+ *
+ * The pairwise statement extends to all finite subsets by induction.
+ *
+ * Antisymmetry is @b not required — filtered is parallel to, not
+ * downstream of, @c :posetal::IsPosetal in the Form-chain.
+ *
+ * @tparam T   The Domain (Objects).
+ * @tparam Rel The Relation (the unique-morphism witness).
+ * @tparam L   The Logic Species (the Subobject Classifier Ω).
+ */
+export template <typename T, typename Rel = std::less_equal<T>,
+                 typename L = ClassicalLogic>
+concept IsFilteredCategory =
+    IsThinCategory<T, Rel, L> &&  // Faithful inclusion: filtered ⊊ thin.
+    requires {
+      /** @brief Directedness: every pair has an upper bound. */
+      requires is_directed_v<T, Rel>;
+    };
+
+/** @section filtered__Canonical_Witnesses */
+
+static_assert(IsFilteredCategory<bool>,
+              "bool with std::less_equal is the canonical 2-element "
+              "filtered category (true is the upper bound of every pair).");
+
+static_assert(IsFilteredCategory<int>,
+              "int with std::less_equal is filtered (totally ordered "
+              "carriers are trivially directed).");
+
+}  // namespace dedekind::category

--- a/src/main/modules/dedekind/category/species.cppm
+++ b/src/main/modules/dedekind/category/species.cppm
@@ -398,6 +398,58 @@ concept IsAntisymmetric = requires(T a, T b) {
   { Rel{}(a, b) } -> std::convertible_to<bool>;
 } && requires { requires is_antisymmetric_v<T, Rel>; };
 
+/** @section species__Directedness: ∀a,b ∃c. a ≤ c ∧ b ≤ c
+ *
+ *  @brief Trait to mark a relation as @b directed: every pair of
+ *         elements has an upper bound.
+ *
+ *  @details Directedness is the one-sided existence axiom that
+ *  upgrades a preorder / thin category to a @b filtered category
+ *  (#698 row 3): every finite subset has SOME upper bound (induction
+ *  reduces this to the pairwise case).
+ *
+ *  Filtered ⊊ thin: every filtered category is thin, but filtered
+ *  additionally requires the upper-bound existence claim.  Note that
+ *  filtered does @b not require antisymmetry — it is parallel to,
+ *  not downstream of, @c :posetal in the Form-chain.
+ */
+export template <typename T, typename Rel>
+struct is_directed : std::false_type {};
+
+/** @brief Discovery: types may opt in via a nested @c is_directed_v
+ *         template member, mirroring the @c is_reflexive_v /
+ *         @c is_transitive_v / @c is_antisymmetric_v discovery pattern. */
+template <typename T, typename Rel>
+  requires requires { T::template is_directed_v<Rel>; }
+struct is_directed<T, Rel>
+    : std::bool_constant<T::template is_directed_v<Rel>> {};
+
+export template <typename T, typename Rel>
+inline constexpr bool is_directed_v = is_directed<T, Rel>::value;
+
+/** @brief Every totally ordered carrier under @c std::less_equal is
+ *         directed: @c max(a, b) is the upper bound of every pair. */
+template <typename T>
+  requires std::totally_ordered<T>
+struct is_directed<T, std::less_equal<T>> : std::true_type {};
+
+/**
+ * @concept IsDirected
+ * @brief Formal verification of the directedness axiom:
+ *        ∀ a, b ∈ T. ∃ c ∈ T. Rel(a, c) ∧ Rel(b, c).
+ *
+ * @details At the value level, every pair has an upper bound under
+ * @c Rel.  Specialised at trait level rather than constructively
+ * because exhibiting @c c for arbitrary @c a, @c b in a generic
+ * concept body is awkward; the trait specialisation captures the
+ * mathematical content for the canonical witnesses
+ * (@c std::totally_ordered carriers).
+ */
+export template <typename T, typename Rel>
+concept IsDirected = requires(T a, T b) {
+  { Rel{}(a, b) } -> std::convertible_to<bool>;
+} && requires { requires is_directed_v<T, Rel>; };
+
 /** @section species__Categorical_Inverses: The 'Undo' Bricks */
 
 /** @brief In XOR, every element is its own inverse (Involutive). */

--- a/src/test/cpp/modules/dedekind/category/filtered_test.cpp
+++ b/src/test/cpp/modules/dedekind/category/filtered_test.cpp
@@ -1,0 +1,72 @@
+/** @file dedekind/category/filtered_test.cpp
+ *
+ * Unit coverage for @c :category::filtered (the lattice-Form-chain row 3,
+ * #698 Slice 2).
+ *
+ * @c IsFilteredCategory<T, Rel, L> reifies "thin category whose every
+ * finite subset has an upper bound" as thin + directed.  Faithful
+ * inclusion @c IsFilteredCategory ⊊ @c IsThinCategory encoded in the
+ * signature per the project's "faithful specialization in the type
+ * signature from day one" posture (#698).
+ *
+ * Witnesses below pin the canonical entry points and the parallel-to-
+ * @c :posetal status (filtered does @b not require antisymmetry).
+ */
+
+#include <catch2/catch_test_macros.hpp>
+#include <concepts>
+#include <functional>
+
+import dedekind.category;
+
+using namespace dedekind::category;
+
+TEST_CASE("category:filtered — Bool is the canonical 2-element filtered category",
+          "[category][filtered][bool][canonical]") {
+  /** @brief @c bool with @c std::less_equal is filtered: @c true is the
+   *         upper bound of every pair.  Together with reflexivity +
+   *         transitivity (already established in @c :thin) this makes
+   *         @c bool the smallest non-trivial filtered category. */
+  STATIC_CHECK(IsFilteredCategory<bool>);
+  STATIC_CHECK(IsFilteredCategory<bool, std::less_equal<bool>, ClassicalLogic>);
+}
+
+TEST_CASE("category:filtered — totally ordered integral carriers are filtered",
+          "[category][filtered][numeric]") {
+  /** @brief Totally ordered carriers under @c std::less_equal are
+   *         trivially directed: @c max(a, b) is the upper bound of
+   *         every pair, and the @c :species specialisation of
+   *         @c is_directed_v on @c std::totally_ordered captures this. */
+  STATIC_CHECK(IsFilteredCategory<int>);
+  STATIC_CHECK(IsFilteredCategory<unsigned>);
+  STATIC_CHECK(IsFilteredCategory<std::size_t>);
+}
+
+TEST_CASE("category:filtered — IsFilteredCategory faithfully includes IsThinCategory",
+          "[category][filtered][thin][faithful]") {
+  /** @brief Every filtered category is thin (faithful inclusion encoded
+   *         in @c IsFilteredCategory's signature). */
+  STATIC_CHECK(IsThinCategory<bool>);
+  STATIC_CHECK(IsFilteredCategory<bool>);
+
+  STATIC_CHECK(IsThinCategory<int>);
+  STATIC_CHECK(IsFilteredCategory<int>);
+}
+
+TEST_CASE("category:filtered — filtered is parallel to posetal, not downstream",
+          "[category][filtered][posetal][parallel]") {
+  /** @brief Architectural note: filtered does @b not require
+   *         antisymmetry, so @c IsFilteredCategory is @b parallel to
+   *         @c IsPosetal in the Form-chain, not a refinement.
+   *
+   *  For the canonical witnesses (@c bool, @c int) both happen to hold
+   *  because @c std::less_equal is antisymmetric on these carriers,
+   *  but the concept itself does not depend on antisymmetry — a
+   *  preorder with two distinct mutually-@c ≤ elements would satisfy
+   *  filtered (with itself / either as upper bound) but @b not posetal. */
+  STATIC_CHECK(IsFilteredCategory<bool>);
+  STATIC_CHECK(IsPosetal<bool>);  // bool happens to be antisymmetric
+
+  STATIC_CHECK(IsFilteredCategory<int>);
+  STATIC_CHECK(IsPosetal<int>);  // int happens to be antisymmetric
+}

--- a/src/test/cpp/modules/dedekind/category/filtered_test.cpp
+++ b/src/test/cpp/modules/dedekind/category/filtered_test.cpp
@@ -21,8 +21,9 @@ import dedekind.category;
 
 using namespace dedekind::category;
 
-TEST_CASE("category:filtered — Bool is the canonical 2-element filtered category",
-          "[category][filtered][bool][canonical]") {
+TEST_CASE(
+    "category:filtered — Bool is the canonical 2-element filtered category",
+    "[category][filtered][bool][canonical]") {
   /** @brief @c bool with @c std::less_equal is filtered: @c true is the
    *         upper bound of every pair.  Together with reflexivity +
    *         transitivity (already established in @c :thin) this makes
@@ -42,8 +43,9 @@ TEST_CASE("category:filtered — totally ordered integral carriers are filtered"
   STATIC_CHECK(IsFilteredCategory<std::size_t>);
 }
 
-TEST_CASE("category:filtered — IsFilteredCategory faithfully includes IsThinCategory",
-          "[category][filtered][thin][faithful]") {
+TEST_CASE(
+    "category:filtered — IsFilteredCategory faithfully includes IsThinCategory",
+    "[category][filtered][thin][faithful]") {
   /** @brief Every filtered category is thin (faithful inclusion encoded
    *         in @c IsFilteredCategory's signature). */
   STATIC_CHECK(IsThinCategory<bool>);


### PR DESCRIPTION
Slice 2 of #698. **Branches off main directly** — depends only on `:thin` (Slice 0, merged via #699), NOT on Slice 1 (#700), since filtered categories don't require antisymmetry.

## What lands

### New: `:category::filtered` partition

```cpp
template <typename T, typename Rel = std::less_equal<T>,
          typename L = ClassicalLogic>
concept IsFilteredCategory =
    IsThinCategory<T, Rel, L> &&  // Faithful inclusion: filtered ⊊ thin
    requires {
      requires is_directed_v<T, Rel>;  // ∀ a, b. ∃ c. a ≤ c ∧ b ≤ c
    };
```

### New: `is_directed` trait family in `:species`

Mirrors the existing `is_reflexive` / `is_transitive` / `is_antisymmetric` pattern:

```cpp
// :species
export template <typename T, typename Rel>
struct is_directed : std::false_type {};

// Opt-in discovery via T::is_directed_v<Rel>
template <typename T, typename Rel>
  requires requires { T::template is_directed_v<Rel>; }
struct is_directed<T, Rel> : std::bool_constant<T::template is_directed_v<Rel>> {};

// Canonical specialisation: totally ordered ⇒ directed (max is the upper bound)
template <typename T>
  requires std::totally_ordered<T>
struct is_directed<T, std::less_equal<T>> : std::true_type {};
```

## Form-chain row

This is row 3 of the lattice Form-chain from #698:

```
IsThinCategory                 (row 1 — Slice 0, merged)
    ↓ + antisymmetry
IsPosetal                       (row 2 — Slice 1, PR #700 in flight)

IsThinCategory                 (row 1, parallel branch)
    ↓ + directedness
IsFilteredCategory              (row 3 — THIS PR)

row 2 + row 3 + cofiltered + universality
    ↓
IsLatticeCategory               (row 4 — Slice 3, deferred)
```

## Architectural notes

**Filtered is parallel to posetal, not downstream.** Filtered requires thin + directed but NOT antisymmetry — so `IsFilteredCategory` is *parallel* to `IsPosetal` in the Form-chain. Documented in the partition header and exercised by [`filtered_test.cpp`](src/test/cpp/modules/dedekind/category/filtered_test.cpp)'s "parallel" test case. This is *why* Slice 2 is independent of Slice 1: no antisymmetry dependency.

**Why filtered matters.** Filtered categories are:
- The indexing shape for **filtered colimits** (which preserve finite limits).
- The categorical machinery behind **unrestricted-fusion mereology** (Leśniewskian / gunk-friendly variants) — arbitrary fusion in Sub(X) needs filtered cocompleteness of the ambient.

Whether the project ever exercises that gunk-axis machinery is open per #698; this slice names the row regardless, so the `IsLatticeCategory` assembly in Slice 3 can encode the faithful inclusion `IsLatticeCategory ⊊ IsFilteredCategory` definitionally.

## Canonical witnesses

- `IsFilteredCategory<bool>` — Gemini's canonical 2-element example.
- `IsFilteredCategory<int>` / `<unsigned>` / `<std::size_t>` — totally ordered carriers under `std::less_equal` are trivially directed.

## Net

+262 / -0 across 4 files (1 new partition + 1 new test file + 1 trait addition in `:species` + umbrella re-export). CI authoritative.

## Adjacent

- [#698](https://github.com/vincentk/dedekind/issues/698) — design issue with the full Form-chain.
- [#699](https://github.com/vincentk/dedekind/pull/699) — Slice 0 (merged).
- [#700](https://github.com/vincentk/dedekind/pull/700) — Slice 1 (in flight, independent of this PR).