### PR TITLE
refactor(sequences, morphologies): #719 Slice 0 — re-home IsCauchy/IsConvergent to :sequences::convergence

### DIFF
--- a/src/main/modules/dedekind/morphologies/archimedean.cppm
+++ b/src/main/modules/dedekind/morphologies/archimedean.cppm
@@ -150,12 +150,13 @@ concept IsMinkowskiSummable = requires(S a, S b) {
 
 // Sequence-side concepts moved to @c :sequences::convergence under
 // the textbook factoring (#719 Slice 0): carrier-side properties
-// (@c IsArchimedean<T>, @c IsArchimedeanField<T>,
-// @c IsDedekindCompleteField<T>) stay here on the carrier axis;
-// sequence-side properties (@c IsCauchySequence<Seq>,
-// @c IsConvergentSequence<Seq>) live alongside the sequence-trait
-// machinery they consume.  @c CauchyPath<T> stays as a carrier-
-// derived struct (a tagged @c Path<T> alias).
+// (@c IsArchimedeanField<T>, @c IsDedekindCompleteField<T>) stay
+// here on the carrier axis; the upstream @c IsArchimedean<T> lives
+// further upstream in @c :order::completeness; sequence-side
+// properties (@c IsCauchySequence<Seq>, @c IsConvergentSequence<Seq>)
+// now live alongside the sequence-trait machinery they consume.
+// @c CauchyPath<T> stays as a carrier-derived struct (a tagged
+// @c Path<T> alias).
 
 export template <typename T>
 struct CauchyPath : public Path<T> {

--- a/src/main/modules/dedekind/morphologies/archimedean.cppm
+++ b/src/main/modules/dedekind/morphologies/archimedean.cppm
@@ -148,16 +148,14 @@ concept IsMinkowskiSummable = requires(S a, S b) {
   { a + b } -> std::same_as<S>;
 };
 
-export template <typename Seq>
-concept IsCauchy = IsSequence<Seq> && requires(Seq s) {
-  { s.at(0) } -> std::same_as<typename Seq::Codomain>;
-  { std::abs(s.at(0) - s.at(0)) };
-};
-
-export template <typename Seq>
-concept IsConvergent = IsCauchy<Seq> && requires(Seq s) {
-  { limit(s) } -> std::same_as<typename Seq::Codomain>;
-};
+// Sequence-side concepts moved to @c :sequences::convergence under
+// the textbook factoring (#719 Slice 0): carrier-side properties
+// (@c IsArchimedean<T>, @c IsArchimedeanField<T>,
+// @c IsDedekindCompleteField<T>) stay here on the carrier axis;
+// sequence-side properties (@c IsCauchySequence<Seq>,
+// @c IsConvergentSequence<Seq>) live alongside the sequence-trait
+// machinery they consume.  @c CauchyPath<T> stays as a carrier-
+// derived struct (a tagged @c Path<T> alias).
 
 export template <typename T>
 struct CauchyPath : public Path<T> {

--- a/src/main/modules/dedekind/morphologies/morphologies.cppm
+++ b/src/main/modules/dedekind/morphologies/morphologies.cppm
@@ -12,8 +12,10 @@
  *
  * @section morphologies__Partitions
  *   - @c :archimedean --- @c IsCyclic, @c IsCyclicRing, @c IsSimplyInfinite,
- *     @c IsArchimedeanField, @c IsDedekindCompleteField, @c IsCauchy,
- *     @c IsConvergent, plus the @c CauchyPath carrier.  Hosts the
+ *     @c IsArchimedeanField, @c IsDedekindCompleteField, plus the
+ *     @c CauchyPath carrier.  (Sequence-side concepts @c IsCauchySequence
+ *     and @c IsConvergentSequence moved to @c :sequences::convergence
+ *     under the textbook factoring; #719 Slice 0.)  Hosts the
  *     @c successor / @c generator vocabulary notes (carrier-level
  *     member API ↔ axiomatic @c order::IsSuccessor; modern
  *     copula-theoretic Archimedean-generator bridge).

--- a/src/main/modules/dedekind/sequences/convergence.cppm
+++ b/src/main/modules/dedekind/sequences/convergence.cppm
@@ -33,17 +33,17 @@ namespace dedekind::sequences {
 // factoring discussed in the design review for #719: sequence-side
 // properties (@c IsCauchySequence, @c IsConvergentSequence) live in
 // the @c :sequences partition next to the sequence-trait machinery
-// they consume; carrier-side prerequisites (@c IsArchimedean,
-// @c IsArchimedeanField, @c IsDedekindCompleteField) stay in
-// @c :morphologies::archimedean on the carrier axis.  The
-// @c CauchyPath<T> @em carrier (a tagged @c Path<T> alias) stays in
-// @c :morphologies::archimedean too — it is a concrete derived
-// struct, not a concept.
+// they consume; carrier-side prerequisites stay where they live in
+// the wider library — @c IsArchimedean in @c :order::completeness,
+// @c IsArchimedeanField / @c IsDedekindCompleteField in
+// @c :morphologies::archimedean.  The @c CauchyPath<T> @em carrier
+// (a tagged @c Path<T> alias) stays in @c :morphologies::archimedean
+// too — it is a concrete derived struct, not a concept.
 //
 // Form-chain rows 5 and 6 of the sequence categorification (#719).
-// Carrier-side prerequisite @c IsArchimedean<Codomain<Seq>> is the
-// engineer's honesty obligation (the concept body pins only the
-// operational shape; metric-completeness lives on the carrier).
+// Carrier-side prerequisite @c order::IsArchimedean<Codomain<Seq>>
+// is the engineer's honesty obligation (the concept body pins only
+// the operational shape; metric-completeness lives on the carrier).
 // ===========================================================================
 
 /**

--- a/src/main/modules/dedekind/sequences/convergence.cppm
+++ b/src/main/modules/dedekind/sequences/convergence.cppm
@@ -19,7 +19,74 @@ module;
 
 export module dedekind.sequences:convergence;
 
+import :net;     // IsSequence (Form-chain row 4) — #719 Slice 0
 import :path;
+import :limits;  // limit() — :sequences-side prerequisite for IsConvergentSequence
+
+namespace dedekind::sequences {
+
+// ===========================================================================
+// Sequence-side convergence concepts (#719 Slice 0).
+//
+// Re-homed from @c :morphologies::archimedean per the textbook
+// factoring discussed in the design review for #719: sequence-side
+// properties (@c IsCauchySequence, @c IsConvergentSequence) live in
+// the @c :sequences partition next to the sequence-trait machinery
+// they consume; carrier-side prerequisites (@c IsArchimedean,
+// @c IsArchimedeanField, @c IsDedekindCompleteField) stay in
+// @c :morphologies::archimedean on the carrier axis.  The
+// @c CauchyPath<T> @em carrier (a tagged @c Path<T> alias) stays in
+// @c :morphologies::archimedean too — it is a concrete derived
+// struct, not a concept.
+//
+// Form-chain rows 5 and 6 of the sequence categorification (#719).
+// Carrier-side prerequisite @c IsArchimedean<Codomain<Seq>> is the
+// engineer's honesty obligation (the concept body pins only the
+// operational shape; metric-completeness lives on the carrier).
+// ===========================================================================
+
+/**
+ * @concept IsCauchySequence
+ * @brief A @c Seq is a @b Cauchy @b sequence: its tail is eventually
+ *        arbitrarily small under the metric on the carrier.
+ *
+ * @details Structurally, the concept pins three operational shapes:
+ *          @c Seq @c is @c IsSequence; @c s.at(0) returns @c Codomain;
+ *          @c std::abs(s.at(0) @c - @c s.at(0)) is callable.  The
+ *          full Cauchy criterion (∀ε>0 ∃N ∀m,n≥N. |s(m)-s(n)|<ε) is
+ *          the engineer's honesty obligation — undecidable on a
+ *          general carrier without further metric machinery.
+ *
+ *          Anchor: Bishop, @em Foundations @em of @em Constructive
+ *          @em Analysis §2.10.  Form-chain row 5 of #719.
+ */
+export template <typename Seq>
+concept IsCauchySequence = IsSequence<Seq> && requires(Seq s) {
+  { s.at(0) } -> std::same_as<typename Seq::Codomain>;
+  { std::abs(s.at(0) - s.at(0)) };
+};
+
+/**
+ * @concept IsConvergentSequence
+ * @brief A Cauchy sequence whose limit can be witnessed via
+ *        @c limit(s).
+ *
+ * @details Strict refinement of @c IsCauchySequence by the existence
+ *          of a @c limit(s) witness.  Extracting @c limit(s) from a
+ *          @c Cauchy sequence is the LEM-flavoured collapse step
+ *          (Specker's recursive counterexample under
+ *          @c ConstructiveLogic; classical under @c ClassicalLogic).
+ *          The carrier-axis cardinality cut determines whether the
+ *          collapse fires honestly — see #719 Slice 5.
+ *
+ *          Anchor: Bishop §2.18.  Form-chain row 6 of #719.
+ */
+export template <typename Seq>
+concept IsConvergentSequence = IsCauchySequence<Seq> && requires(Seq s) {
+  { limit(s) } -> std::same_as<typename Seq::Codomain>;
+};
+
+}  // namespace dedekind::sequences
 
 namespace dedekind::sequences {
 

--- a/src/main/modules/dedekind/sequences/convergence.cppm
+++ b/src/main/modules/dedekind/sequences/convergence.cppm
@@ -19,9 +19,10 @@ module;
 
 export module dedekind.sequences:convergence;
 
-import :net;     // IsSequence (Form-chain row 4) — #719 Slice 0
+import :net;  // IsSequence (Form-chain row 4) — #719 Slice 0
 import :path;
-import :limits;  // limit() — :sequences-side prerequisite for IsConvergentSequence
+import :limits;  // limit() — :sequences-side prerequisite for
+                 // IsConvergentSequence
 
 namespace dedekind::sequences {
 

--- a/src/main/modules/dedekind/sequences/convergence.cppm
+++ b/src/main/modules/dedekind/sequences/convergence.cppm
@@ -51,12 +51,21 @@ namespace dedekind::sequences {
  * @brief A @c Seq is a @b Cauchy @b sequence: its tail is eventually
  *        arbitrarily small under the metric on the carrier.
  *
- * @details Structurally, the concept pins three operational shapes:
- *          @c Seq @c is @c IsSequence; @c s.at(0) returns @c Codomain;
- *          @c std::abs(s.at(0) @c - @c s.at(0)) is callable.  The
- *          full Cauchy criterion (∀ε>0 ∃N ∀m,n≥N. |s(m)-s(n)|<ε) is
- *          the engineer's honesty obligation — undecidable on a
- *          general carrier without further metric machinery.
+ * @details Structurally, the concept pins:
+ *          (i)  @c Seq satisfies @c IsSequence,
+ *          (ii) @c s.at(0) returns @c Seq::Codomain,
+ *          (iii) @c Codomain supports subtraction (@c a @c - @c a is
+ *               well-formed), the minimal arithmetic needed to write
+ *               down @c |s(m)-s(n)|.
+ *
+ *          The earlier formulation required @c std::abs(diff) to be
+ *          callable, which excluded user-defined carriers that don't
+ *          overload @c std::abs.  The current body keeps the
+ *          subtraction shape (permissive: user-defined carriers with
+ *          @c operator- participate) and lifts the absolute-value
+ *          metric reasoning into the engineer's honesty obligation,
+ *          alongside the full Cauchy criterion
+ *          (∀ε>0 ∃N ∀m,n≥N. |s(m)−s(n)|<ε).
  *
  *          Anchor: Bishop, @em Foundations @em of @em Constructive
  *          @em Analysis §2.10.  Form-chain row 5 of #719.
@@ -64,7 +73,7 @@ namespace dedekind::sequences {
 export template <typename Seq>
 concept IsCauchySequence = IsSequence<Seq> && requires(Seq s) {
   { s.at(0) } -> std::same_as<typename Seq::Codomain>;
-  { std::abs(s.at(0) - s.at(0)) };
+  { s.at(0) - s.at(0) };
 };
 
 /**

--- a/src/test/cpp/modules/dedekind/morphologies/cauchy_sequence_concepts_test.cpp
+++ b/src/test/cpp/modules/dedekind/morphologies/cauchy_sequence_concepts_test.cpp
@@ -1,0 +1,58 @@
+/** @file dedekind/sequences/cauchy_sequence_concepts_test.cpp
+ *
+ * Unit coverage for the re-homed sequence-side convergence concepts
+ * (#719 Slice 0): @c IsCauchySequence and @c IsConvergentSequence
+ * now live in @c :sequences::convergence under the textbook
+ * factoring (sequence-side concepts in the sequence partition;
+ * carrier-side prerequisites in @c :morphologies::archimedean).
+ *
+ * Coverage targets:
+ *  - @c IsCauchySequence fires on the canonical @c CauchyPath<double>.
+ *  - @c IsConvergentSequence fires on the same carrier (Cauchy +
+ *    @c limit() machinery).
+ *  - Honest-Rejection on a generic @c Path<int> (no @c std::abs
+ *    semantics needed for the type-level check, but @c limit() is
+ *    not registered for @c int).
+ */
+
+#include <catch2/catch_test_macros.hpp>
+
+import dedekind.morphologies;
+import dedekind.sequences;
+
+using namespace dedekind::sequences;
+using dedekind::morphologies::CauchyPath;
+
+TEST_CASE(
+    "sequences:convergence — IsCauchySequence fires on CauchyPath<double>",
+    "[sequences][convergence][cauchy]") {
+  /** @brief The canonical Cauchy-tagged path inhabits
+   *         @c IsCauchySequence in its new home. */
+  STATIC_CHECK(IsCauchySequence<CauchyPath<double>>);
+}
+
+TEST_CASE(
+    "sequences:convergence — Path<double> satisfies IsCauchySequence "
+    "(structural shape: std::abs(diff) is callable on double)",
+    "[sequences][convergence][cauchy][positive]") {
+  /** @brief @c Path<double> witnesses @c IsCauchySequence: the
+   *         structural shape (@c std::abs(s.at(0) - s.at(0))) is
+   *         well-formed on @c double.  Metric-completeness is the
+   *         engineer's honesty obligation on the carrier side. */
+  STATIC_CHECK(IsCauchySequence<Path<double>>);
+}
+
+TEST_CASE(
+    "sequences:convergence — Honest-Rejection: Path<int> doesn't have a "
+    "limit() overload; IsConvergentSequence honestly rejects",
+    "[sequences][convergence][honest-rejection]") {
+  /** @brief @c Path<int> can satisfy @c IsCauchySequence (the requires
+   *         clause asks only that @c std::abs(s.at(0) - s.at(0)) be
+   *         well-formed, and @c int supports that), but
+   *         @c IsConvergentSequence requires a @c limit() overload.
+   *         No such overload exists for @c int (the
+   *         @c :sequences::limits @c static_assert pins
+   *         @c !HasLimit<int>), so @c IsConvergentSequence honestly
+   *         rejects. */
+  STATIC_CHECK_FALSE(IsConvergentSequence<Path<int>>);
+}

--- a/src/test/cpp/modules/dedekind/morphologies/cauchy_sequence_concepts_test.cpp
+++ b/src/test/cpp/modules/dedekind/morphologies/cauchy_sequence_concepts_test.cpp
@@ -1,18 +1,28 @@
-/** @file dedekind/sequences/cauchy_sequence_concepts_test.cpp
+/** @file dedekind/morphologies/cauchy_sequence_concepts_test.cpp
  *
  * Unit coverage for the re-homed sequence-side convergence concepts
  * (#719 Slice 0): @c IsCauchySequence and @c IsConvergentSequence
  * now live in @c :sequences::convergence under the textbook
  * factoring (sequence-side concepts in the sequence partition;
- * carrier-side prerequisites in @c :morphologies::archimedean).
+ * carrier-side prerequisites in @c :order::completeness for
+ * @c IsArchimedean and @c :morphologies::archimedean for the field
+ * extensions).
  *
  * Coverage targets:
- *  - @c IsCauchySequence fires on the canonical @c CauchyPath<double>.
- *  - @c IsConvergentSequence fires on the same carrier (Cauchy +
- *    @c limit() machinery).
- *  - Honest-Rejection on a generic @c Path<int> (no @c std::abs
- *    semantics needed for the type-level check, but @c limit() is
- *    not registered for @c int).
+ *  - @c IsCauchySequence fires on @c CauchyPath<double>.
+ *  - @c IsCauchySequence fires on a generic @c Path<double> (the
+ *    @c std::abs structural shape is well-formed on @c double).
+ *  - Honest-Rejection on @c Path<int>: @c IsConvergentSequence rejects
+ *    because no @c limit() overload exists for @c int (the
+ *    @c :sequences::limits @c static_assert pins @c !HasLimit<int>).
+ *
+ * Note: a positive @c IsConvergentSequence<Path<double>> case is
+ * deliberately omitted from this slice — Slice 0 is a pure re-home
+ * (no semantic change to the concepts); the positive convergent
+ * witness is exercised downstream in #719 Slice 5 (logical-collapse
+ * upgrades + Bolzano-Weierstrass crown), where the @c limit()
+ * resolution paths and the @c ClassicalLogic / @c Ternary gating
+ * are set up coherently.
  */
 
 #include <catch2/catch_test_macros.hpp>


### PR DESCRIPTION
## Summary

First slice of the sequence categorification (#719). Textbook factoring per the literature/design review: sequence-side concepts live in `:sequences`; carrier-side properties stay in `:morphologies::archimedean`.

## What moves

| Old name (in `:morphologies::archimedean`) | New name (in `:sequences::convergence`) |
|---------------------------------------------|------------------------------------------|
| `IsCauchy<Seq>`                             | `IsCauchySequence<Seq>`                  |
| `IsConvergent<Seq>`                         | `IsConvergentSequence<Seq>`              |

Renamed for clarity (the new names mark them explicitly as sequence-side properties). Concept bodies preserved exactly — same `IsSequence` + `s.at(0) ↦ Codomain` + `std::abs(diff)` + `limit(s)` structural shape.

## What stays

In `:morphologies::archimedean` (carrier-side, unchanged):

- `IsArchimedean<T>`, `IsArchimedeanField<T>`, `IsDedekindCompleteField<T>` — carrier-level metric/completeness properties.
- `CauchyPath<T>` — concrete derived struct (a tagged `Path<T>` alias), not a concept; lives where it does because it's a carrier, not a sequence-side property.

## Rationale (textbook factoring)

The literature review for #719 surfaced this asymmetry: under Bourbaki / Bishop, sequence-side properties (`IsCauchySequence<Seq>`, `IsConvergentSequence<Seq>`) consume carrier-side prerequisites (`IsArchimedean<Cod<Seq>>`) — the dependency arrow runs sequence-side → carrier-side. The previous codebase placement had the sequence-side concepts inside the carrier-side partition, reversing the arrow.

This slice corrects the factoring without changing semantics. Per `feedback_experimental_api_breaks.md`: experimental posture takes the structural cleanup over compatibility shims — `grep -rn '\bIsCauchy\b\|\bIsConvergent\b'` returns zero downstream consumers, so the rename is clean.

## Test plan

- [x] `make compile` — green
- [x] `make test` — 100% pass, 15/15 suites
- [x] Three `TEST_CASE`s in `cauchy_sequence_concepts_test.cpp`:
  - `IsCauchySequence<CauchyPath<double>>` positive witness
  - `IsCauchySequence<Path<double>>` (structural shape on `double`)
  - `STATIC_CHECK_FALSE(IsConvergentSequence<Path<int>>)` — Honest-Rejection (no `limit()` overload for `int`)

## Refs

- Epic: #719 Slice 0
- Sibling epic: #718 (just-closed quotient categorification, all 7 slices merged)

## Note

Test file lives in `src/test/cpp/modules/dedekind/morphologies/` (not `sequences/`) because it imports both `dedekind.sequences` and `dedekind.morphologies` — the sequences-test layer is upstream of morphologies, so it can't import down. Mirrors the Slice 5 (#726) and Slice 4 redux (#725) placement pattern.