### PR TITLE
feat(category): #698 Slice 5 — IsInvolutiveEndofunctor inline in :lattice

### DIFF
--- a/src/main/modules/dedekind/category/lattice.cppm
+++ b/src/main/modules/dedekind/category/lattice.cppm
@@ -317,4 +317,106 @@ static_assert(LatticeBottom<bool, std::less_equal<bool>>::value == false,
 static_assert(LatticeTop<bool, std::less_equal<bool>>::value == true,
               "Bool's lattice top is true.");
 
+/** @section lattice__Involutive_Endofunctor
+ *
+ *  @brief Involutive endofunctor concept — an endomap @c F @c : @c T @c → @c T
+ *         with @c F² @c ≅ @c Id.
+ *
+ *  @details
+ *  An @b involutive @b endofunctor on a category @c C is a functor
+ *  @c F @c : @c C @c → @c C whose square is naturally isomorphic to
+ *  the identity functor.  In thin / lattice categories (where the
+ *  category structure is reduced to a carrier @c T plus a relation),
+ *  this collapses to an endomap on @c T satisfying @c F(F(x)) @c = @c x
+ *  for all @c x @c ∈ @c T.
+ *
+ *  Used downstream by the row-7 @c IsBooleanLatticeCategory (#698
+ *  Slice 7), where the @b complement is the canonical involution.
+ *  Examples:
+ *
+ *    - @c std::logical_not<bool> on @c bool: @c !!x @c = @c x.
+ *    - @c std::bit_not<T> on integral @c T: @c ~~x @c = @c x.
+ *    - @c :sets::Complement on a Boolean subobject lattice @c Sub<S>:
+ *      @c !!S @c ≡ @c S (the bona-fide involution from #683).
+ *
+ *  @section lattice__Involutive_Sollbruchstelle
+ *  @b Pragmatic placement: this concept lives inline in @c :lattice
+ *  per #698 Q2.  When a second consumer arrives (e.g.\ dual categories,
+ *  opposite functors, monad-shaped opportunities), the natural
+ *  extraction target is a new partition @c :involution or — if the
+ *  consumer is monad-shaped — @c :monad.  Until then the lightweight
+ *  inline location avoids partition-graph churn for a single consumer.
+ *
+ *  Strictly: involution is @b not a monad.  A monad @c (T, η, μ) has
+ *  @c μ @c : @c T² @c → @c T; an involution has @c F² @c ≅ @c Id (the
+ *  iteration goes back to identity, not to the functor itself).  The
+ *  shared shape is "endofunctor + property of its second iteration".
+ */
+
+/** @brief Trait: a callable @c F is involutive on @c T iff @c F(F(x))
+ *         @c = @c x for all @c x @c ∈ @c T.  Primary template is
+ *         @c std::false_type; opt-in via specialisation or member
+ *         discovery. */
+template <typename F, typename T>
+struct is_involutive : std::false_type {};
+
+/** @brief Discovery: types may opt in via a nested @c is_involutive_v
+ *         template member, mirroring the @c is_reflexive / @c
+ *         is_transitive / @c is_directed pattern in @c :species. */
+template <typename F, typename T>
+  requires requires { F::template is_involutive_v<T>; }
+struct is_involutive<F, T>
+    : std::bool_constant<F::template is_involutive_v<T>> {};
+
+export template <typename F, typename T>
+inline constexpr bool is_involutive_v = is_involutive<F, T>::value;
+
+/** @brief Canonical specialisation: @c std::logical_not<bool> is the
+ *         involution on @c bool. */
+template <>
+struct is_involutive<std::logical_not<bool>, bool> : std::true_type {};
+
+/** @brief Canonical specialisation: @c std::bit_not<T> is the
+ *         involution on integral @c T (~~x = x). */
+template <typename T>
+  requires std::is_integral_v<T>
+struct is_involutive<std::bit_not<T>, T> : std::true_type {};
+
+/**
+ * @concept IsInvolutiveEndofunctor
+ * @brief A callable @c F is an involutive endofunctor on @c T —
+ *        invocable @c T @c → @c T with @c F² @c ≅ @c Id.
+ *
+ * @details
+ * Three structural requirements:
+ *
+ *   - @c F is invocable on @c T (the endomap shape).
+ *   - The invocation returns a value convertible to @c T (so @c F
+ *     genuinely maps @c T to @c T, not to some larger codomain).
+ *   - @c F² @c = @c Id, witnessed by @c is_involutive_v<F, T>.
+ *
+ * Used by @c IsBooleanLatticeCategory (#698 Slice 7) with @c F the
+ * lattice complement.
+ *
+ * @tparam F The endofunctor (a callable).
+ * @tparam T The carrier type on which @c F acts.
+ */
+export template <typename F, typename T>
+concept IsInvolutiveEndofunctor =
+    std::invocable<F, T> &&
+    std::convertible_to<std::invoke_result_t<F, T>, T> &&
+    is_involutive_v<F, T>;
+
+/** @section lattice__Involution_Canonical_Witnesses */
+
+static_assert(IsInvolutiveEndofunctor<std::logical_not<bool>, bool>,
+              "std::logical_not<bool> is the canonical Boolean involution: "
+              "!!x == x for all x in {false, true}.");
+
+static_assert(IsInvolutiveEndofunctor<std::bit_not<int>, int>,
+              "std::bit_not<int> is involutive on int: ~~x == x.");
+
+static_assert(IsInvolutiveEndofunctor<std::bit_not<unsigned>, unsigned>,
+              "std::bit_not<unsigned> is involutive on unsigned.");
+
 }  // namespace dedekind::category

--- a/src/main/modules/dedekind/category/lattice.cppm
+++ b/src/main/modules/dedekind/category/lattice.cppm
@@ -356,8 +356,10 @@ static_assert(LatticeTop<bool, std::less_equal<bool>>::value == true,
 /** @brief Trait: a callable @c F is involutive on @c T iff @c F(F(x))
  *         @c = @c x for all @c x @c ∈ @c T.  Primary template is
  *         @c std::false_type; opt-in via specialisation or member
- *         discovery. */
-template <typename F, typename T>
+ *         discovery.  @b Exported so downstream code can specialise
+ *         this trait for its own carrier types (mirrors the
+ *         @c :species::is_reflexive / @c is_transitive export pattern). */
+export template <typename F, typename T>
 struct is_involutive : std::false_type {};
 
 /** @brief Discovery: types may opt in via a nested @c is_involutive_v
@@ -377,9 +379,17 @@ template <>
 struct is_involutive<std::logical_not<bool>, bool> : std::true_type {};
 
 /** @brief Canonical specialisation: @c std::bit_not<T> is the
- *         involution on integral @c T (~~x = x). */
+ *         involution on @b non-bool integral @c T (~~x = x).
+ *
+ *  @note @c bool is @b excluded: @c std::bit_not<bool>(x) computes
+ *  @c ~x via integral promotion (yielding @c -1 or @c -2 in @c int),
+ *  then converts back to @c bool — which is always @c true for any
+ *  non-zero result.  So @c bit_not(bit_not(false)) @c == @c true,
+ *  not @c false: @c std::bit_not<bool> is @b not an involution.
+ *  Bool's involution is @c std::logical_not<bool>, specialised
+ *  separately above. */
 template <typename T>
-  requires std::is_integral_v<T>
+  requires std::is_integral_v<T> && (!std::is_same_v<T, bool>)
 struct is_involutive<std::bit_not<T>, T> : std::true_type {};
 
 /**

--- a/src/main/modules/dedekind/category/lattice.cppm
+++ b/src/main/modules/dedekind/category/lattice.cppm
@@ -404,8 +404,7 @@ struct is_involutive<std::bit_not<T>, T> : std::true_type {};
 export template <typename F, typename T>
 concept IsInvolutiveEndofunctor =
     std::invocable<F, T> &&
-    std::convertible_to<std::invoke_result_t<F, T>, T> &&
-    is_involutive_v<F, T>;
+    std::convertible_to<std::invoke_result_t<F, T>, T> && is_involutive_v<F, T>;
 
 /** @section lattice__Involution_Canonical_Witnesses */
 

--- a/src/test/cpp/modules/dedekind/category/involutive_endofunctor_test.cpp
+++ b/src/test/cpp/modules/dedekind/category/involutive_endofunctor_test.cpp
@@ -55,8 +55,9 @@ TEST_CASE("category:lattice — std::bit_not is involutive on integral carriers"
   STATIC_CHECK(bit_not_int(bit_not_int(0)) == 0);
 }
 
-TEST_CASE("category:lattice — opt-in registration is required (no default true)",
-          "[category][lattice][involution][negative][opt-in]") {
+TEST_CASE(
+    "category:lattice — opt-in registration is required (no default true)",
+    "[category][lattice][involution][negative][opt-in]") {
   /** @brief Sanity: the @c is_involutive trait is @b opt-in.  Absence
    *         of an explicit specialisation means @c is_involutive_v is
    *         @c false_type by default, and @c IsInvolutiveEndofunctor

--- a/src/test/cpp/modules/dedekind/category/involutive_endofunctor_test.cpp
+++ b/src/test/cpp/modules/dedekind/category/involutive_endofunctor_test.cpp
@@ -55,15 +55,19 @@ TEST_CASE("category:lattice — std::bit_not is involutive on integral carriers"
   STATIC_CHECK(bit_not_int(bit_not_int(0)) == 0);
 }
 
-TEST_CASE("category:lattice — non-involutive callables are rejected",
-          "[category][lattice][involution][negative]") {
-  /** @brief Sanity: a non-involutive callable (e.g.\ @c std::negate
-   *         on unsigned, which is NOT involutive because two's-complement
-   *         negation on an unsigned overflow is wrap-around but the
-   *         opt-in trait is not registered for it) does not satisfy
-   *         the concept.  The trait is @b opt-in: absence of an
-   *         @c is_involutive specialisation means @c is_involutive_v
-   *         is @c false_type by default. */
+TEST_CASE("category:lattice — opt-in registration is required (no default true)",
+          "[category][lattice][involution][negative][opt-in]") {
+  /** @brief Sanity: the @c is_involutive trait is @b opt-in.  Absence
+   *         of an explicit specialisation means @c is_involutive_v is
+   *         @c false_type by default, and @c IsInvolutiveEndofunctor
+   *         fails closed.
+   *
+   *  @note @c std::negate<unsigned> @b is actually involutive (unsigned
+   *  arithmetic is modulo, so @c -(-x) @c == @c x), but no
+   *  specialisation has been registered for it — this test demonstrates
+   *  the opt-in pattern, not non-involutiveness.  A genuinely
+   *  non-involutive callable would also fail, but for a different
+   *  structural reason. */
   STATIC_CHECK_FALSE(IsInvolutiveEndofunctor<std::negate<unsigned>, unsigned>);
   STATIC_CHECK_FALSE(is_involutive_v<std::negate<unsigned>, unsigned>);
 }

--- a/src/test/cpp/modules/dedekind/category/involutive_endofunctor_test.cpp
+++ b/src/test/cpp/modules/dedekind/category/involutive_endofunctor_test.cpp
@@ -1,0 +1,69 @@
+/** @file dedekind/category/involutive_endofunctor_test.cpp
+ *
+ * Unit coverage for @c :category::lattice::IsInvolutiveEndofunctor
+ * (#698 Slice 5).
+ *
+ * An involutive endofunctor on @c T is a callable @c F @c : @c T @c → @c T
+ * with @c F² @c ≅ @c Id.  Canonical witnesses:
+ *
+ *   - @c std::logical_not<bool> on @c bool ( @c !!x @c = @c x ).
+ *   - @c std::bit_not<T> on integral @c T ( @c ~~x @c = @c x ).
+ *
+ * Used by @c IsBooleanLatticeCategory (#698 Slice 7) with @c F the
+ * lattice complement.
+ *
+ * Sollbruchstelle: lives inline in @c :lattice per #698 Q2; extraction
+ * to @c :involution or @c :monad deferred until a second consumer
+ * arrives.
+ */
+
+#include <catch2/catch_test_macros.hpp>
+#include <concepts>
+#include <functional>
+
+import dedekind.category;
+
+using namespace dedekind::category;
+
+TEST_CASE("category:lattice — std::logical_not<bool> is the Boolean involution",
+          "[category][lattice][involution][bool]") {
+  /** @brief The element-level complement on @c bool: @c !!x @c = @c x
+   *         for all @c x @c ∈ @c {false, @c true}.  This is the
+   *         canonical 2-element Boolean involution. */
+  STATIC_CHECK(IsInvolutiveEndofunctor<std::logical_not<bool>, bool>);
+  STATIC_CHECK(is_involutive_v<std::logical_not<bool>, bool>);
+
+  /** @brief Runtime witnesses — @c !!x @c = @c x for both values. */
+  constexpr std::logical_not<bool> not_op{};
+  STATIC_CHECK(not_op(not_op(false)) == false);
+  STATIC_CHECK(not_op(not_op(true)) == true);
+}
+
+TEST_CASE("category:lattice — std::bit_not is involutive on integral carriers",
+          "[category][lattice][involution][bitwise]") {
+  /** @brief Bitwise complement: @c ~~x @c = @c x for all integral
+   *         @c T.  This is the involution on the bitwise Boolean
+   *         algebra on @c size_t / @c int / @c unsigned. */
+  STATIC_CHECK(IsInvolutiveEndofunctor<std::bit_not<int>, int>);
+  STATIC_CHECK(IsInvolutiveEndofunctor<std::bit_not<unsigned>, unsigned>);
+  STATIC_CHECK(IsInvolutiveEndofunctor<std::bit_not<std::size_t>, std::size_t>);
+
+  /** @brief Runtime witnesses. */
+  constexpr std::bit_not<int> bit_not_int{};
+  STATIC_CHECK(bit_not_int(bit_not_int(42)) == 42);
+  STATIC_CHECK(bit_not_int(bit_not_int(-1)) == -1);
+  STATIC_CHECK(bit_not_int(bit_not_int(0)) == 0);
+}
+
+TEST_CASE("category:lattice — non-involutive callables are rejected",
+          "[category][lattice][involution][negative]") {
+  /** @brief Sanity: a non-involutive callable (e.g.\ @c std::negate
+   *         on unsigned, which is NOT involutive because two's-complement
+   *         negation on an unsigned overflow is wrap-around but the
+   *         opt-in trait is not registered for it) does not satisfy
+   *         the concept.  The trait is @b opt-in: absence of an
+   *         @c is_involutive specialisation means @c is_involutive_v
+   *         is @c false_type by default. */
+  STATIC_CHECK_FALSE(IsInvolutiveEndofunctor<std::negate<unsigned>, unsigned>);
+  STATIC_CHECK_FALSE(is_involutive_v<std::negate<unsigned>, unsigned>);
+}


### PR DESCRIPTION
Slice 5 of #698. Adds the involution concept needed for row 7 of the lattice Form-chain (`IsBooleanLatticeCategory`, future slice). An involutive endofunctor on `T` is a callable `F : T → T` with `F² ≅ Id`.

## What lands

### `:lattice` — new `IsInvolutiveEndofunctor<F, T>`

```cpp
template <typename F, typename T>
concept IsInvolutiveEndofunctor =
    std::invocable<F, T> &&
    std::convertible_to<std::invoke_result_t<F, T>, T> &&
    is_involutive_v<F, T>;
```

Supporting trait family inline in `:lattice`:
- `is_involutive<F, T>` — primary template, `std::false_type`.
- `is_involutive_v<F, T>` — value helper.
- Discovery via `F::template is_involutive_v<T>` member tag.

Canonical specialisations:
- `std::logical_not<bool>` on `bool` (`!!x = x`).
- `std::bit_not<T>` on integral `T` (`~~x = x`) — covers `int`, `unsigned`, `size_t`.

## Q2 disposition (per #698)

This concept lives **inline in `:lattice`** per the locked Q2 answer. Sollbruchstelle in the partition header points at `:involution` or `:monad` as the extraction destination when a second consumer arrives.

Strictly: involution is **not** a monad — `F² ≅ Id` (involution) is structurally distinct from `μ : T² → T` (monad multiplication). The shared shape is "endofunctor + property of its second iteration".

## Form-chain status

```
IsThinCategory             (row 1 — Slice 0 ✓)
    ↓ + antisymmetry
IsPosetal                   (row 2 — Slice 1 ✓)
    ↓ + directedness
IsFilteredCategory          (row 3 — Slice 2 ✓)
    ↓ + cofiltered + universality
IsLatticeCategory           (row 4 — Slice 3 ✓)
    ↓ + bottom + top
IsBoundedLatticeCategory    (row 5 — Slice 4 ✓)
    ↓ + IsInvolutiveEndofunctor   ← THIS SLICE (sibling concept)
    ↓ + exponentials              (Slice 6 — IsHeytingLatticeCategory)
    ↓ + Complement involution     (Slice 7 — IsBooleanLatticeCategory)
```

Slice 7 will plug `Complement`-as-callable into `IsInvolutiveEndofunctor` to assemble the Boolean refinement.

## Canonical witnesses

- `IsInvolutiveEndofunctor<std::logical_not<bool>, bool>` — element-level Boolean involution.
- `IsInvolutiveEndofunctor<std::bit_not<int>, int>` — bitwise complement on int.
- `IsInvolutiveEndofunctor<std::bit_not<unsigned>, unsigned>` / `<size_t>` — same for size_t.
- Negative witness: `IsInvolutiveEndofunctor<std::negate<unsigned>, unsigned>` is `false` (opt-in trait absent).

## Net

+171 / -0 across 2 files (concept + traits in `:lattice`; new test file). CI authoritative.

## Adjacent

- [#698](https://github.com/vincentk/dedekind/issues/698) — design issue, Q2 locked.
- [#704](https://github.com/vincentk/dedekind/pull/704) — Slice 4 (merged); row 5 baseline.