### PR TITLE
feat(algebra, morphologies, paper): #718 Slice 5 — Birkhoff HSP-closed witness (paper crown)

### DIFF
--- a/docs/paper/paper.tex
+++ b/docs/paper/paper.tex
@@ -811,6 +811,43 @@ static_assert(WitnessesFirstIso<mod_2_arrow, connector>);  // ← THE crown
 \end{cpp}
 \end{listing}
 
+\paragraph{Birkhoff's HSP closure: a variety is closed under H, S, P.}
+The Quotient functor sits inside the deeper Birkhoff classification: a class $K$ of algebras is a variety (equationally definable) iff $K$ is closed under H (quotients), S (subalgebras), and P (direct products)~\cite{burris1981universalalgebra}~(§II.10--11).
+The dedekind library realises HSP closure as \emph{trait propagation}: the carrier-side registries \cppinline{quotient_algebra_base<Q>}, \cppinline{subalgebra_base<S>}, and \cppinline{product_algebra_base<P>} each lift the species traits (\cppinline{is_associative_v}, \cppinline{is_commutative_v}, \cppinline{is_distributive_v}, \cppinline{is_periodic}, \cppinline{is_idempotent}, \cppinline{is_saturating}) uniformly from a base algebra to its HSP-derived carriers.
+Listing~\ref{lst:hsp-closed} pins Birkhoff at the canonical cyclic-ring base $\mathbb{Z}/6\mathbb{Z}$: the variety ``carriers with associative $+$ and commutative $+$'' is HSP-closed by the propagation specs, witnessed by eight \cppinline{static_assert}s (two axioms times four carriers).
+A regression in any of the three propagation legs surfaces at compile time; the synthetic markers stand in as type-level placeholders for any concrete H/S/P-construction over $\mathbb{Z}/6\mathbb{Z}$.
+
+\begin{listing}[ht]
+\caption{Birkhoff's HSP closure typed.  Base $\mathbb{Z}/6\mathbb{Z}$ + three synthetic HSP markers wired to the carrier-side registries; the trait propagation lifts both axioms of the variety uniformly to all three HSP-derived carriers.  Any future H/S/P construction over $\mathbb{Z}/6\mathbb{Z}$ (or any other base in the variety) follows the same one-line opt-in pattern.}
+\label{lst:hsp-closed}
+\begin{cpp}
+// --- Synthetic HSP markers wired to Modular<6> -----------------------
+struct H_image_of_Z6 {};   // type-level placeholder for any H-image of Z/6Z
+struct S_subalg_of_Z6 {};  // ... S-subalgebra ...
+struct P_product_of_Z6 {}; // ... P-direct-product ...
+
+template <> struct quotient_algebra_base<H_image_of_Z6> { using type = Modular<6>; };
+template <> struct subalgebra_base      <S_subalg_of_Z6> { using type = Modular<6>; };
+template <> struct product_algebra_base <P_product_of_Z6>{ using type = Modular<6>; };
+
+// --- THE Birkhoff HSP-closed crown -----------------------------------
+// Variety V: carriers with associative + AND commutative +.
+// V is HSP-closed by the propagation specs.
+
+using Z6 = Modular<6>;  using H = H_image_of_Z6;
+using S  = S_subalg_of_Z6;  using P = P_product_of_Z6;
+
+static_assert(is_associative_v<Z6, std::plus<Z6>>);  // base ∈ V
+static_assert(is_associative_v<H,  std::plus<H>>);   // H closure (quotient)
+static_assert(is_associative_v<S,  std::plus<S>>);   // S closure (subalgebra)
+static_assert(is_associative_v<P,  std::plus<P>>);   // P closure (product)
+static_assert(is_commutative_v<Z6, std::plus<Z6>>);  // (same four, both axioms)
+static_assert(is_commutative_v<H,  std::plus<H>>);
+static_assert(is_commutative_v<S,  std::plus<S>>);
+static_assert(is_commutative_v<P,  std::plus<P>>);
+\end{cpp}
+\end{listing}
+
 \paragraph{The intersection's deliberate scope.}
 Two distinct mechanisms compose into the intersection $\mathbf{Ddk} = \mathbf{Jlt} \cap \mathbf{Alg}(-)_{\beth_1}$, and naming them separately matters because they pay for different things.
 The $\beth_1$ ceiling from §\ref{sec:alg-sigma} is \emph{foundational}: it stops the encoding from courting the Russell-style self-reference of a meta-category-of-everything, the same way ZFC's missing set-of-all-sets is shaped to forbid such an object.

--- a/docs/paper/paper.tex
+++ b/docs/paper/paper.tex
@@ -1228,12 +1228,16 @@ the simpler set at compile time.
 \end{figure}
 
 The third pillar.  The carrier lattice of Figure~\ref{fig:carrier-lattice}
-in load-bearing form: HSP propagation lifts axioms componentwise
-along quotients (\textbf{H}, e.g. \texttt{Complex},
-\texttt{Dual}) and direct products (\textbf{P}, e.g. $V_n(R)$,
-\texttt{Diagonal}); localizations such as \texttt{Frac} sit alongside
-HSP rather than inside it, and $\operatorname{End}_R$ is the
-partial-axiom rank-$n$ extension.  The algebraic lattice's compile-time-reduction
+in load-bearing form: HSP propagation lifts axioms uniformly along
+quotients (\textbf{H}, e.g.\ \texttt{Complex}, \texttt{Dual} via
+\cppinline{quotient_algebra_base<Q>}), subalgebras (\textbf{S}, via
+\cppinline{subalgebra_base<S>}), and direct products (\textbf{P},
+e.g.\ $V_n(R)$, \texttt{Diagonal} via
+\cppinline{product_algebra_base<P>}) --- the three carrier-side
+registries jointly realise Birkhoff's HSP closure
+(Listing~\ref{lst:hsp-closed}); localizations such as \texttt{Frac}
+sit alongside HSP rather than inside it, and $\operatorname{End}_R$
+is the partial-axiom rank-$n$ extension.  The algebraic lattice's compile-time-reduction
 showcases live in the sister section §\ref{sec:linalg}
 \emph{Linear Algebra}: linear programming
 (§\ref{sec:lp-centrepiece}), forward-mode automatic differentiation

--- a/src/main/modules/dedekind/algebra/quotient.cppm
+++ b/src/main/modules/dedekind/algebra/quotient.cppm
@@ -432,8 +432,8 @@ struct is_periodic<S, std::plus<S>>
 template <typename S>
   requires IsSubalgebraOf<S>
 struct is_periodic<S, std::multiplies<S>>
-    : is_periodic<subalgebra_base_t<S>,
-                  std::multiplies<subalgebra_base_t<S>>> {};
+    : is_periodic<subalgebra_base_t<S>, std::multiplies<subalgebra_base_t<S>>> {
+};
 
 template <typename S>
   requires IsSubalgebraOf<S>

--- a/src/main/modules/dedekind/algebra/quotient.cppm
+++ b/src/main/modules/dedekind/algebra/quotient.cppm
@@ -346,4 +346,110 @@ concept IsSubalgebra = IsSubobject<S, A> && is_closed_under_v<S, A, Op> &&
                          { op(a, a) } -> std::convertible_to<A>;
                        };
 
+// ---------------------------------------------------------------------------
+// subalgebra_base<S>::type — carrier-side registry mirroring
+// quotient_algebra_base and product_algebra_base.  The propagation
+// specs below lift the species traits (is_associative, is_commutative,
+// is_distributive, …) from the ambient algebra A to its subalgebra S
+// uniformly, completing the HSP closure of axioms on the trait registry.
+// ---------------------------------------------------------------------------
+
+/** @brief @c subalgebra_base<S>: carrier-side declaration that @c S
+ *         is a subalgebra of some base algebra (the S operation in
+ *         Birkhoff HSP).  Specialise the @c ::type member at the
+ *         carrier-defining partition; the propagation specs below
+ *         then lift the species-trait pins from base to @c S. */
+export template <typename S>
+struct subalgebra_base {};
+
+/** @brief Convenience alias for @c subalgebra_base<S>::type. */
+export template <typename S>
+using subalgebra_base_t = typename subalgebra_base<S>::type;
+
+/** @concept IsSubalgebraOf
+ *  @brief @c S is declared as a subalgebra of some base algebra.
+ *  @details Triggered by a specialisation of @c subalgebra_base<S>
+ *           exposing a @c ::type member.  Sibling of
+ *           @c IsQuotientAlgebra and @c IsProductAlgebra; all three
+ *           are HSP operations that preserve the structural species
+ *           traits of @c Base. */
+export template <typename S>
+concept IsSubalgebraOf = requires { typename subalgebra_base<S>::type; };
+
+// --- S (subalgebra) propagation: structural traits lift from Base. ---------
+//
+// A subalgebra @c S of @c Base inherits the same axioms as @c Base
+// for the corresponding operation, because @c S's operations are the
+// restrictions of @c Base's operations.  Identical propagation
+// pattern as the H (quotient_algebra_base) and P (product_algebra_base)
+// sections above.
+
+template <typename S>
+  requires IsSubalgebraOf<S>
+inline constexpr bool is_associative_v<S, std::plus<S>> =
+    is_associative_v<subalgebra_base_t<S>, std::plus<subalgebra_base_t<S>>>;
+
+template <typename S>
+  requires IsSubalgebraOf<S>
+inline constexpr bool is_associative_v<S, std::multiplies<S>> =
+    is_associative_v<subalgebra_base_t<S>,
+                     std::multiplies<subalgebra_base_t<S>>>;
+
+template <typename S>
+  requires IsSubalgebraOf<S>
+inline constexpr bool is_commutative_v<S, std::plus<S>> =
+    is_commutative_v<subalgebra_base_t<S>, std::plus<subalgebra_base_t<S>>>;
+
+template <typename S>
+  requires IsSubalgebraOf<S>
+inline constexpr bool is_commutative_v<S, std::multiplies<S>> =
+    is_commutative_v<subalgebra_base_t<S>,
+                     std::multiplies<subalgebra_base_t<S>>>;
+
+template <typename S>
+  requires IsSubalgebraOf<S>
+inline constexpr bool is_distributive_v<S, std::multiplies<S>, std::plus<S>> =
+    is_distributive_v<subalgebra_base_t<S>,
+                      std::multiplies<subalgebra_base_t<S>>,
+                      std::plus<subalgebra_base_t<S>>>;
+
+template <typename S>
+  requires IsSubalgebraOf<S>
+struct is_saturating<S, std::plus<S>>
+    : is_saturating<subalgebra_base_t<S>, std::plus<subalgebra_base_t<S>>> {};
+
+template <typename S>
+  requires IsSubalgebraOf<S>
+struct is_saturating<S, std::multiplies<S>>
+    : is_saturating<subalgebra_base_t<S>,
+                    std::multiplies<subalgebra_base_t<S>>> {};
+
+template <typename S>
+  requires IsSubalgebraOf<S>
+struct is_periodic<S, std::plus<S>>
+    : is_periodic<subalgebra_base_t<S>, std::plus<subalgebra_base_t<S>>> {};
+
+template <typename S>
+  requires IsSubalgebraOf<S>
+struct is_periodic<S, std::multiplies<S>>
+    : is_periodic<subalgebra_base_t<S>,
+                  std::multiplies<subalgebra_base_t<S>>> {};
+
+template <typename S>
+  requires IsSubalgebraOf<S>
+struct is_idempotent<S, std::plus<S>>
+    : is_idempotent<subalgebra_base_t<S>, std::plus<subalgebra_base_t<S>>> {};
+
+template <typename S>
+  requires IsSubalgebraOf<S>
+struct is_idempotent<S, std::multiplies<S>>
+    : is_idempotent<subalgebra_base_t<S>,
+                    std::multiplies<subalgebra_base_t<S>>> {};
+
 }  // namespace dedekind::category
+
+// The Birkhoff HSP-closed @b exhibit (typed crown) lives downstream in
+// the test surface — it consumes both @c :algebra::quotient (the
+// propagation specs above) and @c :morphologies::cyclic (for the
+// concrete @c Modular<N> base).  See
+// @c src/test/cpp/modules/dedekind/algebra/hsp_closed_test.cpp.

--- a/src/test/cpp/modules/dedekind/morphologies/hsp_closed_test.cpp
+++ b/src/test/cpp/modules/dedekind/morphologies/hsp_closed_test.cpp
@@ -147,3 +147,31 @@ TEST_CASE(
   STATIC_CHECK(is_commutative_v<S, std::plus<S>>);    // S
   STATIC_CHECK(is_commutative_v<P, std::plus<P>>);    // P
 }
+
+TEST_CASE(
+    "algebra:hsp_closed — S propagation: distributivity + is_periodic "
+    "also lift to subalgebras",
+    "[algebra][quotient][HSP][birkhoff][S][completeness]") {
+  /** @brief The S-propagation specs added in this slice cover six
+   *         traits total: is_associative_v, is_commutative_v,
+   *         is_distributive_v, is_saturating, is_periodic,
+   *         is_idempotent.  The crown above only exercised the first
+   *         two; this test additionally exercises is_distributive_v
+   *         and is_periodic so silent regressions in those
+   *         propagation specs surface at compile time.
+   *
+   *         Modular<6> is distributive over (*, +) and periodic
+   *         under + by construction, so both legs fire on Z6 and
+   *         propagate to S via subalgebra_base. */
+  using S = hsp_closed_witnesses::S_subalg_of_Z6;
+
+  // Distributivity propagation:
+  STATIC_CHECK(is_distributive_v<Z6, std::multiplies<Z6>, std::plus<Z6>>);
+  STATIC_CHECK(is_distributive_v<S, std::multiplies<S>, std::plus<S>>);
+
+  // is_periodic propagation (struct trait; tests the struct-inheritance
+  // path of the propagation spec, complementing the variable-template
+  // paths covered above):
+  STATIC_CHECK(is_periodic_v<Z6, std::plus<Z6>>);
+  STATIC_CHECK(is_periodic_v<S, std::plus<S>>);
+}

--- a/src/test/cpp/modules/dedekind/morphologies/hsp_closed_test.cpp
+++ b/src/test/cpp/modules/dedekind/morphologies/hsp_closed_test.cpp
@@ -35,7 +35,6 @@
  */
 
 #include <catch2/catch_test_macros.hpp>
-
 #include <functional>
 
 import dedekind.algebra;
@@ -139,12 +138,12 @@ TEST_CASE(
 
   // The four-fold static_assert pinning Birkhoff: base + three HSP
   // legs, each carrier showing both axioms of V.
-  STATIC_CHECK(is_associative_v<Z6, std::plus<Z6>>);    // base
-  STATIC_CHECK(is_associative_v<H, std::plus<H>>);      // H
-  STATIC_CHECK(is_associative_v<S, std::plus<S>>);      // S
-  STATIC_CHECK(is_associative_v<P, std::plus<P>>);      // P
-  STATIC_CHECK(is_commutative_v<Z6, std::plus<Z6>>);    // base
-  STATIC_CHECK(is_commutative_v<H, std::plus<H>>);      // H
-  STATIC_CHECK(is_commutative_v<S, std::plus<S>>);      // S
-  STATIC_CHECK(is_commutative_v<P, std::plus<P>>);      // P
+  STATIC_CHECK(is_associative_v<Z6, std::plus<Z6>>);  // base
+  STATIC_CHECK(is_associative_v<H, std::plus<H>>);    // H
+  STATIC_CHECK(is_associative_v<S, std::plus<S>>);    // S
+  STATIC_CHECK(is_associative_v<P, std::plus<P>>);    // P
+  STATIC_CHECK(is_commutative_v<Z6, std::plus<Z6>>);  // base
+  STATIC_CHECK(is_commutative_v<H, std::plus<H>>);    // H
+  STATIC_CHECK(is_commutative_v<S, std::plus<S>>);    // S
+  STATIC_CHECK(is_commutative_v<P, std::plus<P>>);    // P
 }

--- a/src/test/cpp/modules/dedekind/morphologies/hsp_closed_test.cpp
+++ b/src/test/cpp/modules/dedekind/morphologies/hsp_closed_test.cpp
@@ -1,0 +1,150 @@
+/** @file dedekind/algebra/hsp_closed_test.cpp
+ *
+ * Birkhoff's HSP theorem — typed witness at the propagation level
+ * (#718 Slice 5, paper-§3 crown).
+ *
+ * Theorem (Birkhoff 1935; Burris-Sankappanavar §II.11): a class K of
+ * algebras is a @b variety (equationally definable) iff K is closed
+ * under H (homomorphic images / quotients), S (subalgebras), and P
+ * (direct products).
+ *
+ * The dedekind codebase realises HSP closure as @b trait @b propagation:
+ * each equationally-defined axiom (@c is_associative_v,
+ * @c is_commutative_v, @c is_distributive_v, @c is_periodic,
+ * @c is_idempotent, @c is_saturating) propagates uniformly from a
+ * base algebra @c B to any @c Q with @c quotient_algebra_base<Q>
+ * @c = @c B (H), to any @c S with @c subalgebra_base<S> @c = @c B
+ * (S, added in this slice), or to any @c P with
+ * @c product_algebra_base<P> @c = @c B (P).
+ *
+ * This exhibit pins the closure at the canonical cyclic-ring base
+ * @c Modular<6>.  The variety @c V is "carriers with associative @c +
+ * AND commutative @c +".  Synthetic H/S/P markers wire to the three
+ * registries; the eight static_asserts witness that the variety is
+ * HSP-closed at this base by direct propagation.
+ *
+ * The same propagation works for @b any concrete H/S/P-construction
+ * over @c Modular<6> (or over any other base in @c V) — the synthetic
+ * markers stand in as type-level placeholders for any such
+ * construction.
+ *
+ * Coverage targets:
+ *  - All eight @c static_assert legs (compile-time, via STATIC_CHECK).
+ *  - Regression-of-propagation safety: if a propagation spec breaks,
+ *    the corresponding leg honestly fails.
+ */
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <functional>
+
+import dedekind.algebra;
+import dedekind.category;
+import dedekind.morphologies;
+
+namespace dedekind::category::hsp_closed_witnesses {
+
+/** @brief Synthetic type-level marker for a generic H-image of
+ *         @c Modular<6>.  No operator overloads needed — the
+ *         propagation operates purely on the trait registry. */
+struct H_image_of_Z6 {};
+
+/** @brief Synthetic marker for a generic subalgebra of @c Modular<6>. */
+struct S_subalg_of_Z6 {};
+
+/** @brief Synthetic marker for a generic direct product of @c Modular<6>. */
+struct P_product_of_Z6 {};
+
+}  // namespace dedekind::category::hsp_closed_witnesses
+
+namespace dedekind::category {
+
+template <>
+struct quotient_algebra_base<hsp_closed_witnesses::H_image_of_Z6> {
+  using type = dedekind::morphologies::Modular<6>;
+};
+
+template <>
+struct subalgebra_base<hsp_closed_witnesses::S_subalg_of_Z6> {
+  using type = dedekind::morphologies::Modular<6>;
+};
+
+template <>
+struct product_algebra_base<hsp_closed_witnesses::P_product_of_Z6> {
+  using type = dedekind::morphologies::Modular<6>;
+};
+
+}  // namespace dedekind::category
+
+using namespace dedekind::category;
+using dedekind::morphologies::Modular;
+using Z6 = Modular<6>;
+
+TEST_CASE(
+    "algebra:hsp_closed — base Modular<6> in V (associative + commutative +)",
+    "[algebra][quotient][HSP][birkhoff][base]") {
+  /** @brief The variety V we exercise: carriers with both
+   *         associative + and commutative +.  @c Modular<6> is the
+   *         canonical cyclic-ring inhabitant. */
+  STATIC_CHECK(is_associative_v<Z6, std::plus<Z6>>);
+  STATIC_CHECK(is_commutative_v<Z6, std::plus<Z6>>);
+}
+
+TEST_CASE(
+    "algebra:hsp_closed — H closure: associativity and commutativity "
+    "propagate to quotients",
+    "[algebra][quotient][HSP][birkhoff][H]") {
+  /** @brief H leg of Birkhoff: @c quotient_algebra_base propagation
+   *         lifts both axioms from the base @c Modular<6> to any
+   *         @c Q registered as a quotient. */
+  using H = hsp_closed_witnesses::H_image_of_Z6;
+  STATIC_CHECK(is_associative_v<H, std::plus<H>>);
+  STATIC_CHECK(is_commutative_v<H, std::plus<H>>);
+}
+
+TEST_CASE(
+    "algebra:hsp_closed — S closure: associativity and commutativity "
+    "propagate to subalgebras",
+    "[algebra][quotient][HSP][birkhoff][S]") {
+  /** @brief S leg of Birkhoff (new in #718 Slice 5):
+   *         @c subalgebra_base propagation lifts both axioms from the
+   *         base to any registered subalgebra. */
+  using S = hsp_closed_witnesses::S_subalg_of_Z6;
+  STATIC_CHECK(is_associative_v<S, std::plus<S>>);
+  STATIC_CHECK(is_commutative_v<S, std::plus<S>>);
+}
+
+TEST_CASE(
+    "algebra:hsp_closed — P closure: associativity and commutativity "
+    "propagate componentwise to direct products",
+    "[algebra][quotient][HSP][birkhoff][P]") {
+  /** @brief P leg of Birkhoff: @c product_algebra_base propagation
+   *         lifts both axioms componentwise from the base to any
+   *         registered direct product. */
+  using P = hsp_closed_witnesses::P_product_of_Z6;
+  STATIC_CHECK(is_associative_v<P, std::plus<P>>);
+  STATIC_CHECK(is_commutative_v<P, std::plus<P>>);
+}
+
+TEST_CASE(
+    "algebra:hsp_closed — Birkhoff HSP theorem realised: the variety "
+    "of associative-commutative + carriers is closed under H, S, P",
+    "[algebra][quotient][HSP][birkhoff][crown]") {
+  /** @brief The Birkhoff crown: all three HSP operations applied to
+   *         a base in V yield carriers still in V.  Pinned at compile
+   *         time via the propagation specs in :algebra::quotient. */
+  using H = hsp_closed_witnesses::H_image_of_Z6;
+  using S = hsp_closed_witnesses::S_subalg_of_Z6;
+  using P = hsp_closed_witnesses::P_product_of_Z6;
+
+  // The four-fold static_assert pinning Birkhoff: base + three HSP
+  // legs, each carrier showing both axioms of V.
+  STATIC_CHECK(is_associative_v<Z6, std::plus<Z6>>);    // base
+  STATIC_CHECK(is_associative_v<H, std::plus<H>>);      // H
+  STATIC_CHECK(is_associative_v<S, std::plus<S>>);      // S
+  STATIC_CHECK(is_associative_v<P, std::plus<P>>);      // P
+  STATIC_CHECK(is_commutative_v<Z6, std::plus<Z6>>);    // base
+  STATIC_CHECK(is_commutative_v<H, std::plus<H>>);      // H
+  STATIC_CHECK(is_commutative_v<S, std::plus<S>>);      // S
+  STATIC_CHECK(is_commutative_v<P, std::plus<P>>);      // P
+}


### PR DESCRIPTION
## Summary

Sixth slice of the quotient categorification (#718). **Second paper-§3 crown.** Birkhoff's HSP theorem pinned as compile-time trait-propagation witnesses at the canonical cyclic-ring base `ℤ/6ℤ`.

## The theorem, typed

Birkhoff 1935 / Burris-Sankappanavar §II.11: a class K of algebras is a **variety** (equationally definable) iff K is closed under H (homomorphic images / quotients), S (subalgebras), and P (direct products).

The codebase realises HSP closure as **trait propagation**: each equationally-defined axiom (`is_associative_v`, `is_commutative_v`, `is_distributive_v`, `is_periodic`, `is_idempotent`, `is_saturating`) propagates uniformly from a base algebra B to:

| Leg | Registry                    | Status                                  |
|:---:|-----------------------------|-----------------------------------------|
| H   | `quotient_algebra_base<Q>`  | Pre-existing                            |
| **S** | **`subalgebra_base<S>`**  | **NEW in this slice**                   |
| P   | `product_algebra_base<P>`   | Pre-existing                            |

## Surface added

### `:algebra::quotient` — S leg of HSP completed

- `subalgebra_base<S>::type` carrier-side registry (mirrors `quotient_algebra_base`/`product_algebra_base`).
- `IsSubalgebraOf<S>` concept (triggered by the registry).
- S-propagation specs for 6 traits: `is_associative_v`, `is_commutative_v`, `is_distributive_v` (variable templates) + `is_saturating`, `is_periodic`, `is_idempotent` (struct traits). Exactly mirrors H and P sections.

### `hsp_closed_test.cpp` — the typed crown

Three synthetic markers (`H_image_of_Z6`, `S_subalg_of_Z6`, `P_product_of_Z6`) wired to `Modular<6>` via the three registries. Eight `STATIC_CHECK`s witness the closure:

```cpp
using Z6 = Modular<6>;  using H = H_image_of_Z6;
using S  = S_subalg_of_Z6;  using P = P_product_of_Z6;

STATIC_CHECK(is_associative_v<Z6, std::plus<Z6>>);  // base ∈ V
STATIC_CHECK(is_associative_v<H,  std::plus<H>>);   // H closure
STATIC_CHECK(is_associative_v<S,  std::plus<S>>);   // S closure (NEW)
STATIC_CHECK(is_associative_v<P,  std::plus<P>>);   // P closure
// + same four for is_commutative_v.
```

A regression in any of the three propagation legs surfaces at compile time.

### Paper listing (`docs/paper/paper.tex`, §2.3.5)

New paragraph + Listing 5 next to the Quotient functor discussion, alongside the existing First-Iso listing. Shows the synthetic markers + registry hookups + eight static_asserts as a self-contained exhibit. Future HSP instances over different bases follow the same one-line opt-in pattern.

## Reuse

Any future H/S/P-construction over any base in any variety follows the same pattern:

```cpp
template <> struct subalgebra_base<my_subalgebra> { using type = my_base; };
// And any axiom of the variety propagates automatically.
```

## Test placement

`hsp_closed_test.cpp` lives in `src/test/cpp/modules/dedekind/morphologies/` (not `algebra/`) because the test imports both `dedekind.algebra` (for the propagation specs) and `dedekind.morphologies` (for `Modular<6>` as the concrete base). The `:algebra` test target doesn't see `:morphologies` (would cycle); the `:morphologies` test target sees both.

## Anchor citations

- Birkhoff 1935, *On the structure of abstract algebras*, Proc. Cambridge Phil. Soc. 31 (the HSP theorem itself, already cited in `algebra/quotient.cppm:14-19`).
- Burris & Sankappanavar, *A Course in Universal Algebra*, §II.10-11 (the modern formulation).

## Test plan

- [x] `make compile` — green
- [x] `make test` — 100% pass, 15/15 suites
- [x] Five TEST_CASEs in `hsp_closed_test.cpp` (base + H + S + P + combined crown)
- [x] Paper listing added (paper.tex)

## Refs

- Epic: #718
- Slice 3 (`IsSubalgebra` concept, prerequisite): PR #723 (merged)
- Slice 4 redux (sibling crown — First-Iso): PR #725 (merged)