### PR TITLE
feat(category): #698 Slice 4 — IsBoundedLatticeCategory + lattice_bottom/top traits

### DIFF
--- a/src/main/modules/dedekind/category/lattice.cppm
+++ b/src/main/modules/dedekind/category/lattice.cppm
@@ -174,4 +174,67 @@ static_assert(IsLatticeCategory<int>,
               "trivially directed and codirected (max / min are the "
               "join / meet).");
 
+/**
+ * @concept IsBoundedLatticeCategory
+ * @brief A lattice category that has a designated bottom (initial) and
+ *        top (terminal) element — row 5 of the lattice Form-chain (#698
+ *        Slice 4).
+ *
+ * @details
+ * Faithful inclusion @c IsBoundedLatticeCategory @c ⊊ @c IsLatticeCategory
+ * encoded definitionally per the project's @em "faithful specialization
+ * in the type signature from day one" posture (#698).
+ *
+ * The bounded refinement adds two value-witnesses to the row-4 content:
+ *
+ *   - @b bottom (lattice-internal initial): @c lattice_bottom_v<T, Rel>
+ *     is a @c constexpr @c T value with @c Rel(⊥, x) for all @c x.
+ *   - @b top (lattice-internal terminal): @c lattice_top_v<T, Rel> is
+ *     a @c constexpr @c T value with @c Rel(x, ⊤) for all @c x.
+ *
+ * These are the @b internal initial / terminal of the lattice viewed
+ * as a thin category — distinct from the @b global initial / terminal
+ * of @c :limit (@c std::nullptr_t and @c std::monostate, respectively),
+ * which name the unique initial / terminal of the outer category of
+ * sets, not of any particular lattice.  The trait family @c
+ * lattice_bottom / @c lattice_top in @c :species provides the
+ * per-(T, Rel) value-witnesses; concept gates @c HasLatticeBottom /
+ * @c HasLatticeTop probe whether a specialisation is in scope.
+ *
+ * Faithful per #698 Q3: the Form-chain commits to categorical
+ * universal-property witnesses (the bottom / top are designated
+ * elements of the carrier, not operational @c lower_bound() /
+ * @c upper_bound() member functions on a Sub<S>).
+ *
+ * @tparam T    The Domain (Objects).
+ * @tparam Rel  The Relation.
+ * @tparam Join The join operation (default @c std::ranges::max).
+ * @tparam Meet The meet operation (default @c std::ranges::min).
+ * @tparam L    The Logic Species.
+ */
+export template <typename T, typename Rel = std::less_equal<T>,
+                 typename Join = decltype(std::ranges::max),
+                 typename Meet = decltype(std::ranges::min),
+                 typename L = ClassicalLogic>
+concept IsBoundedLatticeCategory =
+    IsLatticeCategory<T, Rel, Join, Meet, L> &&  // Faithful: bounded ⊊ lattice.
+    HasLatticeBottom<T, Rel> &&  // Initial object inside the lattice.
+    HasLatticeTop<T, Rel>;       // Terminal object inside the lattice.
+
+/** @section lattice__Bounded_Canonical_Witnesses */
+
+static_assert(IsBoundedLatticeCategory<bool>,
+              "bool is a bounded lattice category: bottom = false, top = "
+              "true (the canonical 2-element bounded lattice; also the "
+              "subobject classifier Ω in Set).");
+
+static_assert(IsBoundedLatticeCategory<int>,
+              "int is bounded: lattice_bottom_v = INT_MIN, "
+              "lattice_top_v = INT_MAX.");
+
+static_assert(lattice_bottom_v<bool, std::less_equal<bool>> == false,
+              "Bool's lattice bottom is false.");
+static_assert(lattice_top_v<bool, std::less_equal<bool>> == true,
+              "Bool's lattice top is true.");
+
 }  // namespace dedekind::category

--- a/src/main/modules/dedekind/category/lattice.cppm
+++ b/src/main/modules/dedekind/category/lattice.cppm
@@ -99,6 +99,9 @@ module;
 #include <algorithm>
 #include <concepts>
 #include <functional>
+#include <limits>       // std::numeric_limits — LatticeBottom/Top
+                        // specialisations for arithmetic carriers.
+#include <type_traits>  // std::is_arithmetic_v — same specialisations.
 
 export module dedekind.category:lattice;
 
@@ -107,6 +110,9 @@ import :posetal;   // IsPosetal — row 2 (thin + antisymmetric);
                    // IsOrderLatticeOperations — bottom-up algebraic surface
 import :filtered;  // IsFilteredCategory — row 3 (directed thin cat)
 import :species;   // is_codirected_v — cofiltered companion to is_directed_v
+import :limit;     // IsInitialObject / IsTerminalObject — row 5
+                   // universal-property witnesses (relaxed via tag
+                   // discovery to admit LatticeBottom/LatticeTop).
 
 namespace dedekind::category {
 
@@ -174,6 +180,61 @@ static_assert(IsLatticeCategory<int>,
               "trivially directed and codirected (max / min are the "
               "join / meet).");
 
+/** @section lattice__Bounded_Witnesses
+ *
+ *  @brief Structural witness types for the bottom (initial) and top
+ *         (terminal) of the lattice over @c (T, @c Rel), playing the
+ *         role of initial / terminal objects of the lattice viewed as
+ *         a thin category.
+ *
+ *  @details Each wrapper type:
+ *
+ *    - Declares the @c is_initial_object_tag / @c is_terminal_object_tag
+ *      typedef so it satisfies the relaxed @c :limit::IsInitialObject /
+ *      @c IsTerminalObject (tag-discovery branch).
+ *    - Exposes the corresponding carrier element as a @c constexpr
+ *      @c value member (extractable when consumers need the actual
+ *      lattice element).
+ *
+ *  Specialisations are provided for arithmetic carriers under
+ *  @c std::less_equal: @c std::numeric_limits<T>::min() / @c max() are
+ *  the lattice bottom / top.  This covers @c bool (false / true),
+ *  @c int (INT_MIN / INT_MAX), @c unsigned (0 / UINT_MAX), @c size_t,
+ *  and the rest of the arithmetic family.
+ *
+ *  Downstream sub-categories (set algebras, posets with named extremes,
+ *  …) opt in by specialising the wrappers for their @c (T, @c Rel)
+ *  pair; no change to @c :species or duplicate concept surface.
+ */
+
+/** @brief Primary template: undefined — no value, no tag.  Specialise
+ *         to register the bottom of the lattice over @c (T, @c Rel). */
+export template <typename T, typename Rel>
+struct LatticeBottom;
+
+/** @brief Primary template: undefined.  Specialise to register the
+ *         top of the lattice over @c (T, @c Rel). */
+export template <typename T, typename Rel>
+struct LatticeTop;
+
+/** @brief Canonical specialisation: arithmetic carriers under
+ *         @c std::less_equal have bottom @c = @c numeric_limits<T>::min(). */
+template <typename T>
+  requires std::is_arithmetic_v<T>
+struct LatticeBottom<T, std::less_equal<T>> {
+  using is_initial_object_tag = void;
+  static constexpr T value = std::numeric_limits<T>::min();
+};
+
+/** @brief Canonical specialisation: arithmetic carriers under
+ *         @c std::less_equal have top @c = @c numeric_limits<T>::max(). */
+template <typename T>
+  requires std::is_arithmetic_v<T>
+struct LatticeTop<T, std::less_equal<T>> {
+  using is_terminal_object_tag = void;
+  static constexpr T value = std::numeric_limits<T>::max();
+};
+
 /**
  * @concept IsBoundedLatticeCategory
  * @brief A lattice category that has a designated bottom (initial) and
@@ -185,26 +246,26 @@ static_assert(IsLatticeCategory<int>,
  * encoded definitionally per the project's @em "faithful specialization
  * in the type signature from day one" posture (#698).
  *
- * The bounded refinement adds two value-witnesses to the row-4 content:
+ * The bounded refinement adds two @b structural witness types:
  *
- *   - @b bottom (lattice-internal initial): @c lattice_bottom_v<T, Rel>
- *     is a @c constexpr @c T value with @c Rel(⊥, x) for all @c x.
- *   - @b top (lattice-internal terminal): @c lattice_top_v<T, Rel> is
- *     a @c constexpr @c T value with @c Rel(x, ⊤) for all @c x.
+ *   - @c LatticeBottom<T, Rel> — declared as an initial-object witness
+ *     via @c :limit::IsInitialObject (relaxed with tag-discovery).
+ *   - @c LatticeTop<T, Rel> — declared as a terminal-object witness
+ *     via @c :limit::IsTerminalObject (relaxed similarly).
  *
- * These are the @b internal initial / terminal of the lattice viewed
- * as a thin category — distinct from the @b global initial / terminal
- * of @c :limit (@c std::nullptr_t and @c std::monostate, respectively),
- * which name the unique initial / terminal of the outer category of
- * sets, not of any particular lattice.  The trait family @c
- * lattice_bottom / @c lattice_top in @c :species provides the
- * per-(T, Rel) value-witnesses; concept gates @c HasLatticeBottom /
- * @c HasLatticeTop probe whether a specialisation is in scope.
+ * These are the lattice's @b own initial / terminal objects —
+ * universal-property witnesses local to the lattice over @c (T, Rel)
+ * viewed as a thin category.  Distinct from the strict-global
+ * @c std::same_as<T, Zero> / @c std::same_as<T, One> branches of the
+ * @c :limit concepts, which name the unique initial / terminal of the
+ * ambient category of sets.  The tag-discovery relaxation of @c :limit
+ * (in turn) admits both readings without parallel concept surface.
  *
  * Faithful per #698 Q3: the Form-chain commits to categorical
- * universal-property witnesses (the bottom / top are designated
- * elements of the carrier, not operational @c lower_bound() /
- * @c upper_bound() member functions on a Sub<S>).
+ * universal-property witnesses — bottom / top are designated structural
+ * witness types satisfying @c IsInitialObject / @c IsTerminalObject,
+ * not operational @c lower_bound() / @c upper_bound() member functions
+ * on a Sub<S>.
  *
  * @tparam T    The Domain (Objects).
  * @tparam Rel  The Relation.
@@ -218,8 +279,8 @@ export template <typename T, typename Rel = std::less_equal<T>,
                  typename L = ClassicalLogic>
 concept IsBoundedLatticeCategory =
     IsLatticeCategory<T, Rel, Join, Meet, L> &&  // Faithful: bounded ⊊ lattice.
-    HasLatticeBottom<T, Rel> &&  // Initial object inside the lattice.
-    HasLatticeTop<T, Rel>;       // Terminal object inside the lattice.
+    IsInitialObject<LatticeBottom<T, Rel>> &&    // Universal-property initial.
+    IsTerminalObject<LatticeTop<T, Rel>>;        // Universal-property terminal.
 
 /** @section lattice__Bounded_Canonical_Witnesses */
 
@@ -229,12 +290,12 @@ static_assert(IsBoundedLatticeCategory<bool>,
               "subobject classifier Ω in Set).");
 
 static_assert(IsBoundedLatticeCategory<int>,
-              "int is bounded: lattice_bottom_v = INT_MIN, "
-              "lattice_top_v = INT_MAX.");
+              "int is bounded: LatticeBottom = INT_MIN, "
+              "LatticeTop = INT_MAX.");
 
-static_assert(lattice_bottom_v<bool, std::less_equal<bool>> == false,
+static_assert(LatticeBottom<bool, std::less_equal<bool>>::value == false,
               "Bool's lattice bottom is false.");
-static_assert(lattice_top_v<bool, std::less_equal<bool>> == true,
+static_assert(LatticeTop<bool, std::less_equal<bool>>::value == true,
               "Bool's lattice top is true.");
 
 }  // namespace dedekind::category

--- a/src/main/modules/dedekind/category/lattice.cppm
+++ b/src/main/modules/dedekind/category/lattice.cppm
@@ -217,19 +217,28 @@ struct LatticeBottom;
 export template <typename T, typename Rel>
 struct LatticeTop;
 
-/** @brief Canonical specialisation: arithmetic carriers under
- *         @c std::less_equal have bottom @c = @c numeric_limits<T>::min(). */
+/** @brief Canonical specialisation: @b integral carriers under
+ *         @c std::less_equal have bottom @c = @c numeric_limits<T>::min().
+ *
+ *  @note Floating-point carriers are intentionally @b excluded — they
+ *  fail upstream @c IsThinCategory because @c is_transitive_v in
+ *  @c :species is specialised only for integral + @c bool (IEEE 754 NaN
+ *  breaks transitivity / reflexivity, see @c :thin tests).  Limiting
+ *  this specialisation to @c std::is_integral_v also avoids the
+ *  @c numeric_limits<T>::min() vs @c lowest() trap on floats:
+ *  @c min() returns the smallest positive normal for floats, not the
+ *  most-negative value. */
 template <typename T>
-  requires std::is_arithmetic_v<T>
+  requires std::is_integral_v<T>
 struct LatticeBottom<T, std::less_equal<T>> {
   using is_initial_object_tag = void;
   static constexpr T value = std::numeric_limits<T>::min();
 };
 
-/** @brief Canonical specialisation: arithmetic carriers under
+/** @brief Canonical specialisation: @b integral carriers under
  *         @c std::less_equal have top @c = @c numeric_limits<T>::max(). */
 template <typename T>
-  requires std::is_arithmetic_v<T>
+  requires std::is_integral_v<T>
 struct LatticeTop<T, std::less_equal<T>> {
   using is_terminal_object_tag = void;
   static constexpr T value = std::numeric_limits<T>::max();
@@ -280,7 +289,17 @@ export template <typename T, typename Rel = std::less_equal<T>,
 concept IsBoundedLatticeCategory =
     IsLatticeCategory<T, Rel, Join, Meet, L> &&  // Faithful: bounded ⊊ lattice.
     IsInitialObject<LatticeBottom<T, Rel>> &&    // Universal-property initial.
-    IsTerminalObject<LatticeTop<T, Rel>>;        // Universal-property terminal.
+    IsTerminalObject<LatticeTop<T, Rel>> &&      // Universal-property terminal.
+    requires {
+      /** @brief The wrappers must expose the corresponding carrier
+       *         element as a @c constexpr @c value member.  Without
+       *         this, a tag-only specialisation (initial-object tag
+       *         declared but no @c value) would silently satisfy the
+       *         universal-property check while providing no usable
+       *         bottom / top — defeating the structural contract. */
+      { LatticeBottom<T, Rel>::value } -> std::convertible_to<T>;
+      { LatticeTop<T, Rel>::value } -> std::convertible_to<T>;
+    };
 
 /** @section lattice__Bounded_Canonical_Witnesses */
 

--- a/src/main/modules/dedekind/category/limit.cppm
+++ b/src/main/modules/dedekind/category/limit.cppm
@@ -138,8 +138,7 @@ auto unit() {
  */
 export template <typename T>
 concept IsTerminalObject =
-    std::same_as<T, One> ||
-    requires { typename T::is_terminal_object_tag; };
+    std::same_as<T, One> || requires { typename T::is_terminal_object_tag; };
 
 /**
  * @concept IsBoundaryProjection
@@ -234,8 +233,7 @@ concept HasUniqueMorphismFrom = std::same_as<Z, Zero> && requires {
  */
 export template <typename T>
 concept IsInitialObject =
-    std::same_as<T, Zero> ||
-    requires { typename T::is_initial_object_tag; };
+    std::same_as<T, Zero> || requires { typename T::is_initial_object_tag; };
 
 /**
  * @concept IsProjectedInitialObject

--- a/src/main/modules/dedekind/category/limit.cppm
+++ b/src/main/modules/dedekind/category/limit.cppm
@@ -119,13 +119,27 @@ auto unit() {
 
 /**
  * @concept IsTerminalObject
- * @brief A type that is (or maps canonically to) the Terminal Object One.
- * @details `std::monostate` (aliased as `One`) is the sole terminal object.
- * Any type T that produces a valid `IsTerminalMorphism` via `unit<T>()` also
- * satisfies this concept.
+ * @brief A type that plays the role of a terminal object — either the
+ *        canonical global @c One (@c std::monostate, the unique
+ *        terminal of the ambient category of sets) or an opt-in
+ *        structural witness via the @c is_terminal_object_tag typedef.
+ *
+ * @details The strict @c std::same_as<T, One> branch is the historical
+ * reading: @c One is the unique terminal in the umbrella category Set.
+ * The tag-discovery branch admits @b structural witness types declared
+ * downstream — e.g.\ @c :lattice::LatticeTop<T, Rel> registers itself
+ * as a terminal object of the lattice over @c (T, Rel) viewed as a
+ * thin category (#698 Slice 4).
+ *
+ * Categorical content: initial / terminal exist @em relative @em to a
+ * category.  The strict global reading covers Set; the tag-based
+ * extension lets sub-categories (lattices, posets, …) name their own
+ * terminal-witness types without parameterising the concept by category.
  */
 export template <typename T>
-concept IsTerminalObject = std::same_as<T, One>;
+concept IsTerminalObject =
+    std::same_as<T, One> ||
+    requires { typename T::is_terminal_object_tag; };
 
 /**
  * @concept IsBoundaryProjection
@@ -201,12 +215,27 @@ concept HasUniqueMorphismFrom = std::same_as<Z, Zero> && requires {
 
 /**
  * @concept IsInitialObject
- * @brief A type that is the Initial Object Zero.
- * @details `std::nullptr_t` (aliased as `Zero`) is the sole initial object.
- * It is the unique type from which a morphism to every other species exists.
+ * @brief A type that plays the role of an initial object — either the
+ *        canonical global @c Zero (@c std::nullptr_t, the unique
+ *        initial of the ambient category of sets) or an opt-in
+ *        structural witness via the @c is_initial_object_tag typedef.
+ *
+ * @details The strict @c std::same_as<T, Zero> branch is the historical
+ * reading: @c Zero is the unique initial in the umbrella category Set.
+ * The tag-discovery branch admits @b structural witness types declared
+ * downstream — e.g.\ @c :lattice::LatticeBottom<T, Rel> registers
+ * itself as an initial object of the lattice over @c (T, Rel) viewed
+ * as a thin category (#698 Slice 4).
+ *
+ * Categorical content: initial / terminal exist @em relative @em to a
+ * category.  The strict global reading covers Set; the tag-based
+ * extension lets sub-categories (lattices, posets, …) name their own
+ * initial-witness types without parameterising the concept by category.
  */
 export template <typename T>
-concept IsInitialObject = std::same_as<T, Zero>;
+concept IsInitialObject =
+    std::same_as<T, Zero> ||
+    requires { typename T::is_initial_object_tag; };
 
 /**
  * @concept IsProjectedInitialObject

--- a/src/main/modules/dedekind/category/species.cppm
+++ b/src/main/modules/dedekind/category/species.cppm
@@ -44,9 +44,6 @@ module;
 #include <algorithm>
 #include <concepts>
 #include <functional>
-#include <limits>  // std::numeric_limits — used by lattice_bottom/top
-                   // specialisations for arithmetic carriers (#698 Slice 4).
-#include <type_traits>  // std::is_arithmetic_v — same specialisations.
 
 export module dedekind.category:species;
 
@@ -498,89 +495,6 @@ export template <typename T, typename Rel>
 concept IsCodirected = requires(T a, T b) {
   { Rel{}(a, b) } -> std::convertible_to<bool>;
 } && requires { requires is_codirected_v<T, Rel>; };
-
-/** @section species__Lattice_Extremes: bottom (initial) and top (terminal)
- *
- *  @brief Value-witnesses for the bottom (initial) and top (terminal)
- *         elements of a lattice over @c T under @c Rel.
- *
- *  @details The lattice over @c (T, @c Rel) viewed as a thin category has
- *  an @b initial object iff there exists @c ⊥ @c ∈ @c T with
- *  @c Rel(⊥, @c x) for all @c x — i.e.\ the lattice has a @b bottom.
- *  Dually, the @b terminal object is the lattice @b top @c ⊤ with
- *  @c Rel(x, @c ⊤) for all @c x.
- *
- *  These are lattice-internal initial / terminal — distinct from the
- *  outer category-theoretic @c :limit::IsInitialObject (which pins
- *  @c std::nullptr_t as the unique global initial) and @c :limit::
- *  IsTerminalObject (@c std::monostate).  The lattice's @b own
- *  initial / terminal are per-(T, Rel) carrier elements.
- *
- *  Mirrors the @c :category:partial::partial_identity_v pattern:
- *  primary template is undefined; specialisations provide a
- *  @c constexpr @c value member.  The detection concepts @c
- *  HasLatticeBottom / @c HasLatticeTop fire when a specialisation is
- *  in scope.  Used by @c :lattice::IsBoundedLatticeCategory (#698
- *  Slice 4) as the faithful row-5 witness.
- */
-
-/** @brief Primary template: undefined (no @c value member).
- *  Specialise to provide the bottom element of the lattice. */
-template <typename T, typename Rel>
-struct lattice_bottom;
-
-/** @brief Primary template: undefined.  Specialise to provide the
- *  top element of the lattice. */
-template <typename T, typename Rel>
-struct lattice_top;
-
-/** @brief Specialisation for arithmetic types under @c std::less_equal:
- *         @c std::numeric_limits<T>::min() is the lattice bottom. */
-template <typename T>
-  requires std::is_arithmetic_v<T>
-struct lattice_bottom<T, std::less_equal<T>> {
-  static constexpr T value = std::numeric_limits<T>::min();
-};
-
-/** @brief Specialisation for arithmetic types under @c std::less_equal:
- *         @c std::numeric_limits<T>::max() is the lattice top.  Note
- *         @c std::numeric_limits<bool>::min/max give @c false/true,
- *         which is exactly the 2-element Boolean lattice's bottom/top. */
-template <typename T>
-  requires std::is_arithmetic_v<T>
-struct lattice_top<T, std::less_equal<T>> {
-  static constexpr T value = std::numeric_limits<T>::max();
-};
-
-/** @brief Value-witness for the lattice bottom. */
-export template <typename T, typename Rel>
-inline constexpr T lattice_bottom_v = lattice_bottom<T, Rel>::value;
-
-/** @brief Value-witness for the lattice top. */
-export template <typename T, typename Rel>
-inline constexpr T lattice_top_v = lattice_top<T, Rel>::value;
-
-/**
- * @concept HasLatticeBottom
- * @brief A lattice-internal initial object exists for @c (T, @c Rel) —
- *        i.e.\ @c lattice_bottom<T, Rel> is specialised with a
- *        @c constexpr @c value member.
- */
-export template <typename T, typename Rel>
-concept HasLatticeBottom = requires {
-  { lattice_bottom<T, Rel>::value } -> std::convertible_to<T>;
-};
-
-/**
- * @concept HasLatticeTop
- * @brief A lattice-internal terminal object exists for @c (T, @c Rel) —
- *        i.e.\ @c lattice_top<T, Rel> is specialised with a
- *        @c constexpr @c value member.
- */
-export template <typename T, typename Rel>
-concept HasLatticeTop = requires {
-  { lattice_top<T, Rel>::value } -> std::convertible_to<T>;
-};
 
 /** @section species__Categorical_Inverses: The 'Undo' Bricks */
 

--- a/src/main/modules/dedekind/category/species.cppm
+++ b/src/main/modules/dedekind/category/species.cppm
@@ -44,6 +44,9 @@ module;
 #include <algorithm>
 #include <concepts>
 #include <functional>
+#include <limits>       // std::numeric_limits — used by lattice_bottom/top
+                        // specialisations for arithmetic carriers (#698 Slice 4).
+#include <type_traits>  // std::is_arithmetic_v — same specialisations.
 
 export module dedekind.category:species;
 
@@ -495,6 +498,89 @@ export template <typename T, typename Rel>
 concept IsCodirected = requires(T a, T b) {
   { Rel{}(a, b) } -> std::convertible_to<bool>;
 } && requires { requires is_codirected_v<T, Rel>; };
+
+/** @section species__Lattice_Extremes: bottom (initial) and top (terminal)
+ *
+ *  @brief Value-witnesses for the bottom (initial) and top (terminal)
+ *         elements of a lattice over @c T under @c Rel.
+ *
+ *  @details The lattice over @c (T, @c Rel) viewed as a thin category has
+ *  an @b initial object iff there exists @c ⊥ @c ∈ @c T with
+ *  @c Rel(⊥, @c x) for all @c x — i.e.\ the lattice has a @b bottom.
+ *  Dually, the @b terminal object is the lattice @b top @c ⊤ with
+ *  @c Rel(x, @c ⊤) for all @c x.
+ *
+ *  These are lattice-internal initial / terminal — distinct from the
+ *  outer category-theoretic @c :limit::IsInitialObject (which pins
+ *  @c std::nullptr_t as the unique global initial) and @c :limit::
+ *  IsTerminalObject (@c std::monostate).  The lattice's @b own
+ *  initial / terminal are per-(T, Rel) carrier elements.
+ *
+ *  Mirrors the @c :category:partial::partial_identity_v pattern:
+ *  primary template is undefined; specialisations provide a
+ *  @c constexpr @c value member.  The detection concepts @c
+ *  HasLatticeBottom / @c HasLatticeTop fire when a specialisation is
+ *  in scope.  Used by @c :lattice::IsBoundedLatticeCategory (#698
+ *  Slice 4) as the faithful row-5 witness.
+ */
+
+/** @brief Primary template: undefined (no @c value member).
+ *  Specialise to provide the bottom element of the lattice. */
+template <typename T, typename Rel>
+struct lattice_bottom;
+
+/** @brief Primary template: undefined.  Specialise to provide the
+ *  top element of the lattice. */
+template <typename T, typename Rel>
+struct lattice_top;
+
+/** @brief Specialisation for arithmetic types under @c std::less_equal:
+ *         @c std::numeric_limits<T>::min() is the lattice bottom. */
+template <typename T>
+  requires std::is_arithmetic_v<T>
+struct lattice_bottom<T, std::less_equal<T>> {
+  static constexpr T value = std::numeric_limits<T>::min();
+};
+
+/** @brief Specialisation for arithmetic types under @c std::less_equal:
+ *         @c std::numeric_limits<T>::max() is the lattice top.  Note
+ *         @c std::numeric_limits<bool>::min/max give @c false/true,
+ *         which is exactly the 2-element Boolean lattice's bottom/top. */
+template <typename T>
+  requires std::is_arithmetic_v<T>
+struct lattice_top<T, std::less_equal<T>> {
+  static constexpr T value = std::numeric_limits<T>::max();
+};
+
+/** @brief Value-witness for the lattice bottom. */
+export template <typename T, typename Rel>
+inline constexpr T lattice_bottom_v = lattice_bottom<T, Rel>::value;
+
+/** @brief Value-witness for the lattice top. */
+export template <typename T, typename Rel>
+inline constexpr T lattice_top_v = lattice_top<T, Rel>::value;
+
+/**
+ * @concept HasLatticeBottom
+ * @brief A lattice-internal initial object exists for @c (T, @c Rel) —
+ *        i.e.\ @c lattice_bottom<T, Rel> is specialised with a
+ *        @c constexpr @c value member.
+ */
+export template <typename T, typename Rel>
+concept HasLatticeBottom = requires {
+  { lattice_bottom<T, Rel>::value } -> std::convertible_to<T>;
+};
+
+/**
+ * @concept HasLatticeTop
+ * @brief A lattice-internal terminal object exists for @c (T, @c Rel) —
+ *        i.e.\ @c lattice_top<T, Rel> is specialised with a
+ *        @c constexpr @c value member.
+ */
+export template <typename T, typename Rel>
+concept HasLatticeTop = requires {
+  { lattice_top<T, Rel>::value } -> std::convertible_to<T>;
+};
 
 /** @section species__Categorical_Inverses: The 'Undo' Bricks */
 

--- a/src/main/modules/dedekind/category/species.cppm
+++ b/src/main/modules/dedekind/category/species.cppm
@@ -44,8 +44,8 @@ module;
 #include <algorithm>
 #include <concepts>
 #include <functional>
-#include <limits>       // std::numeric_limits — used by lattice_bottom/top
-                        // specialisations for arithmetic carriers (#698 Slice 4).
+#include <limits>  // std::numeric_limits — used by lattice_bottom/top
+                   // specialisations for arithmetic carriers (#698 Slice 4).
 #include <type_traits>  // std::is_arithmetic_v — same specialisations.
 
 export module dedekind.category:species;

--- a/src/test/cpp/modules/dedekind/category/bounded_lattice_test.cpp
+++ b/src/test/cpp/modules/dedekind/category/bounded_lattice_test.cpp
@@ -26,7 +26,8 @@ import dedekind.category;
 using namespace dedekind::category;
 
 TEST_CASE(
-    "category:bounded-lattice — bool is the canonical 2-element bounded lattice",
+    "category:bounded-lattice — bool is the canonical 2-element bounded "
+    "lattice",
     "[category][lattice][bounded][bool][canonical]") {
   /** @brief @c bool under @c std::less_equal has bottom = @c false,
    *         top = @c true — the canonical 2-element bounded lattice
@@ -39,7 +40,8 @@ TEST_CASE(
 }
 
 TEST_CASE(
-    "category:bounded-lattice — integral carriers are bounded via numeric_limits",
+    "category:bounded-lattice — integral carriers are bounded via "
+    "numeric_limits",
     "[category][lattice][bounded][numeric]") {
   /** @brief Integral carriers under @c std::less_equal are bounded:
    *         bottom = @c numeric_limits<T>::min(), top = max(). */
@@ -51,11 +53,14 @@ TEST_CASE(
   STATIC_CHECK(LatticeTop<int, std::less_equal<int>>::value == INT_MAX);
 
   STATIC_CHECK(LatticeBottom<unsigned, std::less_equal<unsigned>>::value == 0u);
-  STATIC_CHECK(LatticeTop<unsigned, std::less_equal<unsigned>>::value == UINT_MAX);
+  STATIC_CHECK(LatticeTop<unsigned, std::less_equal<unsigned>>::value ==
+               UINT_MAX);
 }
 
-TEST_CASE("category:bounded-lattice — relaxed :limit concepts still fire on global Zero/One",
-          "[category][lattice][bounded][limit][relaxed]") {
+TEST_CASE(
+    "category:bounded-lattice — relaxed :limit concepts still fire on global "
+    "Zero/One",
+    "[category][lattice][bounded][limit][relaxed]") {
   /** @brief The relaxation to @c :limit::IsInitialObject /
    *         @c IsTerminalObject preserves the existing strict-global
    *         branch — @c Zero and @c One still satisfy.  Verifies that

--- a/src/test/cpp/modules/dedekind/category/bounded_lattice_test.cpp
+++ b/src/test/cpp/modules/dedekind/category/bounded_lattice_test.cpp
@@ -1,0 +1,69 @@
+/** @file dedekind/category/bounded_lattice_test.cpp
+ *
+ * Unit coverage for @c :category::lattice::IsBoundedLatticeCategory
+ * (row 5 of the lattice Form-chain, #698 Slice 4).
+ *
+ * Faithful inclusion encoded in the signature:
+ *   IsBoundedLatticeCategory ⊊ IsLatticeCategory ⊊ IsFilteredCategory
+ *                              ⊊ IsThinCategory
+ *
+ * The bounded refinement requires lattice-internal initial / terminal
+ * elements via the @c HasLatticeBottom / @c HasLatticeTop traits in
+ * @c :species.  Distinct from @c :limit's strict @c IsInitialObject
+ * (which pins @c std::nullptr_t globally) — these are per-(T, Rel)
+ * lattice-internal bottom / top.
+ */
+
+#include <catch2/catch_test_macros.hpp>
+#include <climits>
+#include <concepts>
+#include <functional>
+
+import dedekind.category;
+
+using namespace dedekind::category;
+
+TEST_CASE("category:bounded-lattice — bool is the canonical 2-element bounded lattice",
+          "[category][lattice][bounded][bool][canonical]") {
+  /** @brief @c bool under @c std::less_equal has bottom = @c false,
+   *         top = @c true — the canonical 2-element bounded lattice
+   *         (also the subobject classifier Ω in Set). */
+  STATIC_CHECK(IsBoundedLatticeCategory<bool>);
+  STATIC_CHECK(HasLatticeBottom<bool, std::less_equal<bool>>);
+  STATIC_CHECK(HasLatticeTop<bool, std::less_equal<bool>>);
+  STATIC_CHECK(lattice_bottom_v<bool, std::less_equal<bool>> == false);
+  STATIC_CHECK(lattice_top_v<bool, std::less_equal<bool>> == true);
+}
+
+TEST_CASE("category:bounded-lattice — integral carriers are bounded via numeric_limits",
+          "[category][lattice][bounded][numeric]") {
+  /** @brief Integral carriers under @c std::less_equal are bounded:
+   *         bottom = @c numeric_limits<T>::min(), top = max(). */
+  STATIC_CHECK(IsBoundedLatticeCategory<int>);
+  STATIC_CHECK(IsBoundedLatticeCategory<unsigned>);
+  STATIC_CHECK(IsBoundedLatticeCategory<std::size_t>);
+
+  STATIC_CHECK(lattice_bottom_v<int, std::less_equal<int>> == INT_MIN);
+  STATIC_CHECK(lattice_top_v<int, std::less_equal<int>> == INT_MAX);
+
+  STATIC_CHECK(lattice_bottom_v<unsigned, std::less_equal<unsigned>> == 0u);
+  STATIC_CHECK(lattice_top_v<unsigned, std::less_equal<unsigned>> == UINT_MAX);
+}
+
+TEST_CASE("category:bounded-lattice — Form-chain faithful inclusions hold",
+          "[category][lattice][bounded][faithful][form-chain]") {
+  /** @brief Every bounded lattice category is a lattice, posetal,
+   *         filtered, and thin — all encoded definitionally in
+   *         @c IsBoundedLatticeCategory's signature chain. */
+  STATIC_CHECK(IsThinCategory<bool>);
+  STATIC_CHECK(IsPosetal<bool>);
+  STATIC_CHECK(IsFilteredCategory<bool>);
+  STATIC_CHECK(IsLatticeCategory<bool>);
+  STATIC_CHECK(IsBoundedLatticeCategory<bool>);
+
+  STATIC_CHECK(IsThinCategory<int>);
+  STATIC_CHECK(IsPosetal<int>);
+  STATIC_CHECK(IsFilteredCategory<int>);
+  STATIC_CHECK(IsLatticeCategory<int>);
+  STATIC_CHECK(IsBoundedLatticeCategory<int>);
+}

--- a/src/test/cpp/modules/dedekind/category/bounded_lattice_test.cpp
+++ b/src/test/cpp/modules/dedekind/category/bounded_lattice_test.cpp
@@ -7,11 +7,13 @@
  *   IsBoundedLatticeCategory ⊊ IsLatticeCategory ⊊ IsFilteredCategory
  *                              ⊊ IsThinCategory
  *
- * The bounded refinement requires lattice-internal initial / terminal
- * elements via the @c HasLatticeBottom / @c HasLatticeTop traits in
- * @c :species.  Distinct from @c :limit's strict @c IsInitialObject
- * (which pins @c std::nullptr_t globally) — these are per-(T, Rel)
- * lattice-internal bottom / top.
+ * The bounded refinement requires structural witness types
+ * @c LatticeBottom<T, Rel> and @c LatticeTop<T, Rel> declared in
+ * @c :lattice — each carries the @c is_initial_object_tag / @c
+ * is_terminal_object_tag typedef so the relaxed @c :limit::
+ * IsInitialObject / @c IsTerminalObject (tag-discovery branch) fires.
+ * No parallel concept surface; the universal-property reading is
+ * carried by the existing @c :limit categorical concepts.
  */
 
 #include <catch2/catch_test_macros.hpp>
@@ -24,22 +26,20 @@ import dedekind.category;
 using namespace dedekind::category;
 
 TEST_CASE(
-    "category:bounded-lattice — bool is the canonical 2-element bounded "
-    "lattice",
+    "category:bounded-lattice — bool is the canonical 2-element bounded lattice",
     "[category][lattice][bounded][bool][canonical]") {
   /** @brief @c bool under @c std::less_equal has bottom = @c false,
    *         top = @c true — the canonical 2-element bounded lattice
    *         (also the subobject classifier Ω in Set). */
   STATIC_CHECK(IsBoundedLatticeCategory<bool>);
-  STATIC_CHECK(HasLatticeBottom<bool, std::less_equal<bool>>);
-  STATIC_CHECK(HasLatticeTop<bool, std::less_equal<bool>>);
-  STATIC_CHECK(lattice_bottom_v<bool, std::less_equal<bool>> == false);
-  STATIC_CHECK(lattice_top_v<bool, std::less_equal<bool>> == true);
+  STATIC_CHECK(IsInitialObject<LatticeBottom<bool, std::less_equal<bool>>>);
+  STATIC_CHECK(IsTerminalObject<LatticeTop<bool, std::less_equal<bool>>>);
+  STATIC_CHECK(LatticeBottom<bool, std::less_equal<bool>>::value == false);
+  STATIC_CHECK(LatticeTop<bool, std::less_equal<bool>>::value == true);
 }
 
 TEST_CASE(
-    "category:bounded-lattice — integral carriers are bounded via "
-    "numeric_limits",
+    "category:bounded-lattice — integral carriers are bounded via numeric_limits",
     "[category][lattice][bounded][numeric]") {
   /** @brief Integral carriers under @c std::less_equal are bounded:
    *         bottom = @c numeric_limits<T>::min(), top = max(). */
@@ -47,11 +47,21 @@ TEST_CASE(
   STATIC_CHECK(IsBoundedLatticeCategory<unsigned>);
   STATIC_CHECK(IsBoundedLatticeCategory<std::size_t>);
 
-  STATIC_CHECK(lattice_bottom_v<int, std::less_equal<int>> == INT_MIN);
-  STATIC_CHECK(lattice_top_v<int, std::less_equal<int>> == INT_MAX);
+  STATIC_CHECK(LatticeBottom<int, std::less_equal<int>>::value == INT_MIN);
+  STATIC_CHECK(LatticeTop<int, std::less_equal<int>>::value == INT_MAX);
 
-  STATIC_CHECK(lattice_bottom_v<unsigned, std::less_equal<unsigned>> == 0u);
-  STATIC_CHECK(lattice_top_v<unsigned, std::less_equal<unsigned>> == UINT_MAX);
+  STATIC_CHECK(LatticeBottom<unsigned, std::less_equal<unsigned>>::value == 0u);
+  STATIC_CHECK(LatticeTop<unsigned, std::less_equal<unsigned>>::value == UINT_MAX);
+}
+
+TEST_CASE("category:bounded-lattice — relaxed :limit concepts still fire on global Zero/One",
+          "[category][lattice][bounded][limit][relaxed]") {
+  /** @brief The relaxation to @c :limit::IsInitialObject /
+   *         @c IsTerminalObject preserves the existing strict-global
+   *         branch — @c Zero and @c One still satisfy.  Verifies that
+   *         the existing ETCS / topoi consumers continue to fire. */
+  STATIC_CHECK(IsInitialObject<Zero>);
+  STATIC_CHECK(IsTerminalObject<One>);
 }
 
 TEST_CASE("category:bounded-lattice — Form-chain faithful inclusions hold",

--- a/src/test/cpp/modules/dedekind/category/bounded_lattice_test.cpp
+++ b/src/test/cpp/modules/dedekind/category/bounded_lattice_test.cpp
@@ -23,8 +23,10 @@ import dedekind.category;
 
 using namespace dedekind::category;
 
-TEST_CASE("category:bounded-lattice — bool is the canonical 2-element bounded lattice",
-          "[category][lattice][bounded][bool][canonical]") {
+TEST_CASE(
+    "category:bounded-lattice — bool is the canonical 2-element bounded "
+    "lattice",
+    "[category][lattice][bounded][bool][canonical]") {
   /** @brief @c bool under @c std::less_equal has bottom = @c false,
    *         top = @c true — the canonical 2-element bounded lattice
    *         (also the subobject classifier Ω in Set). */
@@ -35,8 +37,10 @@ TEST_CASE("category:bounded-lattice — bool is the canonical 2-element bounded 
   STATIC_CHECK(lattice_top_v<bool, std::less_equal<bool>> == true);
 }
 
-TEST_CASE("category:bounded-lattice — integral carriers are bounded via numeric_limits",
-          "[category][lattice][bounded][numeric]") {
+TEST_CASE(
+    "category:bounded-lattice — integral carriers are bounded via "
+    "numeric_limits",
+    "[category][lattice][bounded][numeric]") {
   /** @brief Integral carriers under @c std::less_equal are bounded:
    *         bottom = @c numeric_limits<T>::min(), top = max(). */
   STATIC_CHECK(IsBoundedLatticeCategory<int>);


### PR DESCRIPTION
Slice 4 of #698. Row 5 of the lattice Form-chain — adds the lattice-internal initial / terminal (bottom / top) refinement on top of `IsLatticeCategory`.

> **History note**: the initial implementation routed through new value-witness traits in `:species` (`lattice_bottom_v`, `lattice_top_v`, `HasLatticeBottom`, `HasLatticeTop`). User feedback flagged two concerns — `:species` was being used as a junkyard for value witnesses outside its taxonomic-bricks-for-relations-and-operations purpose, and the design introduced a parallel concept surface alongside `:limit`'s existing `IsInitialObject` / `IsTerminalObject` instead of reusing them. The audit trail of that misstep + the correction is visible in the PR's commit history. Final design (below) reverts the `:species` additions and reuses `:limit`'s concepts via opt-in tag discovery.

## What lands

### `:limit` — relaxed `IsInitialObject` / `IsTerminalObject` via opt-in tag

```cpp
template <typename T>
concept IsInitialObject =
    std::same_as<T, Zero> ||
    requires { typename T::is_initial_object_tag; };

template <typename T>
concept IsTerminalObject =
    std::same_as<T, One> ||
    requires { typename T::is_terminal_object_tag; };
```

The strict global `Zero` / `One` branch is preserved — every existing ETCS / topoi consumer continues to fire. The tag-discovery branch admits downstream structural witness types.

### `:lattice` — `LatticeBottom<T, Rel>` / `LatticeTop<T, Rel>` wrappers + `IsBoundedLatticeCategory`

```cpp
// Structural witness types — declared as initial / terminal of the
// lattice over (T, Rel) viewed as a thin category.
template <typename T, typename Rel> struct LatticeBottom;
template <typename T, typename Rel> struct LatticeTop;

// Canonical specialisation: integral carriers under std::less_equal
// (floats intentionally excluded — they fail upstream IsThinCategory
// because is_transitive_v gates on integral + bool only).
template <typename T> requires std::is_integral_v<T>
struct LatticeBottom<T, std::less_equal<T>> {
  using is_initial_object_tag = void;
  static constexpr T value = std::numeric_limits<T>::min();
};
// (same shape for LatticeTop with std::numeric_limits<T>::max())

template <typename T, typename Rel = std::less_equal<T>, ...>
concept IsBoundedLatticeCategory =
    IsLatticeCategory<T, Rel, ...> &&            // Faithful: bounded ⊊ lattice
    IsInitialObject<LatticeBottom<T, Rel>> &&    // Universal-property initial
    IsTerminalObject<LatticeTop<T, Rel>> &&      // Universal-property terminal
    requires {
      { LatticeBottom<T, Rel>::value } -> std::convertible_to<T>;
      { LatticeTop<T, Rel>::value } -> std::convertible_to<T>;
    };
```

## How `:lattice` connects to `:limit`

This is the architectural payoff of the correction: `:lattice` is a *consumer* of `:limit`'s concepts, not a sibling with parallel surface.

```
:limit (upstream)
  IsInitialObject<T>  ──[relaxed]──►  matches strict Zero  OR  T::is_initial_object_tag
                                                              ▲
                                                              │ declares
:lattice (downstream)                                         │
  LatticeBottom<T, Rel>  ─────────────────────────────────────┘
                       (specialised for integral carriers)
                                                              ▲
                                                              │ used by
  IsBoundedLatticeCategory<...> = ... &&                       │
      IsInitialObject<LatticeBottom<T, Rel>> ───────► resolves via this chain
```

The categorical content "the lattice has an initial object" is expressed *through* `:limit`'s universal-property machinery — exactly as it should be.

## Q3 disposition (faithful per #698)

The literal `IsInitialObject` / `IsTerminalObject` in `:limit` were too narrow (strict for global Zero / One). The relaxation widens them with the tag-discovery branch *without* breaking existing consumers. The lattice's initial / terminal are now structurally witnessed by the `LatticeBottom` / `LatticeTop` wrapper types, satisfying the relaxed concepts. Faithful in the original sense: bottom / top are designated structural witness types satisfying `IsInitialObject` / `IsTerminalObject`, not operational member functions.

## Canonical witnesses

- `IsBoundedLatticeCategory<bool>`: bottom = `false`, top = `true`.
- `IsBoundedLatticeCategory<int>`: bottom = `INT_MIN`, top = `INT_MAX`.
- `IsBoundedLatticeCategory<unsigned>`: bottom = `0`, top = `UINT_MAX`.
- `IsBoundedLatticeCategory<size_t>`: same shape.
- Regression: `IsInitialObject<Zero>` and `IsTerminalObject<One>` still fire — existing ETCS / topoi consumers preserved.

## Form-chain status

```
IsThinCategory                  (row 1 — Slice 0 ✓)
    ↓ + antisymmetry
IsPosetal                        (row 2 — Slice 1 ✓)
    ↓ + directedness
IsFilteredCategory               (row 3 — Slice 2 ✓)
    ↓ + cofiltered + universality
IsLatticeCategory                (row 4 — Slice 3 ✓)
    ↓ + bottom + top
IsBoundedLatticeCategory         (row 5 — THIS SLICE)
    ↓ + IsInvolutiveEndofunctor (Slice 5 — inline in :lattice per #698 Q2)
    ↓ + exponentials            (Slice 6 — IsHeytingLatticeCategory)
    ↓ + complement involution   (Slice 7 — IsBooleanLatticeCategory)
```

## Adjacent

- [#698](https://github.com/vincentk/dedekind/issues/698) — design issue with locked roadmap + design-question answers.
- [#699](https://github.com/vincentk/dedekind/pull/699) / [#700](https://github.com/vincentk/dedekind/pull/700) / [#701](https://github.com/vincentk/dedekind/pull/701) / [#702](https://github.com/vincentk/dedekind/pull/702) — Slices 0–3 (merged).