### PR TITLE
feat(category): #698 Slice 9 — :etcs harmonisation

### DIFF
--- a/src/main/modules/dedekind/category/concrete.cppm
+++ b/src/main/modules/dedekind/category/concrete.cppm
@@ -269,6 +269,28 @@ constexpr auto join(const S1& lhs, const S2& rhs) {
   return set_union(lhs, rhs);
 }
 
+/** @brief Lattice alias: complement @c = set_complement on @c Sub(A).
+ *
+ *  @details The third Form-chain lattice op (#698 Slice 9), paralleling
+ *  the @c meet / @c join aliases above.  Required by
+ *  @c :lattice::IsSubobjectLattice for the @c complement(a) free-function
+ *  shape.  Result inhabits the same subobject family
+ *  (@c IsSubobjectFamilyMember-shaped) because @c set_complement returns
+ *  a @c Subobject<A, ...> with the same @c Ambient and @c logic_species
+ *  as the input — pointwise lift of @c L::NOT through @c χ.
+ *
+ *  @note Strength of the resulting complement depends on @c L:
+ *  classical → bona-fide Boolean complement; Kleene → involutive
+ *  rotation that fails Boolean complement laws at @c Unknown.  The
+ *  concept body of @c IsSubobjectLattice requires the @b shape;
+ *  the semantic strength is established at the @c L-witness level
+ *  (Slice 7's @c is_complement_v opt-in trait). */
+export template <typename S>
+  requires IsSubobject<S, typename S::Ambient>
+constexpr auto complement(const S& s) {
+  return set_complement(s);
+}
+
 /** @section concrete__Witnesses
  *
  * @details Compiler-validated witnesses pinning that the canonical

--- a/src/main/modules/dedekind/category/etcs.cppm
+++ b/src/main/modules/dedekind/category/etcs.cppm
@@ -285,8 +285,7 @@ concept HasAxiom10PowerObjectLattice =
       /** @brief @c logic_species typedef anchors the classifier @c L
        *  (Slice 9 — required by @c :lattice::IsSubobjectLattice). */
       typename S::logic_species;
-    } &&
-    requires(S lhs, S rhs) {
+    } && requires(S lhs, S rhs) {
       requires IsSetObject<decltype(meet(lhs, rhs)), typename S::Ambient>;
       requires IsSetObject<decltype(join(lhs, rhs)), typename S::Ambient>;
     };
@@ -301,8 +300,10 @@ concept HasAxiom10PowerObjectLattice =
  *  logic).  The codebase commits to one direction of this
  *  bi-implication only:
  *
- *      @c L @c = @c ClassicalLogic @c ⟹ Sub(A) Boolean   (Diaconescu's classical-Ω direction)
- *      @c L @c = @c TernaryLogic   @c ⟹ Sub(A) Heyting   (constructive-collapse path)
+ *      @c L @c = @c ClassicalLogic @c ⟹ Sub(A) Boolean   (Diaconescu's
+ * classical-Ω direction)
+ *      @c L @c = @c TernaryLogic   @c ⟹ Sub(A) Heyting   (constructive-collapse
+ * path)
  *
  *  The Boolean refinement is exposed via the parallel
  *  @c :lattice::IsBooleanSubobjectLattice<S> concept rather than

--- a/src/main/modules/dedekind/category/etcs.cppm
+++ b/src/main/modules/dedekind/category/etcs.cppm
@@ -253,17 +253,63 @@ concept HasAxiom7PullbackReindexingDefinitionalSurface =
 
 /**
  * @brief ETCS axiom 10 witness: power-object lattice completeness.
- * @details meet/join on subobjects follows from the subobject classifier
- * (Axiom 7) inducing a Heyting algebra on Sub(A). The Axiom of Choice proper
- * (every epimorphism splits) is aspirational and not yet encoded here.
+ * @details meet/join/complement on subobjects follows from the subobject
+ * classifier (Axiom 7) inducing a Heyting algebra on Sub(A) (Boolean if
+ * the topos is Boolean, i.e.\ L = ClassicalLogic).  The Axiom of Choice
+ * proper (every epimorphism splits) is aspirational and not yet encoded
+ * here.
+ *
+ * @section etcs__Axiom_10_Slice_9_Generalisation
+ * #698 Slice 9 generalises the body to the full Form-chain row 7
+ * surface: in addition to @c meet / @c join, the carrier must expose
+ * @c complement and a @c SubsetEqRel callable for the lattice @c ≤
+ * (refined as the Form-chain @c Rel slot).  This is the Axiom 10
+ * upgrade restoring textbook ETCS faithfulness: in a Boolean topos,
+ * Sub(A) is a complete Boolean algebra under @c (≤, @c ∧, @c ∨, @c ¬,
+ * @c ⊥, @c ⊤) — the concept now reflects that completely.
+ *
+ * Concrete carriers (@c Set<T, L, P>, @c Subobject<A, Chi>) provide:
+ *   - @c logic_species typedef (the @c L for Sub's classifier);
+ *   - @c SubsetEqRel nested type (the binary @c ≤ callable returning
+ *     @c L::Ω);
+ *   - free functions @c meet, @c join, @c complement returning
+ *     same-family @c IsSubobjectFamilyMember-shaped results.
+ *
+ * Together these satisfy @c :lattice::IsSubobjectLattice, completing the
+ * Form-chain @c IsSet @c ⟹ @c IsSubobjectLattice<Sub(A)> bind.
  */
 export template <typename S>
 concept HasAxiom10PowerObjectLattice =
     IsSetObject<S, typename S::Ambient> && IsCompatibleSetPair<S, S> &&
+    requires {
+      /** @brief @c logic_species typedef anchors the classifier @c L
+       *  (Slice 9 — required by @c :lattice::IsSubobjectLattice). */
+      typename S::logic_species;
+    } &&
     requires(S lhs, S rhs) {
       requires IsSetObject<decltype(meet(lhs, rhs)), typename S::Ambient>;
       requires IsSetObject<decltype(join(lhs, rhs)), typename S::Ambient>;
     };
+
+/** @section etcs__Axiom_10_Complement_Sollbruchstelle
+ *
+ *  @brief The @c complement clause is @b deferred from Axiom 10 pending
+ *         a fix to @c Set::χ's static-member initialisation path
+ *         (#698 Slice 9, follow-up).
+ *
+ *  @details Adding @c requires @c IsSetObject<decltype(complement(lhs)),
+ *  typename @c S::Ambient> here triggers instantiation of
+ *  @c set_complement(s) → @c classify<A>(!s.χ) → @c Set::χ's static
+ *  initialiser, which requires the @c Predicate to be default-
+ *  constructible.  Capturing lambdas produced by the comprehension
+ *  DSL (e.g.\ @c BoundScout's @c operator>'s captured @c rhs in
+ *  expressions.cppm:1262) are @b not default-constructible, so the
+ *  static-init fails.
+ *
+ *  The full @c IsSet @c ⟹ @c IsSubobjectLattice static_assert
+ *  awaits a separate @c Set::χ static-init refactor (likely a guarded
+ *  definition requiring @c std::default_initializable<Predicate>, or a
+ *  re-design of the @c χ self-reference).  Tracked as a follow-up. */
 
 /**
  * @concept HasETCSAxioms

--- a/src/main/modules/dedekind/category/etcs.cppm
+++ b/src/main/modules/dedekind/category/etcs.cppm
@@ -285,8 +285,7 @@ concept HasAxiom10PowerObjectLattice =
       /** @brief @c logic_species typedef anchors the classifier @c L
        *  (Slice 9 — required by @c :lattice::IsSubobjectLattice). */
       typename S::logic_species;
-    } &&
-    requires(S lhs, S rhs) {
+    } && requires(S lhs, S rhs) {
       requires IsSetObject<decltype(meet(lhs, rhs)), typename S::Ambient>;
       requires IsSetObject<decltype(join(lhs, rhs)), typename S::Ambient>;
     };

--- a/src/main/modules/dedekind/category/etcs.cppm
+++ b/src/main/modules/dedekind/category/etcs.cppm
@@ -285,30 +285,42 @@ concept HasAxiom10PowerObjectLattice =
       /** @brief @c logic_species typedef anchors the classifier @c L
        *  (Slice 9 — required by @c :lattice::IsSubobjectLattice). */
       typename S::logic_species;
-    } && requires(S lhs, S rhs) {
+    } &&
+    requires(S lhs, S rhs) {
       requires IsSetObject<decltype(meet(lhs, rhs)), typename S::Ambient>;
       requires IsSetObject<decltype(join(lhs, rhs)), typename S::Ambient>;
     };
 
-/** @section etcs__Axiom_10_Complement_Sollbruchstelle
+/** @section etcs__Axiom_10_Diaconescu_Note
  *
- *  @brief The @c complement clause is @b deferred from Axiom 10 pending
- *         a fix to @c Set::χ's static-member initialisation path
- *         (#698 Slice 9, follow-up).
+ *  @brief Diaconescu's classical direction (#698 Slice 9 review).
  *
- *  @details Adding @c requires @c IsSetObject<decltype(complement(lhs)),
- *  typename @c S::Ambient> here triggers instantiation of
- *  @c set_complement(s) → @c classify<A>(!s.χ) → @c Set::χ's static
- *  initialiser, which requires the @c Predicate to be default-
- *  constructible.  Capturing lambdas produced by the comprehension
- *  DSL (e.g.\ @c BoundScout's @c operator>'s captured @c rhs in
- *  expressions.cppm:1262) are @b not default-constructible, so the
- *  static-init fails.
+ *  @details The standard textbook ETCS Axiom 10 is the @b Axiom of
+ *  Choice: every epimorphism splits.  Diaconescu (1975) showed that
+ *  in a topos, AC implies the topos is Boolean (classical internal
+ *  logic).  The codebase commits to one direction of this
+ *  bi-implication only:
  *
- *  The full @c IsSet @c ⟹ @c IsSubobjectLattice static_assert
- *  awaits a separate @c Set::χ static-init refactor (likely a guarded
- *  definition requiring @c std::default_initializable<Predicate>, or a
- *  re-design of the @c χ self-reference).  Tracked as a follow-up. */
+ *      @c L @c = @c ClassicalLogic @c ⟹ Sub(A) Boolean   (Diaconescu's classical-Ω direction)
+ *      @c L @c = @c TernaryLogic   @c ⟹ Sub(A) Heyting   (constructive-collapse path)
+ *
+ *  The Boolean refinement is exposed via the parallel
+ *  @c :lattice::IsBooleanSubobjectLattice<S> concept rather than
+ *  baked into Axiom 10's body.  An earlier attempt to gate the
+ *  conditional inside @c HasAxiom10PowerObjectLattice triggered
+ *  instantiation of @c set_complement(s) → @c !s.χ → @c Set::χ's
+ *  static-init for capturing-lambda Predicates produced by the
+ *  comprehension DSL, which fails default-construction.  The
+ *  parallel-track design avoids that ODR-use cascade; the static
+ *  asserts in @c :sets carrier files pin the L-parametric route
+ *  type-checked at the carrier sites without inducing the cascade.
+ *
+ *  The reverse direction (Boolean Sub(A) @c ⟹ full AC) is the
+ *  splitting-epi witness, which is genuinely aspirational and not yet
+ *  encoded.  The header table's @c (asp.) marker on row 10 names this
+ *  remaining gap.  Tracked as a separate concept (e.g.\
+ *  @c HasAxiom10AxiomOfChoiceFull) if and when the project commits to
+ *  it. */
 
 /**
  * @concept HasETCSAxioms

--- a/src/main/modules/dedekind/category/etcs.cppm
+++ b/src/main/modules/dedekind/category/etcs.cppm
@@ -260,31 +260,32 @@ concept HasAxiom7PullbackReindexingDefinitionalSurface =
  * here.
  *
  * @section etcs__Axiom_10_Slice_9_Generalisation
- * #698 Slice 9 generalises the body to the full Form-chain row 7
- * surface: in addition to @c meet / @c join, the carrier must expose
- * @c complement and a @c SubsetEqRel callable for the lattice @c ≤
- * (refined as the Form-chain @c Rel slot).  This is the Axiom 10
- * upgrade restoring textbook ETCS faithfulness: in a Boolean topos,
- * Sub(A) is a complete Boolean algebra under @c (≤, @c ∧, @c ∨, @c ¬,
- * @c ⊥, @c ⊤) — the concept now reflects that completely.
+ * #698 Slice 9 adds a single typedef requirement to the body — the
+ * carrier must expose its @c logic_species (verified as an
+ * @c IsLogicalSpecies) — alongside the pre-existing @c meet / @c join
+ * structural shape.  The classical-direction Boolean refinement
+ * (Diaconescu) and the @c complement clause live in the parallel
+ * @c :lattice::IsSubobjectLattice / @c IsBooleanSubobjectLattice
+ * concepts rather than inside Axiom 10's body — see the Diaconescu
+ * note below for why.
  *
  * Concrete carriers (@c Set<T, L, P>, @c Subobject<A, Chi>) provide:
  *   - @c logic_species typedef (the @c L for Sub's classifier);
- *   - @c SubsetEqRel nested type (the binary @c ≤ callable returning
- *     @c L::Ω);
- *   - free functions @c meet, @c join, @c complement returning
- *     same-family @c IsSubobjectFamilyMember-shaped results.
- *
- * Together these satisfy @c :lattice::IsSubobjectLattice, completing the
- * Form-chain @c IsSet @c ⟹ @c IsSubobjectLattice<Sub(A)> bind.
+ *   - free functions @c meet, @c join (and @c complement at the
+ *     parallel @c :lattice concept) returning same-family
+ *     @c IsSubobjectFamilyMember-shaped results.
  */
 export template <typename S>
 concept HasAxiom10PowerObjectLattice =
     IsSetObject<S, typename S::Ambient> && IsCompatibleSetPair<S, S> &&
     requires {
       /** @brief @c logic_species typedef anchors the classifier @c L
-       *  (Slice 9 — required by @c :lattice::IsSubobjectLattice). */
+       *  (Slice 9 — required by @c :lattice::IsSubobjectLattice).
+       *  Verified as an @c IsLogicalSpecies so unrelated types with
+       *  an accidental @c logic_species typedef don't satisfy the
+       *  axiom by accident (#713 review, Copilot). */
       typename S::logic_species;
+      requires IsLogicalSpecies<typename S::logic_species>;
     } && requires(S lhs, S rhs) {
       requires IsSetObject<decltype(meet(lhs, rhs)), typename S::Ambient>;
       requires IsSetObject<decltype(join(lhs, rhs)), typename S::Ambient>;

--- a/src/main/modules/dedekind/category/lattice.cppm
+++ b/src/main/modules/dedekind/category/lattice.cppm
@@ -928,4 +928,41 @@ concept IsSubobjectLattice = requires(S a, S b) {
  *  stratification named in Slice 8's Sollbruchstelle text), not as a
  *  CT-vocabulary primitive of this concept. */
 
+/**
+ * @concept IsBooleanSubobjectLattice
+ * @brief A subobject lattice over a @b classical classifier — the
+ *        Boolean refinement that closes the L-parametric gap (#698
+ *        Slice 9 review pass).
+ *
+ * @details
+ * Mechanises the user's downstream intuition: parametrising a set
+ * carrier with @c ClassicalLogic should automatically participate in
+ * the Boolean lattice surface; parametrising with @c TernaryLogic
+ * should not.  The previous parallel-track architecture left this
+ * documentation-only ("easy to forget" per the review thread); this
+ * concept makes it @b type-checked.
+ *
+ * @section lattice__IsBooleanSubobjectLattice_Justification
+ * In topos-theoretic terms: a topos with classical subobject
+ * classifier (@c Ω @c = @c bool) has Boolean @c Sub(A) for every
+ * ambient @c A.  This is automatic — no semantic opt-in required at
+ * the family level beyond the @c logic_species commitment.
+ * @b Diaconescu's theorem (1975) further says the full Axiom of
+ * Choice would propagate Boolean-ness in the reverse direction, but
+ * the converse direction we use here (classical @c Ω @c ⟹ Boolean
+ * @c Sub(A)) is uncontroversial.
+ *
+ * The concept is therefore just @c IsSubobjectLattice @c +
+ * @c L @c = @c ClassicalLogic — no extra structural laws beyond
+ * what @c IsSubobjectLattice already checks.  Kleene / Heyting
+ * carriers fail closed because their @c logic_species @c ≠ @c
+ * ClassicalLogic.
+ *
+ * @tparam S The subobject carrier.
+ */
+export template <typename S>
+concept IsBooleanSubobjectLattice =
+    IsSubobjectLattice<S> &&
+    std::same_as<typename S::logic_species, ClassicalLogic>;
+
 }  // namespace dedekind::category

--- a/src/main/modules/dedekind/category/lattice.cppm
+++ b/src/main/modules/dedekind/category/lattice.cppm
@@ -882,42 +882,53 @@ concept IsSubobjectFamilyMember = requires {
  *           @c logic_species, and @c SubsetEqRel typedefs.
  */
 export template <typename S>
-concept IsSubobjectLattice =
-    requires {
-      typename S::Ambient;
-      typename S::logic_species;
-      requires IsLogicalSpecies<typename S::logic_species>;
-      typename S::SubsetEqRel;
-    } &&
-    /** @brief Form-chain refinement: @c S is a thin category under its
-     *         carrier-provided @c SubsetEqRel.  Row 1 inclusion is
-     *         type-checked; reflexivity / transitivity of the carrier's
-     *         relation are registered as opt-in traits in Slice 9. */
-    IsThinCategory<S, typename S::SubsetEqRel, typename S::logic_species> &&
-    requires(S a, S b) {
-      /** @brief CT-vocabulary free functions for the binary lattice
-       *  operations (binary product / coproduct in the subobject category).
-       *  Results inhabit the same subobject family — anchored on
-       *  @c (S::Ambient, S::logic_species) per the family concept. */
-      {
-        meet(a, b)
-      } -> IsSubobjectFamilyMember<typename S::Ambient,
-                                   typename S::logic_species>;
-      {
-        join(a, b)
-      } -> IsSubobjectFamilyMember<typename S::Ambient,
-                                   typename S::logic_species>;
-    } && requires(S a) {
-      /** @brief Complement is required unconditionally: classical
-       *         carriers get a bona-fide Boolean complement, Kleene
-       *         carriers get the involutive rotation that fails
-       *         Boolean complement laws at @c Unknown.  The semantic
-       *         strength is established at the @c L-witness level,
-       *         not the concept boundary. */
-      {
-        complement(a)
-      } -> IsSubobjectFamilyMember<typename S::Ambient,
-                                   typename S::logic_species>;
-    };
+concept IsSubobjectLattice = requires(S a, S b) {
+  /** @brief CT-vocabulary metadata: @c S exposes an ambient and a
+   *         classifier logic species. */
+  typename S::Ambient;
+  typename S::logic_species;
+  requires IsLogicalSpecies<typename S::logic_species>;
+
+  /** @brief CT-vocabulary free functions for the binary lattice
+   *         operations (binary product / coproduct in the subobject
+   *         category).  Results inhabit the same subobject family —
+   *         anchored on @c (S::Ambient, S::logic_species) per the
+   *         family concept. */
+  {
+    meet(a, b)
+  } -> IsSubobjectFamilyMember<typename S::Ambient,
+                               typename S::logic_species>;
+  {
+    join(a, b)
+  } -> IsSubobjectFamilyMember<typename S::Ambient,
+                               typename S::logic_species>;
+} && requires(S a) {
+  /** @brief Complement is required unconditionally: classical carriers
+   *         get a bona-fide Boolean complement, Kleene carriers get
+   *         the involutive rotation that fails Boolean complement
+   *         laws at @c Unknown.  The semantic strength is established
+   *         at the @c L-witness level, not the concept boundary. */
+  {
+    complement(a)
+  } -> IsSubobjectFamilyMember<typename S::Ambient,
+                               typename S::logic_species>;
+};
+
+/** @section lattice__IsSubobjectLattice_Order_Derivability
+ *
+ *  @brief The Form-chain @c ≤ relation on a subobject lattice is
+ *         @b derivable from @c meet:
+ *
+ *      @c a @c ≤ @c b @c ⟺ @c meet(a, @c b) @c = @c a
+ *                    @c ⟺ @c join(a, @c b) @c = @c b
+ *
+ *  This is a standard textbook equivalence (Birkhoff, "Lattice Theory",
+ *  §1.4).  Hence @c IsSubobjectLattice's body does @b not require a
+ *  separate @c subset_eq / @c operator<= clause — the row-1 (thin)
+ *  inclusion content is recoverable from the row-3 (filtered) lattice
+ *  ops.  Carriers exposing a direct @c operator<= or free
+ *  @c subset_eq do so as @b set-side sugar (the Pierce-style
+ *  stratification named in Slice 8's Sollbruchstelle text), not as a
+ *  CT-vocabulary primitive of this concept. */
 
 }  // namespace dedekind::category

--- a/src/main/modules/dedekind/category/lattice.cppm
+++ b/src/main/modules/dedekind/category/lattice.cppm
@@ -896,12 +896,10 @@ concept IsSubobjectLattice = requires(S a, S b) {
    *         family concept. */
   {
     meet(a, b)
-  } -> IsSubobjectFamilyMember<typename S::Ambient,
-                               typename S::logic_species>;
+  } -> IsSubobjectFamilyMember<typename S::Ambient, typename S::logic_species>;
   {
     join(a, b)
-  } -> IsSubobjectFamilyMember<typename S::Ambient,
-                               typename S::logic_species>;
+  } -> IsSubobjectFamilyMember<typename S::Ambient, typename S::logic_species>;
 } && requires(S a) {
   /** @brief Complement is required unconditionally: classical carriers
    *         get a bona-fide Boolean complement, Kleene carriers get
@@ -910,8 +908,7 @@ concept IsSubobjectLattice = requires(S a, S b) {
    *         at the @c L-witness level, not the concept boundary. */
   {
     complement(a)
-  } -> IsSubobjectFamilyMember<typename S::Ambient,
-                               typename S::logic_species>;
+  } -> IsSubobjectFamilyMember<typename S::Ambient, typename S::logic_species>;
 };
 
 /** @section lattice__IsSubobjectLattice_Order_Derivability

--- a/src/main/modules/dedekind/category/lattice.cppm
+++ b/src/main/modules/dedekind/category/lattice.cppm
@@ -819,67 +819,39 @@ concept IsSubobjectFamilyMember = requires {
  * inherited @b pointwise from the lattice structure on @c Ω.  Direction
  * is Ω → @c Sub(A); not the reverse without representability.
  *
- * @section lattice__IsSubobjectLattice_Form_Chain_Refinement
- * @c IsSubobjectLattice<S> @b refines @c IsThinCategory<S,
- * S::SubsetEqRel, S::logic_species>: a subobject family @b is a thin
- * category under @c subset_eq (the @c Rel slot), provided the
- * @b carrier exposes its own @c SubsetEqRel callable type as a
- * typedef.  The refinement is structural — the type checker sees the
- * Form-chain row 1 inclusion directly.
- *
- * The @c SubsetEqRel type belongs to the carrier so @c :lattice does
- * @b not invent a new function-object wrapper struct (per #712 review
- * — "Please no lambdas, IsPredicate instead to have domain and
- * codomain").  Concretely the carrier provides a @b binary callable
- * type invoked as @c rel(a, b) @c -> @c L::Ω — what
- * @c :cartesian::IsBinaryRelation names structurally, with
- * @c Codomain @c = @c L::Ω relaxing IsBinaryRelation's bool default
- * to the carrier's classifier.  Following the project's
- * @c :morphism::infer_morphism convention for binary operators, such
- * a callable exposes @c Domain @c = @c S (the first arg type) and
- * @c Codomain @c = @c L::Ω.  Slice 9 supplies the carriers (@c Set,
- * @c Subobject) and their @c SubsetEqRel typedefs.
+ * @section lattice__IsSubobjectLattice_Structural_Shape
+ * @c IsSubobjectLattice<S> checks the carrier's CT-vocabulary metadata
+ * plus the family-typed shape of @c meet / @c join / @c complement.
+ * The Form-chain row 1 (thin) @c ≤ relation is @b derivable from
+ * @c meet (see the derivability section below); the concept therefore
+ * doesn't need a separate @c subset_eq / @c operator<= clause or a
+ * carrier-side @c SubsetEqRel typedef.
  *
  * The strength @c S inherits at higher rows is determined by
  * @c L @c = @c S::logic_species:
  *
- *   - @c L @c = @c ClassicalLogic → @c S inherits @b Boolean structure
- *     (row 7), per Slice 7's @c IsBooleanLatticeCategory.  The
- *     @c complement free function is a bona-fide Boolean complement.
- *   - @c L @c = @c TernaryLogic → @c S inherits @b Heyting structure
- *     only (row 6, the "tricky to decide" escape door).  The
- *     @c complement free function still exists and is involutive
- *     (Kleene rotation), but @b not a Boolean complement —
- *     complement laws fail at @c Unknown.
+ *   - @c L @c = @c ClassicalLogic → @c S participates in
+ *     @c IsBooleanSubobjectLattice (below) — the Boolean refinement
+ *     mirroring Diaconescu's classical-Ω direction.
+ *   - @c L @c = @c TernaryLogic → @c S stays Heyting-only (the
+ *     "tricky to decide" escape door, Slice 8 constructive collapse).
  *
- * Complement is therefore required @b unconditionally, with its
- * semantic strength (Boolean vs Kleene-involution-only)
- * established at the @c L-witness level rather than gated at the
- * concept boundary (per #712 review — the OR-trick gating
- * complement on @c ClassicalLogic was too restrictive).
+ * Complement is required @b unconditionally; its semantic strength
+ * (Boolean vs Kleene-involution-only) is established at the
+ * @c L-witness level via the parallel @c IsBooleanSubobjectLattice
+ * concept, not gated inside this concept's body.
  *
  * @section lattice__IsSubobjectLattice_CT_Vocabulary
  * The concept body uses CT-vocabulary primitives: the carrier exposes
- * @c Ambient and @c logic_species typedefs plus a @c SubsetEqRel
- * callable type, and free functions @c meet, @c join, @c complement
- * exist with the right shape.  Operator sugar (@c <=, @c &, @c |,
- * @c !) lives in @c :sets as forwarders.  Pierce-style stratification:
- * abstract content in the body, set-theoretic hints in the defaults.
+ * @c Ambient and @c logic_species typedefs, and free functions
+ * @c meet, @c join, @c complement exist with the right shape.
+ * Operator sugar (@c <=, @c &, @c |, @c !) lives in @c :sets as
+ * forwarders.  Pierce-style stratification: abstract content in the
+ * body, set-theoretic hints in the defaults.
  *
- * @section lattice__IsSubobjectLattice_Sollbruchstelle
- * This concept is the @b architectural commit of Slice 8.  Carrier
- * witnesses (@c SubsetEqRel typedefs on @c Set / @c Subobject, the
- * @c meet / @c join / @c complement free functions, the @c
- * HasAxiom10PowerObjectLattice generalisation in @c :etcs) land in
- * Slice 9 with the @c :etcs harmonisation.  Ternary's Form-chain
- * participation (rows 1–6) also lands in Slice 9 — once a concrete
- * @c :etcs carrier instantiates @c S::logic_species @c = @c
- * TernaryLogic and supplies a @c SubsetEqRel, the Form-chain rows
- * fire by structural recognition without @c :lattice carrying any
- * Ternary-specific function-object struct types.
- *
- * @tparam S The subobject carrier.  Must expose @c Ambient,
- *           @c logic_species, and @c SubsetEqRel typedefs.
+ * @tparam S The subobject carrier.  Must expose @c Ambient and
+ *           @c logic_species typedefs (the latter satisfying
+ *           @c IsLogicalSpecies).
  */
 export template <typename S>
 concept IsSubobjectLattice = requires(S a, S b) {

--- a/src/main/modules/dedekind/category/topoi.cppm
+++ b/src/main/modules/dedekind/category/topoi.cppm
@@ -318,6 +318,15 @@ concept IsSubobject = requires(S s, typename S::Member m) {
 export template <typename A, typename Chi>
 struct Subobject {
   using Ambient = A;
+
+  /** @brief The logic species @c L is derived from the characteristic
+   *  morphism's codomain @c Cod<Chi> via @c GetLogic.  Concretely:
+   *  @c GetLogic<bool>::type @c = @c ClassicalLogic;
+   *  @c GetLogic<Ternary>::type @c = @c TernaryLogic.  Required by
+   *  @c :lattice::IsSubobjectLattice as a CT-vocabulary metadata
+   *  typedef (#698 Slice 9). */
+  using logic_species = typename GetLogic<Cod<Chi>>::type;
+
   Chi χ;  // The Rule: A ⟶ Ω
 
   /**

--- a/src/test/cpp/modules/dedekind/category/subobject_lattice_etcs_test.cpp
+++ b/src/test/cpp/modules/dedekind/category/subobject_lattice_etcs_test.cpp
@@ -30,24 +30,23 @@ import dedekind.category;
 
 using namespace dedekind::category;
 
-TEST_CASE(
-    "category:subobject-lattice-etcs — Subobject<bool, Chi> participates",
-    "[category][lattice][subobject][etcs][topoi]") {
+TEST_CASE("category:subobject-lattice-etcs — Subobject<bool, Chi> participates",
+          "[category][lattice][subobject][etcs][topoi]") {
   /** @brief A @c Subobject<bool, Chi> produced by @c classify
    *         satisfies @c IsSubobjectLattice — Slice 9 added the
-   *         @c logic_species typedef (via @c GetLogic<Cod<Chi>>) and
-   *         member @c operator<= returning @c L::Ω.  The free
-   *         meet / join / complement are provided in
-   *         @c :etcs::concrete. */
+   *         @c logic_species typedef (via @c GetLogic<Cod<Chi>>); the
+   *         free @c meet / @c join / @c complement are provided in
+   *         @c :etcs::concrete; the @c ≤ relation is derivable from
+   *         @c meet (Birkhoff §1.4) and therefore not required by the
+   *         concept body. */
   auto pred = [](const bool&) { return true; };
   using SubBool = decltype(classify<bool>(pred));
   STATIC_CHECK(IsSubobjectLattice<SubBool>);
 }
 
-TEST_CASE(
-    "category:subobject-lattice-etcs — Subobject exposes logic_species",
-    "[category][lattice][subobject][etcs][topoi][metadata]") {
-  /** @brief Slice 9 additions: @c Subobject<A, Chi>::logic_species is
+TEST_CASE("category:subobject-lattice-etcs — Subobject exposes logic_species",
+          "[category][lattice][subobject][etcs][topoi][metadata]") {
+  /** @brief Slice 9 addition: @c Subobject<A, Chi>::logic_species is
    *         derived from @c Chi's codomain via @c GetLogic.  Predicates
    *         returning @c bool resolve to @c ClassicalLogic. */
   auto pred = [](const bool&) { return true; };

--- a/src/test/cpp/modules/dedekind/category/subobject_lattice_etcs_test.cpp
+++ b/src/test/cpp/modules/dedekind/category/subobject_lattice_etcs_test.cpp
@@ -1,0 +1,57 @@
+/** @file dedekind/category/subobject_lattice_etcs_test.cpp
+ *
+ * #698 Slice 9 — `:etcs` harmonisation on the @c :topoi side.
+ *
+ * Witnesses that the architectural commit of Slice 8 (the
+ * @c IsSubobjectLattice<S> concept) fires structurally on
+ * @c Subobject<A, Chi> after the Slice 9 additions:
+ *
+ *   - @c Subobject<A, Chi> now exposes @c logic_species via
+ *     @c GetLogic<Cod<Chi>>;
+ *   - member @c operator<= returns @c L::Ω (identity-case
+ *     @c L::True; heterogeneous-Chi @c L::Unknown when @c L
+ *     admits it).
+ *
+ * The @c :sets-side carriers (@c Ø, @c UniversalSet, @c SingletonSet,
+ * @c Set<T, L, P>) are witnessed in
+ * @c test/cpp/modules/dedekind/sets/subobject_lattice_carriers_test.cpp
+ * (which can import @c dedekind.sets).
+ *
+ * The post-#712-review refactor uses @b structural recognition via
+ * @c { a @c <= @c b } @c -> @c L::Ω instead of carrier-side
+ * @c SubsetEqRel nested-struct typedefs — no new function-object
+ * structs anywhere ("Structs will lock us in").
+ */
+
+#include <catch2/catch_test_macros.hpp>
+#include <concepts>
+
+import dedekind.category;
+
+using namespace dedekind::category;
+
+TEST_CASE(
+    "category:subobject-lattice-etcs — Subobject<bool, Chi> participates",
+    "[category][lattice][subobject][etcs][topoi]") {
+  /** @brief A @c Subobject<bool, Chi> produced by @c classify
+   *         satisfies @c IsSubobjectLattice — Slice 9 added the
+   *         @c logic_species typedef (via @c GetLogic<Cod<Chi>>) and
+   *         member @c operator<= returning @c L::Ω.  The free
+   *         meet / join / complement are provided in
+   *         @c :etcs::concrete. */
+  auto pred = [](const bool&) { return true; };
+  using SubBool = decltype(classify<bool>(pred));
+  STATIC_CHECK(IsSubobjectLattice<SubBool>);
+}
+
+TEST_CASE(
+    "category:subobject-lattice-etcs — Subobject exposes logic_species",
+    "[category][lattice][subobject][etcs][topoi][metadata]") {
+  /** @brief Slice 9 additions: @c Subobject<A, Chi>::logic_species is
+   *         derived from @c Chi's codomain via @c GetLogic.  Predicates
+   *         returning @c bool resolve to @c ClassicalLogic. */
+  auto pred = [](const bool&) { return true; };
+  using SubBool = decltype(classify<bool>(pred));
+  STATIC_CHECK(std::same_as<SubBool::Ambient, bool>);
+  STATIC_CHECK(std::same_as<SubBool::logic_species, ClassicalLogic>);
+}

--- a/src/test/cpp/modules/dedekind/category/subobject_lattice_etcs_test.cpp
+++ b/src/test/cpp/modules/dedekind/category/subobject_lattice_etcs_test.cpp
@@ -7,20 +7,19 @@
  * @c Subobject<A, Chi> after the Slice 9 additions:
  *
  *   - @c Subobject<A, Chi> now exposes @c logic_species via
- *     @c GetLogic<Cod<Chi>>;
- *   - member @c operator<= returns @c L::Ω (identity-case
- *     @c L::True; heterogeneous-Chi @c L::Unknown when @c L
- *     admits it).
+ *     @c GetLogic<Cod<Chi>> (the single new typedef in Slice 9).
  *
- * The @c :sets-side carriers (@c Ø, @c UniversalSet, @c SingletonSet,
- * @c Set<T, L, P>) are witnessed in
+ * The @c :sets-side carriers (@c Ø, @c UniversalSet, @c SingletonSet)
+ * are witnessed in
  * @c test/cpp/modules/dedekind/sets/subobject_lattice_carriers_test.cpp
  * (which can import @c dedekind.sets).
  *
- * The post-#712-review refactor uses @b structural recognition via
- * @c { a @c <= @c b } @c -> @c L::Ω instead of carrier-side
- * @c SubsetEqRel nested-struct typedefs — no new function-object
- * structs anywhere ("Structs will lock us in").
+ * The concept body uses @b structural recognition on
+ * @c meet / @c join / @c complement shapes; the Form-chain row-1
+ * @c ≤ relation is @b derivable from @c meet (Birkhoff §1.4) and is
+ * not a separate clause.  No carrier-side @c SubsetEqRel typedef and
+ * no new function-object structs introduced ("Structs will lock us
+ * in", #712 review).
  */
 
 #include <catch2/catch_test_macros.hpp>

--- a/src/test/cpp/modules/dedekind/sets/subobject_lattice_carriers_test.cpp
+++ b/src/test/cpp/modules/dedekind/sets/subobject_lattice_carriers_test.cpp
@@ -52,9 +52,8 @@ TEST_CASE(
   STATIC_CHECK(IsSubobjectLattice<SingletonSet<bool>>);
 }
 
-TEST_CASE(
-    "sets:subobject-lattice — IsSet still fires post-Axiom-10 update",
-    "[sets][lattice][subobject][etcs][axiom10][regression]") {
+TEST_CASE("sets:subobject-lattice — IsSet still fires post-Axiom-10 update",
+          "[sets][lattice][subobject][etcs][axiom10][regression]") {
   /** @brief Regression: the Axiom 10 generalisation added a
    *         @c logic_species typedef requirement.  The canonical
    *         carriers all expose it pre-Slice-9, so @c IsSet still

--- a/src/test/cpp/modules/dedekind/sets/subobject_lattice_carriers_test.cpp
+++ b/src/test/cpp/modules/dedekind/sets/subobject_lattice_carriers_test.cpp
@@ -52,6 +52,29 @@ TEST_CASE(
   STATIC_CHECK(IsSubobjectLattice<SingletonSet<bool>>);
 }
 
+TEST_CASE(
+    "sets:subobject-lattice — ClassicalLogic carriers fire IsBooleanSubobjectLattice",
+    "[sets][lattice][subobject][boolean][classical]") {
+  /** @brief Mechanises the user's downstream intuition: parametrising a
+   *         carrier with @c ClassicalLogic automatically participates in
+   *         the Boolean refinement.  Type-checked, not documented. */
+  STATIC_CHECK(IsBooleanSubobjectLattice<Ø<bool>>);
+  STATIC_CHECK(IsBooleanSubobjectLattice<UniversalSet<bool>>);
+  STATIC_CHECK(IsBooleanSubobjectLattice<SingletonSet<bool>>);
+  STATIC_CHECK(IsBooleanSubobjectLattice<Ø<bool, ClassicalLogic>>);
+}
+
+TEST_CASE(
+    "sets:subobject-lattice — TernaryLogic carriers do NOT fire IsBooleanSubobjectLattice",
+    "[sets][lattice][subobject][boolean][kleene][negative]") {
+  /** @brief Honest Rejection: parametrising a carrier with
+   *         @c TernaryLogic falls out of the Boolean refinement.
+   *         Heyting structure still holds via @c IsSubobjectLattice. */
+  STATIC_CHECK_FALSE(IsBooleanSubobjectLattice<Ø<bool, TernaryLogic>>);
+  STATIC_CHECK_FALSE(IsBooleanSubobjectLattice<UniversalSet<bool, TernaryLogic>>);
+  STATIC_CHECK_FALSE(IsBooleanSubobjectLattice<SingletonSet<bool, TernaryLogic>>);
+}
+
 TEST_CASE("sets:subobject-lattice — IsSet still fires post-Axiom-10 update",
           "[sets][lattice][subobject][etcs][axiom10][regression]") {
   /** @brief Regression: the Axiom 10 generalisation added a

--- a/src/test/cpp/modules/dedekind/sets/subobject_lattice_carriers_test.cpp
+++ b/src/test/cpp/modules/dedekind/sets/subobject_lattice_carriers_test.cpp
@@ -52,9 +52,8 @@ TEST_CASE(
   STATIC_CHECK(IsSubobjectLattice<SingletonSet<bool>>);
 }
 
-TEST_CASE(
-    "sets:subobject-lattice — complement free function actually runs",
-    "[sets][lattice][subobject][complement][runtime]") {
+TEST_CASE("sets:subobject-lattice — complement free function actually runs",
+          "[sets][lattice][subobject][complement][runtime]") {
   /** @brief Codecov touch: the @c complement(s) free function in
    *         @c :etcs::concrete forwards to @c set_complement(s).  The
    *         concept-level static asserts in this file check the

--- a/src/test/cpp/modules/dedekind/sets/subobject_lattice_carriers_test.cpp
+++ b/src/test/cpp/modules/dedekind/sets/subobject_lattice_carriers_test.cpp
@@ -53,6 +53,19 @@ TEST_CASE(
 }
 
 TEST_CASE(
+    "sets:subobject-lattice — complement free function actually runs",
+    "[sets][lattice][subobject][complement][runtime]") {
+  /** @brief Codecov touch: the @c complement(s) free function in
+   *         @c :etcs::concrete forwards to @c set_complement(s).  The
+   *         concept-level static asserts in this file check the
+   *         function's @em shape via @c decltype; this runtime call
+   *         exercises the forwarder body so coverage sees it. */
+  constexpr UniversalSet<bool> univ{};
+  const auto univ_complement = complement(univ);
+  STATIC_CHECK(IsSubobject<decltype(univ_complement), bool>);
+}
+
+TEST_CASE(
     "sets:subobject-lattice — ClassicalLogic carriers fire "
     "IsBooleanSubobjectLattice",
     "[sets][lattice][subobject][boolean][classical]") {

--- a/src/test/cpp/modules/dedekind/sets/subobject_lattice_carriers_test.cpp
+++ b/src/test/cpp/modules/dedekind/sets/subobject_lattice_carriers_test.cpp
@@ -8,16 +8,24 @@
  *
  *   - All three already exposed @c Ambient + @c logic_species
  *     pre-Slice-9.
- *   - All three already had @c operator<= returning @c L::Ω
- *     pre-Slice-9.
  *   - The free @c meet / @c join / @c complement (Slice 9 added the
  *     @c complement alias in @c :etcs::concrete) produce
- *     @c IsSubobjectFamilyMember-shaped results.
+ *     @c IsSubobjectFamilyMember-shaped results — the family is
+ *     anchored on (@c S::Ambient, @c S::logic_species).
  *
- * The post-#712-review refactor uses @b structural recognition via
- * @c { a @c <= @c b } @c -> @c L::Ω instead of carrier-side
- * @c SubsetEqRel nested-struct typedefs — no new function-object
- * structs anywhere ("Structs will lock us in").
+ * The concept body uses @b structural recognition: it checks the
+ * carrier's CT-vocabulary metadata (Ambient + logic_species) plus the
+ * shape of @c meet / @c join / @c complement free functions — no
+ * carrier-side @c SubsetEqRel typedef, no @c operator<= clause.  The
+ * Form-chain row-1 @c ≤ relation is @b derivable from @c meet
+ * (Birkhoff §1.4), so the concept doesn't need a separate subset_eq
+ * requirement.  No new function-object structs anywhere ("Structs
+ * will lock us in", #712 review).
+ *
+ * @c IsBooleanSubobjectLattice<S> is the parallel L-parametric
+ * Boolean refinement: ClassicalLogic carriers fire it; TernaryLogic
+ * carriers fall out (Diaconescu's classical direction).  See the
+ * @c [boolean] / @c [kleene] test cases below.
  *
  * The full @c IsSet @c ⟹ @c IsSubobjectLattice static_assert is
  * deferred to a follow-up pending a @c Set::χ static-init refactor

--- a/src/test/cpp/modules/dedekind/sets/subobject_lattice_carriers_test.cpp
+++ b/src/test/cpp/modules/dedekind/sets/subobject_lattice_carriers_test.cpp
@@ -53,7 +53,8 @@ TEST_CASE(
 }
 
 TEST_CASE(
-    "sets:subobject-lattice — ClassicalLogic carriers fire IsBooleanSubobjectLattice",
+    "sets:subobject-lattice — ClassicalLogic carriers fire "
+    "IsBooleanSubobjectLattice",
     "[sets][lattice][subobject][boolean][classical]") {
   /** @brief Mechanises the user's downstream intuition: parametrising a
    *         carrier with @c ClassicalLogic automatically participates in
@@ -65,14 +66,17 @@ TEST_CASE(
 }
 
 TEST_CASE(
-    "sets:subobject-lattice — TernaryLogic carriers do NOT fire IsBooleanSubobjectLattice",
+    "sets:subobject-lattice — TernaryLogic carriers do NOT fire "
+    "IsBooleanSubobjectLattice",
     "[sets][lattice][subobject][boolean][kleene][negative]") {
   /** @brief Honest Rejection: parametrising a carrier with
    *         @c TernaryLogic falls out of the Boolean refinement.
    *         Heyting structure still holds via @c IsSubobjectLattice. */
   STATIC_CHECK_FALSE(IsBooleanSubobjectLattice<Ø<bool, TernaryLogic>>);
-  STATIC_CHECK_FALSE(IsBooleanSubobjectLattice<UniversalSet<bool, TernaryLogic>>);
-  STATIC_CHECK_FALSE(IsBooleanSubobjectLattice<SingletonSet<bool, TernaryLogic>>);
+  STATIC_CHECK_FALSE(
+      IsBooleanSubobjectLattice<UniversalSet<bool, TernaryLogic>>);
+  STATIC_CHECK_FALSE(
+      IsBooleanSubobjectLattice<SingletonSet<bool, TernaryLogic>>);
 }
 
 TEST_CASE("sets:subobject-lattice — IsSet still fires post-Axiom-10 update",

--- a/src/test/cpp/modules/dedekind/sets/subobject_lattice_carriers_test.cpp
+++ b/src/test/cpp/modules/dedekind/sets/subobject_lattice_carriers_test.cpp
@@ -1,0 +1,65 @@
+/** @file dedekind/sets/subobject_lattice_carriers_test.cpp
+ *
+ * #698 Slice 9 — `:etcs` harmonisation on the @c :sets side.
+ *
+ * Witnesses that the @c :sets carriers (@c Ø, @c UniversalSet,
+ * @c SingletonSet) participate in @c :lattice::IsSubobjectLattice
+ * structurally:
+ *
+ *   - All three already exposed @c Ambient + @c logic_species
+ *     pre-Slice-9.
+ *   - All three already had @c operator<= returning @c L::Ω
+ *     pre-Slice-9.
+ *   - The free @c meet / @c join / @c complement (Slice 9 added the
+ *     @c complement alias in @c :etcs::concrete) produce
+ *     @c IsSubobjectFamilyMember-shaped results.
+ *
+ * The post-#712-review refactor uses @b structural recognition via
+ * @c { a @c <= @c b } @c -> @c L::Ω instead of carrier-side
+ * @c SubsetEqRel nested-struct typedefs — no new function-object
+ * structs anywhere ("Structs will lock us in").
+ *
+ * The full @c IsSet @c ⟹ @c IsSubobjectLattice static_assert is
+ * deferred to a follow-up pending a @c Set::χ static-init refactor
+ * (capturing-lambda Predicates fail default-construction at the
+ * out-of-class definition); see the Sollbruchstelle text in
+ * @c :etcs::etcs at the Axiom 10 section.
+ */
+
+#include <catch2/catch_test_macros.hpp>
+#include <concepts>
+
+import dedekind.category;
+import dedekind.sets;
+
+using namespace dedekind::category;
+using namespace dedekind::sets;
+
+TEST_CASE("sets:subobject-lattice — Ø participates in IsSubobjectLattice",
+          "[sets][lattice][subobject][etcs][empty]") {
+  STATIC_CHECK(IsSubobjectLattice<Ø<bool>>);
+}
+
+TEST_CASE(
+    "sets:subobject-lattice — UniversalSet participates in IsSubobjectLattice",
+    "[sets][lattice][subobject][etcs][universal]") {
+  STATIC_CHECK(IsSubobjectLattice<UniversalSet<bool>>);
+}
+
+TEST_CASE(
+    "sets:subobject-lattice — SingletonSet participates in IsSubobjectLattice",
+    "[sets][lattice][subobject][etcs][singleton]") {
+  STATIC_CHECK(IsSubobjectLattice<SingletonSet<bool>>);
+}
+
+TEST_CASE(
+    "sets:subobject-lattice — IsSet still fires post-Axiom-10 update",
+    "[sets][lattice][subobject][etcs][axiom10][regression]") {
+  /** @brief Regression: the Axiom 10 generalisation added a
+   *         @c logic_species typedef requirement.  The canonical
+   *         carriers all expose it pre-Slice-9, so @c IsSet still
+   *         fires.  Defensive witness from the @c :sets side. */
+  STATIC_CHECK(IsSet<Ø<bool>>);
+  STATIC_CHECK(IsSet<UniversalSet<bool>>);
+  STATIC_CHECK(IsSet<SingletonSet<bool>>);
+}


### PR DESCRIPTION
## Summary

Wires the Slice 8 architectural commit (`IsSubobjectLattice<S>` concept) to the canonical `:topoi` and `:sets` carriers. Two minimal carrier-side additions, one concept-side refactor, and the Axiom 10 typedef generalisation.

**Carrier-side:**
- `Subobject<A, Chi>` exposes `logic_species` via `GetLogic<Cod<Chi>>`. Five lines, the only new typedef.
- `complement(s)` thin alias in `:etcs::concrete`, paralleling the existing `meet` / `join` aliases.

**Concept-side refactor** (post-#712 review):

Original IsSubobjectLattice from Slice 8 required:
- `S::SubsetEqRel` typedef
- `IsThinCategory<S, SubsetEqRel, L>` refinement
- `meet`/`join`/`complement` return-shape constraints

Slice 9 drops the first two:
- No `S::SubsetEqRel` typedef requirement
- No `IsThinCategory` refinement
- No separate `≤` clause in the body

The `≤` relation is **derivable from `meet`** (Birkhoff §1.4: `a ≤ b ⟺ a ∧ b = a ⟺ a ∨ b = b`), so the concept body doesn't need a separate clause for the row-1 (thin) inclusion. Carriers exposing `operator<=` / `subset_eq` do so as **set-side sugar** (the Pierce-style stratification named in Slice 8's Sollbruchstelle text), not as a CT-vocabulary primitive of this concept.

This is the response to the review thread "You appear to be introducing structs again, when you could be using IsPredicate :-) Is the reflex that strong? :-)" — every per-carrier `SubsetEqRel` nested struct I had drafted is gone. No new function-object structs introduced anywhere.

The refactor also fixes a real overload-resolution issue: `SingletonSet` deliberately deletes `operator<=>` to defend against the bool-conversion trap, which made the original `{ a <= b }` clause in IsSubobjectLattice resolve to the deleted spaceship before reaching the templated `operator<=`. Dropping the `<=` clause makes the concept fire on `SingletonSet` too.

**Axiom 10:**
- `HasAxiom10PowerObjectLattice<S>` now requires `typename S::logic_species` (anchors the classifier for the Slice 8 constructive-collapse architecture).
- The `complement` clause is **deferred** — triggers `set_complement(s)` → `classify<A>(!s.χ)` → `Set::χ`'s static-init path, which requires the `Predicate` to be default-constructible. Capturing-lambda Predicates from the comprehension DSL (`expressions.cppm:1262`) are not. Tracked as a follow-up in the new Sollbruchstelle text at `etcs.cppm`.

## Test plan

- [x] `make compile` clean (no warnings)
- [x] `test_category "[etcs]"` — 235 assertions in 33 test cases pass (includes Subobject<bool, Chi> participating in IsSubobjectLattice + `logic_species` resolves correctly)
- [x] `test_sets "[lattice]"` — IsSubobjectLattice fires on Ø<bool>, UniversalSet<bool>, SingletonSet<bool>; IsSet still fires post Axiom 10 generalisation
- [ ] CI green
- [ ] Flip to ready-for-review

## NO new structs

Three review-driven principles converging in this slice:

1. "Structs will lock us in one way or another" (#712 review pass 2)
2. "Please no lambdas, IsPredicate instead to have domain and codomain" (#712 review pass 3)
3. "You appear to be introducing structs again, when you could be using IsPredicate :-)" (#712 review pass 4)

Slice 9 carries them through: structural recognition only, free functions for CT-vocabulary primitives, carrier typedefs only when load-bearing.

cc #698

🤖 Generated with [Claude Code](https://claude.com/claude-code)