### PR TITLE
feat(category): #718 Slice 2 — rewire :image through :factorisation; image_of factory; Set witness; arrow auto-upgrade

### DIFF
--- a/src/main/modules/dedekind/category/factorisation.cppm
+++ b/src/main/modules/dedekind/category/factorisation.cppm
@@ -281,6 +281,27 @@ static_assert(IsRegularMono<Identity<int>>,
               "of the degenerate parallel pair (id, id).");
 
 // ---------------------------------------------------------------------------
+// Arrow-side automatic upgrades: every regular epi is an epi (by
+// definition — a coequalizer is automatically right-cancellable);
+// dually every regular mono is a mono.  Registering the regular-side
+// trait alone is sufficient; the upstream epi / mono trait fires
+// transitively.
+//
+// Symmetric to the category-level IsExactCategory ⇒ IsRegularCategory ⇒
+// IsFactorisationSystem upgrade chain above: textbook implications
+// become typed-implication upgrade specialisations at the trait
+// registry layer.
+// ---------------------------------------------------------------------------
+
+template <typename E>
+  requires is_regular_epi_v<E>
+inline constexpr bool is_epic_arrow_v<E> = true;
+
+template <typename M>
+  requires is_regular_mono_v<M>
+inline constexpr bool is_monic_arrow_v<M> = true;
+
+// ---------------------------------------------------------------------------
 // Upgrade-chain witnesses: exercise the IsExactCategory ⇒ IsRegularCategory
 // ⇒ IsFactorisationSystem propagation chain on a category-shape-tagged
 // toy carrier.  A future change that breaks either implication is caught

--- a/src/main/modules/dedekind/category/image.cppm
+++ b/src/main/modules/dedekind/category/image.cppm
@@ -100,18 +100,29 @@
 module;
 
 #include <concepts>
+#include <utility>  // std::forward, std::remove_cvref_t
 
 export module dedekind.category:image;
 
-import :morphism;  // For IsArrow / Cod / Dom
-import :pullback;  // For IsParallelPair
-import :topoi;     // For IsSubobject / IsQuotient
+import :morphism;       // For IsArrow / Cod / Dom / Identity
+import :pullback;       // For IsParallelPair
+import :topoi;          // For IsSubobject / IsQuotient / Subobject
+import :factorisation;  // For IsFactorisationSystem / IsRegularCategory /
+                        // IsExactCategory — the categorical context for the
+                        // (regular epi, mono) factorisation system this
+                        // partition narrates (#718 Slice 2).
+import :cartesian;      // For CanonicalSetCCC — Set witness site (#718 Slice 2).
+import :logic;          // For Ternary — default codomain of image_of's
+                        // predicate (Honest Rejection until concrete
+                        // specialisation, see image_of below).
 
 namespace dedekind::category {
 
 /**
  * @concept IsImageOf
- * @brief @c S realises the image of arrow @c F as a Subobject of @c Cod<F>.
+ * @brief @c S realises the image of arrow @c F as a Subobject of @c Cod<F>
+ *        — the @b mono @b side of the (regular epi, mono) factorisation
+ *        system pinned in @c :factorisation.
  *
  * @details Structurally, @c IsImageOf<S, F> is exactly @c IsArrow<F>
  * @c && @c IsSubobject<S, @c Cod<F>>.  The added value over the bare
@@ -124,6 +135,13 @@ namespace dedekind::category {
  * factorisation @c F @c = @c m @c ∘ @c e) is the engineer's honesty
  * obligation, as for @c IsNNO.  C++ concepts cannot quantify over
  * the universal property; they pin the operational signature only.
+ *
+ * Categorical context (#718 Slice 2): @c IsImageOf is the @b mono @b
+ * leg of the @c IsFactorisationSystem<C> pair in @c :factorisation.
+ * In a regular category (@c IsRegularCategory<C>), every arrow's
+ * image is a regular subobject and the factorisation is unique up to
+ * iso; in @b Set and every topos this is the canonical (regular
+ * epi, mono) factorisation.
  *
  * @tparam S The candidate image species (a Subobject of @c Cod<F>).
  * @tparam F The arrow whose image @c S claims to realise.
@@ -178,5 +196,107 @@ concept IsImageOf = IsArrow<F> && IsSubobject<S, Cod<F>>;
  */
 export template <typename Q, typename F, typename G>
 concept IsCoequalizer = IsParallelPair<F, G> && IsQuotient<Q, Cod<F>>;
+
+/**
+ * @section image__Factorisation_Cross_Reference
+ *
+ * @c IsImageOf (mono leg) + @c IsCoequalizer (epi leg) jointly realise
+ * the (regular epi, mono) factorisation system named in
+ * @c :factorisation as @c IsFactorisationSystem<C>.  The
+ * decomposition F = m ∘ e, with e the regular epi onto Im(F) and m
+ * the mono Im(F) ↪ Cod<F>, is what @c IsRegularCategory<C> witnesses
+ * universally; in @b Set / @b CanonicalSetCCC and every topos this
+ * factorisation is unique up to isomorphism.  The witnesses below pin
+ * the canonical Set instances of the categorical chain.
+ */
+
+// ---------------------------------------------------------------------------
+// Set / CanonicalSetCCC witness for the (regular epi, mono) factorisation
+// system.  Set is the exemplar exact category (Borceux vol 2 §2; "in Set
+// and more generally any topos, every epimorphism is the coequalizer of
+// its kernel pair") — registering IsExactCategory auto-upgrades to
+// IsRegularCategory and IsFactorisationSystem via the chain set up in
+// :factorisation (Slice 1).
+// ---------------------------------------------------------------------------
+
+template <typename A>
+inline constexpr bool is_exact_category_v<CanonicalSetCCC<A>> = true;
+
+static_assert(IsExactCategory<CanonicalSetCCC<int>>,
+              "CanonicalSetCCC<A> is exact: every equivalence relation "
+              "on a Set object is the kernel pair of some arrow.");
+static_assert(IsRegularCategory<CanonicalSetCCC<int>>,
+              "CanonicalSetCCC<A> is regular by the IsExactCategory ⇒ "
+              "IsRegularCategory upgrade.");
+static_assert(IsFactorisationSystem<CanonicalSetCCC<int>>,
+              "CanonicalSetCCC<A> admits the canonical (regular epi, mono) "
+              "factorisation system by the IsRegularCategory ⇒ "
+              "IsFactorisationSystem upgrade.");
+
+// ---------------------------------------------------------------------------
+// image_of(f) — factory producing the image of an arrow F as a Subobject
+// of Cod<F>.  Sollbruchstelle for the categorical anchor; concrete
+// realisations specialise the predicate for specific carrier patterns
+// (e.g. Slice 4's First-Iso-Theorem needs the mod_n case to compute
+// concretely on ℤ/nℤ).  Also feeds #602 (image-of-set-under-function)
+// at the per-arrow-not-per-set level.
+// ---------------------------------------------------------------------------
+
+/**
+ * @brief The characteristic predicate of @c image_of(F) — recognises @c y
+ *        as "in the image of @c F".
+ *
+ * @details Default behaviour: returns @c Ternary::Unknown because the
+ * existential @c ∃x ∈ Dom<F>. F(x) = y is undecidable on a general
+ * @c IsArrow without further structure on @c Dom<F> (e.g.\ finite
+ * enumerability, inversion, or a comprehension-DSL hook).  Concrete
+ * specialisations override for specific @c F — Slice 4 lands the
+ * @c mod_n case, where the image is the interval [0, n).
+ *
+ * @tparam F The arrow whose image this predicate classifies.
+ */
+export template <typename F>
+  requires IsArrow<F>
+struct ImageChi {
+  F f;
+  using Domain = Cod<F>;
+  using Codomain = Ternary;
+
+  /** @brief Default Honest-Rejection classifier: returns
+   *  @c Ternary::Unknown.  Specialisations on specific @c F fire
+   *  the @c True / @c False answer; until then, the image is
+   *  honestly opaque. */
+  constexpr Ternary operator()(const Cod<F>&) const noexcept {
+    return Ternary::Unknown;
+  }
+};
+
+/**
+ * @brief Factory: @c image_of(f) constructs the image of @c f as a
+ *        @c Subobject of @c Cod<F>.
+ *
+ * @details The returned @c Subobject's characteristic predicate
+ * (@c ImageChi above) recognises @c y as "@c y is in the image of
+ * @c f".  Pairs with @c IsImageOf at the type level: the result
+ * satisfies @c IsImageOf<decltype(image_of(f)), F> for every
+ * @c IsArrow @c F.  The Slice-2 realisation defers the existential
+ * resolution to @c Ternary::Unknown (Honest Rejection); concrete
+ * carrier-specific specialisations of @c ImageChi land in later
+ * slices (Slice 4's First-Iso-Theorem exhibit).
+ *
+ * @tparam F The arrow whose image is being constructed.
+ */
+export template <typename F>
+  requires IsArrow<F>
+constexpr auto image_of(F&& f) {
+  using FT = std::remove_cvref_t<F>;
+  return Subobject<Cod<FT>, ImageChi<FT>>{ImageChi<FT>{std::forward<F>(f)}};
+}
+
+// Witness: image_of(Identity<int>) is an IsSubobject of int — the trivial
+// image is the whole carrier.  Pins the type signature at compile time.
+static_assert(IsSubobject<decltype(image_of(Identity<int>{})), int>,
+              "image_of(Identity<int>) realises a Subobject of int — the "
+              "trivial image-of-identity exhibit.");
 
 }  // namespace dedekind::category

--- a/src/main/modules/dedekind/category/image.cppm
+++ b/src/main/modules/dedekind/category/image.cppm
@@ -288,8 +288,7 @@ struct ImageChi {
  * @tparam F The arrow whose image is being constructed.
  */
 export template <typename F>
-  requires IsArrow<F> &&
-           std::constructible_from<std::remove_cvref_t<F>, F&&>
+  requires IsArrow<F> && std::constructible_from<std::remove_cvref_t<F>, F&&>
 constexpr auto image_of(F&& f) {
   using FT = std::remove_cvref_t<F>;
   return Subobject<Cod<FT>, ImageChi<FT>>{ImageChi<FT>{std::forward<F>(f)}};

--- a/src/main/modules/dedekind/category/image.cppm
+++ b/src/main/modules/dedekind/category/image.cppm
@@ -100,7 +100,8 @@
 module;
 
 #include <concepts>
-#include <utility>  // std::forward, std::remove_cvref_t
+#include <type_traits>  // std::remove_cvref_t
+#include <utility>      // std::forward
 
 export module dedekind.category:image;
 
@@ -287,7 +288,8 @@ struct ImageChi {
  * @tparam F The arrow whose image is being constructed.
  */
 export template <typename F>
-  requires IsArrow<F>
+  requires IsArrow<F> &&
+           std::constructible_from<std::remove_cvref_t<F>, F&&>
 constexpr auto image_of(F&& f) {
   using FT = std::remove_cvref_t<F>;
   return Subobject<Cod<FT>, ImageChi<FT>>{ImageChi<FT>{std::forward<F>(f)}};

--- a/src/main/modules/dedekind/category/image.cppm
+++ b/src/main/modules/dedekind/category/image.cppm
@@ -111,10 +111,10 @@ import :factorisation;  // For IsFactorisationSystem / IsRegularCategory /
                         // IsExactCategory — the categorical context for the
                         // (regular epi, mono) factorisation system this
                         // partition narrates (#718 Slice 2).
-import :cartesian;      // For CanonicalSetCCC — Set witness site (#718 Slice 2).
-import :logic;          // For Ternary — default codomain of image_of's
-                        // predicate (Honest Rejection until concrete
-                        // specialisation, see image_of below).
+import :cartesian;  // For CanonicalSetCCC — Set witness site (#718 Slice 2).
+import :logic;      // For Ternary — default codomain of image_of's
+                    // predicate (Honest Rejection until concrete
+                    // specialisation, see image_of below).
 
 namespace dedekind::category {
 

--- a/src/test/cpp/modules/dedekind/category/factorisation_test.cpp
+++ b/src/test/cpp/modules/dedekind/category/factorisation_test.cpp
@@ -31,13 +31,69 @@ TEST_CASE(
   /** @brief Identity<T> is the canonical witness for both legs of the
    *         (regular epi, mono) factorisation system: the coequalizer
    *         and equalizer of the degenerate parallel pair (id, id) are
-   *         both id itself. */
+   *         both id itself.
+   *
+   *         Note: Identity<T> is independently registered as both
+   *         @c is_epic_arrow_v and @c is_monic_arrow_v in @c :morphism,
+   *         so the @c IsEpicArrow / @c IsMonicArrow assertions here
+   *         don't exercise the auto-upgrade — see the
+   *         @c regular_only_arrow witness below for the upgrade test. */
   STATIC_CHECK(IsRegularEpi<Identity<int>>);
   STATIC_CHECK(IsRegularMono<Identity<int>>);
-  // Arrow auto-upgrade chain: every regular epi is an epi by the
-  // is_regular_epi_v ⇒ is_epic_arrow_v partial spec in :factorisation.
   STATIC_CHECK(IsEpicArrow<Identity<int>>);
   STATIC_CHECK(IsMonicArrow<Identity<int>>);
+}
+
+namespace dedekind::category {
+namespace _auto_upgrade_witnesses {
+/** @brief Arrow-shaped struct registered ONLY as @c is_regular_epi_v.
+ *         The auto-upgrade in @c :factorisation must lift it to
+ *         @c is_epic_arrow_v transitively. */
+struct regular_epi_only_arrow {
+  using Domain = int;
+  using Codomain = int;
+  constexpr int operator()(int x) const noexcept { return x; }
+};
+
+/** @brief Dual: arrow registered ONLY as @c is_regular_mono_v. */
+struct regular_mono_only_arrow {
+  using Domain = int;
+  using Codomain = int;
+  constexpr int operator()(int x) const noexcept { return x; }
+};
+}  // namespace _auto_upgrade_witnesses
+
+template <>
+inline constexpr bool is_regular_epi_v<
+    _auto_upgrade_witnesses::regular_epi_only_arrow> = true;
+template <>
+inline constexpr bool is_regular_mono_v<
+    _auto_upgrade_witnesses::regular_mono_only_arrow> = true;
+}  // namespace dedekind::category
+
+TEST_CASE(
+    "category:factorisation — arrow auto-upgrade: regular epi/mono ⇒ epi/mono",
+    "[category][factorisation][auto-upgrade][arrow]") {
+  /** @brief @c is_regular_epi_v ⇒ @c is_epic_arrow_v auto-upgrade is
+   *         catchable only with a witness that's registered ONLY on
+   *         the regular-side trait.  The @c regular_epi_only_arrow
+   *         above lives in @c _auto_upgrade_witnesses and is opted-
+   *         into @c is_regular_epi_v but @b not @c is_epic_arrow_v.
+   *         The auto-upgrade in @c :factorisation must then fire
+   *         @c IsEpicArrow transitively. */
+  STATIC_CHECK(
+      IsRegularEpi<
+          dedekind::category::_auto_upgrade_witnesses::regular_epi_only_arrow>);
+  STATIC_CHECK(
+      IsEpicArrow<
+          dedekind::category::_auto_upgrade_witnesses::regular_epi_only_arrow>);
+
+  STATIC_CHECK(
+      IsRegularMono<
+          dedekind::category::_auto_upgrade_witnesses::regular_mono_only_arrow>);
+  STATIC_CHECK(
+      IsMonicArrow<
+          dedekind::category::_auto_upgrade_witnesses::regular_mono_only_arrow>);
 }
 
 TEST_CASE(

--- a/src/test/cpp/modules/dedekind/category/factorisation_test.cpp
+++ b/src/test/cpp/modules/dedekind/category/factorisation_test.cpp
@@ -1,0 +1,95 @@
+/** @file dedekind/category/factorisation_test.cpp
+ *
+ * Unit coverage for @c :category::factorisation (#718 Slice 1) and the
+ * @c :image rewire + @c image_of factory (#718 Slice 2).
+ *
+ * Coverage targets:
+ *  - The five Form-chain concepts (rows 4–8 of #718): @c IsRegularEpi,
+ *    @c IsRegularMono, @c IsFactorisationSystem, @c IsRegularCategory,
+ *    @c IsExactCategory.
+ *  - The two upgrade chains: @c IsExactCategory ⇒ @c IsRegularCategory
+ *    ⇒ @c IsFactorisationSystem (category-level) and
+ *    @c is_regular_epi_v ⇒ @c is_epic_arrow_v plus the dual (arrow-level).
+ *  - The @c image_of(F) factory runtime body and the @c ImageChi<F>
+ *    Honest-Rejection default classifier (@c Ternary::Unknown).
+ *
+ * Existential / structural witnesses live as @c static_assert inside
+ * the main partition (cf.\ @c feedback_static_assert_in_main.md); the
+ * runtime exercises below ensure the factory bodies are covered by
+ * codecov in addition to the type-checked compile-time witnesses.
+ */
+
+#include <catch2/catch_test_macros.hpp>
+
+import dedekind.category;
+
+using namespace dedekind::category;
+
+TEST_CASE(
+    "category:factorisation — Identity<int> is the trivial regular epi / mono",
+    "[category][factorisation][regular-epi][regular-mono][identity]") {
+  /** @brief Identity<T> is the canonical witness for both legs of the
+   *         (regular epi, mono) factorisation system: the coequalizer
+   *         and equalizer of the degenerate parallel pair (id, id) are
+   *         both id itself. */
+  STATIC_CHECK(IsRegularEpi<Identity<int>>);
+  STATIC_CHECK(IsRegularMono<Identity<int>>);
+  // Arrow auto-upgrade chain: every regular epi is an epi by the
+  // is_regular_epi_v ⇒ is_epic_arrow_v partial spec in :factorisation.
+  STATIC_CHECK(IsEpicArrow<Identity<int>>);
+  STATIC_CHECK(IsMonicArrow<Identity<int>>);
+}
+
+TEST_CASE(
+    "category:factorisation — CanonicalSetCCC is exact, regular, and admits "
+    "the (regular epi, mono) factorisation system",
+    "[category][factorisation][set][upgrade-chain]") {
+  /** @brief @b Set (CanonicalSetCCC<A>) is the exemplar exact category
+   *         (Borceux vol 2 §2; "in Set and any topos, every epimorphism
+   *         is the coequalizer of its kernel pair").  The upgrade chain
+   *         @c IsExactCategory ⇒ @c IsRegularCategory ⇒
+   *         @c IsFactorisationSystem fires from the single
+   *         @c is_exact_category_v opt-in registered in @c :image. */
+  STATIC_CHECK(IsExactCategory<CanonicalSetCCC<int>>);
+  STATIC_CHECK(IsRegularCategory<CanonicalSetCCC<int>>);
+  STATIC_CHECK(IsFactorisationSystem<CanonicalSetCCC<int>>);
+}
+
+TEST_CASE(
+    "category:factorisation — negative gate: int is not category-shaped, so "
+    "the category-level concepts honestly reject",
+    "[category][factorisation][negative][category-shape-gate]") {
+  /** @brief A non-category-shaped type (@c int has no @c ::Arrow /
+   *         @c ::Species / @c ::Id aliases) cannot satisfy any of the
+   *         category-level concepts, even if the variable trait were
+   *         force-registered.  The @c IsSmallCategoryShape gate added
+   *         in Slice 1's Copilot pass enforces this. */
+  STATIC_CHECK_FALSE(IsRegularCategory<int>);
+  STATIC_CHECK_FALSE(IsExactCategory<int>);
+  STATIC_CHECK_FALSE(IsFactorisationSystem<int>);
+}
+
+TEST_CASE(
+    "image:image_of — factory produces a Subobject of Cod<F>",
+    "[category][image][image-of][factory]") {
+  /** @brief The @c image_of(f) factory constructs a @c Subobject of
+   *         @c Cod<F> from any @c IsArrow @c F.  This runtime test
+   *         exercises the factory body (construction of
+   *         @c Subobject<Cod<F>, ImageChi<F>>) and the
+   *         @c ImageChi::operator() Honest-Rejection default
+   *         (@c Ternary::Unknown).  Concrete carrier-specific
+   *         specialisations of @c ImageChi<F> land in #718 Slice 4
+   *         (First-Iso-Theorem). */
+  constexpr Identity<int> id_int{};
+  constexpr auto image = image_of(id_int);
+
+  // Type-level: the result is a Subobject of int — the trivial
+  // image-of-identity exhibit (the whole carrier).
+  STATIC_CHECK(IsSubobject<decltype(image), int>);
+
+  // Runtime: the default classifier returns Ternary::Unknown (Honest
+  // Rejection until a concrete specialisation overrides).
+  CHECK(image(42) == Ternary::Unknown);
+  CHECK(image(0) == Ternary::Unknown);
+  CHECK(image(-1) == Ternary::Unknown);
+}

--- a/src/test/cpp/modules/dedekind/category/factorisation_test.cpp
+++ b/src/test/cpp/modules/dedekind/category/factorisation_test.cpp
@@ -69,9 +69,8 @@ TEST_CASE(
   STATIC_CHECK_FALSE(IsFactorisationSystem<int>);
 }
 
-TEST_CASE(
-    "image:image_of — factory produces a Subobject of Cod<F>",
-    "[category][image][image-of][factory]") {
+TEST_CASE("image:image_of — factory produces a Subobject of Cod<F>",
+          "[category][image][image-of][factory]") {
   /** @brief The @c image_of(f) factory constructs a @c Subobject of
    *         @c Cod<F> from any @c IsArrow @c F.  This runtime test
    *         exercises the factory body (construction of

--- a/src/test/cpp/modules/dedekind/category/factorisation_test.cpp
+++ b/src/test/cpp/modules/dedekind/category/factorisation_test.cpp
@@ -64,11 +64,11 @@ struct regular_mono_only_arrow {
 }  // namespace _auto_upgrade_witnesses
 
 template <>
-inline constexpr bool is_regular_epi_v<
-    _auto_upgrade_witnesses::regular_epi_only_arrow> = true;
+inline constexpr bool
+    is_regular_epi_v<_auto_upgrade_witnesses::regular_epi_only_arrow> = true;
 template <>
-inline constexpr bool is_regular_mono_v<
-    _auto_upgrade_witnesses::regular_mono_only_arrow> = true;
+inline constexpr bool
+    is_regular_mono_v<_auto_upgrade_witnesses::regular_mono_only_arrow> = true;
 }  // namespace dedekind::category
 
 TEST_CASE(
@@ -88,12 +88,10 @@ TEST_CASE(
       IsEpicArrow<
           dedekind::category::_auto_upgrade_witnesses::regular_epi_only_arrow>);
 
-  STATIC_CHECK(
-      IsRegularMono<
-          dedekind::category::_auto_upgrade_witnesses::regular_mono_only_arrow>);
-  STATIC_CHECK(
-      IsMonicArrow<
-          dedekind::category::_auto_upgrade_witnesses::regular_mono_only_arrow>);
+  STATIC_CHECK(IsRegularMono<dedekind::category::_auto_upgrade_witnesses::
+                                 regular_mono_only_arrow>);
+  STATIC_CHECK(IsMonicArrow<dedekind::category::_auto_upgrade_witnesses::
+                                regular_mono_only_arrow>);
 }
 
 TEST_CASE(

--- a/src/test/cpp/modules/dedekind/category/factorisation_test.cpp
+++ b/src/test/cpp/modules/dedekind/category/factorisation_test.cpp
@@ -78,17 +78,28 @@ TEST_CASE("image:image_of — factory produces a Subobject of Cod<F>",
    *         @c ImageChi::operator() Honest-Rejection default
    *         (@c Ternary::Unknown).  Concrete carrier-specific
    *         specialisations of @c ImageChi<F> land in #718 Slice 4
-   *         (First-Iso-Theorem). */
-  constexpr Identity<int> id_int{};
-  constexpr auto image = image_of(id_int);
+   *         (First-Iso-Theorem).
+   *
+   *         Note: tests deliberately invoke the factory at @b runtime
+   *         (no @c constexpr) so codecov sees the function bodies
+   *         hit, not only compile-time evaluation. */
+  // Type-level witness via a constexpr instance — pins the type shape.
+  constexpr Identity<int> id_int_const{};
+  constexpr auto image_const = image_of(id_int_const);
+  STATIC_CHECK(IsSubobject<decltype(image_const), int>);
 
-  // Type-level: the result is a Subobject of int — the trivial
-  // image-of-identity exhibit (the whole carrier).
-  STATIC_CHECK(IsSubobject<decltype(image), int>);
+  // Runtime witness — exercises the factory body, the Subobject
+  // construction, the ImageChi default classifier, and the
+  // Subobject::operator() forwarder all at runtime.
+  Identity<int> id_int_runtime{};
+  auto image_runtime = image_of(id_int_runtime);
+  CHECK(image_runtime(42) == Ternary::Unknown);
+  CHECK(image_runtime(0) == Ternary::Unknown);
+  CHECK(image_runtime(-1) == Ternary::Unknown);
 
-  // Runtime: the default classifier returns Ternary::Unknown (Honest
-  // Rejection until a concrete specialisation overrides).
-  CHECK(image(42) == Ternary::Unknown);
-  CHECK(image(0) == Ternary::Unknown);
-  CHECK(image(-1) == Ternary::Unknown);
+  // Also exercise the Subobject::ι inclusion arm at runtime (it's
+  // wired up by the factory but not otherwise touched).
+  using Img = decltype(image_runtime);
+  typename Img::Member m{17};
+  CHECK(image_runtime.ι(m) == 17);
 }


### PR DESCRIPTION
## Summary

Third slice of the quotient categorification (#718). Bridges Slice 1's `:factorisation` partition into the existing `:image` narrative, lands the Set/CanonicalSetCCC witness that was deferred from Slice 1, introduces the `image_of(f)` factory (Sollbruchstelle for #602), and folds in the arrow-side auto-upgrade analogous to the category-level upgrade chain.

## What lands

| # | Change | Where |
|---|--------|-------|
| 1 | Doxygen rewire — `IsImageOf` / `IsCoequalizer` cross-reference `:factorisation` as the categorical context | `:image` |
| 2 | Set witness — `is_exact_category_v<CanonicalSetCCC<A>> = true`; auto-upgrades to `IsRegularCategory` and `IsFactorisationSystem` via Slice 1's chain | `:image` |
| 3 | `image_of(f)` factory + `ImageChi<F>` predicate — Sollbruchstelle for `∃x ∈ Dom<F>. F(x) = y` (Honest-Rejection default; concrete specialisations land in Slice 4's First-Iso-Theorem) | `:image` |
| 4 | Arrow auto-upgrade — `is_regular_epi_v ⇒ is_epic_arrow_v`, `is_regular_mono_v ⇒ is_monic_arrow_v` (mirror of the category-level chain) | `:factorisation` |

## Honoured promises

The Slice 1 `IsExactCategory` docstring promised the Set witness would ship in Slice 2; this PR delivers it. Three new inline `static_assert`s pin the chain:

```cpp
static_assert(IsExactCategory<CanonicalSetCCC<int>>);
static_assert(IsRegularCategory<CanonicalSetCCC<int>>);
static_assert(IsFactorisationSystem<CanonicalSetCCC<int>>);
```

Plus the factory witness:
```cpp
static_assert(IsSubobject<decltype(image_of(Identity<int>{})), int>);
```

## Sollbruchstellen flagged

- `ImageChi<F>::operator()` returns `Ternary::Unknown` by default — the existential `∃x. F(x) = y` is undecidable on a general `IsArrow`. Concrete specialisations on specific carrier patterns (e.g. `mod_n` on `ℤ`, where the image is the interval `[0, n)`) land in Slice 4 alongside the First-Iso-Theorem exhibit.
- Topos-shaped categories other than `CanonicalSetCCC` (e.g. presheaf topoi, Grothendieck topoi) are not registered here; per-topos witnesses ship when concrete carriers materialise.

## Arrow auto-upgrade rationale

Mirrors the textbook fact that every regular epi is an epi (a coequalizer is automatically right-cancellable) and dually for mono. The codebase already has the category-level analog: `IsExactCategory ⇒ IsRegularCategory ⇒ IsFactorisationSystem`. The arrow-level upgrades complete the symmetry — registering only the regular-side trait now suffices, the upstream `is_epic_arrow_v` / `is_monic_arrow_v` fires transitively.

## Adjacent

- Feeds **#602** (image-of-set-under-function): the `image_of(f)` factory provides the per-arrow API that `image(f, S)` (per-set) was missing.
- Sets up **#718 Slice 4** (First-Iso-Theorem): the `image_of(mod_n)` concrete specialisation lands there, exercising `A/ker(f) ≅ im(f)` as a typed `static_assert`.

## Test plan

- [x] `make compile` — green.
- [x] `make test` — 100% pass, 15/15 suites.
- [x] Inline `static_assert`s cover the Set witness + the auto-upgrade chain + the trivial `image_of(Identity<int>)` realisation.

## Refs

- Epic: #718
- Slice 1: PR #721 (merged)
- Slice 0: PR #720 (merged)