### PR TITLE
refactor(category): #681 Set::χ structural refactor (WIP — controlled blast)

### DIFF
--- a/src/main/modules/dedekind/category/concrete.cppm
+++ b/src/main/modules/dedekind/category/concrete.cppm
@@ -135,8 +135,8 @@ concept SetAsProduct = IsSetObject<S, Underlying> && requires {
   // operationally equivalent: the Classifier dimension is the L::Ω
   // value at any @c a, and downstream consumers consume the codomain
   // not the predicate-type wrapper.
-  requires std::same_as<
-      std::invoke_result_t<S const&, Underlying const&>, Classifier>;
+  requires std::same_as<std::invoke_result_t<S const&, Underlying const&>,
+                        Classifier>;
 };
 
 /**
@@ -199,9 +199,8 @@ concept IsCompatibleSetPair =
     IsSubobject<S1, typename S1::Ambient> &&
     IsSubobject<S2, typename S2::Ambient> &&
     std::same_as<typename S1::Ambient, typename S2::Ambient> &&
-    std::same_as<
-        std::invoke_result_t<S1 const&, typename S1::Ambient const&>,
-        std::invoke_result_t<S2 const&, typename S2::Ambient const&>>;
+    std::same_as<std::invoke_result_t<S1 const&, typename S1::Ambient const&>,
+                 std::invoke_result_t<S2 const&, typename S2::Ambient const&>>;
 
 /** @brief Set intersection: materialize @c A @c ∩ @c B from
  *         the carriers-as-predicates @c S1, @c S2.  Post-#681
@@ -211,8 +210,7 @@ export template <typename S1, typename S2>
   requires IsCompatibleSetPair<S1, S2>
 constexpr auto set_intersection(const S1& lhs, const S2& rhs) {
   using A = typename S1::Ambient;
-  return classify<A>(
-      [lhs, rhs](const A& a) { return lhs(a) && rhs(a); });
+  return classify<A>([lhs, rhs](const A& a) { return lhs(a) && rhs(a); });
 }
 
 /** @brief Set union: materialize @c A @c ∪ @c B from carriers as
@@ -221,8 +219,7 @@ export template <typename S1, typename S2>
   requires IsCompatibleSetPair<S1, S2>
 constexpr auto set_union(const S1& lhs, const S2& rhs) {
   using A = typename S1::Ambient;
-  return classify<A>(
-      [lhs, rhs](const A& a) { return lhs(a) || rhs(a); });
+  return classify<A>([lhs, rhs](const A& a) { return lhs(a) || rhs(a); });
 }
 
 /** @brief Set complement: materialize @c A^c from carrier-as-predicate. */

--- a/src/main/modules/dedekind/category/concrete.cppm
+++ b/src/main/modules/dedekind/category/concrete.cppm
@@ -218,10 +218,8 @@ export template <typename S1, typename S2>
   requires IsCompatibleSetPair<S1, S2>
 constexpr auto set_intersection(const S1& lhs, const S2& rhs) {
   using A = typename S1::Ambient;
-  using L = typename GetLogic<
-      std::invoke_result_t<S1 const&, A const&>>::type;
-  return classify<A>(
-      [lhs, rhs](const A& a) { return L::AND(lhs(a), rhs(a)); });
+  using L = typename GetLogic<std::invoke_result_t<S1 const&, A const&>>::type;
+  return classify<A>([lhs, rhs](const A& a) { return L::AND(lhs(a), rhs(a)); });
 }
 
 /** @brief Set union: materialize @c A @c ∪ @c B from carriers as
@@ -230,10 +228,8 @@ export template <typename S1, typename S2>
   requires IsCompatibleSetPair<S1, S2>
 constexpr auto set_union(const S1& lhs, const S2& rhs) {
   using A = typename S1::Ambient;
-  using L = typename GetLogic<
-      std::invoke_result_t<S1 const&, A const&>>::type;
-  return classify<A>(
-      [lhs, rhs](const A& a) { return L::OR(lhs(a), rhs(a)); });
+  using L = typename GetLogic<std::invoke_result_t<S1 const&, A const&>>::type;
+  return classify<A>([lhs, rhs](const A& a) { return L::OR(lhs(a), rhs(a)); });
 }
 
 /** @brief Set complement: materialize @c A^c from carrier-as-predicate.
@@ -242,8 +238,7 @@ export template <typename S>
   requires IsSubobject<S, typename S::Ambient>
 constexpr auto set_complement(const S& s) {
   using A = typename S::Ambient;
-  using L = typename GetLogic<
-      std::invoke_result_t<S const&, A const&>>::type;
+  using L = typename GetLogic<std::invoke_result_t<S const&, A const&>>::type;
   return classify<A>([s](const A& a) { return L::NOT(s(a)); });
 }
 

--- a/src/main/modules/dedekind/category/concrete.cppm
+++ b/src/main/modules/dedekind/category/concrete.cppm
@@ -125,11 +125,18 @@ concept IsSetObject = IsSubobject<S, A> && requires {
  *                     @c s.χ.
  */
 export template <typename S, typename Underlying, typename Classifier>
-concept SetAsProduct = IsSetObject<S, Underlying> && requires(const S& s) {
-  // Match the projected type of s.χ exactly (after stripping cv-ref) so
-  // the seam captures the structural identity rather than relying on
-  // implicit conversions.  Per PR #650 review.
-  requires std::same_as<std::remove_cvref_t<decltype(s.χ)>, Classifier>;
+concept SetAsProduct = IsSetObject<S, Underlying> && requires {
+  // Post-#681 structural refactor: the carrier IS the characteristic
+  // morphism, so there is no named @c s.χ projector to match against
+  // @c Classifier.  We capture the (Underlying, Classifier) seam
+  // instead by matching @c Classifier to the codomain of @c S-as-
+  // predicate — i.e.\ @c L::Ω.  Slightly different semantic surface
+  // (Classifier = the codomain, not the predicate-type itself), but
+  // operationally equivalent: the Classifier dimension is the L::Ω
+  // value at any @c a, and downstream consumers consume the codomain
+  // not the predicate-type wrapper.
+  requires std::same_as<
+      std::invoke_result_t<S const&, Underlying const&>, Classifier>;
 };
 
 /**
@@ -180,7 +187,8 @@ concept IsConcrete = IsSmallCategory<C> && IsSpecies<typename C::Species>;
 export template <typename S>
 concept HasTernarySupport =
     IsSubobject<S, typename S::Ambient> &&
-    std::same_as<Cod<decltype(std::declval<S>().χ)>, Ternary>;
+    std::same_as<std::invoke_result_t<S const&, typename S::Ambient const&>,
+                 Ternary>;
 
 /**
  * @concept IsCompatibleSetPair
@@ -191,51 +199,58 @@ concept IsCompatibleSetPair =
     IsSubobject<S1, typename S1::Ambient> &&
     IsSubobject<S2, typename S2::Ambient> &&
     std::same_as<typename S1::Ambient, typename S2::Ambient> &&
-    std::same_as<Cod<decltype(std::declval<S1>().χ)>,
-                 Cod<decltype(std::declval<S2>().χ)>>;
+    std::same_as<
+        std::invoke_result_t<S1 const&, typename S1::Ambient const&>,
+        std::invoke_result_t<S2 const&, typename S2::Ambient const&>>;
 
-/** @brief Set intersection: materialize @c A @c ∩ @c B from @c χ_A @c ∧ @c χ_B.
- */
+/** @brief Set intersection: materialize @c A @c ∩ @c B from
+ *         the carriers-as-predicates @c S1, @c S2.  Post-#681
+ *         structural refactor: invocation @c s(a) replaces named
+ *         @c s.χ access. */
 export template <typename S1, typename S2>
   requires IsCompatibleSetPair<S1, S2>
 constexpr auto set_intersection(const S1& lhs, const S2& rhs) {
   using A = typename S1::Ambient;
-  return classify<A>(lhs.χ && rhs.χ);
+  return classify<A>(
+      [lhs, rhs](const A& a) { return lhs(a) && rhs(a); });
 }
 
-/** @brief Set union: materialize @c A @c ∪ @c B from @c χ_A @c ∨ @c χ_B. */
+/** @brief Set union: materialize @c A @c ∪ @c B from carriers as
+ *         predicates. */
 export template <typename S1, typename S2>
   requires IsCompatibleSetPair<S1, S2>
 constexpr auto set_union(const S1& lhs, const S2& rhs) {
   using A = typename S1::Ambient;
-  return classify<A>(lhs.χ || rhs.χ);
+  return classify<A>(
+      [lhs, rhs](const A& a) { return lhs(a) || rhs(a); });
 }
 
-/** @brief Set complement: materialize @c A^c from @c ¬χ_A. */
+/** @brief Set complement: materialize @c A^c from carrier-as-predicate. */
 export template <typename S>
   requires IsSubobject<S, typename S::Ambient>
 constexpr auto set_complement(const S& s) {
   using A = typename S::Ambient;
-  return classify<A>(!s.χ);
+  return classify<A>([s](const A& a) { return !s(a); });
 }
 
-/** @brief Membership: @c x @c ∈ @c S evaluated via @c χ_S(x). */
+/** @brief Membership: @c x @c ∈ @c S evaluated via @c S's structural
+ *         call (the carrier IS the characteristic morphism). */
 export template <typename S>
   requires IsSubobject<S, typename S::Ambient>
 constexpr auto in(const typename S::Ambient& x, const S& s) {
-  return s.χ(x);
+  return s(x);
 }
 
 /**
  * @brief Membership through an embedding arrow @c e @c : @c X @c → @c A,
- *        then @c χ_S.
- * @details Evaluates @c x @c ∈_e @c S as @c χ_S(e(x)).
+ *        then the carrier-as-predicate.  Evaluates @c x @c ∈_e @c S as
+ *        @c s(e(x)).
  */
 export template <typename S, IsArrow E>
   requires IsSubobject<S, typename S::Ambient> &&
            std::same_as<Cod<E>, typename S::Ambient>
 constexpr auto in_via(const Dom<E>& x, E&& embedding, const S& s) {
-  return s.χ(std::forward<E>(embedding)(x));
+  return s(std::forward<E>(embedding)(x));
 }
 
 /**

--- a/src/main/modules/dedekind/category/concrete.cppm
+++ b/src/main/modules/dedekind/category/concrete.cppm
@@ -93,36 +93,42 @@ concept IsSetObject = IsSubobject<S, A> && requires {
  * @details
  * Names the @em product reading of a set object explicitly --- a set is a
  * pair of (i) its underlying ambient species @p Underlying, accessed
- * type-level via @c S::Ambient, and (ii) its characteristic morphism
- * @p Classifier, accessed value-level via the projector @c s.χ.  Sibling
- * to @c IsSetObject, which names the @em predicate reading "S is a
- * subobject of A".  The two readings carve the same surface from
- * different angles.
+ * type-level via @c S::Ambient, and (ii) its classifier codomain
+ * @p Classifier, recognised structurally via the call shape
+ * @c S(a) @c -> @c Classifier.  Sibling to @c IsSetObject, which names
+ * the @em predicate reading "S is a subobject of A".  The two readings
+ * carve the same surface from different angles.
+ *
+ * @par Post-#681 semantic shift
+ * Prior to the structural refactor, @c Classifier named the @em type of
+ * the characteristic-morphism projector (@c decltype(s.χ)).  The static
+ * @c χ projector has been retired in favour of structural recognition
+ * (@c S @b is the characteristic morphism via @c operator()), so
+ * @c Classifier is now @em the codomain @c L::Ω that @c S(a) produces,
+ * not the predicate-type wrapper.  Concrete examples: for a Set under
+ * @c ClassicalLogic, @c Classifier @c = @c bool; for a Set under
+ * @c TernaryLogic, @c Classifier @c = @c Ternary.
  *
  * @par Why this concept exists (#573 / #644 --- Sollbruchstelle)
  * The user's framing for the HAS-A maturation: "a set should be a product
  * in the @c :cartesian sense of an underlying and predicates."  This
  * concept names that seam.  It refines @c IsSetObject by adding a typed
- * obligation that the classifier projects to @p Classifier --- a
- * structural witness that the (Underlying, Classifier) decomposition is
- * recoverable.  Downstream slices (#573 slice 3 @c AlgebraAsProduct,
+ * obligation that the classifier codomain @b is @p Classifier ---
+ * a structural witness that the (Underlying, Classifier) decomposition
+ * is recoverable.  Downstream slices (#573 slice 3 @c AlgebraAsProduct,
  * slice 4 pilot witness) compose on this name.
  *
  * @par Relation to @c IsProductParthood
  * The bridge concept @c IsProductParthood in @c :limit asserts the
  * structural product-as-parthood reading uniformly via
  * @c IsProjectedProduct.  @c SetAsProduct is the set-level specialisation,
- * but the asymmetry "Underlying is a type, Classifier is a value" makes
- * a direct @c IsProductParthood composition awkward at this slice ---
- * the parts are accessed through different kinds of projectors
- * (type-level @c ::Ambient vs.\ value-level @c .χ).  The concepts are
- * logical siblings, not typed dependencies; future slices may unify the
- * projector vocabulary once a natural meeting point emerges.
+ * but the asymmetry "Underlying is a type, Classifier is a codomain"
+ * keeps a direct @c IsProductParthood composition awkward at this
+ * slice; the concepts are logical siblings, not typed dependencies.
  *
  * @tparam S           The set object.
  * @tparam Underlying  The ambient species (an @c IsSpecies object).
- * @tparam Classifier  The characteristic-morphism type projected from
- *                     @c s.χ.
+ * @tparam Classifier  The codomain of @c S-as-predicate (@c L::Ω).
  */
 export template <typename S, typename Underlying, typename Classifier>
 concept SetAsProduct = IsSetObject<S, Underlying> && requires {
@@ -202,32 +208,43 @@ concept IsCompatibleSetPair =
     std::same_as<std::invoke_result_t<S1 const&, typename S1::Ambient const&>,
                  std::invoke_result_t<S2 const&, typename S2::Ambient const&>>;
 
-/** @brief Set intersection: materialize @c A @c ∩ @c B from
- *         the carriers-as-predicates @c S1, @c S2.  Post-#681
- *         structural refactor: invocation @c s(a) replaces named
- *         @c s.χ access. */
+/** @brief Set intersection: materialize @c A @c ∩ @c B from the
+ *         carriers-as-predicates @c S1, @c S2.  Post-#681 structural
+ *         refactor: invocation @c s(a) replaces named @c s.χ access;
+ *         the meet uses @c L::AND directly so the operation works for
+ *         any @c IsLogicalSpecies @c L (not just @c bool / @c Ternary
+ *         where C++ @c operator&& happens to be defined). */
 export template <typename S1, typename S2>
   requires IsCompatibleSetPair<S1, S2>
 constexpr auto set_intersection(const S1& lhs, const S2& rhs) {
   using A = typename S1::Ambient;
-  return classify<A>([lhs, rhs](const A& a) { return lhs(a) && rhs(a); });
+  using L = typename GetLogic<
+      std::invoke_result_t<S1 const&, A const&>>::type;
+  return classify<A>(
+      [lhs, rhs](const A& a) { return L::AND(lhs(a), rhs(a)); });
 }
 
 /** @brief Set union: materialize @c A @c ∪ @c B from carriers as
- *         predicates. */
+ *         predicates.  Uses @c L::OR directly per #715 review. */
 export template <typename S1, typename S2>
   requires IsCompatibleSetPair<S1, S2>
 constexpr auto set_union(const S1& lhs, const S2& rhs) {
   using A = typename S1::Ambient;
-  return classify<A>([lhs, rhs](const A& a) { return lhs(a) || rhs(a); });
+  using L = typename GetLogic<
+      std::invoke_result_t<S1 const&, A const&>>::type;
+  return classify<A>(
+      [lhs, rhs](const A& a) { return L::OR(lhs(a), rhs(a)); });
 }
 
-/** @brief Set complement: materialize @c A^c from carrier-as-predicate. */
+/** @brief Set complement: materialize @c A^c from carrier-as-predicate.
+ *         Uses @c L::NOT directly per #715 review. */
 export template <typename S>
   requires IsSubobject<S, typename S::Ambient>
 constexpr auto set_complement(const S& s) {
   using A = typename S::Ambient;
-  return classify<A>([s](const A& a) { return !s(a); });
+  using L = typename GetLogic<
+      std::invoke_result_t<S const&, A const&>>::type;
+  return classify<A>([s](const A& a) { return L::NOT(s(a)); });
 }
 
 /** @brief Membership: @c x @c ∈ @c S evaluated via @c S's structural

--- a/src/main/modules/dedekind/category/etcs.cppm
+++ b/src/main/modules/dedekind/category/etcs.cppm
@@ -119,11 +119,13 @@ concept HasAxiom2Identity =
 export template <typename A>
 concept HasAxiom3TerminalObject = IsTerminalObject<One>;
 
-/** @brief ETCS axiom 4 witness: membership is evaluation through χ. */
+/** @brief ETCS axiom 4 witness: membership is evaluation through the
+ *  carrier-as-characteristic-morphism.  Post-#681 structural refactor:
+ *  @c IsSubobject already requires the structural call shape
+ *  @c { s(a) } @c -> @c LogicalValue, so the membership-as-evaluation
+ *  reading lands on the @c IsSubobject witness itself. */
 export template <typename S>
-concept HasAxiom4WellPointedness =
-    IsSubobject<S, typename S::Ambient> &&
-    IsPredicate<std::remove_cvref_t<decltype(std::declval<S>().χ)>>;
+concept HasAxiom4WellPointedness = IsSubobject<S, typename S::Ambient>;
 
 /** @brief ETCS axiom 5 witness: products exist for ambient species A. */
 export template <typename A>
@@ -230,13 +232,14 @@ concept HasAxiom10ChoiceSplitEpicLawSurface =
 export template <typename S, IsArrow E>
   requires IsSubobject<S, typename S::Ambient> &&
            std::same_as<Cod<E>, typename S::Ambient> &&
-           std::equality_comparable<Cod<decltype(std::declval<S>().χ)>>
+           std::equality_comparable<std::invoke_result_t<
+               S const&, typename S::Ambient const&>>
 constexpr bool classifier_reindexing_definitional_witness_at(const S& s,
                                                              const E& embedding,
                                                              const Dom<E>& x) {
   const auto embedded = embedding(x);
-  const auto via_classifier = s.χ(embedded);
-  return via_classifier == s.χ(embedded);
+  const auto via_classifier = s(embedded);
+  return via_classifier == s(embedded);
 }
 
 /**
@@ -249,7 +252,8 @@ export template <typename S, typename E>
 concept HasAxiom7PullbackReindexingDefinitionalSurface =
     HasAxiom7SubobjectClassifier<S> && IsArrow<E> &&
     std::same_as<Cod<E>, typename S::Ambient> &&
-    std::equality_comparable<Cod<decltype(std::declval<S>().χ)>>;
+    std::equality_comparable<
+        std::invoke_result_t<S const&, typename S::Ambient const&>>;
 
 /**
  * @brief ETCS axiom 10 witness: power-object lattice completeness.

--- a/src/main/modules/dedekind/category/etcs.cppm
+++ b/src/main/modules/dedekind/category/etcs.cppm
@@ -232,8 +232,8 @@ concept HasAxiom10ChoiceSplitEpicLawSurface =
 export template <typename S, IsArrow E>
   requires IsSubobject<S, typename S::Ambient> &&
            std::same_as<Cod<E>, typename S::Ambient> &&
-           std::equality_comparable<std::invoke_result_t<
-               S const&, typename S::Ambient const&>>
+           std::equality_comparable<
+               std::invoke_result_t<S const&, typename S::Ambient const&>>
 constexpr bool classifier_reindexing_definitional_witness_at(const S& s,
                                                              const E& embedding,
                                                              const Dom<E>& x) {

--- a/src/main/modules/dedekind/category/topoi.cppm
+++ b/src/main/modules/dedekind/category/topoi.cppm
@@ -280,11 +280,26 @@ static_assert(
  * @concept IsSubobject
  * @brief The categorical witness of a monomorphism ι: S ↣ A.
  *
+ * @details
+ * @section topoi__IsSubobject_Structural_Refactor
+ * Structural recognition (#681 / Slice 9 follow-up): @c S @b is the
+ * characteristic morphism — invoked via @c s(a), not accessed via a
+ * named @c s.χ member.  The earlier @c { s.χ } @c -> @c IsPredicate
+ * clause forced every @c IsSubobject-checked type to materialise @c χ
+ * as a struct member; for @c Set carriers this was a static
+ * @c default-initialised Set instance, which @b fails for capturing-
+ * lambda Predicates (the comprehension DSL).
+ *
+ * Project's architectural commitment ("undecidable functionality can't
+ * be struct-built"): structural call recognition replaces named-member
+ * lookup.  Same lesson as the Slice 6 @c IsExponential refactor
+ * (carrier IS the exponential via call shape).
+ *
  * @tparam S The Subobject Species (The "Body").
  * @tparam A The Ambient Species (The "Space").
  */
 export template <typename S, typename A>
-concept IsSubobject = requires(S s, typename S::Member m) {
+concept IsSubobject = requires(S s, typename S::Member m, A const& a) {
   /**
    * @brief ι: S ↣ A
    * The canonical inclusion morphism. Every member of S must
@@ -293,18 +308,16 @@ concept IsSubobject = requires(S s, typename S::Member m) {
   { s.ι(m) } -> std::same_as<A>;
 
   /**
-   * @brief χ: A ⟶ Ω
-   * Every subobject in a Topos is uniquely classified by a
-   * morphism into the subobject classifier Ω.
+   * @brief χ: A ⟶ Ω — recognised structurally as S's call shape.
+   *        @c s(a) returns a logical value (the carrier's classifier's
+   *        Ω).  S itself IS the characteristic morphism; no named
+   *        @c χ member required at the concept body.
    */
-  { s.χ } -> IsPredicate;
+  { s(a) } -> LogicalValue;
 
   // Metadata verification: The declared ambient must match A.
   typename S::Ambient;
   requires std::same_as<typename S::Ambient, A>;
-
-  // Characteristic morphism verification: χ must classify elements of A.
-  requires std::same_as<Dom<decltype(s.χ)>, A>;
 };
 
 /**
@@ -339,6 +352,14 @@ struct Subobject {
 
   /** @brief ι: S ↣ A (The Textbook Inclusion) */
   constexpr A ι(const Member& m) const { return m.value; }
+
+  /** @brief Subobject IS the characteristic morphism — invocation
+   *         @c s(a) forwards to the stored @c χ field.  Structural
+   *         predicate shape (per the @c IsSubobject refactor in
+   *         this file): callers use @c s(a) rather than @c s.χ(a),
+   *         so @c Set and @c Subobject expose a uniform predicate
+   *         surface. */
+  constexpr auto operator()(const A& a) const { return χ(a); }
 
   /**
    * @section topoi__Pullback_Projections

--- a/src/main/modules/dedekind/category/topoi.cppm
+++ b/src/main/modules/dedekind/category/topoi.cppm
@@ -358,8 +358,13 @@ struct Subobject {
    *         predicate shape (per the @c IsSubobject refactor in
    *         this file): callers use @c s(a) rather than @c s.χ(a),
    *         so @c Set and @c Subobject expose a uniform predicate
-   *         surface. */
-  constexpr auto operator()(const A& a) const { return χ(a); }
+   *         surface.
+   *
+   *  @note Return type is @c decltype(auto) so cv/ref qualifiers from
+   *  @c χ(a) are preserved (#715 review): if a future @c Chi returns
+   *  a reference or non-trivially-copyable Ω, the forwarder doesn't
+   *  silently copy. */
+  constexpr decltype(auto) operator()(const A& a) const { return χ(a); }
 
   /**
    * @section topoi__Pullback_Projections

--- a/src/main/modules/dedekind/numbers/rational.cppm
+++ b/src/main/modules/dedekind/numbers/rational.cppm
@@ -525,19 +525,20 @@ static_assert(
     "ℚ's underlying carrier IS Rational<default_integer> — the textbook "
     "universe-over-carrier reading.");
 
-// #573 slice 4 pilot witness: ℚ walks SetAsProduct.  The universe value
-// is a UniversalSet over Rational<default_integer> --- its Ambient is the
-// underlying species, its χ is the always-True classifier.  Names the
-// (Underlying, Classifier) product reading of the ambient rational set
-// concretely on the canonical pilot carrier.
+// #573 slice 4 pilot witness: ℚ walks SetAsProduct.  Post-#681 structural
+// refactor: @c SetAsProduct's Classifier dimension is now the codomain
+// of the carrier-as-predicate (the @c L::Ω value at any @c a), not the
+// predicate-type wrapper itself.  For ℚ under @c ClassicalLogic the
+// codomain is @c bool.  Same CT content (the universe value is a
+// UniversalSet over Rational<default_integer> classified by Ω), now
+// expressed structurally rather than via a named @c .χ projector.
 static_assert(
     dedekind::category::SetAsProduct<std::remove_cvref_t<decltype(ℚ)>,
-                                     Rational<default_integer>,
-                                     std::remove_cvref_t<decltype(ℚ.χ)>>,
+                                     Rational<default_integer>, bool>,
     "#573 slice 4: ℚ must witness SetAsProduct over "
-    "(Rational<default_integer>, "
-    "χ-type).  The universe value is a UniversalSet whose Ambient matches the "
-    "rational carrier and whose χ is recoverable as a typed member.");
+    "(Rational<default_integer>, ClassicalLogic::Ω = bool).  The universe "
+    "value is a UniversalSet whose Ambient matches the rational carrier "
+    "and whose classifier codomain is bool.");
 
 // `Q` constant + `RationalSet` alias removed under ℚ-retarget
 // chiselling --- callers spell @c element<ℚ> directly off the universe

--- a/src/main/modules/dedekind/sets/expressions.cppm
+++ b/src/main/modules/dedekind/sets/expressions.cppm
@@ -590,10 +590,13 @@ class Set {
   constexpr T ι(const Member& m) const { return m.value; }
 
   /** @brief χ: T → Ω — arrow-form classifier for the IsSubobject
-   *  contract.  Static self-reference (SHAPE-only — semantic
-   *  membership query lives in @c operator() below, predicate-aware).
-   *  Same pattern as Ø / UniversalSet / SingletonSet's χ. */
-  static const Set χ;
+   *  contract — historically a static self-reference (now retired).
+   *  Post-#681 structural refactor: @c Set @b is the characteristic
+   *  morphism via @c operator() below; the @c IsSubobject concept
+   *  recognises this structurally with @c { s(a) } @c -> @c LogicalValue
+   *  rather than via a named @c .χ member.  No static-init cascade for
+   *  non-default-constructible Predicates (e.g.\ capturing-lambda
+   *  predicates produced by the comprehension DSL). */
 
   using logic_species = L;
   using cardinality_type = ℵ_0;
@@ -859,12 +862,13 @@ class Set {
   Predicate predicate_;
 };
 
-// Out-of-class χ definition — completes the IsSubobject self-reference
-// declared in-class at @c Set::χ above.  Default-initializes
-// @c predicate_ via @c Predicate{}; the SHAPE is what the contract
-// reads (semantics live in @c operator() which IS predicate-aware).
-template <typename T, typename L, typename Predicate>
-inline const Set<T, L, Predicate> Set<T, L, Predicate>::χ{Predicate{}};
+// Out-of-class χ definition retired (#681 structural refactor).  The
+// @c IsSubobject concept now recognises @c Set as the characteristic
+// morphism via its @c operator() call shape, not via a named static
+// @c χ member.  Removing the static eliminates the @c Predicate{}
+// default-construction cascade that previously blocked comprehension-
+// DSL Sets from participating in the @c IsSubobject / Form-chain
+// surfaces.
 
 /** @brief Symbolic image-of-intensional-Set predicate (#602 layer 1).
  *

--- a/src/main/modules/dedekind/sets/expressions.cppm
+++ b/src/main/modules/dedekind/sets/expressions.cppm
@@ -886,10 +886,12 @@ class Set {
  *  is well-formed and type-checked, with the result honestly tagged
  *  @c TernaryLogic.
  *
- *  Default-constructible by design: the @c Set<U, TernaryLogic, ...>
- *  @c χ static initializer requires the predicate type to
- *  default-construct.  Captureless / no source-set + arrow storage in
- *  the closure for the same reason.
+ *  Captureless / no source-set + arrow storage in the closure: keeps
+ *  the predicate value-light and structurally compatible with the
+ *  comprehension-DSL paths.  (Historically also default-constructible
+ *  to satisfy the now-retired @c Set::χ static-initialiser; that
+ *  static is gone post-#681, but captureless predicates are still
+ *  preferable for symbolic-image purposes.)
  *
  *  @tparam U The codomain element type — read off from @c Cod<F> at
  *  the @c image call site.  Parameterising by @c U keeps the predicate

--- a/src/test/cpp/modules/dedekind/sets/set_as_product_test.cpp
+++ b/src/test/cpp/modules/dedekind/sets/set_as_product_test.cpp
@@ -23,21 +23,25 @@ TEST_CASE("Concrete: SetAsProduct seam — Set := (Underlying, Classifier)",
           "[category][concrete][sets][product][parthood]") {
   // classify<T>(predicate) (from :category:topoi) materialises a
   // Subobject<A, χ> whose Ambient is T and whose χ is the rule-arrow
-  // built from the predicate.  This is the natural test target for the
-  // (Underlying, Classifier) reading.
+  // built from the predicate.  Post-#681 structural refactor:
+  // @c SetAsProduct's Classifier dimension is the codomain of the
+  // carrier-as-predicate (L::Ω), not the predicate-type wrapper.  For
+  // a bool-returning lambda under ClassicalLogic the Classifier is bool.
   const auto s_even = classify<int>([](const int& x) { return x % 2 == 0; });
 
-  using ChiType = std::remove_cvref_t<decltype(s_even.χ)>;
+  // Classifier = codomain of S(a) — i.e.\ @c ClassicalLogic::Ω = bool.
+  using ClassifierΩ = bool;
 
   SECTION("set object witnesses both readings (predicate and product)") {
     // Predicate reading (sibling): S is a subobject of int.
     STATIC_CHECK(IsSetObject<decltype(s_even), int>);
-    // Product reading (this slice): S decomposes as (int, χ-type).
-    STATIC_CHECK(SetAsProduct<decltype(s_even), int, ChiType>);
+    // Product reading (this slice): S decomposes as (int, classifier-Ω).
+    STATIC_CHECK(SetAsProduct<decltype(s_even), int, ClassifierΩ>);
   }
 
   SECTION("Underlying must match S::Ambient") {
-    // A wrong Underlying must not satisfy the concept.
-    STATIC_CHECK_FALSE(SetAsProduct<decltype(s_even), bool, ChiType>);
+    // A wrong Underlying must not satisfy the concept (fails on the
+    // IsSetObject prerequisite, not on the Classifier match).
+    STATIC_CHECK_FALSE(SetAsProduct<decltype(s_even), bool, ClassifierΩ>);
   }
 }


### PR DESCRIPTION
## Summary

Removes `Set::χ` static + out-of-class definition. Refactors `IsSubobject` to recognise the carrier structurally as the characteristic morphism via its call shape (`{ s(a) } -> LogicalValue`), not via a named `.χ` member. Same lesson as the Slice 6 `IsExponential` refactor: structural typing replaces named-member-lookup.

## Why

The project's commitment from the Slice 8/9 review pass: **"It's not possible to build struct-type code for undecidable functionality. All we can hope to achieve is a type-check ruling out pathological behaviour."**

`Set::χ` as a static `const Set` instance was struct-type code for undecidable functionality: it forced `Predicate{}` default-construction, which fails the moment Predicate isn't default-constructible — exactly what happens for capturing-lambda predicates produced by the comprehension DSL (`Set{x | x > threshold}`-style). The static-init cascade then bled into anything that touched `s.χ` via `decltype` substitution.

The fix: the carrier IS the predicate (via `operator()`), no named χ at the concept boundary.

## Changes

### `:topoi`
- `IsSubobject<S, A>`: structural body via `{ s(a) } -> LogicalValue`. Dropped `{ s.χ } -> IsPredicate` and `Dom<decltype(s.χ)>` clause.
- `Subobject<A, Chi>`: added `operator()(a) → χ(a)` forwarder so Subobject participates in the structural shape uniformly with Set.

### `:concrete`
- `SetAsProduct`: Classifier match via `invoke_result`, not `decltype(s.χ)`. Semantic shift: Classifier is now the *codomain* (L::Ω), not the predicate-type wrapper.
- `HasTernarySupport`, `IsCompatibleSetPair`: structural via `invoke_result`.
- `set_intersection`, `set_union`, `set_complement`: lambda-composition over carriers-as-predicates instead of `lhs.χ && rhs.χ` etc.
- `in`, `in_via`: `s(x)` / `s(e(x))` instead of `s.χ(...)`.

### `:etcs`
- `HasAxiom4WellPointedness`: reduces to `IsSubobject<S, ...>` (the structural call clause is already in IsSubobject's body).
- `HasAxiom7PullbackReindexingDefinitionalSurface` + `classifier_reindexing_definitional_witness_at`: use `invoke_result` and `s(x)`.

### `:sets/expressions`
- `Set::χ` static declaration retired.
- Out-of-class `inline const Set<T, L, Predicate> Set<T, L, Predicate>::χ{Predicate{}};` retired.

## Reference

#681 (Set DSL tests). The unlock enables idiomatic comprehension expressions to participate in `IsSubobject` / `IsSubobjectLattice` / `IsBooleanSubobjectLattice` surfaces — captured-rhs predicates no longer get blocked by the static-init cascade. Also unlocks the Diaconescu conditional clause in `HasAxiom10PowerObjectLattice` named in the Slice 9 Sollbruchstelle.

## Status

**WIP draft.** Pushing pro-actively to CI so the cascade surfaces — almost certainly other sites (in `:sets`, downstream consumers) still reference `s.χ` and will need to migrate. Local has not been rebuilt since the architectural commit; CI is now the working surface.

## Test plan

- [ ] CI surfaces remaining `s.χ` call sites
- [ ] Each surfaced site refactored to structural call shape
- [ ] All existing tests still pass
- [ ] New positive witness: comprehension Set fires `IsSubobjectLattice` / `IsBooleanSubobjectLattice` end-to-end
- [ ] Local build clean
- [ ] Flip to ready-for-review

🤖 Generated with [Claude Code](https://claude.com/claude-code)