### PR TITLE
feat(category): #706 IsArrowExponential — refinement + Axiom 6 migration

### DIFF
--- a/src/main/modules/dedekind/category/cartesian.cppm
+++ b/src/main/modules/dedekind/category/cartesian.cppm
@@ -129,6 +129,44 @@ concept IsExponential = requires(E e, A a) {
 };
 
 /**
+ * @concept IsArrowExponential
+ * @brief An exponential @c E @c : @c A @c → @c B that also satisfies
+ *        the project's morphism vocabulary (@c IsArrow with matching
+ *        @c Domain / @c Codomain typedefs).  #706.
+ *
+ * @details
+ * Refines @c IsExponential to additionally require @c IsArrow's
+ * structural commitments — @c E::Domain typedef equal to @c A,
+ * @c E::Codomain typedef equal to @c B.  Function-space inhabitants
+ * (@c std::function<B(A)>, raw lambdas) satisfy @c IsExponential but
+ * @b not @c IsArrowExponential because they don't expose the
+ * @c Domain / @c Codomain typedefs.  Project-shipped arrow-shaped
+ * exponentials — outputs of @c arrow<A, B>(…), @c HeytingExponential,
+ * @c :morphism::Morphism, etc. — satisfy both.
+ *
+ * @section cartesian__IsArrowExponential_Consumer
+ * Migrated from an ad hoc @c IsExponential<…> @c && @c IsArrow<…>
+ * combination at @c :etcs::HasAxiom6Exponentiation, which named the
+ * same content inline.  Refactoring that consumer to the named
+ * refinement removes a chicken-and-egg seam (the supply for the
+ * refinement was inlined at the one demand site) — see #706 for the
+ * triage rationale.
+ *
+ * Consumers that want the project's morphism discipline gate on
+ * @c IsArrowExponential; consumers that accept any callable
+ * (function-spaces, raw lambdas, structural-only) use the bare
+ * @c IsExponential.  Split mirrors the @c :morphism @c IsArrow
+ * vs.\ generic-callable distinction.
+ *
+ * @tparam E The exponential object (must be @c IsArrow-shaped).
+ * @tparam A The domain.
+ * @tparam B The codomain.
+ */
+export template <typename E, typename A, typename B>
+concept IsArrowExponential = IsExponential<E, A, B> && IsArrow<E> &&
+                             std::same_as<Dom<E>, A> && std::same_as<Cod<E>, B>;
+
+/**
  * @brief Internal Hom Factory (Exponential)
  * @details 1. Fully Automatic: Inferred from lambda signature
  */

--- a/src/main/modules/dedekind/category/etcs.cppm
+++ b/src/main/modules/dedekind/category/etcs.cppm
@@ -131,10 +131,12 @@ concept HasAxiom4WellPointedness = IsSubobject<S, typename S::Ambient>;
 export template <typename A>
 concept HasAxiom5CartesianProduct = IsProduct<std::pair<A, A>, A, A>;
 
-/** @brief ETCS axiom 6 witness: exponentials B^A exist (here A^A witness). */
+/** @brief ETCS axiom 6 witness: exponentials B^A exist (here A^A
+ *  witness).  Uses the named @c IsArrowExponential refinement (#706)
+ *  rather than the ad hoc @c IsExponential @c && @c IsArrow combination
+ *  that lived here previously. */
 export template <typename A>
-concept HasAxiom6Exponentiation =
-    IsExponential<Exponential<A, A>, A, A> && IsArrow<Exponential<A, A>>;
+concept HasAxiom6Exponentiation = IsArrowExponential<Exponential<A, A>, A, A>;
 
 /** @brief ETCS axiom 7 witness: every set is represented by a subobject. */
 export template <typename S>

--- a/src/test/cpp/modules/dedekind/category/cartesian_test.cpp
+++ b/src/test/cpp/modules/dedekind/category/cartesian_test.cpp
@@ -224,3 +224,24 @@ TEST_CASE(
     STATIC_CHECK(!IsBinaryFunction<R, int, int>);
   }
 }
+
+TEST_CASE(
+    "Cartesian: IsArrowExponential — IsExponential + IsArrow refinement (#706)",
+    "[category][cartesian][exponential][isarrow]") {
+  /** @brief @c IsArrowExponential refines @c IsExponential to additionally
+   *         require the project's @c IsArrow morphism discipline (explicit
+   *         @c Domain / @c Codomain typedefs).  Function-space inhabitants
+   *         satisfy @c IsExponential but @b not @c IsArrowExponential —
+   *         the discipline is honest about the distinction. */
+
+  // Negative witness: std::function<B(A)> is IsExponential but not IsArrow.
+  STATIC_CHECK(IsExponential<std::function<bool(int)>, int, bool>);
+  STATIC_CHECK_FALSE(IsArrowExponential<std::function<bool(int)>, int, bool>);
+
+  // Positive witness: an arrow-shaped exponential from the arrow<A, B> factory
+  // satisfies both — the project's canonical arrow shape.
+  using ProjectArrow = Exponential<int, bool>;
+  STATIC_CHECK(IsExponential<ProjectArrow, int, bool>);
+  STATIC_CHECK(IsArrow<ProjectArrow>);
+  STATIC_CHECK(IsArrowExponential<ProjectArrow, int, bool>);
+}


### PR DESCRIPTION
## Summary

Closes #706.

Defines `IsArrowExponential<E, A, B>` as the refinement `IsExponential<E, A, B> && IsArrow<E> && Dom<E> == A && Cod<E> == B`. Migrates `HasAxiom6Exponentiation` from an inlined `IsExponential && IsArrow` combination to the named refinement.

## Why now (chicken-and-egg triage)

Per the post-#715 triage discussion: `HasAxiom6Exponentiation` was already manually doing the combination at [etcs.cppm:137](src/main/modules/dedekind/category/etcs.cppm#L137). The inlined supply pattern is exactly what flagged #706 as core-feature-with-existing-consumer (vs #707 which had no inlined consumer and was closed as cosmetics-out-of-scope).

## What

- **New concept** `IsArrowExponential<E, A, B>` in `:cartesian` — adds `IsArrow<E>` + `Dom<E> == A` + `Cod<E> == B` to the structural `IsExponential` body.
- **Migration** of `HasAxiom6Exponentiation` to use the named refinement.
- **Test** in `cartesian_test.cpp`: positive on `Exponential<int, bool>` (arrow factory output, satisfies both); negative on `std::function<bool(int)>` (function-space — `IsExponential` ✓, `IsArrowExponential` ✗).

## Test plan

- [x] Local edits clean
- [ ] CI green
- [ ] Flip to ready-for-review

🤖 Generated with [Claude Code](https://claude.com/claude-code)