### PR TITLE
feat(category): #698 Slice 3 — :lattice partition (IsLatticeCategory)

### DIFF
--- a/src/main/modules/dedekind/category/category.cppm
+++ b/src/main/modules/dedekind/category/category.cppm
@@ -54,6 +54,9 @@ export import :thin;       // Thin Categories (preorders; row 1 of the
 export import :posetal;    // Partial Orders (thin + antisymmetric)
 export import :filtered;   // Filtered Categories (thin + directed; row 3
                            // of the lattice Form-chain; #698 Slice 2)
+export import :lattice;    // Lattice Categories (posetal + filtered +
+                           // cofiltered + universality; row 4 of the
+                           // lattice Form-chain; #698 Slice 3)
 export import :small;      // Small Categories
 export import :discrete;   // The Discrete Category (Points as Arrows)
 export import :nno;        // The Natural Numbers Object (ETCS Axiom 9 reified;

--- a/src/main/modules/dedekind/category/lattice.cppm
+++ b/src/main/modules/dedekind/category/lattice.cppm
@@ -1,0 +1,177 @@
+/**
+ * @file dedekind/category/lattice.cppm
+ * @partition :lattice
+ * @brief Lattice categories — the Form-chain row 4 (#698).
+ *
+ * @section lattice__Categorical_Definition
+ * A @b lattice (in the categorical reading: a thin bicartesian category)
+ * is a thin antisymmetric category in which every pair of objects has
+ * both a binary product (meet, ∧) and a binary coproduct (join, ∨).
+ *
+ * In the order-theoretic encoding the codebase uses across
+ * @c :mereology, @c :posetal, @c :thin, @c :filtered: a lattice over
+ * carrier @c T with relation @c Rel and topos @c L assembles
+ *
+ *   - @b posetal: thin (preorder) + antisymmetric;
+ *   - @b filtered: every pair has SOME upper bound (directedness);
+ *   - @b cofiltered: every pair has SOME lower bound (codirectedness);
+ *   - @b universality: the upper / lower bounds are unique (join / meet).
+ *     In the posetal case (antisymmetric) this is @em automatic — if
+ *     two least upper bounds @c a, @c b exist for a set, then
+ *     @c a @c ≤ @c b and @c b @c ≤ @c a, hence @c a @c = @c b.
+ *
+ * Operationally, the bottom-up algebraic content — join / meet as
+ * binary operations satisfying commutativity, associativity, idempotence,
+ * and absorption — is named upstream by
+ * @c :posetal::IsOrderLatticeOperations.  @c IsLatticeCategory @b binds
+ * the top-down universal-property reading to the bottom-up algebraic
+ * one: every carrier satisfying both presentations is a lattice in the
+ * categorical sense.
+ *
+ * @section lattice__Form_Chain
+ * Row 4 of the lattice Form-chain (#698):
+ *
+ * @code
+ *   IsThinCategory          (row 1, :thin — preorder)
+ *       ↓ + antisymmetry
+ *   IsPosetal               (row 2, :posetal — poset)
+ *       ↓ + directedness  ↓ + codirectedness
+ *   IsFilteredCategory      (row 3, :filtered — directed poset)
+ *       ↓ + cofiltered + universality
+ *   IsLatticeCategory       (row 4, THIS PARTITION)
+ *       ↓ + initial + terminal
+ *   IsBoundedLatticeCategory  (row 5 — future slice)
+ *       ↓ + exponentials
+ *   IsHeytingLatticeCategory  (row 6 — future slice)
+ *       ↓ + complement involution
+ *   IsBooleanLatticeCategory  (row 7 — future slice)
+ * @endcode
+ *
+ * Each `↓ +` is a @b faithful inclusion encoded definitionally in the
+ * signature, per the project's @em "faithful specialization in the type
+ * signature from day one" posture (#698).
+ *
+ * @section lattice__ETCS_Connection_Sollbruchstelle
+ * @b Planned downstream connection — not yet structurally landed:
+ *
+ * In an ETCS topos (every @c :etcs::IsSet carrier), the subobject family
+ * @c Sub(S) is automatically a @b Boolean lattice:
+ *
+ *   - Axiom 3 (terminal)        → initial / terminal in Sub(S) (∅, S).
+ *   - Axiom 5 (products)        → binary meets (intersection = pullback).
+ *   - Axiom 5 + Axiom 7 (Ω)     → binary joins (union via classifier).
+ *   - Axiom 6 (exponentials)    → relative complement (Heyting structure).
+ *   - Axiom 7 (classical Ω)     → complement involution (Boolean).
+ *   - Axiom 10                  → direct: Sub(S) is a power-object lattice.
+ *
+ * In other words, @c IsSet<S> @b implies @c IsBooleanLatticeCategory<Sub<S>,
+ * ClassicalLogic> once the Form-chain reaches row 7 AND a @c Sub<S>
+ * categorical wrapper exists to host the witness.  This connection is
+ * a @b Sollbruchstelle: the partition header names it so future slices
+ * (rows 5–7 of the chain + the @c Sub<S> wrapper + the harmonization of
+ * @c HasAxiom10PowerObjectLattice with the Form-chain) have an
+ * unambiguous target.
+ *
+ * Until those slices land, the ETCS connection lives at the
+ * @em documentation level only — @c IsLatticeCategory does @b not yet
+ * require or witness anything about @c :etcs::IsSet.
+ *
+ * @section lattice__Boolean_Witness
+ * @c bool with @c std::less_equal participates: the 2-element poset is
+ * also a (Boolean) lattice, and totally-ordered carriers under
+ * @c std::less_equal trivially satisfy directedness and codirectedness
+ * (max / min are the join / meet).  Pinning @c bool here anchors the
+ * Form-chain at its smallest non-trivial example.
+ *
+ * @see https://en.wikipedia.org/wiki/Lattice_(order)
+ * @see https://ncatlab.org/nlab/show/lattice
+ *
+ * @copyright 2026 The Dedekind Authors
+ * Licensed under the Apache License, Version 2.0.
+ *
+ * @note "Two presentations meet here: the top-down universal-property
+ *        reading (thin + bicartesian) and the bottom-up algebraic
+ *        reading (commutative semilattices with absorption).  Each
+ *        side is a witness of the other."
+ */
+module;
+
+#include <algorithm>
+#include <concepts>
+#include <functional>
+
+export module dedekind.category:lattice;
+
+import :logic;
+import :posetal;   // IsPosetal — row 2 (thin + antisymmetric);
+                   // IsOrderLatticeOperations — bottom-up algebraic surface
+import :filtered;  // IsFilteredCategory — row 3 (directed thin cat)
+import :species;   // is_codirected_v — cofiltered companion to is_directed_v
+
+namespace dedekind::category {
+
+/**
+ * @concept IsLatticeCategory
+ * @brief A posetal category that is both filtered and cofiltered, with
+ *        joins and meets given by the algebraic lattice operations.
+ *
+ * @details
+ * The Form-witness for row 4 of the lattice Form-chain (#698).  Binds:
+ *
+ *   - the @b top-down categorical content (thin + antisymmetric +
+ *     filtered + cofiltered);
+ *   - the @b bottom-up algebraic content (@c IsOrderLatticeOperations:
+ *     join / meet operations satisfying commutativity, associativity,
+ *     idempotence, and absorption).
+ *
+ * Both presentations describe the same Form; every carrier satisfying
+ * @c IsLatticeCategory participates in both.
+ *
+ * Faithful inclusions encoded definitionally:
+ *
+ *   IsLatticeCategory ⊊ IsFilteredCategory ⊊ IsThinCategory
+ *   IsLatticeCategory ⊊ IsPosetal           ⊊ IsThinCategory
+ *
+ * (Filtered and posetal are parallel branches above thin; lattice
+ * conjoins them and adds cofiltered + the algebraic join/meet
+ * existence.)
+ *
+ * @tparam T    The Domain (Objects).
+ * @tparam Rel  The Relation (the unique-morphism witness).
+ * @tparam Join The join operation (default @c std::ranges::max).
+ * @tparam Meet The meet operation (default @c std::ranges::min).
+ * @tparam L    The Logic Species (the Subobject Classifier Ω).
+ */
+export template <typename T, typename Rel = std::less_equal<T>,
+                 typename Join = decltype(std::ranges::max),
+                 typename Meet = decltype(std::ranges::min),
+                 typename L = ClassicalLogic>
+concept IsLatticeCategory =
+    IsPosetal<T, Rel, L> &&             // Faithful: lattice ⊊ posetal.
+    IsFilteredCategory<T, Rel, L> &&    // Faithful: lattice ⊊ filtered.
+    requires {
+      /** @brief Cofiltered: every pair has a lower bound. */
+      requires is_codirected_v<T, Rel>;
+    } &&
+    /** @brief Bottom-up algebraic content: join / meet as operations
+     *         with the lattice laws (commutativity, associativity,
+     *         idempotence, absorption).  Universality of the bounds
+     *         (LUB / GLB) is automatic for posetal carriers by
+     *         antisymmetry, so the Form-witness is complete with the
+     *         algebraic surface bundled in. */
+    IsOrderLatticeOperations<T, Join, Meet>;
+
+/** @section lattice__Canonical_Witnesses */
+
+static_assert(IsLatticeCategory<bool>,
+              "bool with std::less_equal, std::ranges::max/min is the "
+              "canonical 2-element lattice category (also the smallest "
+              "non-trivial Boolean algebra; pending the row-7 Form-chain "
+              "extension that will witness this categorically).");
+
+static_assert(IsLatticeCategory<int>,
+              "int is a lattice category — totally ordered carriers are "
+              "trivially directed and codirected (max / min are the "
+              "join / meet).");
+
+}  // namespace dedekind::category

--- a/src/main/modules/dedekind/category/lattice.cppm
+++ b/src/main/modules/dedekind/category/lattice.cppm
@@ -147,8 +147,8 @@ export template <typename T, typename Rel = std::less_equal<T>,
                  typename Meet = decltype(std::ranges::min),
                  typename L = ClassicalLogic>
 concept IsLatticeCategory =
-    IsPosetal<T, Rel, L> &&             // Faithful: lattice ⊊ posetal.
-    IsFilteredCategory<T, Rel, L> &&    // Faithful: lattice ⊊ filtered.
+    IsPosetal<T, Rel, L> &&           // Faithful: lattice ⊊ posetal.
+    IsFilteredCategory<T, Rel, L> &&  // Faithful: lattice ⊊ filtered.
     requires {
       /** @brief Cofiltered: every pair has a lower bound. */
       requires is_codirected_v<T, Rel>;

--- a/src/main/modules/dedekind/category/species.cppm
+++ b/src/main/modules/dedekind/category/species.cppm
@@ -450,6 +450,52 @@ concept IsDirected = requires(T a, T b) {
   { Rel{}(a, b) } -> std::convertible_to<bool>;
 } && requires { requires is_directed_v<T, Rel>; };
 
+/** @section species__Codirectedness: ∀a,b ∃c. c ≤ a ∧ c ≤ b
+ *
+ *  @brief Trait to mark a relation as @b codirected: every pair of
+ *         elements has a lower bound.
+ *
+ *  @details Codirectedness is the dual of directedness — every pair has
+ *  SOME lower bound, not necessarily a greatest lower bound (meet).
+ *  Combined with directedness and posetal structure (antisymmetry), it
+ *  upgrades a filtered category to a @b lattice category (#698 row 4):
+ *
+ *    lattice = posetal + filtered (UB exists) + cofiltered (LB exists)
+ *            + universality (UB / LB are unique by antisymmetry)
+ *
+ *  Filtered and cofiltered are dual existence axioms; together with
+ *  antisymmetry they suffice for the Form-witness assembly of
+ *  @c IsLatticeCategory in @c :lattice.
+ */
+export template <typename T, typename Rel>
+struct is_codirected : std::false_type {};
+
+/** @brief Discovery: types may opt in via a nested @c is_codirected_v
+ *         template member, mirroring the sibling trait patterns. */
+template <typename T, typename Rel>
+  requires requires { T::template is_codirected_v<Rel>; }
+struct is_codirected<T, Rel>
+    : std::bool_constant<T::template is_codirected_v<Rel>> {};
+
+export template <typename T, typename Rel>
+inline constexpr bool is_codirected_v = is_codirected<T, Rel>::value;
+
+/** @brief Every totally ordered carrier under @c std::less_equal is
+ *         codirected: @c min(a, b) is the lower bound of every pair. */
+template <typename T>
+  requires std::totally_ordered<T>
+struct is_codirected<T, std::less_equal<T>> : std::true_type {};
+
+/**
+ * @concept IsCodirected
+ * @brief Formal verification of the codirectedness axiom:
+ *        ∀ a, b ∈ T. ∃ c ∈ T. Rel(c, a) ∧ Rel(c, b).
+ */
+export template <typename T, typename Rel>
+concept IsCodirected = requires(T a, T b) {
+  { Rel{}(a, b) } -> std::convertible_to<bool>;
+} && requires { requires is_codirected_v<T, Rel>; };
+
 /** @section species__Categorical_Inverses: The 'Undo' Bricks */
 
 /** @brief In XOR, every element is its own inverse (Involutive). */

--- a/src/test/cpp/modules/dedekind/category/lattice_test.cpp
+++ b/src/test/cpp/modules/dedekind/category/lattice_test.cpp
@@ -13,8 +13,8 @@
  *   IsLatticeCategory ⊊ IsPosetal           ⊊ IsThinCategory
  */
 
-#include <catch2/catch_test_macros.hpp>
 #include <algorithm>
+#include <catch2/catch_test_macros.hpp>
 #include <concepts>
 #include <functional>
 
@@ -44,7 +44,8 @@ TEST_CASE("category:lattice — totally ordered integral carriers are lattices",
 }
 
 TEST_CASE(
-    "category:lattice — IsLatticeCategory faithfully includes the Form-chain rows above",
+    "category:lattice — IsLatticeCategory faithfully includes the Form-chain "
+    "rows above",
     "[category][lattice][faithful][form-chain]") {
   /** @brief Every lattice category is filtered, posetal, and thin —
    *         encoded in @c IsLatticeCategory's signature definitionally. */

--- a/src/test/cpp/modules/dedekind/category/lattice_test.cpp
+++ b/src/test/cpp/modules/dedekind/category/lattice_test.cpp
@@ -1,0 +1,60 @@
+/** @file dedekind/category/lattice_test.cpp
+ *
+ * Unit coverage for @c :category::lattice (the lattice-Form-chain row 4,
+ * #698 Slice 3).
+ *
+ * @c IsLatticeCategory<T, Rel, Join, Meet, L> is the Form-witness that
+ * binds the top-down universal-property reading (thin + antisymmetric +
+ * filtered + cofiltered) to the bottom-up algebraic reading
+ * (@c IsOrderLatticeOperations: commutative semilattices with absorption).
+ *
+ * Faithful inclusions encoded in the signature:
+ *   IsLatticeCategory ⊊ IsFilteredCategory ⊊ IsThinCategory
+ *   IsLatticeCategory ⊊ IsPosetal           ⊊ IsThinCategory
+ */
+
+#include <catch2/catch_test_macros.hpp>
+#include <algorithm>
+#include <concepts>
+#include <functional>
+
+import dedekind.category;
+
+using namespace dedekind::category;
+
+TEST_CASE("category:lattice — Bool is the canonical 2-element lattice category",
+          "[category][lattice][bool][canonical]") {
+  /** @brief @c bool with @c std::less_equal, @c std::ranges::max,
+   *         @c std::ranges::min is the smallest non-trivial lattice
+   *         category — also the canonical Boolean algebra (the
+   *         categorical witness of that Boolean structure lands in a
+   *         future slice; #698). */
+  STATIC_CHECK(IsLatticeCategory<bool>);
+}
+
+TEST_CASE("category:lattice — totally ordered integral carriers are lattices",
+          "[category][lattice][numeric]") {
+  /** @brief Totally ordered carriers under @c std::less_equal are
+   *         trivially both directed (max is the upper bound) and
+   *         codirected (min is the lower bound), and the lattice
+   *         operations are @c std::ranges::max / @c std::ranges::min. */
+  STATIC_CHECK(IsLatticeCategory<int>);
+  STATIC_CHECK(IsLatticeCategory<unsigned>);
+  STATIC_CHECK(IsLatticeCategory<std::size_t>);
+}
+
+TEST_CASE(
+    "category:lattice — IsLatticeCategory faithfully includes the Form-chain rows above",
+    "[category][lattice][faithful][form-chain]") {
+  /** @brief Every lattice category is filtered, posetal, and thin —
+   *         encoded in @c IsLatticeCategory's signature definitionally. */
+  STATIC_CHECK(IsThinCategory<bool>);
+  STATIC_CHECK(IsPosetal<bool>);
+  STATIC_CHECK(IsFilteredCategory<bool>);
+  STATIC_CHECK(IsLatticeCategory<bool>);
+
+  STATIC_CHECK(IsThinCategory<int>);
+  STATIC_CHECK(IsPosetal<int>);
+  STATIC_CHECK(IsFilteredCategory<int>);
+  STATIC_CHECK(IsLatticeCategory<int>);
+}


### PR DESCRIPTION
Slice 3 of #698. Row 4 of the lattice Form-chain — the **Form-witness home**, the meeting point of the top-down universal-property reading and the bottom-up algebraic reading.

## What lands

### New: `:category::lattice` partition

```cpp
template <typename T, typename Rel = std::less_equal<T>,
          typename Join = decltype(std::ranges::max),
          typename Meet = decltype(std::ranges::min),
          typename L = ClassicalLogic>
concept IsLatticeCategory =
    IsPosetal<T, Rel, L> &&             // Faithful: lattice ⊊ posetal
    IsFilteredCategory<T, Rel, L> &&    // Faithful: lattice ⊊ filtered
    requires {
      requires is_codirected_v<T, Rel>; // cofiltered (LB exists)
    } &&
    IsOrderLatticeOperations<T, Join, Meet>; // bottom-up algebraic surface
```

Both presentations are required: the top-down categorical content (thin + antisymmetric + filtered + cofiltered) AND the bottom-up algebraic content (`IsOrderLatticeOperations` from `:posetal`: join/meet as operations with the lattice laws). Each is a witness of the other.

### New: `is_codirected` trait family in `:species`

Dual to `is_directed` from Slice 2. Specialised for `std::totally_ordered<T>` under `std::less_equal<T>` — every totally ordered carrier is trivially codirected (min is the lower bound).

### Form-chain status

```
IsThinCategory             (row 1, :thin       — Slice 0 ✓)
    ↓ + antisymmetry
IsPosetal                   (row 2, :posetal    — Slice 1 ✓)
    ↓ + directedness
IsFilteredCategory          (row 3, :filtered   — Slice 2 ✓)
    ↓ + cofiltered + universality (algebraic Join/Meet existence)
IsLatticeCategory           (row 4, :lattice    — THIS SLICE)
    ↓ + initial + terminal  → IsBoundedLatticeCategory (future)
    ↓ + exponentials        → IsHeytingLatticeCategory (future)
    ↓ + complement invol.   → IsBooleanLatticeCategory (future)
    ↓ + Sub<S> wrapper      → ETCS connection (future)
```

## ETCS connection — documented as Sollbruchstelle

The categorical fact: every `:etcs::IsSet<S>` implies `Sub(S)` is a Boolean lattice (ETCS Axioms 3 + 5 + 6 + 7 + 10). To witness this in code mechanically would require:

- Form-chain rows 5–7 (`IsBoundedLatticeCategory`, `IsHeytingLatticeCategory`, `IsBooleanLatticeCategory`);
- a `Sub<S>` categorical wrapper hosting subobject-lattice content;
- harmonization of `HasAxiom10PowerObjectLattice` with the Form-chain.

That's 4+ follow-up slices. This PR ships **row 4 only**, with the ETCS connection named in `:lattice`'s partition header as planned work — the Sollbruchstelle is structurally visible but not yet load-bearing. `IsLatticeCategory` does NOT yet require or witness anything about `:etcs::IsSet`.

## Canonical witnesses

- `IsLatticeCategory<bool>` — Gemini's canonical 2-element example.
- `IsLatticeCategory<int>` / `<unsigned>` / `<size_t>` — totally ordered carriers under `std::less_equal` + `std::ranges::max/min`.

## Net

+286 / -0 across 4 files (1 new partition + 1 new test file + 1 trait addition + umbrella re-export). CI authoritative.

## Adjacent

- [#698](https://github.com/vincentk/dedekind/issues/698) — design issue with the full Form-chain.
- [#699](https://github.com/vincentk/dedekind/pull/699) / [#700](https://github.com/vincentk/dedekind/pull/700) / [#701](https://github.com/vincentk/dedekind/pull/701) — Slices 0–2 (merged).