### PR TITLE
feat(sequences): #719 Slice 1 — sequence-shape concepts (bounded/monotone/periodic/absorptive/subsequence)

### DIFF
--- a/src/main/modules/dedekind/sequences/convergence.cppm
+++ b/src/main/modules/dedekind/sequences/convergence.cppm
@@ -96,6 +96,99 @@ concept IsConvergentSequence = IsCauchySequence<Seq> && requires(Seq s) {
   { limit(s) } -> std::same_as<typename Seq::Codomain>;
 };
 
+// ===========================================================================
+// Sequence-shape concepts (#719 Slice 1).
+//
+// Boundedness, monotonicity, periodicity, absorptivity, and the
+// subsequence relation are @b properties @b of @b the @b value (which
+// specific sequence), not of the carrier type — a @c Path<double> can
+// be bounded or unbounded, monotone or oscillating.  C++ concepts gate
+// on types, so each property is pinned by an opt-in trait the carrier
+// (or a tagged carrier wrapper) registers when it @b guarantees the
+// property.  Same honesty discipline as @c :morphism's
+// @c is_epic_arrow_v and the relation traits in @c :cartesian: the
+// concept names the structural role; the witness opts in.
+//
+// Periodic / absorptive are the dual compression readings surfaced in
+// the #719 design review: periodic compresses the index
+// (@c ℕ ↠ ℤ/Nℤ); absorptive compresses the codomain (eventually
+// constant; @c ℕ → @c {z}).  Both lift the carrier-axis vocabulary
+// (@c is_periodic_v / @c is_absorptive_v in @c :species) onto the
+// sequence axis.
+//
+// Anchors: Bishop §2 (bounded / monotone); Bolzano-Weierstrass
+// (subsequence, feeds #719 Slice 5).  Form-chain rows 5a–5e of #719.
+// ===========================================================================
+
+/** @brief Opt-in: @c Seq is order-bounded (image bounded above and
+ *         below).  The bound witnesses are the engineer's obligation. */
+export template <typename Seq>
+inline constexpr bool is_bounded_sequence_v = false;
+
+/** @concept IsBoundedSequence
+ *  @brief A sequence whose image is order-bounded.  Bishop §2. */
+export template <typename Seq>
+concept IsBoundedSequence = IsSequence<Seq> && is_bounded_sequence_v<Seq>;
+
+/** @brief Opt-in: @c Seq is monotone (@c s(n) ≤ s(n+1) for all n, or
+ *         the reverse).  Direction is the witness's concern. */
+export template <typename Seq>
+inline constexpr bool is_monotone_sequence_v = false;
+
+/** @concept IsMonotoneSequence
+ *  @brief A monotone sequence.  Bishop §2; together with
+ *         @c IsBoundedSequence drives the monotone-convergence upgrade
+ *         (LEM-gated, #719 Slice 5). */
+export template <typename Seq>
+concept IsMonotoneSequence = IsSequence<Seq> && is_monotone_sequence_v<Seq>;
+
+/** @brief Opt-in: @c Seq is periodic with period @c N
+ *         (@c s(n) @c = @c s(n+N) for all n).  Index-side compression:
+ *         the sequence factors through @c ℕ/Nℤ.  Sequence-axis analog
+ *         of @c :species's @c is_periodic_v<T, Op>. */
+export template <typename Seq, std::size_t N>
+inline constexpr bool is_periodic_sequence_v = false;
+
+/** @concept IsPeriodicSequence
+ *  @brief A period-@c N sequence.  Honest-Rejection foil for the
+ *         monotone / Cauchy rows (a non-constant periodic sequence is
+ *         bounded but neither monotone nor Cauchy). */
+export template <typename Seq, std::size_t N>
+concept IsPeriodicSequence = IsSequence<Seq> && is_periodic_sequence_v<Seq, N>;
+
+/** @brief Opt-in: @c Seq is absorptive (eventually constant —
+ *         @c ∃N, z. ∀n≥N. s(n) = z).  Codomain-side compression: the
+ *         tail factors through a singleton @c {z}.  Dual of
+ *         @c is_periodic_sequence_v; sequence-axis analog of
+ *         @c :species's @c is_absorptive_v. */
+export template <typename Seq>
+inline constexpr bool is_absorptive_sequence_v = false;
+
+/** @concept IsAbsorptiveSequence
+ *  @brief An eventually-constant sequence.  The simplest convergent
+ *         case (limit = the absorbing value); period-1-eventually
+ *         dual to @c IsPeriodicSequence. */
+export template <typename Seq>
+concept IsAbsorptiveSequence = IsSequence<Seq> && is_absorptive_sequence_v<Seq>;
+
+/** @brief Opt-in: @c Sub is a subsequence of @c Sup — there is a
+ *         strictly increasing index map @c φ with
+ *         @c Sub(n) @c = @c Sup(φ(n)).  The index map is the
+ *         engineer's obligation. */
+export template <typename Sub, typename Sup>
+inline constexpr bool is_subsequence_v = false;
+
+/** @concept IsSubsequence
+ *  @brief @c Sub is a subsequence of @c Sup (same Codomain, strictly
+ *         increasing index map).  Feeds the Bolzano-Weierstrass row
+ *         (#719 Slice 5: every bounded sequence has a convergent
+ *         subsequence). */
+export template <typename Sub, typename Sup>
+concept IsSubsequence =
+    IsSequence<Sub> && IsSequence<Sup> &&
+    std::same_as<typename Sub::Codomain, typename Sup::Codomain> &&
+    is_subsequence_v<Sub, Sup>;
+
 }  // namespace dedekind::sequences
 
 namespace dedekind::sequences {

--- a/src/main/modules/dedekind/sequences/convergence.cppm
+++ b/src/main/modules/dedekind/sequences/convergence.cppm
@@ -152,9 +152,15 @@ inline constexpr bool is_periodic_sequence_v = false;
 /** @concept IsPeriodicSequence
  *  @brief A period-@c N sequence.  Honest-Rejection foil for the
  *         monotone / Cauchy rows (a non-constant periodic sequence is
- *         bounded but neither monotone nor Cauchy). */
+ *         bounded but neither monotone nor Cauchy).
+ *
+ *  @details Requires @c N @c > @c 0: "period 0" is undefined (the
+ *           @c s(n) @c = @c s(n+N) reading degenerates), so the
+ *           concept rejects @c N @c == @c 0 regardless of any
+ *           accidental trait opt-in. */
 export template <typename Seq, std::size_t N>
-concept IsPeriodicSequence = IsSequence<Seq> && is_periodic_sequence_v<Seq, N>;
+concept IsPeriodicSequence =
+    (N > 0) && IsSequence<Seq> && is_periodic_sequence_v<Seq, N>;
 
 /** @brief Opt-in: @c Seq is absorptive (eventually constant —
  *         @c ∃N, z. ∀n≥N. s(n) = z).  Codomain-side compression: the

--- a/src/test/cpp/modules/dedekind/sequences/sequence_shape_concepts_test.cpp
+++ b/src/test/cpp/modules/dedekind/sequences/sequence_shape_concepts_test.cpp
@@ -54,8 +54,8 @@ struct int_path : Path<int> {
 
 namespace dedekind::sequences {
 template <>
-inline constexpr bool
-    is_bounded_sequence_v<seq_shape_witnesses::bounded_path> = true;
+inline constexpr bool is_bounded_sequence_v<seq_shape_witnesses::bounded_path> =
+    true;
 template <>
 inline constexpr bool
     is_monotone_sequence_v<seq_shape_witnesses::monotone_path> = true;
@@ -109,8 +109,8 @@ TEST_CASE("sequences:shape — IsSubsequence fires on the (sub, super) pair",
   STATIC_CHECK(IsSubsequence<seq_shape_witnesses::sub_path,
                              seq_shape_witnesses::super_path>);
   // Cross-Codomain pair honestly rejects (double vs int):
-  STATIC_CHECK_FALSE(
-      IsSubsequence<seq_shape_witnesses::sub_path, seq_shape_witnesses::int_path>);
+  STATIC_CHECK_FALSE(IsSubsequence<seq_shape_witnesses::sub_path,
+                                   seq_shape_witnesses::int_path>);
   // No opt-in ⇒ honest reject even with matching Codomain:
   STATIC_CHECK_FALSE(IsSubsequence<Path<double>, Path<double>>);
 }

--- a/src/test/cpp/modules/dedekind/sequences/sequence_shape_concepts_test.cpp
+++ b/src/test/cpp/modules/dedekind/sequences/sequence_shape_concepts_test.cpp
@@ -92,6 +92,9 @@ TEST_CASE(
   // Wrong period N honestly rejects (no opt-in for N=2):
   STATIC_CHECK_FALSE(IsPeriodicSequence<seq_shape_witnesses::periodic_path, 2>);
   STATIC_CHECK_FALSE(IsPeriodicSequence<Path<double>, 3>);
+  // Period 0 is degenerate — the concept rejects N == 0 regardless of
+  // any (accidental) opt-in, via the N > 0 guard in the concept body:
+  STATIC_CHECK_FALSE(IsPeriodicSequence<seq_shape_witnesses::periodic_path, 0>);
 }
 
 TEST_CASE(

--- a/src/test/cpp/modules/dedekind/sequences/sequence_shape_concepts_test.cpp
+++ b/src/test/cpp/modules/dedekind/sequences/sequence_shape_concepts_test.cpp
@@ -1,0 +1,116 @@
+/** @file dedekind/sequences/sequence_shape_concepts_test.cpp
+ *
+ * Unit coverage for the sequence-shape concepts (#719 Slice 1):
+ * @c IsBoundedSequence, @c IsMonotoneSequence, @c IsPeriodicSequence,
+ * @c IsAbsorptiveSequence, @c IsSubsequence.
+ *
+ * Each property is a property of the @b value (which sequence), not
+ * the carrier type, so the concepts gate on opt-in traits a tagged
+ * carrier registers when it guarantees the property.  The toy tagged
+ * paths below derive from @c Path<double> (inheriting the
+ * @c IsSequence shape) and opt into the relevant trait.
+ *
+ * Coverage:
+ *  - Each concept fires on its tagged witness.
+ *  - Each concept honestly rejects a plain @c Path<double> (no opt-in).
+ *  - @c IsSubsequence fires on a (sub, super) tagged pair; rejects a
+ *    cross-Codomain pair.
+ */
+
+#include <catch2/catch_test_macros.hpp>
+
+import dedekind.sequences;
+
+using namespace dedekind::sequences;
+
+namespace seq_shape_witnesses {
+
+/** @brief Tagged toy paths — derive from Path<double> to inherit the
+ *         IsSequence shape; the opt-in trait registrations below mark
+ *         each as guaranteeing its shape property. */
+struct bounded_path : Path<double> {
+  using Path<double>::Path;
+};
+struct monotone_path : Path<double> {
+  using Path<double>::Path;
+};
+struct periodic_path : Path<double> {
+  using Path<double>::Path;
+};
+struct absorptive_path : Path<double> {
+  using Path<double>::Path;
+};
+struct sub_path : Path<double> {
+  using Path<double>::Path;
+};
+struct super_path : Path<double> {
+  using Path<double>::Path;
+};
+struct int_path : Path<int> {
+  using Path<int>::Path;
+};
+
+}  // namespace seq_shape_witnesses
+
+namespace dedekind::sequences {
+template <>
+inline constexpr bool
+    is_bounded_sequence_v<seq_shape_witnesses::bounded_path> = true;
+template <>
+inline constexpr bool
+    is_monotone_sequence_v<seq_shape_witnesses::monotone_path> = true;
+template <>
+inline constexpr bool
+    is_periodic_sequence_v<seq_shape_witnesses::periodic_path, 3> = true;
+template <>
+inline constexpr bool
+    is_absorptive_sequence_v<seq_shape_witnesses::absorptive_path> = true;
+template <>
+inline constexpr bool is_subsequence_v<seq_shape_witnesses::sub_path,
+                                       seq_shape_witnesses::super_path> = true;
+}  // namespace dedekind::sequences
+
+TEST_CASE("sequences:shape — IsBoundedSequence fires on the tagged witness",
+          "[sequences][shape][bounded]") {
+  STATIC_CHECK(IsBoundedSequence<seq_shape_witnesses::bounded_path>);
+  STATIC_CHECK_FALSE(IsBoundedSequence<Path<double>>);
+}
+
+TEST_CASE("sequences:shape — IsMonotoneSequence fires on the tagged witness",
+          "[sequences][shape][monotone]") {
+  STATIC_CHECK(IsMonotoneSequence<seq_shape_witnesses::monotone_path>);
+  STATIC_CHECK_FALSE(IsMonotoneSequence<Path<double>>);
+}
+
+TEST_CASE(
+    "sequences:shape — IsPeriodicSequence<S, N> fires on the period-3 witness",
+    "[sequences][shape][periodic]") {
+  /** @brief Period-3 tagged path.  Index-side compression: factors
+   *         through ℕ/3ℤ.  The period N is part of the concept's
+   *         type-level signature. */
+  STATIC_CHECK(IsPeriodicSequence<seq_shape_witnesses::periodic_path, 3>);
+  // Wrong period N honestly rejects (no opt-in for N=2):
+  STATIC_CHECK_FALSE(IsPeriodicSequence<seq_shape_witnesses::periodic_path, 2>);
+  STATIC_CHECK_FALSE(IsPeriodicSequence<Path<double>, 3>);
+}
+
+TEST_CASE(
+    "sequences:shape — IsAbsorptiveSequence fires on the eventually-constant "
+    "witness",
+    "[sequences][shape][absorptive]") {
+  /** @brief Codomain-side compression: eventually constant; the dual
+   *         of periodic. */
+  STATIC_CHECK(IsAbsorptiveSequence<seq_shape_witnesses::absorptive_path>);
+  STATIC_CHECK_FALSE(IsAbsorptiveSequence<Path<double>>);
+}
+
+TEST_CASE("sequences:shape — IsSubsequence fires on the (sub, super) pair",
+          "[sequences][shape][subsequence]") {
+  STATIC_CHECK(IsSubsequence<seq_shape_witnesses::sub_path,
+                             seq_shape_witnesses::super_path>);
+  // Cross-Codomain pair honestly rejects (double vs int):
+  STATIC_CHECK_FALSE(
+      IsSubsequence<seq_shape_witnesses::sub_path, seq_shape_witnesses::int_path>);
+  // No opt-in ⇒ honest reject even with matching Codomain:
+  STATIC_CHECK_FALSE(IsSubsequence<Path<double>, Path<double>>);
+}


### PR DESCRIPTION
## Summary

Second slice of the sequence categorification (#719). Five sequence-shape concepts in `:sequences::convergence`, each gating on an opt-in trait.

## Concepts + opt-in traits

| Concept                     | Trait                          | Reading                                          |
|-----------------------------|--------------------------------|--------------------------------------------------|
| `IsBoundedSequence<Seq>`    | `is_bounded_sequence_v`        | image order-bounded (Bishop §2)                  |
| `IsMonotoneSequence<Seq>`   | `is_monotone_sequence_v`       | `s(n) ≤ s(n+1)` (Bishop §2)                       |
| `IsPeriodicSequence<Seq, N>`| `is_periodic_sequence_v<Seq,N>`| index-side compression `ℕ ↠ ℤ/Nℤ`               |
| `IsAbsorptiveSequence<Seq>` | `is_absorptive_sequence_v`     | codomain-side compression (eventually constant)  |
| `IsSubsequence<Sub, Sup>`   | `is_subsequence_v<Sub, Sup>`   | strictly-increasing index map (feeds Bolzano-W.) |

## Why opt-in traits

Boundedness/monotonicity/periodicity are properties of the **value** (which sequence), not the carrier type — a `Path<double>` can be bounded or unbounded, monotone or oscillating. C++ concepts gate on types, so each property is pinned by an opt-in trait the carrier (or a tagged wrapper) registers when it **guarantees** the property. Same honesty discipline as `:morphism`'s `is_epic_arrow_v` and the `:cartesian` relation traits.

## Periodic / absorptive duality

The dual compression readings surfaced in the #719 design review (your "periodic / absorptive" observation):
- **Periodic** compresses the index: factors through `ℕ ↠ ℤ/Nℤ`.
- **Absorptive** compresses the codomain: eventually-constant tail, `ℕ → {z}`.

Both lift the carrier-axis vocabulary (`is_periodic_v` / `is_absorptive_v` in `:species`) onto the sequence axis.

## Test plan

- [x] `make compile` — green
- [x] `make test` — 100% pass, 15/15 suites
- [x] Five `TEST_CASE`s: each concept fires on its tagged witness (toy paths derived from `Path<double>`) and honestly rejects plain `Path<double>` / wrong-period / cross-Codomain

## Refs

- Epic: #719 Slice 1
- Slice 0: PR #728 (merged)
- IsPeriodicSequence / IsAbsorptiveSequence trace to the periodic/absorptive duality discussion (folded into the #719 epic body earlier)