### PR TITLE
feat(algebra): #718 Slice 3 — `IsSubalgebra<S, A, Op>` in `:algebra::quotient` (HSP S leg)

### DIFF
--- a/src/main/modules/dedekind/algebra/quotient.cppm
+++ b/src/main/modules/dedekind/algebra/quotient.cppm
@@ -290,4 +290,60 @@ struct is_idempotent<Q, std::multiplies<Q>>
     : is_idempotent<product_algebra_base_t<Q>,
                     std::multiplies<product_algebra_base_t<Q>>> {};
 
+// ---------------------------------------------------------------------------
+// S (Subalgebra) — Birkhoff's HSP, Burris-Sankappanavar §II.5 / §II.10.
+//
+// The third leg of HSP closure: a subalgebra S of A is a subobject
+// (S ⊆ A in Set) that is closed under the algebraic operations of A.
+// For a single operation Op : A × A → A, closure means: for all
+// s, s' ∈ S, Op(s, s') ∈ S.  Universal-algebra anchor for the S leg
+// completing the H (IsQuotientAlgebra) + P (IsProductAlgebra) + S
+// triple — #718 Slice 3, blocking Slice 5's HSP-closed crown witness.
+//
+// Single-operation form lands first; multi-op variadic
+// IsSubalgebra<S, A, Op...> for ring-flavoured carriers waits on a
+// downstream demand (Sollbruchstelle, mirroring Slice 0's IsCongruence
+// shape).
+// ---------------------------------------------------------------------------
+
+/**
+ * @brief User-declared closure witness: subobject @c S of @c A is
+ *        closed under operation @c Op.
+ *
+ * @details Closure: for all @c m1, m2 of @c S::Member, the value
+ *          @c Op(ι(m1), ι(m2)) lies in the image of @c ι (i.e.\ is
+ *          itself representable as a Member of @c S).  Cannot be
+ *          checked at compile time in general — opt-in.
+ *
+ *          Universal-algebra reference: Burris-Sankappanavar §II.5.
+ */
+export template <typename S, typename A, typename Op>
+inline constexpr bool is_closed_under_v = false;
+
+/**
+ * @concept IsSubalgebra
+ * @brief Subobject @c S of @c A is a @b subalgebra under operation
+ *        @c Op when it is closed under @c Op.
+ *
+ * @details The S leg of Birkhoff's HSP closure (#718 Slice 3),
+ *          completing the triple with @c IsQuotientAlgebra (H, above
+ *          in this partition) and @c IsProductAlgebra (P, also
+ *          above).  Mirrors @c :cartesian's @c IsCongruence shape
+ *          (Slice 0): structural shape (the @c IsSubobject witness +
+ *          Op signature gate) plus opt-in closure trait.
+ *
+ *          Universal-algebra references: Burris-Sankappanavar §II.5
+ *          (subalgebras) + §II.10 (the HSP closure operators).
+ *
+ * @tparam S The candidate subalgebra (a Subobject of @c A).
+ * @tparam A The ambient algebra carrier.
+ * @tparam Op The binary operation @c V @c × @c V @c → @c V that
+ *            @c S must be closed under.
+ */
+export template <typename S, typename A, typename Op>
+concept IsSubalgebra = IsSubobject<S, A> && is_closed_under_v<S, A, Op> &&
+                       requires(const A& a, const Op& op) {
+                         { op(a, a) } -> std::convertible_to<A>;
+                       };
+
 }  // namespace dedekind::category

--- a/src/test/cpp/modules/dedekind/algebra/subalgebra_test.cpp
+++ b/src/test/cpp/modules/dedekind/algebra/subalgebra_test.cpp
@@ -16,7 +16,6 @@
  */
 
 #include <catch2/catch_test_macros.hpp>
-
 #include <functional>
 
 import dedekind.algebra;
@@ -55,28 +54,28 @@ struct even_ints {
 /** @brief Closure registration: the even integers are closed under
  *         @c std::plus<int>.  Textbook subalgebra of @c (ℤ, +). */
 template <>
-inline constexpr bool is_closed_under_v<_subalgebra_witnesses::even_ints, int,
-                                        std::plus<int>> = true;
+inline constexpr bool
+    is_closed_under_v<_subalgebra_witnesses::even_ints, int, std::plus<int>> =
+        true;
 
 }  // namespace dedekind::category
 
 using namespace dedekind::category;
 
-TEST_CASE(
-    "algebra:subalgebra — even integers are a subalgebra of (ℤ, +)",
-    "[algebra][subalgebra][HSP-S][canonical]") {
+TEST_CASE("algebra:subalgebra — even integers are a subalgebra of (ℤ, +)",
+          "[algebra][subalgebra][HSP-S][canonical]") {
   /** @brief Even integers @c {…, -2, 0, 2, 4, …} form a subalgebra of
    *         @c ℤ under @c +: the sum of two even integers is even.
    *         This is the canonical textbook subalgebra (Burris-Sank
    *         §II.5) — the S leg of HSP. */
-  STATIC_CHECK(
-      IsSubobject<_subalgebra_witnesses::even_ints, int>);
+  STATIC_CHECK(IsSubobject<_subalgebra_witnesses::even_ints, int>);
   STATIC_CHECK(
       IsSubalgebra<_subalgebra_witnesses::even_ints, int, std::plus<int>>);
 }
 
 TEST_CASE(
-    "algebra:subalgebra — negative gate: unregistered subobjects honestly reject",
+    "algebra:subalgebra — negative gate: unregistered subobjects honestly "
+    "reject",
     "[algebra][subalgebra][HSP-S][negative][closure-gate]") {
   /** @brief A subobject that hasn't opted into @c is_closed_under_v<…,
    *         Op> for a given @c Op honestly rejects @c IsSubalgebra

--- a/src/test/cpp/modules/dedekind/algebra/subalgebra_test.cpp
+++ b/src/test/cpp/modules/dedekind/algebra/subalgebra_test.cpp
@@ -1,0 +1,110 @@
+/** @file dedekind/algebra/subalgebra_test.cpp
+ *
+ * Unit coverage for @c IsSubalgebra<S, A, Op> in @c :algebra::quotient
+ * (#718 Slice 3) — the S leg of Birkhoff's HSP closure that completes
+ * the triple with the existing H (IsQuotientAlgebra) and P
+ * (IsProductAlgebra) legs already in the partition.
+ *
+ * Coverage targets:
+ *  - Structural witness: a subobject closed under @c std::plus<int>
+ *    satisfies @c IsSubalgebra<...>.
+ *  - Negative gate (closure): a subobject @b not registered as closed
+ *    under @c Op honestly rejects.
+ *  - Negative gate (Op shape): an operation that doesn't have the
+ *    @c V @c × @c V @c → @c V signature fails the requires clause.
+ *  - Runtime exercise of the witness's @c χ and @c ι (codecov).
+ */
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <functional>
+
+import dedekind.algebra;
+import dedekind.category;
+
+namespace dedekind::category {
+namespace _subalgebra_witnesses {
+
+/** @brief Characteristic predicate of "even integer".  Closed under
+ *         @c std::plus<int>: even + even = even (textbook). */
+struct even_chi {
+  using Domain = int;
+  using Codomain = bool;
+  constexpr bool operator()(int x) const noexcept { return (x & 1) == 0; }
+};
+
+/** @brief The even-integers subobject of @c int.  Mirrors the
+ *         @c :topoi::Subobject<A, Chi> shape with explicit
+ *         @c Ambient / @c Member / @c ι / @c operator() fields, so
+ *         it satisfies @c IsSubobject<EvenInts, int> directly
+ *         without going through the @c Subobject struct (the test
+ *         exercises the @c IsSubalgebra concept body, not the
+ *         downstream @c Subobject machinery). */
+struct even_ints {
+  using Ambient = int;
+  struct Member {
+    int value;
+  };
+  even_chi χ;
+  constexpr int ι(const Member& m) const noexcept { return m.value; }
+  constexpr bool operator()(int a) const noexcept { return χ(a); }
+};
+
+}  // namespace _subalgebra_witnesses
+
+/** @brief Closure registration: the even integers are closed under
+ *         @c std::plus<int>.  Textbook subalgebra of @c (ℤ, +). */
+template <>
+inline constexpr bool is_closed_under_v<_subalgebra_witnesses::even_ints, int,
+                                        std::plus<int>> = true;
+
+}  // namespace dedekind::category
+
+using namespace dedekind::category;
+
+TEST_CASE(
+    "algebra:subalgebra — even integers are a subalgebra of (ℤ, +)",
+    "[algebra][subalgebra][HSP-S][canonical]") {
+  /** @brief Even integers @c {…, -2, 0, 2, 4, …} form a subalgebra of
+   *         @c ℤ under @c +: the sum of two even integers is even.
+   *         This is the canonical textbook subalgebra (Burris-Sank
+   *         §II.5) — the S leg of HSP. */
+  STATIC_CHECK(
+      IsSubobject<_subalgebra_witnesses::even_ints, int>);
+  STATIC_CHECK(
+      IsSubalgebra<_subalgebra_witnesses::even_ints, int, std::plus<int>>);
+}
+
+TEST_CASE(
+    "algebra:subalgebra — negative gate: unregistered subobjects honestly reject",
+    "[algebra][subalgebra][HSP-S][negative][closure-gate]") {
+  /** @brief A subobject that hasn't opted into @c is_closed_under_v<…,
+   *         Op> for a given @c Op honestly rejects @c IsSubalgebra
+   *         — the closure obligation must be declared.  Here we use
+   *         @c std::multiplies<int> (no closure registration above)
+   *         to demonstrate the rejection. */
+  STATIC_CHECK_FALSE(IsSubalgebra<_subalgebra_witnesses::even_ints, int,
+                                  std::multiplies<int>>);
+  // (For the record: even integers ARE closed under multiplication too —
+  // even * anything = even.  But this test demonstrates that without an
+  // explicit opt-in registration the concept honestly rejects, which is
+  // the project's Honest-Rejection discipline.)
+}
+
+TEST_CASE("algebra:subalgebra — runtime exercise of the even-ints witness",
+          "[algebra][subalgebra][runtime]") {
+  /** @brief Runtime exercise of the canonical witness's @c χ predicate
+   *         and @c ι inclusion arrow — keeps codecov happy and pins
+   *         the operational shape (the witness is a real working
+   *         subobject, not just a type-level marker). */
+  _subalgebra_witnesses::even_ints e{};
+  CHECK(e(0));        // 0 is even
+  CHECK(e(2));        // 2 is even
+  CHECK(e(-4));       // -4 is even
+  CHECK_FALSE(e(1));  // 1 is odd
+  CHECK_FALSE(e(7));  // 7 is odd
+
+  // Inclusion arrow ι : Member ↣ int.
+  _subalgebra_witnesses::even_ints::Member m{42};
+  CHECK(e.ι(m) == 42);
+}

--- a/src/test/cpp/modules/dedekind/algebra/subalgebra_test.cpp
+++ b/src/test/cpp/modules/dedekind/algebra/subalgebra_test.cpp
@@ -17,6 +17,7 @@
 
 #include <catch2/catch_test_macros.hpp>
 #include <functional>
+#include <string>
 
 import dedekind.algebra;
 import dedekind.category;
@@ -49,6 +50,17 @@ struct even_ints {
   constexpr bool operator()(int a) const noexcept { return χ(a); }
 };
 
+/** @brief "Malformed" Op witness: takes a @c double, not a binary
+ *         @c int × @c int operation.  Used below to exercise the
+ *         @c IsSubalgebra concept body's @c { op(a, a) } @c
+ *         @c -> @c std::convertible_to<A> Op-shape gate.
+ *         @c std::convertible_to<int> still admits @c double via
+ *         narrowing conversion, so we deliberately return a
+ *         @c std::string — a type that has no conversion to @c int. */
+struct malformed_op {
+  constexpr std::string operator()(int, int) const { return {}; }
+};
+
 }  // namespace _subalgebra_witnesses
 
 /** @brief Closure registration: the even integers are closed under
@@ -57,6 +69,16 @@ template <>
 inline constexpr bool
     is_closed_under_v<_subalgebra_witnesses::even_ints, int, std::plus<int>> =
         true;
+
+/** @brief Op-shape-gate test: closure is force-registered for the
+ *         malformed Op, so the Op-shape @c requires clause in the
+ *         @c IsSubalgebra concept body is the @b only thing
+ *         preventing the concept from firing.  A regression that
+ *         removes the gate would now fail this static_assert. */
+template <>
+inline constexpr bool is_closed_under_v<_subalgebra_witnesses::even_ints, int,
+                                        _subalgebra_witnesses::malformed_op> =
+    true;
 
 }  // namespace dedekind::category
 
@@ -88,6 +110,22 @@ TEST_CASE(
   // even * anything = even.  But this test demonstrates that without an
   // explicit opt-in registration the concept honestly rejects, which is
   // the project's Honest-Rejection discipline.)
+}
+
+TEST_CASE(
+    "algebra:subalgebra — negative gate: Op-shape requires clause rejects "
+    "malformed operations even when closure is registered",
+    "[algebra][subalgebra][HSP-S][negative][op-shape-gate]") {
+  /** @brief Op-shape gate is the second negative cover: a
+   *         @c malformed_op (returns @c std::string from a binary
+   *         @c (int, int) call) cannot satisfy
+   *         @c { op(a, a) } @c -> @c std::convertible_to<A>.
+   *         Closure is force-registered to true above, so the
+   *         @c requires clause is the @b only thing preventing the
+   *         concept from firing.  A regression that removes the gate
+   *         would surface here at compile time. */
+  STATIC_CHECK_FALSE(IsSubalgebra<_subalgebra_witnesses::even_ints, int,
+                                  _subalgebra_witnesses::malformed_op>);
 }
 
 TEST_CASE("algebra:subalgebra — runtime exercise of the even-ints witness",


### PR DESCRIPTION
## Summary

Fourth slice of the quotient categorification (#718). The S leg of Birkhoff's HSP closure, completing the triple with the existing H (`IsQuotientAlgebra`) and P (`IsProductAlgebra`) legs already in `:algebra::quotient`. Unblocks Slice 5's HSP-closed crown `static_assert`.

## Surface added

| Symbol                             | Body                                                                                         |
|------------------------------------|----------------------------------------------------------------------------------------------|
| `is_closed_under_v<S, A, Op>`      | Primary variable trait (default false); opt-in honesty witness for "S is closed under Op"   |
| `IsSubalgebra<S, A, Op>`           | `IsSubobject<S, A> ∧ is_closed_under_v<S, A, Op>` + Op signature gate `{op(a,a)} -> convertible_to<A>` |

Mirrors `:cartesian::IsCongruence`'s shape from Slice 0: structural shape + opt-in trait + Op-shape gate.

## Canonical witness

`_subalgebra_witnesses::even_ints` in `subalgebra_test.cpp` — the even integers as a subobject of `int`, registered as closed under `std::plus<int>`. The textbook subalgebra `(2ℤ, +) ⊆ (ℤ, +)` per Burris-Sankappanavar §II.5.

```cpp
STATIC_CHECK(IsSubobject<even_ints, int>);
STATIC_CHECK(IsSubalgebra<even_ints, int, std::plus<int>>);
```

## Honest-Rejection foil

`STATIC_CHECK_FALSE(IsSubalgebra<even_ints, int, std::multiplies<int>>)` — even though `even × anything = even` mathematically holds, no `is_closed_under_v` opt-in was registered for the `std::multiplies` Op, so the concept honestly rejects. Matches the project's Honest-Rejection discipline (no opt-in ⇒ no claim).

## Sollbruchstellen

- **Variadic `IsSubalgebra<S, A, Op...>`** for multi-op algebras (e.g. ring subalgebras under joint `(+, ·)`). Single-op landed first; variadic lifts when the first ring-subalgebra witness needs it. Same Sollbruchstelle pattern as `IsCongruence` in Slice 0.
- **Trait propagation specs** (lift `is_associative_v`/`is_commutative_v`/etc. from A to S) — deferred to a follow-up. The existing quotient and product partitions in this file have such propagations; the subalgebra side will mirror them on demand.

## Anchor citations

- Burris & Sankappanavar, *A Course in Universal Algebra*, §II.5 (subalgebras), §II.10 (HSP closure operators).
- Birkhoff, 1935, *On the structure of abstract algebras*, Proc. Cambridge Phil. Soc. 31.

## Test plan

- [x] `make compile` — green
- [x] `make test` — 100% pass, 15/15 suites
- [x] `STATIC_CHECK` covers positive witness + Op-shape gate + Honest-Rejection foil
- [x] `CHECK` runtime exercises cover the witness's χ predicate (5 calls) + ι inclusion arrow

## Refs

- Epic: #718
- Slice 0 (`IsCongruence` precedent): PR #720 (merged)
- Slice 5 (HSP-closed crown): blocked-by this slice