### PR TITLE
feat(order): #710 bitwise Boolean lattice on integral carriers

### DIFF
--- a/src/main/modules/dedekind/category/species.cppm
+++ b/src/main/modules/dedekind/category/species.cppm
@@ -1029,7 +1029,7 @@ inline constexpr bool is_distributive_v<T, decltype(std::ranges::min),
  * the direct trait check without creating a circular dependency on
  * @c :mereology.
  */
-template <typename T, typename Op1, typename Op2>
+export template <typename T, typename Op1, typename Op2>
 inline constexpr bool is_absorptive_v = false;
 
 /** @section species__Lattice_Absorber_Registration */

--- a/src/main/modules/dedekind/order/lattice.cppm
+++ b/src/main/modules/dedekind/order/lattice.cppm
@@ -33,8 +33,8 @@
  */
 module;
 #include <algorithm>
-#include <concepts>     // std::convertible_to (HasLatticeOperators)
-#include <cstddef>      // std::size_t — bitwise lattice witness (#710)
+#include <concepts>  // std::convertible_to (HasLatticeOperators)
+#include <cstddef>   // std::size_t — bitwise lattice witness (#710)
 #include <functional>
 #include <type_traits>  // std::is_integral_v — bitwise lattice (#710)
 
@@ -218,9 +218,7 @@ static_assert(IsOrderLattice<bool>,
 export template <typename T>
   requires std::is_integral_v<T>
 struct bit_subset_eq {
-  constexpr bool operator()(T a, T b) const noexcept {
-    return (a & b) == a;
-  }
+  constexpr bool operator()(T a, T b) const noexcept { return (a & b) == a; }
 };
 
 }  // namespace dedekind::order
@@ -240,8 +238,8 @@ struct is_transitive<T, dedekind::order::bit_subset_eq<T>> : std::true_type {};
 
 template <typename T>
   requires std::is_integral_v<T>
-struct is_antisymmetric<T, dedekind::order::bit_subset_eq<T>>
-    : std::true_type {};
+struct is_antisymmetric<T, dedekind::order::bit_subset_eq<T>> : std::true_type {
+};
 
 template <typename T>
   requires std::is_integral_v<T>
@@ -292,12 +290,11 @@ static_assert(
     "(which honestly fails row 7 — see :category::lattice's static_assert "
     "documenting the Honest Rejection).");
 
-static_assert(
-    dedekind::category::IsBooleanLatticeCategory<
-        unsigned, bit_subset_eq<unsigned>, std::bit_or<unsigned>,
-        std::bit_and<unsigned>, std::bit_not<unsigned>>,
-    "unsigned under (bit_subset_eq, |, &, ~) is the bitwise Boolean "
-    "lattice on its bit-width.");
+static_assert(dedekind::category::IsBooleanLatticeCategory<
+                  unsigned, bit_subset_eq<unsigned>, std::bit_or<unsigned>,
+                  std::bit_and<unsigned>, std::bit_not<unsigned>>,
+              "unsigned under (bit_subset_eq, |, &, ~) is the bitwise Boolean "
+              "lattice on its bit-width.");
 
 static_assert(dedekind::category::LatticeBottom<
                   std::size_t, bit_subset_eq<std::size_t>>::value ==

--- a/src/main/modules/dedekind/order/lattice.cppm
+++ b/src/main/modules/dedekind/order/lattice.cppm
@@ -33,8 +33,10 @@
  */
 module;
 #include <algorithm>
-#include <concepts>  // std::convertible_to (HasLatticeOperators)
+#include <concepts>     // std::convertible_to (HasLatticeOperators)
+#include <cstddef>      // std::size_t — bitwise lattice witness (#710)
 #include <functional>
+#include <type_traits>  // std::is_integral_v — bitwise lattice (#710)
 
 export module dedekind.order:lattice;
 
@@ -169,6 +171,142 @@ static_assert(IsOrderLattice<bool>,
               "bool is the canonical Boolean-ring lattice "
               "(under bit_xor / bit_and; both halves of the bundle "
               "fire today).");
+
+/** @section order_lattice__Bitwise_Boolean_Lattice
+ *
+ *  @brief Integral carriers under the @b bitwise Boolean algebra (#710).
+ *
+ *  @details
+ *  An integral carrier @c T (@c int, @c unsigned, @c std::size_t, …)
+ *  has TWO distinct lattice readings on the same underlying set:
+ *
+ *    - The @b Boolean-ring reading (@c IsOrderLattice<bool> above
+ *      already pins this for @c bool): @c (XOR, AND) — additive group
+ *      under XOR, multiplicative monoid under AND.  Algebraic / field-
+ *      flavoured.
+ *    - The @b Boolean-lattice reading (this section, #710): the
+ *      power-set lattice of the bit positions.  @c a @c ⊆_bit @c b
+ *      @c ⟺ @c (a @c & @c b) @c == @c a; meet = @c &; join = @c |;
+ *      complement = @c ~; bottom = @c 0; top = @c ~T(0).  Order-theoretic
+ *      / Form-chain-row-7 flavoured.
+ *
+ *  The two readings are equivalent on Boolean algebras (XOR is the
+ *  symmetric difference @c (a @c | @c b) @c & @c ~(a @c & @c b)), but
+ *  they expose different concept surfaces — @c IsOrderLattice
+ *  (Boolean-ring) above vs.\ @c :category::IsBooleanLatticeCategory
+ *  (Form-chain row 7) here.  Naming both makes the equivalence
+ *  navigable rather than implicit.
+ *
+ *  @section order_lattice__Bitwise_GF_Cross_Reference
+ *  @c :algebra::galois.cppm carries the Galois field machinery
+ *  (@c bool @c = @c 𝔽_2 under @c (XOR, AND); @c 𝔽64 @c = @c GF(2^6)
+ *  with polynomial multiplication mod @c x^6+x+1; @c IsGaloisField
+ *  concept; @c GaloisFieldRegistration CRTP).  For wider integral
+ *  @c T (@c size_t etc.), the field claim requires a specific primitive
+ *  polynomial — the project does not witness @c GF(2^N) for arbitrary
+ *  @c N as field-on-the-primitive type without a struct wrapper.
+ *
+ *  Cross-reading: the bitwise Boolean @b lattice on @c size_t here is
+ *  the lattice of subsets of @c {0, …, 63}; the (would-be) Galois
+ *  @b field @c GF(2^64) on the same carrier is a different algebraic
+ *  structure on the same underlying set.  Don't conflate them.
+ */
+
+/** @brief Bit-subset relation: @c a @c ⊆_bit @c b @c ⟺ @c (a @c &
+ *         @c b) @c == @c a.  Form-chain @c Rel slot for the bitwise
+ *         Boolean lattice on integral carriers (#710). */
+export template <typename T>
+  requires std::is_integral_v<T>
+struct bit_subset_eq {
+  constexpr bool operator()(T a, T b) const noexcept {
+    return (a & b) == a;
+  }
+};
+
+}  // namespace dedekind::order
+
+// Trait specialisations sit in the @c dedekind::category namespace
+// where their primary templates live; re-opening here keeps the
+// bitwise-lattice witnesses self-contained at this site.
+namespace dedekind::category {
+
+template <typename T>
+  requires std::is_integral_v<T>
+struct is_reflexive<T, dedekind::order::bit_subset_eq<T>> : std::true_type {};
+
+template <typename T>
+  requires std::is_integral_v<T>
+struct is_transitive<T, dedekind::order::bit_subset_eq<T>> : std::true_type {};
+
+template <typename T>
+  requires std::is_integral_v<T>
+struct is_antisymmetric<T, dedekind::order::bit_subset_eq<T>>
+    : std::true_type {};
+
+template <typename T>
+  requires std::is_integral_v<T>
+struct is_directed<T, dedekind::order::bit_subset_eq<T>> : std::true_type {};
+
+template <typename T>
+  requires std::is_integral_v<T>
+struct is_codirected<T, dedekind::order::bit_subset_eq<T>> : std::true_type {};
+
+/** @brief Bitwise-lattice bottom: the all-zeros bitmask. */
+template <typename T>
+  requires std::is_integral_v<T>
+struct LatticeBottom<T, dedekind::order::bit_subset_eq<T>> {
+  using is_initial_object_tag = void;
+  static constexpr T value = T{0};
+};
+
+/** @brief Bitwise-lattice top: the all-ones bitmask. */
+template <typename T>
+  requires std::is_integral_v<T>
+struct LatticeTop<T, dedekind::order::bit_subset_eq<T>> {
+  using is_terminal_object_tag = void;
+  static constexpr T value = static_cast<T>(~T{0});
+};
+
+/** @brief Canonical specialisation: @c std::bit_not<T> is the
+ *         complement for the bitwise Boolean lattice on integral @c T.
+ *         Complement laws hold structurally: @c a @c & @c ~a @c = @c 0
+ *         (bottom) and @c a @c | @c ~a @c = @c ~T(0) (top). */
+template <typename T>
+  requires std::is_integral_v<T>
+struct is_complement<std::bit_not<T>, T, dedekind::order::bit_subset_eq<T>,
+                     std::bit_or<T>, std::bit_and<T>> : std::true_type {};
+
+}  // namespace dedekind::category
+
+namespace dedekind::order {
+
+/** @section order_lattice__Bitwise_Canonical_Witnesses */
+
+static_assert(
+    dedekind::category::IsBooleanLatticeCategory<
+        std::size_t, bit_subset_eq<std::size_t>, std::bit_or<std::size_t>,
+        std::bit_and<std::size_t>, std::bit_not<std::size_t>>,
+    "size_t under (bit_subset_eq, |, &, ~) is the bitwise Boolean "
+    "lattice — the power-set lattice of {0, …, 63}.  Distinct from "
+    "the totally-ordered Heyting chain on size_t under std::less_equal "
+    "(which honestly fails row 7 — see :category::lattice's static_assert "
+    "documenting the Honest Rejection).");
+
+static_assert(
+    dedekind::category::IsBooleanLatticeCategory<
+        unsigned, bit_subset_eq<unsigned>, std::bit_or<unsigned>,
+        std::bit_and<unsigned>, std::bit_not<unsigned>>,
+    "unsigned under (bit_subset_eq, |, &, ~) is the bitwise Boolean "
+    "lattice on its bit-width.");
+
+static_assert(dedekind::category::LatticeBottom<
+                  std::size_t, bit_subset_eq<std::size_t>>::value ==
+                  std::size_t{0},
+              "Bitwise lattice bottom on size_t is the all-zeros bitmask.");
+static_assert(dedekind::category::LatticeTop<
+                  std::size_t, bit_subset_eq<std::size_t>>::value ==
+                  ~std::size_t{0},
+              "Bitwise lattice top on size_t is the all-ones bitmask.");
 
 // Set<T, L, P> structurally cannot satisfy @c HasLatticeOperators (#469
 // design note).  After the @c operator^ symmetric-difference slice

--- a/src/main/modules/dedekind/order/lattice.cppm
+++ b/src/main/modules/dedekind/order/lattice.cppm
@@ -256,25 +256,26 @@ struct is_codirected<T, dedekind::order::bit_subset_eq<T>> : std::true_type {};
  *
  *  @details The project's existing specialisations cover @c bool +
  *  the transparent @c std::bit_or<> / @c std::bit_and<> forms, plus
- *  @c std::bit_and<T> for specific @c T.  The missing pieces for the
- *  bitwise Boolean lattice's @c IsLatticeCategory chain to fire on
- *  generic integral @c T:
+ *  @c std::bit_and<T> + idempotent on @c std::bit_or<T> for specific
+ *  @c T.  The pieces this slice still needs for the bitwise Boolean
+ *  lattice's @c IsLatticeCategory chain to fire on generic integral
+ *  @c T:
  *
- *    - @c is_associative_v<T, std::bit_or<T>>
- *    - @c is_idempotent_v<T, std::bit_or<T>>
- *    - @c is_absorptive_v<T, std::bit_or<T>, std::bit_and<T>>
- *    - @c is_absorptive_v<T, std::bit_and<T>, std::bit_or<T>>
- *    - @c is_distributive_v<T, std::bit_or<T>, std::bit_and<T>>
+ *    - @c is_associative<T, std::bit_or<T>>     (struct spec)
+ *    - @c is_absorptive_v<T, std::bit_or<T>, std::bit_and<T>>     (variable spec)
+ *    - @c is_absorptive_v<T, std::bit_and<T>, std::bit_or<T>>     (variable spec)
+ *    - @c is_distributive_v<T, std::bit_or<T>, std::bit_and<T>>   (variable spec)
+ *    - @c is_distributive_v<T, std::bit_and<T>, std::bit_or<T>>   (variable spec)
  *
- *  All are textbook bitwise-operator facts (OR is associative,
- *  idempotent, absorbs over AND, distributes over AND, etc.). */
+ *  Note: @c is_associative_v / @c is_idempotent_v are derived from
+ *  struct traits, so specialisations go on the @b struct (matching
+ *  the pattern used at species.cppm for @c is_idempotent<T,
+ *  std::bit_or<T>>).  @c is_absorptive_v and @c is_distributive_v
+ *  are @b direct variable templates with primary @c = false, so
+ *  specialisations go on the variable. */
 template <typename T>
   requires std::is_integral_v<T>
-inline constexpr bool is_associative_v<T, std::bit_or<T>> = true;
-
-template <typename T>
-  requires std::is_integral_v<T>
-inline constexpr bool is_idempotent_v<T, std::bit_or<T>> = true;
+struct is_associative<T, std::bit_or<T>> : std::true_type {};
 
 template <typename T>
   requires std::is_integral_v<T>

--- a/src/main/modules/dedekind/order/lattice.cppm
+++ b/src/main/modules/dedekind/order/lattice.cppm
@@ -249,6 +249,70 @@ template <typename T>
   requires std::is_integral_v<T>
 struct is_codirected<T, dedekind::order::bit_subset_eq<T>> : std::true_type {};
 
+/** @section order_lattice__Bitwise_Algebra_Trait_Registration
+ *
+ *  @brief Algebra-trait specialisations for @c std::bit_or<T> /
+ *         @c std::bit_and<T> on specific integral @c T (#710).
+ *
+ *  @details The project's existing specialisations cover @c bool +
+ *  the transparent @c std::bit_or<> / @c std::bit_and<> forms, plus
+ *  @c std::bit_and<T> for specific @c T.  The missing pieces for the
+ *  bitwise Boolean lattice's @c IsLatticeCategory chain to fire on
+ *  generic integral @c T:
+ *
+ *    - @c is_associative_v<T, std::bit_or<T>>
+ *    - @c is_idempotent_v<T, std::bit_or<T>>
+ *    - @c is_absorptive_v<T, std::bit_or<T>, std::bit_and<T>>
+ *    - @c is_absorptive_v<T, std::bit_and<T>, std::bit_or<T>>
+ *    - @c is_distributive_v<T, std::bit_or<T>, std::bit_and<T>>
+ *
+ *  All are textbook bitwise-operator facts (OR is associative,
+ *  idempotent, absorbs over AND, distributes over AND, etc.). */
+template <typename T>
+  requires std::is_integral_v<T>
+inline constexpr bool is_associative_v<T, std::bit_or<T>> = true;
+
+template <typename T>
+  requires std::is_integral_v<T>
+inline constexpr bool is_idempotent_v<T, std::bit_or<T>> = true;
+
+template <typename T>
+  requires std::is_integral_v<T>
+inline constexpr bool is_absorptive_v<T, std::bit_or<T>, std::bit_and<T>> =
+    true;
+
+template <typename T>
+  requires std::is_integral_v<T>
+inline constexpr bool is_absorptive_v<T, std::bit_and<T>, std::bit_or<T>> =
+    true;
+
+template <typename T>
+  requires std::is_integral_v<T>
+inline constexpr bool is_distributive_v<T, std::bit_or<T>, std::bit_and<T>> =
+    true;
+
+template <typename T>
+  requires std::is_integral_v<T>
+inline constexpr bool is_distributive_v<T, std::bit_and<T>, std::bit_or<T>> =
+    true;
+
+/** @brief @c HeytingExponential specialisation for the bitwise Boolean
+ *         lattice (#710): on integral @c T under @c bit_subset_eq with
+ *         @c std::bit_and as meet, the relative complement
+ *         @c a @c → @c b @c = @c ~a @c | @c b (Boolean Heyting), and
+ *         the @c eval morphism @c e(x) @c = @c e @c & @c x (meet).
+ *         Required so @c IsHeytingLatticeCategory fires at row 6 of
+ *         the Form-chain for this Rel / Meet pairing. */
+template <typename T>
+  requires std::is_integral_v<T>
+struct HeytingExponential<T, dedekind::order::bit_subset_eq<T>,
+                          std::bit_and<T>> {
+  using Domain = T;
+  using Codomain = T;
+  T value;
+  constexpr T operator()(T x) const noexcept { return value & x; }
+};
+
 /** @brief Bitwise-lattice bottom: the all-zeros bitmask. */
 template <typename T>
   requires std::is_integral_v<T>

--- a/src/main/modules/dedekind/order/lattice.cppm
+++ b/src/main/modules/dedekind/order/lattice.cppm
@@ -207,10 +207,10 @@ static_assert(IsOrderLattice<bool>,
  *  @c N as field-on-the-primitive type without a struct wrapper.
  *
  *  Cross-reading: the bitwise Boolean @b lattice on integral @c T
- *  here is the lattice of subsets of @c {0, …, @c std::numeric_limits<T>::digits-1};
- *  the (would-be) Galois @b field on @c GF(2^N) (with @c N the carrier
- *  bit-width) on the same carrier is a different algebraic structure
- *  on the same underlying set.  Don't conflate them.
+ *  here is the lattice of subsets of @c {0, …, @c
+ * std::numeric_limits<T>::digits-1}; the (would-be) Galois @b field on @c
+ * GF(2^N) (with @c N the carrier bit-width) on the same carrier is a different
+ * algebraic structure on the same underlying set.  Don't conflate them.
  */
 
 /** @brief Bit-subset relation: @c a @c ⊆_bit @c b @c ⟺ @c (a @c &

--- a/src/main/modules/dedekind/order/lattice.cppm
+++ b/src/main/modules/dedekind/order/lattice.cppm
@@ -262,10 +262,14 @@ struct is_codirected<T, dedekind::order::bit_subset_eq<T>> : std::true_type {};
  *  @c T:
  *
  *    - @c is_associative<T, std::bit_or<T>>     (struct spec)
- *    - @c is_absorptive_v<T, std::bit_or<T>, std::bit_and<T>>     (variable spec)
- *    - @c is_absorptive_v<T, std::bit_and<T>, std::bit_or<T>>     (variable spec)
- *    - @c is_distributive_v<T, std::bit_or<T>, std::bit_and<T>>   (variable spec)
- *    - @c is_distributive_v<T, std::bit_and<T>, std::bit_or<T>>   (variable spec)
+ *    - @c is_absorptive_v<T, std::bit_or<T>, std::bit_and<T>>     (variable
+ * spec)
+ *    - @c is_absorptive_v<T, std::bit_and<T>, std::bit_or<T>>     (variable
+ * spec)
+ *    - @c is_distributive_v<T, std::bit_or<T>, std::bit_and<T>>   (variable
+ * spec)
+ *    - @c is_distributive_v<T, std::bit_and<T>, std::bit_or<T>>   (variable
+ * spec)
  *
  *  Note: @c is_associative_v / @c is_idempotent_v are derived from
  *  struct traits, so specialisations go on the @b struct (matching

--- a/src/main/modules/dedekind/order/lattice.cppm
+++ b/src/main/modules/dedekind/order/lattice.cppm
@@ -206,10 +206,11 @@ static_assert(IsOrderLattice<bool>,
  *  polynomial — the project does not witness @c GF(2^N) for arbitrary
  *  @c N as field-on-the-primitive type without a struct wrapper.
  *
- *  Cross-reading: the bitwise Boolean @b lattice on @c size_t here is
- *  the lattice of subsets of @c {0, …, 63}; the (would-be) Galois
- *  @b field @c GF(2^64) on the same carrier is a different algebraic
- *  structure on the same underlying set.  Don't conflate them.
+ *  Cross-reading: the bitwise Boolean @b lattice on integral @c T
+ *  here is the lattice of subsets of @c {0, …, @c std::numeric_limits<T>::digits-1};
+ *  the (would-be) Galois @b field on @c GF(2^N) (with @c N the carrier
+ *  bit-width) on the same carrier is a different algebraic structure
+ *  on the same underlying set.  Don't conflate them.
  */
 
 /** @brief Bit-subset relation: @c a @c ⊆_bit @c b @c ⟺ @c (a @c &
@@ -256,12 +257,11 @@ struct is_codirected<T, dedekind::order::bit_subset_eq<T>> : std::true_type {};
  *
  *  @details The project's existing specialisations cover @c bool +
  *  the transparent @c std::bit_or<> / @c std::bit_and<> forms, plus
- *  @c std::bit_and<T> + idempotent on @c std::bit_or<T> for specific
- *  @c T.  The pieces this slice still needs for the bitwise Boolean
- *  lattice's @c IsLatticeCategory chain to fire on generic integral
- *  @c T:
+ *  @c is_idempotent and @c is_associative for @c std::bit_or<T> on
+ *  integral @c T at @c species.cppm:866-872.  The pieces this slice
+ *  still needs for the bitwise Boolean lattice's @c IsLatticeCategory
+ *  chain to fire on generic integral @c T:
  *
- *    - @c is_associative<T, std::bit_or<T>>     (struct spec)
  *    - @c is_absorptive_v<T, std::bit_or<T>, std::bit_and<T>>     (variable
  * spec)
  *    - @c is_absorptive_v<T, std::bit_and<T>, std::bit_or<T>>     (variable
@@ -271,21 +271,12 @@ struct is_codirected<T, dedekind::order::bit_subset_eq<T>> : std::true_type {};
  *    - @c is_distributive_v<T, std::bit_and<T>, std::bit_or<T>>   (variable
  * spec)
  *
- *  Note: @c is_associative_v / @c is_idempotent_v are derived from
- *  struct traits, so specialisations go on the @b struct (matching
- *  the pattern used at species.cppm for @c is_idempotent<T,
- *  std::bit_or<T>>).  @c is_absorptive_v and @c is_distributive_v
- *  are @b direct variable templates with primary @c = false, so
- *  specialisations go on the variable. */
-template <typename T>
-  requires std::is_integral_v<T>
-struct is_associative<T, std::bit_or<T>> : std::true_type {};
-
-// Variable-template partial specs in this file embed the constraint in
-// the *value* (cf. species.cppm:740 / :745 pattern with std::unsigned_integral
-// / std::integral), not via a requires clause on the template — the
-// requires-form yields "no variable template matches partial
-// specialization" on libc++/clang.
+ *  Variable-template partial specs in this file embed the constraint
+ *  in the @b value (cf. @c species.cppm:740 / :745 pattern with
+ *  @c std::unsigned_integral / @c std::integral), not via a
+ *  @c requires clause on the template — the requires-form yields
+ *  "no variable template matches partial specialization" on
+ *  libc++/clang. */
 template <typename T>
 inline constexpr bool is_absorptive_v<T, std::bit_or<T>, std::bit_and<T>> =
     std::is_integral_v<T>;
@@ -303,14 +294,23 @@ inline constexpr bool is_distributive_v<T, std::bit_and<T>, std::bit_or<T>> =
     std::is_integral_v<T>;
 
 /** @brief @c HeytingExponential specialisation for the bitwise Boolean
- *         lattice (#710): on integral @c T under @c bit_subset_eq with
- *         @c std::bit_and as meet, the relative complement
- *         @c a @c → @c b @c = @c ~a @c | @c b (Boolean Heyting), and
- *         the @c eval morphism @c e(x) @c = @c e @c & @c x (meet).
- *         Required so @c IsHeytingLatticeCategory fires at row 6 of
- *         the Form-chain for this Rel / Meet pairing. */
+ *         lattice (#710): on integral @c T (excluding @c bool — see
+ *         caveat below) under @c bit_subset_eq with @c std::bit_and as
+ *         meet, the relative complement @c a @c → @c b @c = @c ~a @c |
+ *         @c b (Boolean Heyting), and the @c eval morphism
+ *         @c e(x) @c = @c e @c & @c x (meet).  Required so
+ *         @c IsHeytingLatticeCategory fires at row 6 of the Form-chain
+ *         for this Rel / Meet pairing.
+ *
+ *  @note  @c bool is excluded because @c std::bit_not<bool> is not an
+ *         involution under integral promotion (@c ~true via @c int and
+ *         back gives @c true again), so @c ~a @c | @c b miscomputes
+ *         the relative pseudo-complement.  The project documents this
+ *         hazard at @c category/lattice.cppm; @c bool's Heyting
+ *         structure travels via @c std::logical_or / @c std::logical_not
+ *         in the @c :total reading, not this bitwise one. */
 template <typename T>
-  requires std::is_integral_v<T>
+  requires(std::is_integral_v<T> && !std::is_same_v<T, bool>)
 struct HeytingExponential<T, dedekind::order::bit_subset_eq<T>,
                           std::bit_and<T>> {
   using Domain = T;
@@ -336,11 +336,16 @@ struct LatticeTop<T, dedekind::order::bit_subset_eq<T>> {
 };
 
 /** @brief Canonical specialisation: @c std::bit_not<T> is the
- *         complement for the bitwise Boolean lattice on integral @c T.
- *         Complement laws hold structurally: @c a @c & @c ~a @c = @c 0
- *         (bottom) and @c a @c | @c ~a @c = @c ~T(0) (top). */
+ *         complement for the bitwise Boolean lattice on integral @c T
+ *         (excluding @c bool — see caveat).  Complement laws hold
+ *         structurally: @c a @c & @c ~a @c = @c 0 (bottom) and
+ *         @c a @c | @c ~a @c = @c ~T(0) (top).
+ *
+ *  @note  @c bool is excluded for the same reason as @c HeytingExponential
+ *         above: @c std::bit_not<bool> is not an involution under
+ *         integral promotion, so the complement laws would lie. */
 template <typename T>
-  requires std::is_integral_v<T>
+  requires(std::is_integral_v<T> && !std::is_same_v<T, bool>)
 struct is_complement<std::bit_not<T>, T, dedekind::order::bit_subset_eq<T>,
                      std::bit_or<T>, std::bit_and<T>> : std::true_type {};
 
@@ -355,7 +360,8 @@ static_assert(
         std::size_t, bit_subset_eq<std::size_t>, std::bit_or<std::size_t>,
         std::bit_and<std::size_t>, std::bit_not<std::size_t>>,
     "size_t under (bit_subset_eq, |, &, ~) is the bitwise Boolean "
-    "lattice — the power-set lattice of {0, …, 63}.  Distinct from "
+    "lattice — the power-set lattice of {0, …, "
+    "std::numeric_limits<std::size_t>::digits-1}.  Distinct from "
     "the totally-ordered Heyting chain on size_t under std::less_equal "
     "(which honestly fails row 7 — see :category::lattice's static_assert "
     "documenting the Honest Rejection).");

--- a/src/main/modules/dedekind/order/lattice.cppm
+++ b/src/main/modules/dedekind/order/lattice.cppm
@@ -281,25 +281,26 @@ template <typename T>
   requires std::is_integral_v<T>
 struct is_associative<T, std::bit_or<T>> : std::true_type {};
 
+// Variable-template partial specs in this file embed the constraint in
+// the *value* (cf. species.cppm:740 / :745 pattern with std::unsigned_integral
+// / std::integral), not via a requires clause on the template — the
+// requires-form yields "no variable template matches partial
+// specialization" on libc++/clang.
 template <typename T>
-  requires std::is_integral_v<T>
 inline constexpr bool is_absorptive_v<T, std::bit_or<T>, std::bit_and<T>> =
-    true;
+    std::is_integral_v<T>;
 
 template <typename T>
-  requires std::is_integral_v<T>
 inline constexpr bool is_absorptive_v<T, std::bit_and<T>, std::bit_or<T>> =
-    true;
+    std::is_integral_v<T>;
 
 template <typename T>
-  requires std::is_integral_v<T>
 inline constexpr bool is_distributive_v<T, std::bit_or<T>, std::bit_and<T>> =
-    true;
+    std::is_integral_v<T>;
 
 template <typename T>
-  requires std::is_integral_v<T>
 inline constexpr bool is_distributive_v<T, std::bit_and<T>, std::bit_or<T>> =
-    true;
+    std::is_integral_v<T>;
 
 /** @brief @c HeytingExponential specialisation for the bitwise Boolean
  *         lattice (#710): on integral @c T under @c bit_subset_eq with

--- a/src/test/cpp/modules/dedekind/order/bitwise_boolean_lattice_test.cpp
+++ b/src/test/cpp/modules/dedekind/order/bitwise_boolean_lattice_test.cpp
@@ -16,8 +16,8 @@
  * readings.
  */
 
-#include <catch2/catch_test_macros.hpp>
 #include <algorithm>
+#include <catch2/catch_test_macros.hpp>
 #include <concepts>
 #include <cstddef>
 #include <functional>

--- a/src/test/cpp/modules/dedekind/order/bitwise_boolean_lattice_test.cpp
+++ b/src/test/cpp/modules/dedekind/order/bitwise_boolean_lattice_test.cpp
@@ -35,22 +35,24 @@ TEST_CASE(
    *         (@c bit_subset_eq, @c |, @c &, @c ~).  All seven Form-chain
    *         rows fire — this is the power-set lattice of 64 bit
    *         positions, a finite Boolean algebra of dimension 64. */
-  STATIC_CHECK(IsThinCategory<std::size_t, bit_subset_eq<std::size_t>,
-                              ClassicalLogic>);
+  STATIC_CHECK(
+      IsThinCategory<std::size_t, bit_subset_eq<std::size_t>, ClassicalLogic>);
   STATIC_CHECK(
       IsPosetal<std::size_t, bit_subset_eq<std::size_t>, ClassicalLogic>);
   STATIC_CHECK(IsFilteredCategory<std::size_t, bit_subset_eq<std::size_t>,
                                   ClassicalLogic>);
-  STATIC_CHECK(IsBooleanLatticeCategory<
-               std::size_t, bit_subset_eq<std::size_t>, std::bit_or<std::size_t>,
-               std::bit_and<std::size_t>, std::bit_not<std::size_t>>);
+  STATIC_CHECK(
+      IsBooleanLatticeCategory<
+          std::size_t, bit_subset_eq<std::size_t>, std::bit_or<std::size_t>,
+          std::bit_and<std::size_t>, std::bit_not<std::size_t>>);
 }
 
 TEST_CASE("order:bitwise-boolean — unsigned int also fires",
           "[order][lattice][bitwise][boolean][unsigned]") {
-  STATIC_CHECK(IsBooleanLatticeCategory<
-               unsigned, bit_subset_eq<unsigned>, std::bit_or<unsigned>,
-               std::bit_and<unsigned>, std::bit_not<unsigned>>);
+  STATIC_CHECK(
+      IsBooleanLatticeCategory<unsigned, bit_subset_eq<unsigned>,
+                               std::bit_or<unsigned>, std::bit_and<unsigned>,
+                               std::bit_not<unsigned>>);
 }
 
 TEST_CASE("order:bitwise-boolean — bit_subset_eq computes correctly",
@@ -95,8 +97,8 @@ TEST_CASE(
    *         participate in @c IsBooleanLatticeCategory.  Two distinct
    *         algebraic structures, two distinct lattice witnesses. */
   STATIC_CHECK(IsHeytingLatticeCategory<std::size_t>);
-  STATIC_CHECK_FALSE(IsBooleanLatticeCategory<
-                     std::size_t, std::less_equal<std::size_t>,
-                     decltype(std::ranges::max), decltype(std::ranges::min),
-                     std::bit_not<std::size_t>>);
+  STATIC_CHECK_FALSE(
+      IsBooleanLatticeCategory<
+          std::size_t, std::less_equal<std::size_t>, decltype(std::ranges::max),
+          decltype(std::ranges::min), std::bit_not<std::size_t>>);
 }

--- a/src/test/cpp/modules/dedekind/order/bitwise_boolean_lattice_test.cpp
+++ b/src/test/cpp/modules/dedekind/order/bitwise_boolean_lattice_test.cpp
@@ -1,0 +1,102 @@
+/** @file dedekind/order/bitwise_boolean_lattice_test.cpp
+ *
+ * Unit coverage for #710 — the bitwise Boolean lattice on integral
+ * carriers under the bit-subset relation
+ * @c (a @c & @c b) @c == @c a.  Lives in @c :order::lattice (the
+ * order-theoretic-specialisations home for integral carriers); the
+ * Form-chain row-7 concept it instantiates lives upstream in
+ * @c :category::lattice.
+ *
+ * Cross-reference: @c algebra/galois.cppm carries the Galois field
+ * structure on @c bool and @c 𝔽64 — a different algebraic structure
+ * (field, not lattice) on the same/related underlying carriers.
+ * The bitwise Boolean lattice here is the power-set lattice of bit
+ * positions; the Galois field on @c bool (= @c 𝔽_2) is the smallest
+ * non-trivial field.  Same underlying carriers, parallel algebraic
+ * readings.
+ */
+
+#include <catch2/catch_test_macros.hpp>
+#include <concepts>
+#include <cstddef>
+#include <functional>
+
+import dedekind.category;
+import dedekind.order;
+
+using namespace dedekind::category;
+using dedekind::order::bit_subset_eq;
+
+TEST_CASE(
+    "order:bitwise-boolean — size_t fires Form-chain rows 1–7 under "
+    "bit_subset_eq",
+    "[order][lattice][bitwise][boolean][size_t]") {
+  /** @brief @c size_t under the bitwise Boolean algebra:
+   *         (@c bit_subset_eq, @c |, @c &, @c ~).  All seven Form-chain
+   *         rows fire — this is the power-set lattice of 64 bit
+   *         positions, a finite Boolean algebra of dimension 64. */
+  STATIC_CHECK(IsThinCategory<std::size_t, bit_subset_eq<std::size_t>,
+                              ClassicalLogic>);
+  STATIC_CHECK(
+      IsPosetal<std::size_t, bit_subset_eq<std::size_t>, ClassicalLogic>);
+  STATIC_CHECK(IsFilteredCategory<std::size_t, bit_subset_eq<std::size_t>,
+                                  ClassicalLogic>);
+  STATIC_CHECK(IsBooleanLatticeCategory<
+               std::size_t, bit_subset_eq<std::size_t>, std::bit_or<std::size_t>,
+               std::bit_and<std::size_t>, std::bit_not<std::size_t>>);
+}
+
+TEST_CASE("order:bitwise-boolean — unsigned int also fires",
+          "[order][lattice][bitwise][boolean][unsigned]") {
+  STATIC_CHECK(IsBooleanLatticeCategory<
+               unsigned, bit_subset_eq<unsigned>, std::bit_or<unsigned>,
+               std::bit_and<unsigned>, std::bit_not<unsigned>>);
+}
+
+TEST_CASE("order:bitwise-boolean — bit_subset_eq computes correctly",
+          "[order][lattice][bitwise][boolean][value-level]") {
+  /** @brief Value-level witness of the bit-subset relation.
+   *         @c 0b0101 @c ⊆_bit @c 0b1111 because @c (0b0101 @c & @c
+   *         0b1111) @c = @c 0b0101.  @c 0b0110 @c ⊄_bit @c 0b1001
+   *         because they share no bits. */
+  constexpr bit_subset_eq<unsigned> rel{};
+  STATIC_CHECK(rel(0b0000u, 0b1111u));        // bottom ⊆ anything
+  STATIC_CHECK(rel(0b0101u, 0b1111u));        // bits a subset of bits of b
+  STATIC_CHECK(rel(0b0101u, 0b0101u));        // reflexivity
+  STATIC_CHECK_FALSE(rel(0b0110u, 0b1001u));  // disjoint bit patterns
+  STATIC_CHECK_FALSE(rel(0b1111u, 0b0101u));  // a strictly more bits than b
+}
+
+TEST_CASE("order:bitwise-boolean — complement laws hold at value level",
+          "[order][lattice][bitwise][boolean][complement-laws]") {
+  /** @brief Boolean complement laws on the bitwise lattice:
+   *         @c a @c & @c ~a @c = @c 0 (bottom) and @c a @c | @c ~a
+   *         @c = @c ~0 (top). */
+  constexpr std::size_t a = 0b101010ULL;
+  STATIC_CHECK((a & ~a) == std::size_t{0});
+  STATIC_CHECK((a | ~a) == ~std::size_t{0});
+}
+
+TEST_CASE("order:bitwise-boolean — lattice bottom and top recover correctly",
+          "[order][lattice][bitwise][boolean][bounds]") {
+  STATIC_CHECK(LatticeBottom<std::size_t, bit_subset_eq<std::size_t>>::value ==
+               std::size_t{0});
+  STATIC_CHECK(LatticeTop<std::size_t, bit_subset_eq<std::size_t>>::value ==
+               ~std::size_t{0});
+}
+
+TEST_CASE(
+    "order:bitwise-boolean — order-theoretic chain on same carrier stays "
+    "Heyting-only (Slice 7 honest rejection)",
+    "[order][lattice][bitwise][order][negative]") {
+  /** @brief Cross-check: the SAME @c size_t carrier under the
+   *         @b order-theoretic reading (@c std::less_equal,
+   *         @c std::ranges::min / @c max, @c std::bit_not) does NOT
+   *         participate in @c IsBooleanLatticeCategory.  Two distinct
+   *         algebraic structures, two distinct lattice witnesses. */
+  STATIC_CHECK(IsHeytingLatticeCategory<std::size_t>);
+  STATIC_CHECK_FALSE(IsBooleanLatticeCategory<
+                     std::size_t, std::less_equal<std::size_t>,
+                     decltype(std::ranges::max), decltype(std::ranges::min),
+                     std::bit_not<std::size_t>>);
+}

--- a/src/test/cpp/modules/dedekind/order/bitwise_boolean_lattice_test.cpp
+++ b/src/test/cpp/modules/dedekind/order/bitwise_boolean_lattice_test.cpp
@@ -17,6 +17,7 @@
  */
 
 #include <catch2/catch_test_macros.hpp>
+#include <algorithm>
 #include <concepts>
 #include <cstddef>
 #include <functional>

--- a/src/test/cpp/modules/dedekind/order/bitwise_boolean_lattice_test.cpp
+++ b/src/test/cpp/modules/dedekind/order/bitwise_boolean_lattice_test.cpp
@@ -34,8 +34,10 @@ TEST_CASE(
     "[order][lattice][bitwise][boolean][size_t]") {
   /** @brief @c size_t under the bitwise Boolean algebra:
    *         (@c bit_subset_eq, @c |, @c &, @c ~).  All seven Form-chain
-   *         rows fire — this is the power-set lattice of 64 bit
-   *         positions, a finite Boolean algebra of dimension 64. */
+   *         rows fire — this is the power-set lattice of
+   *         @c std::numeric_limits<std::size_t>::digits bit positions
+   *         (64 on LP64 / LLP64; 32 on 32-bit targets), a finite
+   *         Boolean algebra of that dimension. */
   STATIC_CHECK(
       IsThinCategory<std::size_t, bit_subset_eq<std::size_t>, ClassicalLogic>);
   STATIC_CHECK(


### PR DESCRIPTION
## Summary

Closes #710. Adds the bitwise Boolean lattice witness for integral carriers, placed in `:order::lattice` (the existing home for order-theoretic specialisations of integral carriers).

## Why `:order::lattice` (chiselling)

Initially placed in `:category::lattice`; moved here per duplicate-work check:

- `:order::lattice` already carries `HasLatticeOperators<T>` (operator surface for `&`, `|`, `^`, `~`) and `IsOrderLattice<T>` (the Boolean-RING reading bundling `IsCommutativeRing<T, std::bit_xor, std::bit_and>` with the operator surface; fires on `bool` via the Galois-field witness shipped in #378).
- This PR adds the Boolean-LATTICE reading on the same carriers — power-set lattice of bit positions under `(bit_subset_eq, |, &, ~)`. Equivalent to the ring reading on Boolean algebras (XOR ≡ symmetric difference), but exposes a different concept surface (Form-chain row 7 via `:category::IsBooleanLatticeCategory`).
- Placing both readings in `:order::lattice` with explicit cross-reference makes the equivalence navigable rather than implicit.

## Galois field cross-reference

`:algebra::galois.cppm` carries the field machinery (`bool = 𝔽_2`, `𝔽64 = GF(2⁶)` with poly mult mod `x⁶+x+1`, `IsGaloisField`, `GaloisFieldRegistration`). Different algebraic structure on related carriers. Docstring names the parallel so a reader doesn't conflate "Boolean lattice on `size_t`" with "Galois field on `size_t`" — the latter would need a primitive polynomial via a struct wrapper, the former is structural via bit-subset.

## What

- New `bit_subset_eq<T>` Rel callable in `dedekind::order`.
- Trait specialisations in `dedekind::category` (re-opened) for `(T, bit_subset_eq<T>)`: `is_reflexive`, `is_transitive`, `is_antisymmetric`, `is_directed`, `is_codirected`.
- `LatticeBottom<T, bit_subset_eq<T>>::value = T{0}`, `LatticeTop<...> = ~T{0}`.
- `is_complement<std::bit_not<T>, T, bit_subset_eq<T>, std::bit_or<T>, std::bit_and<T>>` registration.
- Static-assert witnesses for `size_t` and `unsigned`.
- Test in `:order` test dir; cross-check that the order-theoretic reading on the same carrier honestly fails row 7 (Slice 7's rejection).

## Test plan

- [ ] CI green
- [ ] Flip to ready-for-review

🤖 Generated with [Claude Code](https://claude.com/claude-code)