### PR TITLE
feat(category): #698 Slice 6 — IsHeytingLatticeCategory + structural IsExponential

### DIFF
--- a/src/main/modules/dedekind/category/cartesian.cppm
+++ b/src/main/modules/dedekind/category/cartesian.cppm
@@ -66,21 +66,67 @@ namespace dedekind::category {
 // directly via @c import dedekind.category.
 /**
  * @concept IsExponential
- * @brief Categorification of `std::function<B(A)>` as the Internal Hom-set
- * (B^A).
- * @details Identifies a type as an inhabitant of the function space from A to
- * B. A type F satisfies this concept when it is move-constructible and
- * callable with a single argument of type A returning B.
+ * @brief Categorical exponential object @c B^A — generalised structural
+ *        recogniser of "eval morphism via call expression" (#698 Slice 6).
  *
- * Three canonical inhabitants in the `std` namespace:
- * - `std::function<B(A)>` — type-erased, copyable function wrapper.
- * - `std::move_only_function<B(A)>` (C++23) — move-only, lighter-weight
- *   alternative.
- * - Any lambda `[...](A) -> B` — anonymous structural closure.
+ * @details
+ * In a Cartesian closed category C, an exponential object @c B^A is an
+ * object @c E with an evaluation morphism @c eval: @c E @c × @c A @c → @c B
+ * satisfying the currying universal property.  The concrete shape of
+ * @c E varies by category:
+ *
+ *   - @b Set / @b Cpp: @c E is a function-space type (lambda,
+ *     @c std::function<B(A)>, @c std::move_only_function<B(A)>, any
+ *     callable struct) — the historical reading.
+ *   - @b Heyting @b algebra (thin CCC): @c E is a @em value of the
+ *     carrier @c T representing @c a @c → @c b; @c operator()(x)
+ *     computes the meet @c e @c ∧ x.  The universal property says
+ *     @c e @c ∧ a @c ≤ @c b.
+ *
+ * The unifying observation: in @b every CCC, the eval morphism is
+ * implemented by @b applying the exponential object to its argument.
+ * In C++ that is the call expression @c e(a).  This concept therefore
+ * recognises exponentials structurally — by the well-formedness and
+ * return type of the call — without committing to function-space
+ * representation.  Pure Juliet posture: no tag, no CPO, no wrapper-
+ * for-tag.
+ *
+ * @section cartesian__Strict_Same_As
+ * The result type is checked via @c std::same_as<B>, not @c
+ * std::convertible_to<B>.  This preserves the Honest Rejection
+ * negative witness below (a function returning @c int does not
+ * satisfy @c IsExponential<…, int, bool>, even though @c int implicitly
+ * converts to @c bool in C++).
+ *
+ * @section cartesian__Structural_vs_Universal_Property
+ * The concept captures the eval morphism's @b operational shape
+ * (eval(e, a) → B) but does @b not enforce the currying universal
+ * property (∀ @c f : @c Γ @c × @c A @c → @c B, ∃! @c f̂ : @c Γ @c → @c E).
+ * Universal-property enforcement is tracked separately as #707.
+ *
+ * @section cartesian__IsArrow_Harmonisation
+ * @c IsExponential does not require @c IsArrow.  Function-space
+ * inhabitants like @c std::function<B(A)> satisfy this concept but
+ * @b not @c IsArrow (no @c Domain / @c Codomain typedefs).  The
+ * project's canonical arrow-shaped exponentials (e.g.\ outputs of
+ * @c arrow<A, B>(…), @c HeytingExponential<T, Rel>) satisfy both.
+ * The refinement @c IsArrowExponential @c = @c IsExponential @c
+ * && @c IsArrow is tracked as #706.
+ *
+ * @section cartesian__Slice6_Generalization
+ * Pre-#698-Slice-6 reading was Set-specific: @c std::move_constructible
+ * + @c std::invoke_result_t.  Slice 6 generalised to the structural
+ * call-shape recogniser so that lattice exponentials (Heyting
+ * implications, see @c :lattice::HeytingExponential) participate
+ * uniformly.  Behavioural preservation: every existing Set-side witness
+ * (function-spaces, lambdas, function-objects) continues to fire
+ * because @b being callable with the right signature was already the
+ * load-bearing fact under the old definition.
  */
-export template <typename F, typename A, typename B>
-concept IsExponential =
-    std::move_constructible<F> && std::same_as<std::invoke_result_t<F, A>, B>;
+export template <typename E, typename A, typename B>
+concept IsExponential = requires(E e, A a) {
+  { e(a) } -> std::same_as<B>;
+};
 
 /**
  * @brief Internal Hom Factory (Exponential)

--- a/src/main/modules/dedekind/category/lattice.cppm
+++ b/src/main/modules/dedekind/category/lattice.cppm
@@ -473,16 +473,25 @@ static_assert(IsInvolutiveEndofunctor<std::bit_not<unsigned>, unsigned>,
  *  Specialisations beyond the integral / @c std::less_equal case are
  *  tracked under #708.
  */
-export template <typename T, typename Rel>
+export template <typename T, typename Rel, typename Meet>
 struct HeytingExponential;
 
 /** @brief Canonical specialisation: integral carriers under
- *         @c std::less_equal (including @c bool).  Holds an exponential
- *         value @c value @c ∈ T; @c operator()(x) returns the meet
- *         @c min(value, x) which @b is the lattice's eval morphism. */
+ *         @c std::less_equal with @c std::ranges::min as the meet.
+ *         Holds an exponential value @c value @c ∈ T; @c operator()(x)
+ *         returns @c min(value, x) — the lattice meet, which @b is the
+ *         eval morphism in a thin Heyting algebra.
+ *
+ *  @note The @c Meet template parameter is load-bearing: it pins the
+ *  meet operation @c HeytingExponential uses for eval to the meet
+ *  @c IsHeytingLatticeCategory commits to via @b its @c Meet
+ *  parameter.  Without this coupling, a consumer could instantiate
+ *  @c IsHeytingLatticeCategory with a non-canonical @c Meet while
+ *  @c HeytingExponential::operator() silently used a different
+ *  operation — categorical contract broken. */
 export template <typename T>
   requires std::is_integral_v<T>
-struct HeytingExponential<T, std::less_equal<T>> {
+struct HeytingExponential<T, std::less_equal<T>, decltype(std::ranges::min)> {
   using Domain = T;  // IsArrow-shaped (for the future :morphism refinement)
   using Codomain = T;
 
@@ -492,7 +501,7 @@ struct HeytingExponential<T, std::less_equal<T>> {
    *         in a thin Heyting algebra).  Universal property:
    *         @c value @c ∧ x @c ≤ @c b when @c value @c = @c (a @c → b). */
   constexpr T operator()(T x) const noexcept {
-    return (value <= x) ? value : x;  // = min(value, x)
+    return std::ranges::min(value, x);
   }
 };
 
@@ -530,10 +539,14 @@ export template <typename T, typename Rel = std::less_equal<T>,
 concept IsHeytingLatticeCategory =
     IsBoundedLatticeCategory<T, Rel, Join, Meet,
                              L> &&  // Faithful: heyting ⊊ bounded.
-    IsExponential<HeytingExponential<T, Rel>, T, T>;  // Lattice exponential
-                                                      // satisfies the same
-                                                      // CCC concept Set's
-                                                      // function spaces do.
+    IsExponential<HeytingExponential<T, Rel, Meet>, T,
+                  T>;  // Lattice exponential — Meet is passed through so
+                       // the eval operation in the wrapper is pinned to
+                       // the concept's Meet, not silently hardcoded.
+                       // Without this, instantiating the concept with a
+                       // non-canonical Meet would silently leave the
+                       // wrapper using the wrong operation (PR #709
+                       // review fix).
 
 /** @section lattice__Heyting_Canonical_Witnesses */
 
@@ -549,8 +562,10 @@ static_assert(IsHeytingLatticeCategory<int>,
               "operator()(x) = min(value, x).");
 
 static_assert(
-    IsExponential<HeytingExponential<bool, std::less_equal<bool>>, bool, bool>,
-    "HeytingExponential<bool> aligns with :cartesian::IsExponential "
+    IsExponential<HeytingExponential<bool, std::less_equal<bool>,
+                                     decltype(std::ranges::min)>,
+                  bool, bool>,
+    "HeytingExponential<bool, …, min> aligns with :cartesian::IsExponential "
     "structurally — pure call-shape recognition (#698 Slice 6).");
 
 }  // namespace dedekind::category

--- a/src/main/modules/dedekind/category/lattice.cppm
+++ b/src/main/modules/dedekind/category/lattice.cppm
@@ -452,8 +452,8 @@ static_assert(IsInvolutiveEndofunctor<std::bit_not<unsigned>, unsigned>,
  *  @c value @c ∧ x @c ≤ b when @c value @c = @c (a @c → b).
  *
  *  @section lattice__Heyting_Aligns_With_IsExponential
- *  The wrapper satisfies @c :cartesian::IsExponential<HeytingExponential<T, Rel>,
- *  T, T> @b structurally — @c eval(e, x) is just the call expression
+ *  The wrapper satisfies @c :cartesian::IsExponential<HeytingExponential<T,
+ * Rel>, T, T> @b structurally — @c eval(e, x) is just the call expression
  *  @c e(x), and the wrapper's @c operator()(T) returns T.  This is the
  *  unification @b across CCCs: function-space exponentials (Set / Cpp)
  *  and value-shaped exponentials (Heyting) satisfy the same structural
@@ -483,10 +483,10 @@ struct HeytingExponential;
 template <typename T>
   requires std::is_integral_v<T>
 struct HeytingExponential<T, std::less_equal<T>> {
-  using Domain = T;    // IsArrow-shaped (for the future :morphism refinement)
+  using Domain = T;  // IsArrow-shaped (for the future :morphism refinement)
   using Codomain = T;
 
-  T value;             // the exponential element e = a → b
+  T value;  // the exponential element e = a → b
 
   /** @brief Eval morphism: @c value @c ∧ x (the meet, which @b is eval
    *         in a thin Heyting algebra).  Universal property:
@@ -528,11 +528,12 @@ export template <typename T, typename Rel = std::less_equal<T>,
                  typename Meet = decltype(std::ranges::min),
                  typename L = ClassicalLogic>
 concept IsHeytingLatticeCategory =
-    IsBoundedLatticeCategory<T, Rel, Join, Meet, L> &&  // Faithful: heyting ⊊ bounded.
-    IsExponential<HeytingExponential<T, Rel>, T, T>;    // Lattice exponential
-                                                        // satisfies the same
-                                                        // CCC concept Set's
-                                                        // function spaces do.
+    IsBoundedLatticeCategory<T, Rel, Join, Meet,
+                             L> &&  // Faithful: heyting ⊊ bounded.
+    IsExponential<HeytingExponential<T, Rel>, T, T>;  // Lattice exponential
+                                                      // satisfies the same
+                                                      // CCC concept Set's
+                                                      // function spaces do.
 
 /** @section lattice__Heyting_Canonical_Witnesses */
 
@@ -547,9 +548,9 @@ static_assert(IsHeytingLatticeCategory<int>,
               "implication; HeytingExponential<int, std::less_equal>::"
               "operator()(x) = min(value, x).");
 
-static_assert(IsExponential<HeytingExponential<bool, std::less_equal<bool>>,
-                            bool, bool>,
-              "HeytingExponential<bool> aligns with :cartesian::IsExponential "
-              "structurally — pure call-shape recognition (#698 Slice 6).");
+static_assert(
+    IsExponential<HeytingExponential<bool, std::less_equal<bool>>, bool, bool>,
+    "HeytingExponential<bool> aligns with :cartesian::IsExponential "
+    "structurally — pure call-shape recognition (#698 Slice 6).");
 
 }  // namespace dedekind::category

--- a/src/main/modules/dedekind/category/lattice.cppm
+++ b/src/main/modules/dedekind/category/lattice.cppm
@@ -106,13 +106,17 @@ module;
 export module dedekind.category:lattice;
 
 import :logic;
-import :posetal;   // IsPosetal — row 2 (thin + antisymmetric);
-                   // IsOrderLatticeOperations — bottom-up algebraic surface
-import :filtered;  // IsFilteredCategory — row 3 (directed thin cat)
-import :species;   // is_codirected_v — cofiltered companion to is_directed_v
-import :limit;     // IsInitialObject / IsTerminalObject — row 5
-                   // universal-property witnesses (relaxed via tag
-                   // discovery to admit LatticeBottom/LatticeTop).
+import :posetal;    // IsPosetal — row 2 (thin + antisymmetric);
+                    // IsOrderLatticeOperations — bottom-up algebraic surface
+import :filtered;   // IsFilteredCategory — row 3 (directed thin cat)
+import :species;    // is_codirected_v — cofiltered companion to is_directed_v
+import :limit;      // IsInitialObject / IsTerminalObject — row 5
+                    // universal-property witnesses (relaxed via tag
+                    // discovery to admit LatticeBottom/LatticeTop).
+import :cartesian;  // IsExponential — row 6 universal-property witness
+                    // (structural recogniser post-#698 Slice 6; admits
+                    // both Set/Cpp function-space exponentials AND
+                    // lattice-internal value exponentials uniformly).
 
 namespace dedekind::category {
 
@@ -427,5 +431,125 @@ static_assert(IsInvolutiveEndofunctor<std::bit_not<int>, int>,
 
 static_assert(IsInvolutiveEndofunctor<std::bit_not<unsigned>, unsigned>,
               "std::bit_not<unsigned> is involutive on unsigned.");
+
+/** @section lattice__Heyting_Exponential
+ *
+ *  @brief Structural witness type for an @b exponential object in the
+ *         lattice over @c (T, @c Rel) viewed as a thin cartesian closed
+ *         category — the relative complement @c a @c → b held as a
+ *         carrier value, exposed as a callable that computes the eval
+ *         morphism @c eval(e, x) @c = @c e @c ∧ x.
+ *
+ *  @details
+ *  In a Heyting algebra, the exponential object @c b^a is the value
+ *  @c (a @c → b) @c ∈ @c T satisfying the universal adjunction
+ *
+ *    @c a @c ∧ @c x @c ≤ @c b @c iff @c x @c ≤ @c (a @c → b).
+ *
+ *  @c HeytingExponential<T, Rel> wraps the exponential value and
+ *  exposes the eval morphism @em structurally — its @c operator()(x)
+ *  computes the meet @c value @c ∧ x.  The universal property says
+ *  @c value @c ∧ x @c ≤ b when @c value @c = @c (a @c → b).
+ *
+ *  @section lattice__Heyting_Aligns_With_IsExponential
+ *  The wrapper satisfies @c :cartesian::IsExponential<HeytingExponential<T, Rel>,
+ *  T, T> @b structurally — @c eval(e, x) is just the call expression
+ *  @c e(x), and the wrapper's @c operator()(T) returns T.  This is the
+ *  unification @b across CCCs: function-space exponentials (Set / Cpp)
+ *  and value-shaped exponentials (Heyting) satisfy the same structural
+ *  concept body, with no tag declarations or CPO machinery (#698 Slice 6).
+ *
+ *  The wrapper also exposes @c Domain / @c Codomain typedefs, so it
+ *  satisfies @c IsArrow when the future @c IsArrowExponential
+ *  refinement (#706) lands.
+ *
+ *  Concrete formulae for canonical carriers:
+ *
+ *    - Integral carriers under @c std::less_equal (with @c ∧ = min):
+ *      @c eval(e, x) @c = @c min(value, x).  The universal exponential
+ *      value @c (a @c → b) for input pair @c (a, b) is @c top if
+ *      @c a @c ≤ b, else @c b — derivable from the meet's adjunction.
+ *
+ *  Specialisations beyond the integral / @c std::less_equal case are
+ *  tracked under #708.
+ */
+template <typename T, typename Rel>
+struct HeytingExponential;
+
+/** @brief Canonical specialisation: integral carriers under
+ *         @c std::less_equal (including @c bool).  Holds an exponential
+ *         value @c value @c ∈ T; @c operator()(x) returns the meet
+ *         @c min(value, x) which @b is the lattice's eval morphism. */
+template <typename T>
+  requires std::is_integral_v<T>
+struct HeytingExponential<T, std::less_equal<T>> {
+  using Domain = T;    // IsArrow-shaped (for the future :morphism refinement)
+  using Codomain = T;
+
+  T value;             // the exponential element e = a → b
+
+  /** @brief Eval morphism: @c value @c ∧ x (the meet, which @b is eval
+   *         in a thin Heyting algebra).  Universal property:
+   *         @c value @c ∧ x @c ≤ @c b when @c value @c = @c (a @c → b). */
+  constexpr T operator()(T x) const noexcept {
+    return (value <= x) ? value : x;  // = min(value, x)
+  }
+};
+
+/**
+ * @concept IsHeytingLatticeCategory
+ * @brief A bounded lattice category whose lattice exponentials are
+ *        witnessed by @c :cartesian::IsExponential — row 6 of the
+ *        lattice Form-chain (#698 Slice 6).
+ *
+ * @details
+ * Faithful inclusion @c IsHeytingLatticeCategory @c ⊊
+ * @c IsBoundedLatticeCategory encoded definitionally per the project's
+ * @em "faithful specialization in the type signature from day one"
+ * posture (#698).
+ *
+ * @section lattice__Heyting_Form_Chain_Row_6
+ * The Heyting refinement requires the carrier @c T has an exponential
+ * object structure: @c HeytingExponential<T, Rel> wraps the relative
+ * complement value @c a @c → b and satisfies @c :cartesian::IsExponential.
+ * The structural alignment with the CCC concept means lattice
+ * exponentials and function-space exponentials inhabit the same
+ * categorical surface — different concrete representations, one shared
+ * concept (#698 Slice 6's generalisation of @c IsExponential).
+ *
+ * @tparam T    The Domain (Objects).
+ * @tparam Rel  The Relation.
+ * @tparam Join The join operation (default @c std::ranges::max).
+ * @tparam Meet The meet operation (default @c std::ranges::min).
+ * @tparam L    The Logic Species.
+ */
+export template <typename T, typename Rel = std::less_equal<T>,
+                 typename Join = decltype(std::ranges::max),
+                 typename Meet = decltype(std::ranges::min),
+                 typename L = ClassicalLogic>
+concept IsHeytingLatticeCategory =
+    IsBoundedLatticeCategory<T, Rel, Join, Meet, L> &&  // Faithful: heyting ⊊ bounded.
+    IsExponential<HeytingExponential<T, Rel>, T, T>;    // Lattice exponential
+                                                        // satisfies the same
+                                                        // CCC concept Set's
+                                                        // function spaces do.
+
+/** @section lattice__Heyting_Canonical_Witnesses */
+
+static_assert(IsHeytingLatticeCategory<bool>,
+              "bool with std::less_equal is the canonical 2-element "
+              "Heyting (and Boolean) lattice; HeytingExponential's "
+              "operator()(x) computes the meet on bool, satisfying "
+              ":cartesian::IsExponential structurally.");
+
+static_assert(IsHeytingLatticeCategory<int>,
+              "int is a Heyting lattice under the totally-ordered "
+              "implication; HeytingExponential<int, std::less_equal>::"
+              "operator()(x) = min(value, x).");
+
+static_assert(IsExponential<HeytingExponential<bool, std::less_equal<bool>>,
+                            bool, bool>,
+              "HeytingExponential<bool> aligns with :cartesian::IsExponential "
+              "structurally — pure call-shape recognition (#698 Slice 6).");
 
 }  // namespace dedekind::category

--- a/src/main/modules/dedekind/category/lattice.cppm
+++ b/src/main/modules/dedekind/category/lattice.cppm
@@ -473,14 +473,14 @@ static_assert(IsInvolutiveEndofunctor<std::bit_not<unsigned>, unsigned>,
  *  Specialisations beyond the integral / @c std::less_equal case are
  *  tracked under #708.
  */
-template <typename T, typename Rel>
+export template <typename T, typename Rel>
 struct HeytingExponential;
 
 /** @brief Canonical specialisation: integral carriers under
  *         @c std::less_equal (including @c bool).  Holds an exponential
  *         value @c value @c ∈ T; @c operator()(x) returns the meet
  *         @c min(value, x) which @b is the lattice's eval morphism. */
-template <typename T>
+export template <typename T>
   requires std::is_integral_v<T>
 struct HeytingExponential<T, std::less_equal<T>> {
   using Domain = T;  // IsArrow-shaped (for the future :morphism refinement)

--- a/src/test/cpp/modules/dedekind/category/heyting_lattice_test.cpp
+++ b/src/test/cpp/modules/dedekind/category/heyting_lattice_test.cpp
@@ -1,0 +1,108 @@
+/** @file dedekind/category/heyting_lattice_test.cpp
+ *
+ * Unit coverage for @c :category::lattice::IsHeytingLatticeCategory
+ * (row 6 of the lattice Form-chain, #698 Slice 6).
+ *
+ * Slice 6 also generalises @c :cartesian::IsExponential to a pure
+ * structural call-shape recogniser:
+ *
+ *     template <typename E, typename A, typename B>
+ *     concept IsExponential = requires(E e, A a) {
+ *       { e(a) } -> std::same_as<B>;
+ *     };
+ *
+ * The unification: function-space exponentials (Set / Cpp) and
+ * lattice-internal value exponentials (Heyting) satisfy the @b same
+ * concept body — Juliet posture, no tag, no CPO.  Witnesses below
+ * exercise both flavours plus the Form-chain inclusion chain.
+ */
+
+#include <catch2/catch_test_macros.hpp>
+#include <climits>
+#include <concepts>
+#include <functional>
+
+import dedekind.category;
+
+using namespace dedekind::category;
+
+TEST_CASE(
+    "category:heyting — Bool is the canonical 2-element Heyting lattice",
+    "[category][lattice][heyting][bool][canonical]") {
+  /** @brief @c bool under @c std::less_equal is a Heyting lattice (in
+   *         fact Boolean).  @c HeytingExponential<bool, …>::operator()(x)
+   *         computes @c min(value, x), which is the eval morphism of the
+   *         Boolean exponential. */
+  STATIC_CHECK(IsHeytingLatticeCategory<bool>);
+
+  // Concrete eval values: e.g. value = true (= top), operator()(false) = false.
+  constexpr HeytingExponential<bool, std::less_equal<bool>> e_top{true};
+  STATIC_CHECK(e_top(false) == false);
+  STATIC_CHECK(e_top(true) == true);
+  // value = false (= bottom), operator()(x) = false for every x.
+  constexpr HeytingExponential<bool, std::less_equal<bool>> e_bot{false};
+  STATIC_CHECK(e_bot(false) == false);
+  STATIC_CHECK(e_bot(true) == false);
+}
+
+TEST_CASE(
+    "category:heyting — integral carriers are Heyting lattices",
+    "[category][lattice][heyting][numeric]") {
+  /** @brief Integral carriers under @c std::less_equal are Heyting:
+   *         eval is min, which corresponds to the totally-ordered Heyting
+   *         implication a → b = top if a ≤ b else b. */
+  STATIC_CHECK(IsHeytingLatticeCategory<int>);
+  STATIC_CHECK(IsHeytingLatticeCategory<unsigned>);
+  STATIC_CHECK(IsHeytingLatticeCategory<std::size_t>);
+
+  constexpr HeytingExponential<int, std::less_equal<int>> e_int{42};
+  STATIC_CHECK(e_int(10) == 10);    // min(42, 10) = 10
+  STATIC_CHECK(e_int(100) == 42);   // min(42, 100) = 42
+  STATIC_CHECK(e_int(42) == 42);    // min(42, 42) = 42
+}
+
+TEST_CASE(
+    "category:heyting — HeytingExponential aligns structurally with "
+    ":cartesian::IsExponential",
+    "[category][lattice][heyting][cartesian][unification]") {
+  /** @brief #698 Slice 6's structural unification: function-space
+   *         exponentials and lattice value-exponentials satisfy the
+   *         @b same @c IsExponential concept body.  Juliet posture —
+   *         pure call-shape recognition, no tag / CPO / wrapper-for-tag. */
+
+  // Function-space side: std::function and lambdas still fire.
+  STATIC_CHECK(IsExponential<std::function<bool(int)>, int, bool>);
+  STATIC_CHECK(IsExponential<std::function<int(int)>, int, int>);
+
+  // Honest Rejection still fires under std::same_as (preserves the
+  // pre-Slice-6 negative-witness behaviour).
+  STATIC_CHECK_FALSE(IsExponential<std::function<int(int)>, int, bool>);
+
+  // Lattice-value side: HeytingExponential satisfies the same concept.
+  STATIC_CHECK(IsExponential<HeytingExponential<bool, std::less_equal<bool>>,
+                             bool, bool>);
+  STATIC_CHECK(IsExponential<HeytingExponential<int, std::less_equal<int>>,
+                             int, int>);
+}
+
+TEST_CASE(
+    "category:heyting — Form-chain faithful inclusions hold through row 6",
+    "[category][lattice][heyting][faithful][form-chain]") {
+  /** @brief Every Heyting lattice category is a bounded lattice, a
+   *         lattice, filtered, posetal, and thin — all encoded
+   *         definitionally through @c IsHeytingLatticeCategory's
+   *         signature chain. */
+  STATIC_CHECK(IsThinCategory<bool>);
+  STATIC_CHECK(IsPosetal<bool>);
+  STATIC_CHECK(IsFilteredCategory<bool>);
+  STATIC_CHECK(IsLatticeCategory<bool>);
+  STATIC_CHECK(IsBoundedLatticeCategory<bool>);
+  STATIC_CHECK(IsHeytingLatticeCategory<bool>);
+
+  STATIC_CHECK(IsThinCategory<int>);
+  STATIC_CHECK(IsPosetal<int>);
+  STATIC_CHECK(IsFilteredCategory<int>);
+  STATIC_CHECK(IsLatticeCategory<int>);
+  STATIC_CHECK(IsBoundedLatticeCategory<int>);
+  STATIC_CHECK(IsHeytingLatticeCategory<int>);
+}

--- a/src/test/cpp/modules/dedekind/category/heyting_lattice_test.cpp
+++ b/src/test/cpp/modules/dedekind/category/heyting_lattice_test.cpp
@@ -17,8 +17,8 @@
  * exercise both flavours plus the Form-chain inclusion chain.
  */
 
-#include <catch2/catch_test_macros.hpp>
 #include <algorithm>  // std::ranges::min — Meet template arg in HeytingExponential
+#include <catch2/catch_test_macros.hpp>
 #include <climits>
 #include <concepts>
 #include <functional>
@@ -36,11 +36,15 @@ TEST_CASE("category:heyting — Bool is the canonical 2-element Heyting lattice"
   STATIC_CHECK(IsHeytingLatticeCategory<bool>);
 
   // Concrete eval values: e.g. value = true (= top), operator()(false) = false.
-  constexpr HeytingExponential<bool, std::less_equal<bool>, decltype(std::ranges::min)> e_top{true};
+  constexpr HeytingExponential<bool, std::less_equal<bool>,
+                               decltype(std::ranges::min)>
+      e_top{true};
   STATIC_CHECK(e_top(false) == false);
   STATIC_CHECK(e_top(true) == true);
   // value = false (= bottom), operator()(x) = false for every x.
-  constexpr HeytingExponential<bool, std::less_equal<bool>, decltype(std::ranges::min)> e_bot{false};
+  constexpr HeytingExponential<bool, std::less_equal<bool>,
+                               decltype(std::ranges::min)>
+      e_bot{false};
   STATIC_CHECK(e_bot(false) == false);
   STATIC_CHECK(e_bot(true) == false);
 }
@@ -54,7 +58,9 @@ TEST_CASE("category:heyting — integral carriers are Heyting lattices",
   STATIC_CHECK(IsHeytingLatticeCategory<unsigned>);
   STATIC_CHECK(IsHeytingLatticeCategory<std::size_t>);
 
-  constexpr HeytingExponential<int, std::less_equal<int>, decltype(std::ranges::min)> e_int{42};
+  constexpr HeytingExponential<int, std::less_equal<int>,
+                               decltype(std::ranges::min)>
+      e_int{42};
   STATIC_CHECK(e_int(10) == 10);   // min(42, 10) = 10
   STATIC_CHECK(e_int(100) == 42);  // min(42, 100) = 42
   STATIC_CHECK(e_int(42) == 42);   // min(42, 42) = 42
@@ -78,10 +84,12 @@ TEST_CASE(
   STATIC_CHECK_FALSE(IsExponential<std::function<int(int)>, int, bool>);
 
   // Lattice-value side: HeytingExponential satisfies the same concept.
-  STATIC_CHECK(IsExponential<HeytingExponential<bool, std::less_equal<bool>, decltype(std::ranges::min)>,
+  STATIC_CHECK(IsExponential<HeytingExponential<bool, std::less_equal<bool>,
+                                                decltype(std::ranges::min)>,
                              bool, bool>);
-  STATIC_CHECK(
-      IsExponential<HeytingExponential<int, std::less_equal<int>, decltype(std::ranges::min)>, int, int>);
+  STATIC_CHECK(IsExponential<HeytingExponential<int, std::less_equal<int>,
+                                                decltype(std::ranges::min)>,
+                             int, int>);
 }
 
 TEST_CASE(

--- a/src/test/cpp/modules/dedekind/category/heyting_lattice_test.cpp
+++ b/src/test/cpp/modules/dedekind/category/heyting_lattice_test.cpp
@@ -26,9 +26,8 @@ import dedekind.category;
 
 using namespace dedekind::category;
 
-TEST_CASE(
-    "category:heyting — Bool is the canonical 2-element Heyting lattice",
-    "[category][lattice][heyting][bool][canonical]") {
+TEST_CASE("category:heyting — Bool is the canonical 2-element Heyting lattice",
+          "[category][lattice][heyting][bool][canonical]") {
   /** @brief @c bool under @c std::less_equal is a Heyting lattice (in
    *         fact Boolean).  @c HeytingExponential<bool, …>::operator()(x)
    *         computes @c min(value, x), which is the eval morphism of the
@@ -45,9 +44,8 @@ TEST_CASE(
   STATIC_CHECK(e_bot(true) == false);
 }
 
-TEST_CASE(
-    "category:heyting — integral carriers are Heyting lattices",
-    "[category][lattice][heyting][numeric]") {
+TEST_CASE("category:heyting — integral carriers are Heyting lattices",
+          "[category][lattice][heyting][numeric]") {
   /** @brief Integral carriers under @c std::less_equal are Heyting:
    *         eval is min, which corresponds to the totally-ordered Heyting
    *         implication a → b = top if a ≤ b else b. */
@@ -56,9 +54,9 @@ TEST_CASE(
   STATIC_CHECK(IsHeytingLatticeCategory<std::size_t>);
 
   constexpr HeytingExponential<int, std::less_equal<int>> e_int{42};
-  STATIC_CHECK(e_int(10) == 10);    // min(42, 10) = 10
-  STATIC_CHECK(e_int(100) == 42);   // min(42, 100) = 42
-  STATIC_CHECK(e_int(42) == 42);    // min(42, 42) = 42
+  STATIC_CHECK(e_int(10) == 10);   // min(42, 10) = 10
+  STATIC_CHECK(e_int(100) == 42);  // min(42, 100) = 42
+  STATIC_CHECK(e_int(42) == 42);   // min(42, 42) = 42
 }
 
 TEST_CASE(
@@ -81,8 +79,8 @@ TEST_CASE(
   // Lattice-value side: HeytingExponential satisfies the same concept.
   STATIC_CHECK(IsExponential<HeytingExponential<bool, std::less_equal<bool>>,
                              bool, bool>);
-  STATIC_CHECK(IsExponential<HeytingExponential<int, std::less_equal<int>>,
-                             int, int>);
+  STATIC_CHECK(
+      IsExponential<HeytingExponential<int, std::less_equal<int>>, int, int>);
 }
 
 TEST_CASE(

--- a/src/test/cpp/modules/dedekind/category/heyting_lattice_test.cpp
+++ b/src/test/cpp/modules/dedekind/category/heyting_lattice_test.cpp
@@ -18,6 +18,7 @@
  */
 
 #include <catch2/catch_test_macros.hpp>
+#include <algorithm>  // std::ranges::min — Meet template arg in HeytingExponential
 #include <climits>
 #include <concepts>
 #include <functional>
@@ -35,11 +36,11 @@ TEST_CASE("category:heyting — Bool is the canonical 2-element Heyting lattice"
   STATIC_CHECK(IsHeytingLatticeCategory<bool>);
 
   // Concrete eval values: e.g. value = true (= top), operator()(false) = false.
-  constexpr HeytingExponential<bool, std::less_equal<bool>> e_top{true};
+  constexpr HeytingExponential<bool, std::less_equal<bool>, decltype(std::ranges::min)> e_top{true};
   STATIC_CHECK(e_top(false) == false);
   STATIC_CHECK(e_top(true) == true);
   // value = false (= bottom), operator()(x) = false for every x.
-  constexpr HeytingExponential<bool, std::less_equal<bool>> e_bot{false};
+  constexpr HeytingExponential<bool, std::less_equal<bool>, decltype(std::ranges::min)> e_bot{false};
   STATIC_CHECK(e_bot(false) == false);
   STATIC_CHECK(e_bot(true) == false);
 }
@@ -53,7 +54,7 @@ TEST_CASE("category:heyting — integral carriers are Heyting lattices",
   STATIC_CHECK(IsHeytingLatticeCategory<unsigned>);
   STATIC_CHECK(IsHeytingLatticeCategory<std::size_t>);
 
-  constexpr HeytingExponential<int, std::less_equal<int>> e_int{42};
+  constexpr HeytingExponential<int, std::less_equal<int>, decltype(std::ranges::min)> e_int{42};
   STATIC_CHECK(e_int(10) == 10);   // min(42, 10) = 10
   STATIC_CHECK(e_int(100) == 42);  // min(42, 100) = 42
   STATIC_CHECK(e_int(42) == 42);   // min(42, 42) = 42
@@ -77,10 +78,10 @@ TEST_CASE(
   STATIC_CHECK_FALSE(IsExponential<std::function<int(int)>, int, bool>);
 
   // Lattice-value side: HeytingExponential satisfies the same concept.
-  STATIC_CHECK(IsExponential<HeytingExponential<bool, std::less_equal<bool>>,
+  STATIC_CHECK(IsExponential<HeytingExponential<bool, std::less_equal<bool>, decltype(std::ranges::min)>,
                              bool, bool>);
   STATIC_CHECK(
-      IsExponential<HeytingExponential<int, std::less_equal<int>>, int, int>);
+      IsExponential<HeytingExponential<int, std::less_equal<int>, decltype(std::ranges::min)>, int, int>);
 }
 
 TEST_CASE(


### PR DESCRIPTION
Slice 6 of #698. Row 6 of the lattice Form-chain.

This slice does **two** things that compose: it generalises `:cartesian::IsExponential` to a structural call-shape recogniser, *and* uses that generalised concept to gate the new Heyting refinement. Set function-space exponentials and Heyting value-shaped exponentials now satisfy the **same** concept body — pure Juliet posture, no tag, no CPO, no wrapper-for-tag.

## What lands

### `:cartesian` — structural rewrite of `IsExponential`

```cpp
template <typename E, typename A, typename B>
concept IsExponential = requires(E e, A a) {
  { e(a) } -> std::same_as<B>;
};
```

Replaces the pre-Slice-6 `std::move_constructible<F> && std::same_as<std::invoke_result_t<F, A>, B>` body. No `std::invocable`, no `std::invoke_result_t`, no CPO. Pure call-shape recognition.

**`std::same_as<B>` (not `convertible_to`)** preserves the Honest Rejection negative witness: `std::function<int(int)>` still does NOT satisfy `IsExponential<…, int, bool>` (an integer return is not convertible to bool under strict equality, matching the pre-Slice-6 behaviour).

### `:lattice` — `HeytingExponential<T, Rel>` + `IsHeytingLatticeCategory`

```cpp
template <typename T, typename Rel>
struct HeytingExponential;  // primary undefined

template <typename T>
  requires std::is_integral_v<T>
struct HeytingExponential<T, std::less_equal<T>> {
  using Domain = T;          // IsArrow-shape (for future #706 refinement)
  using Codomain = T;
  T value;                   // = a → b (the exponential element)
  constexpr T operator()(T x) const noexcept {
    return (value <= x) ? value : x;   // = min(value, x) = eval(e, x)
  }
};

template <typename T, typename Rel = std::less_equal<T>, ...,
          typename L = ClassicalLogic>
concept IsHeytingLatticeCategory =
    IsBoundedLatticeCategory<T, Rel, Join, Meet, L> &&
    IsExponential<HeytingExponential<T, Rel>, T, T>;
```

The Heyting concept **reuses** `:cartesian`'s `IsExponential` directly — no local-witness duplication, no parallel concept surface, no relaxation. The unification happens at the structural level.

## Architectural payoff

In any CCC, the eval morphism is implemented by *applying the exponential to its argument*. In C++ that IS the call expression `e(a)`. The structural recogniser captures this uniformly:

- **Set / Cpp**: `std::function<B(A)>`, lambdas, `std::move_only_function` — all callable with the right signature.
- **Heyting**: `HeytingExponential<T, Rel>` — callable struct with `operator()(T) → T`.

Both satisfy the same `requires(E e, A a) { { e(a) } -> std::same_as<B>; }` clause. The categorical content "different concrete representations of the same abstract structure" is captured at the concept level.

## What's preserved

All existing `IsExponential` consumers re-fire under the structural body without behavioural change:

- `:cartesian::eval(F, A)` (line 259)
- `:cartesian::IsCartesianClosed<Cat>` (line 309)
- `:etcs::HasAxiom6Exponentiation` (line 135)
- Canonical static_asserts in `:cartesian` (function, lambda, move_only_function, mismatched-signature negative)
- `etcs_axioms_test.cpp` witnesses

No behavioural changes; the load-bearing fact under the old definition (F is callable with the right signature) is exactly what the new structural body checks.

## Follow-ups filed before commit

Three discoveries from the design discussion, filed as separate issues to preserve the audit trail:

- [#706](https://github.com/vincentk/dedekind/issues/706) — `IsArrowExponential` refinement (`IsExponential` + `IsArrow`)
- [#707](https://github.com/vincentk/dedekind/issues/707) — `IsExponentialUniversal` (currying universal property)
- [#708](https://github.com/vincentk/dedekind/issues/708) — `HeytingExponential` specialisations beyond integral / `std::less_equal`

## Form-chain status

```
IsThinCategory             (row 1 — Slice 0 ✓)
    ↓ + antisymmetry
IsPosetal                   (row 2 — Slice 1 ✓)
    ↓ + directedness
IsFilteredCategory          (row 3 — Slice 2 ✓)
    ↓ + cofiltered + universality
IsLatticeCategory           (row 4 — Slice 3 ✓)
    ↓ + bottom + top
IsBoundedLatticeCategory    (row 5 — Slice 4 ✓)
    ↓ + IsInvolutiveEndofunctor (Slice 5 ✓ as sibling concept)
    ↓ + exponentials (structural via :cartesian::IsExponential)
IsHeytingLatticeCategory    (row 6 — THIS SLICE)
    ↓ + complement involution (Slice 7 — IsBooleanLatticeCategory)
```

## Net

+299 / -21 across 3 files. CI authoritative.