### PR TITLE
feat(sequences): #719 Slice 1b — orbit bridge aligning carrier-axis & sequence-axis periodicity

### DIFF
--- a/src/main/modules/dedekind/sequences/convergence.cppm
+++ b/src/main/modules/dedekind/sequences/convergence.cppm
@@ -203,17 +203,21 @@ concept IsSubsequence =
 //
 // A periodic carrier (T, Op) — @c is_periodic_v<T, Op> with finite
 // @c cyclic_order_v<T, Op> @c = @c N — generates an @b orbit @b
-// sequence  n ↦ Opⁿ(generator)  that cycles with period N.  This
-// makes the two @c is_periodic notions provably one: the carrier-axis
-// trait in @c :species and the sequence-axis trait above are bridged
-// by the orbit construction.  Same propagation shape as #718's HSP
-// trait-lifting (carrier trait ⇒ derived-carrier trait).
+// sequence  n ↦ Opⁿ(generator)  for which @c N is @b a @b period.
+// (It is the @em minimal period when the element generates the whole
+// group; an arbitrary element's orbit may have a smaller minimal
+// period dividing N.  N is always a valid period — the non-minimal
+// convention used here.)  This makes the two @c is_periodic notions
+// provably one: the carrier-axis trait in @c :species and the
+// sequence-axis trait above are bridged by the orbit construction.
+// Same propagation shape as #718's HSP trait-lifting (carrier trait ⇒
+// derived-carrier trait).
 //
 // @c OrbitSequence<T, Op> is the reified orbit, a distinct sequence
 // type (deriving the @c IsSequence shape from @c Path<T>) so the
 // type-level propagation has something to key on.  The exact orbit
 // indexing is immaterial to the periodicity claim — what propagates
-// is the @b period, read off @c cyclic_order_v.
+// is the period @c N, read off @c cyclic_order_v.
 // ===========================================================================
 
 /** @brief The orbit sequence @c n ↦ Opⁿ(generator) of a carrier
@@ -222,11 +226,23 @@ concept IsSubsequence =
  *  @details Derives the sequence shape from @c Path<T>; the generator
  *  function folds @c Op over copies of the stored generator element.
  *  The carrier's periodicity (if any) propagates to this type's
- *  @c is_periodic_sequence_v via the bridge below. */
+ *  @c is_periodic_sequence_v via the bridge below.
+ *
+ *  @note When @c cyclic_order_v<T, Op> @c = @c order @c > @c 0, the
+ *  index @c n is reduced @c mod @c order before folding, so @c at(n)
+ *  is @c O(order) rather than @c O(n) — the orbit only has @c order
+ *  distinct values regardless of @c n. */
 export template <typename T, typename Op>
 struct OrbitSequence : Path<T> {
   constexpr OrbitSequence(T gen, Op op) {
     this->generator = [gen, op](std::size_t n) {
+      // For a periodic carrier the orbit has only `order` distinct
+      // values; reduce n to keep at() bounded by the cyclic order
+      // rather than the (arbitrarily large) query index.
+      constexpr std::size_t order = dedekind::category::cyclic_order_v<T, Op>;
+      if constexpr (order > 0) {
+        n %= order;
+      }
       T acc = gen;
       for (std::size_t i = 0; i < n; ++i) {
         acc = op(acc, gen);
@@ -238,9 +254,9 @@ struct OrbitSequence : Path<T> {
 
 /** @brief The orbit bridge.  If @c (T, Op) is a periodic carrier with
  *         @c cyclic_order_v<T, Op> @c = @c N @c > @c 0, then its orbit
- *         sequence is a period-@c N sequence.  @c N is deduced from the
- *         query and gated against the carrier's cyclic order, so the
- *         propagation fires exactly at the true period. */
+ *         sequence is a period-@c N sequence (@c N is @b a period; see
+ *         the section note on minimality).  @c N is deduced from the
+ *         query and gated against the carrier's cyclic order. */
 template <typename T, typename Op, std::size_t N>
   requires(N > 0 && dedekind::category::is_periodic_v<T, Op> &&
            N == dedekind::category::cyclic_order_v<T, Op>)

--- a/src/main/modules/dedekind/sequences/convergence.cppm
+++ b/src/main/modules/dedekind/sequences/convergence.cppm
@@ -19,7 +19,7 @@ module;
 
 export module dedekind.sequences:convergence;
 
-import dedekind.category;  // is_periodic_v / cyclic_order_v — the orbit bridge
+import dedekind.category; // is_periodic_v / cyclic_order_v — the orbit bridge
 
 import :net;  // IsSequence (Form-chain row 4) — #719 Slice 0
 import :path;

--- a/src/main/modules/dedekind/sequences/convergence.cppm
+++ b/src/main/modules/dedekind/sequences/convergence.cppm
@@ -19,6 +19,8 @@ module;
 
 export module dedekind.sequences:convergence;
 
+import dedekind.category;  // is_periodic_v / cyclic_order_v — the orbit bridge
+
 import :net;  // IsSequence (Form-chain row 4) — #719 Slice 0
 import :path;
 import :limits;  // limit() — :sequences-side prerequisite for
@@ -194,6 +196,55 @@ concept IsSubsequence =
     IsSequence<Sub> && IsSequence<Sup> &&
     std::same_as<typename Sub::Codomain, typename Sup::Codomain> &&
     is_subsequence_v<Sub, Sup>;
+
+// ===========================================================================
+// The orbit bridge (#719 Slice 1b): carrier-axis periodicity ⇒
+// sequence-axis periodicity.
+//
+// A periodic carrier (T, Op) — @c is_periodic_v<T, Op> with finite
+// @c cyclic_order_v<T, Op> @c = @c N — generates an @b orbit @b
+// sequence  n ↦ Opⁿ(generator)  that cycles with period N.  This
+// makes the two @c is_periodic notions provably one: the carrier-axis
+// trait in @c :species and the sequence-axis trait above are bridged
+// by the orbit construction.  Same propagation shape as #718's HSP
+// trait-lifting (carrier trait ⇒ derived-carrier trait).
+//
+// @c OrbitSequence<T, Op> is the reified orbit, a distinct sequence
+// type (deriving the @c IsSequence shape from @c Path<T>) so the
+// type-level propagation has something to key on.  The exact orbit
+// indexing is immaterial to the periodicity claim — what propagates
+// is the @b period, read off @c cyclic_order_v.
+// ===========================================================================
+
+/** @brief The orbit sequence @c n ↦ Opⁿ(generator) of a carrier
+ *         @c (T, Op), reified as a distinct @c IsSequence type.
+ *
+ *  @details Derives the sequence shape from @c Path<T>; the generator
+ *  function folds @c Op over copies of the stored generator element.
+ *  The carrier's periodicity (if any) propagates to this type's
+ *  @c is_periodic_sequence_v via the bridge below. */
+export template <typename T, typename Op>
+struct OrbitSequence : Path<T> {
+  constexpr OrbitSequence(T gen, Op op) {
+    this->generator = [gen, op](std::size_t n) {
+      T acc = gen;
+      for (std::size_t i = 0; i < n; ++i) {
+        acc = op(acc, gen);
+      }
+      return acc;
+    };
+  }
+};
+
+/** @brief The orbit bridge.  If @c (T, Op) is a periodic carrier with
+ *         @c cyclic_order_v<T, Op> @c = @c N @c > @c 0, then its orbit
+ *         sequence is a period-@c N sequence.  @c N is deduced from the
+ *         query and gated against the carrier's cyclic order, so the
+ *         propagation fires exactly at the true period. */
+template <typename T, typename Op, std::size_t N>
+  requires(N > 0 && dedekind::category::is_periodic_v<T, Op> &&
+           N == dedekind::category::cyclic_order_v<T, Op>)
+inline constexpr bool is_periodic_sequence_v<OrbitSequence<T, Op>, N> = true;
 
 }  // namespace dedekind::sequences
 

--- a/src/main/modules/dedekind/sequences/convergence.cppm
+++ b/src/main/modules/dedekind/sequences/convergence.cppm
@@ -128,7 +128,16 @@ export template <typename Seq>
 inline constexpr bool is_bounded_sequence_v = false;
 
 /** @concept IsBoundedSequence
- *  @brief A sequence whose image is order-bounded.  Bishop §2. */
+ *  @brief A sequence whose image is order-bounded.  Bishop §2.
+ *
+ *  @section convergence__Bounded_Mandelbrot Mandelbrot connection
+ *  Orbit-boundedness @b is the Mandelbrot membership criterion:
+ *  @c c @c ∈ @c M @c ⟺ the orbit @c mandelbrot_orbit(c) @c = @c
+ *  iterate(0, @c z↦z²+c) (in @c :numbers::mandelbrot) is bounded
+ *  @c ⟺ @c IsBoundedSequence holds for that orbit.  The escape-time
+ *  machinery (@c orbit_escape_time) is the negation: an escaping
+ *  parameter's orbit is @b unbounded, so @c IsBoundedSequence
+ *  honestly rejects it. */
 export template <typename Seq>
 concept IsBoundedSequence = IsSequence<Seq> && is_bounded_sequence_v<Seq>;
 
@@ -159,7 +168,17 @@ inline constexpr bool is_periodic_sequence_v = false;
  *  @details Requires @c N @c > @c 0: "period 0" is undefined (the
  *           @c s(n) @c = @c s(n+N) reading degenerates), so the
  *           concept rejects @c N @c == @c 0 regardless of any
- *           accidental trait opt-in. */
+ *           accidental trait opt-in.
+ *
+ *  @section convergence__Periodic_Mandelbrot Mandelbrot connection
+ *  In @c :numbers::mandelbrot, a parameter @c c in a @b hyperbolic @b
+ *  component of period @c N has an orbit that settles into an
+ *  attracting @c N-cycle — eventually period-@c N.  The main cardioid
+ *  is the period-1 component (the orbit converges to an attracting
+ *  fixed point — eventually @c IsAbsorptiveSequence); the period-2
+ *  bulb is eventually period-2; and so on.  The bulbs of the
+ *  Mandelbrot set are the geometric picture of @c IsPeriodicSequence
+ *  on the @c z↦z²+c iteration. */
 export template <typename Seq, std::size_t N>
 concept IsPeriodicSequence =
     (N > 0) && IsSequence<Seq> && is_periodic_sequence_v<Seq, N>;
@@ -175,7 +194,23 @@ inline constexpr bool is_absorptive_sequence_v = false;
 /** @concept IsAbsorptiveSequence
  *  @brief An eventually-constant sequence.  The simplest convergent
  *         case (limit = the absorbing value); period-1-eventually
- *         dual to @c IsPeriodicSequence. */
+ *         dual to @c IsPeriodicSequence.
+ *
+ *  @section convergence__Absorptive_Mandelbrot Mandelbrot connection
+ *  This concept's canonical consumer is the @b escape-time @b
+ *  divergence path in @c :numbers::mandelbrot.  @c orbit_divergence_path
+ *  produces a monotone @c Path<Ternary> that is @c Unknown until the
+ *  orbit escapes and @c True forever after — @b eventually @b constant,
+ *  i.e.\ an @c IsAbsorptiveSequence whose absorbing value is the
+ *  Kleene-@c True that is the absorbing element of Kleene @c OR.  The
+ *  partition's own comment names this: "True is the absorbing element
+ *  of Kleene OR, so once the path reaches True it stays there."
+ *
+ *  This is where the @b absorptive reading earns its keep: not via
+ *  @c :species's lattice-absorption @c is_absorptive_v (a looser,
+ *  shared-name analogy — there is no orbit-style theorem linking the
+ *  two), but via escape-time dynamics, where the eventually-constant
+ *  escape indicator is genuinely an absorptive sequence. */
 export template <typename Seq>
 concept IsAbsorptiveSequence = IsSequence<Seq> && is_absorptive_sequence_v<Seq>;
 
@@ -231,7 +266,23 @@ concept IsSubsequence =
  *  @note When @c cyclic_order_v<T, Op> @c = @c order @c > @c 0, the
  *  index @c n is reduced @c mod @c order before folding, so @c at(n)
  *  is @c O(order) rather than @c O(n) — the orbit only has @c order
- *  distinct values regardless of @c n. */
+ *  distinct values regardless of @c n.
+ *
+ *  @section convergence__Orbit_vs_Iteration Group orbit vs.\ iteration
+ *  @c OrbitSequence is the @b group-flavoured orbit
+ *  (@c n ↦ Opⁿ(generator), folding a binary @c Op).  Its
+ *  dynamical-systems sibling is the @b unary-iteration sequence
+ *  @c n ↦ fⁿ(seed) produced by @c iterate(seed, @c f) — e.g.\
+ *  @c mandelbrot_orbit(c) @c = @c iterate(0, @c z↦z²+c) in
+ *  @c :numbers::mandelbrot.  Both are "iteration sequences"; the
+ *  sequence-shape concepts (@c IsBoundedSequence,
+ *  @c IsPeriodicSequence, @c IsAbsorptiveSequence) apply to either
+ *  regardless of how the orbit is constructed.  A future mechanical
+ *  unification — a typed @c IterationSequence<f, seed> subsuming both
+ *  — would let the periodicity bridge fire on Mandelbrot bulbs too;
+ *  this slice keeps the group-orbit case (where @c cyclic_order_v
+ *  gives the period) and leaves the unary generalisation as a
+ *  named follow-up. */
 export template <typename T, typename Op>
 struct OrbitSequence : Path<T> {
   constexpr OrbitSequence(T gen, Op op) {

--- a/src/test/cpp/modules/dedekind/morphologies/orbit_bridge_test.cpp
+++ b/src/test/cpp/modules/dedekind/morphologies/orbit_bridge_test.cpp
@@ -62,13 +62,16 @@ TEST_CASE(
 TEST_CASE("morphologies:orbit-bridge — runtime: the orbit cycles with period 6",
           "[morphologies][orbit][runtime]") {
   /** @brief Runtime exercise of the OrbitSequence body — the orbit
-   *         values cycle with period 6.  Confirms the type-level
-   *         periodicity claim is backed by the actual orbit. */
-  Orbit6 orbit{Z6{1}, Plus6{}};
+   *         values cycle with the carrier's cyclic order.  Uses
+   *         @c Modular<6>::generator() and @c cyclic_order_v rather
+   *         than the literals 1 and 6, keeping the test aligned with
+   *         the "period read off cyclic_order_v" story. */
+  constexpr std::size_t order = cyclic_order_v<Z6, Plus6>;
+  Orbit6 orbit{Z6::generator(), Plus6{}};
 
-  // The orbit values repeat every 6 steps (the carrier's cyclic order).
-  for (std::size_t n = 0; n < 6; ++n) {
-    CHECK(orbit.at(n) == orbit.at(n + 6));
-    CHECK(orbit.at(n) == orbit.at(n + 12));
+  // The orbit values repeat every `order` steps (the cyclic order).
+  for (std::size_t n = 0; n < order; ++n) {
+    CHECK(orbit.at(n) == orbit.at(n + order));
+    CHECK(orbit.at(n) == orbit.at(n + 2 * order));
   }
 }

--- a/src/test/cpp/modules/dedekind/morphologies/orbit_bridge_test.cpp
+++ b/src/test/cpp/modules/dedekind/morphologies/orbit_bridge_test.cpp
@@ -18,7 +18,6 @@
  */
 
 #include <catch2/catch_test_macros.hpp>
-
 #include <functional>
 
 import dedekind.category;
@@ -45,7 +44,8 @@ TEST_CASE(
 }
 
 TEST_CASE(
-    "morphologies:orbit-bridge — the orbit of Modular<6> is a period-6 sequence",
+    "morphologies:orbit-bridge — the orbit of Modular<6> is a period-6 "
+    "sequence",
     "[morphologies][orbit][periodic][bridge][crown]") {
   /** @brief The bridge: OrbitSequence<Modular<6>, +> is a period-6
    *         sequence.  is_periodic_v(carrier) ⇒ is_periodic_sequence_v
@@ -59,9 +59,8 @@ TEST_CASE(
   STATIC_CHECK_FALSE(IsPeriodicSequence<Orbit6, 0>);  // degenerate guard
 }
 
-TEST_CASE(
-    "morphologies:orbit-bridge — runtime: the orbit cycles with period 6",
-    "[morphologies][orbit][runtime]") {
+TEST_CASE("morphologies:orbit-bridge — runtime: the orbit cycles with period 6",
+          "[morphologies][orbit][runtime]") {
   /** @brief Runtime exercise of the OrbitSequence body — the orbit
    *         values cycle with period 6.  Confirms the type-level
    *         periodicity claim is backed by the actual orbit. */

--- a/src/test/cpp/modules/dedekind/morphologies/orbit_bridge_test.cpp
+++ b/src/test/cpp/modules/dedekind/morphologies/orbit_bridge_test.cpp
@@ -1,0 +1,75 @@
+/** @file dedekind/morphologies/orbit_bridge_test.cpp
+ *
+ * Unit coverage for the orbit bridge (#719 Slice 1b): carrier-axis
+ * periodicity (@c is_periodic_v in @c :species) propagates to
+ * sequence-axis periodicity (@c is_periodic_sequence_v in
+ * @c :sequences::convergence) via the @c OrbitSequence<T, Op>
+ * construction, with the period read off @c cyclic_order_v.
+ *
+ * This makes the two @c is_periodic notions provably one: a periodic
+ * carrier's orbit sequence is a periodic sequence with the same
+ * period.  Witnessed at the canonical cyclic ring @c Modular<6>
+ * (cyclic order 6 under @c +).
+ *
+ * Test lives in the morphologies test dir because it needs both
+ * @c :sequences (for OrbitSequence / is_periodic_sequence_v) and
+ * @c :morphologies (for Modular<N> and its cyclic_order_v
+ * specialisation).
+ */
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <functional>
+
+import dedekind.category;
+import dedekind.morphologies;
+import dedekind.sequences;
+
+using namespace dedekind::sequences;
+using dedekind::category::cyclic_order_v;
+using dedekind::category::is_periodic_v;
+using dedekind::morphologies::Modular;
+
+using Z6 = Modular<6>;
+using Plus6 = std::plus<Z6>;
+using Orbit6 = OrbitSequence<Z6, Plus6>;
+
+TEST_CASE(
+    "morphologies:orbit-bridge — Modular<6> is a periodic carrier of order 6",
+    "[morphologies][orbit][periodic][carrier]") {
+  /** @brief The carrier-axis premise: Modular<6> is periodic under +
+   *         with cyclic order 6.  These are the inputs the orbit
+   *         bridge consumes. */
+  STATIC_CHECK(is_periodic_v<Z6, Plus6>);
+  STATIC_CHECK(cyclic_order_v<Z6, Plus6> == 6);
+}
+
+TEST_CASE(
+    "morphologies:orbit-bridge — the orbit of Modular<6> is a period-6 sequence",
+    "[morphologies][orbit][periodic][bridge][crown]") {
+  /** @brief The bridge: OrbitSequence<Modular<6>, +> is a period-6
+   *         sequence.  is_periodic_v(carrier) ⇒ is_periodic_sequence_v
+   *         (orbit), with the period read off cyclic_order_v.  The two
+   *         is_periodic notions are now provably one. */
+  STATIC_CHECK(IsSequence<Orbit6>);
+  STATIC_CHECK(IsPeriodicSequence<Orbit6, 6>);
+
+  // The period is exactly the cyclic order — wrong periods reject.
+  STATIC_CHECK_FALSE(IsPeriodicSequence<Orbit6, 5>);
+  STATIC_CHECK_FALSE(IsPeriodicSequence<Orbit6, 0>);  // degenerate guard
+}
+
+TEST_CASE(
+    "morphologies:orbit-bridge — runtime: the orbit cycles with period 6",
+    "[morphologies][orbit][runtime]") {
+  /** @brief Runtime exercise of the OrbitSequence body — the orbit
+   *         values cycle with period 6.  Confirms the type-level
+   *         periodicity claim is backed by the actual orbit. */
+  Orbit6 orbit{Z6{1}, Plus6{}};
+
+  // The orbit values repeat every 6 steps (the carrier's cyclic order).
+  for (std::size_t n = 0; n < 6; ++n) {
+    CHECK(orbit.at(n) == orbit.at(n + 6));
+    CHECK(orbit.at(n) == orbit.at(n + 12));
+  }
+}


### PR DESCRIPTION
## Summary

Follow-up to #719 Slice 1 (PR #729), per your design question: align the new sequence-axis `is_periodic_sequence_v` with the carrier-axis `is_periodic_v` in `:species` in an **obvious, mechanical** way.

The two `is_periodic` notions are connected by the **orbit construction**: a periodic carrier `(T, Op)` with `cyclic_order_v<T, Op> = N` generates an orbit sequence `n ↦ Opⁿ(generator)` that cycles with period N. This slice makes that bridge a typed propagation — the two notions become **provably one**.

## What lands

`OrbitSequence<T, Op>` + the bridge propagation in `:sequences::convergence`:

```cpp
template <typename T, typename Op, std::size_t N>
  requires (N > 0 && is_periodic_v<T, Op> && N == cyclic_order_v<T, Op>)
inline constexpr bool is_periodic_sequence_v<OrbitSequence<T, Op>, N> = true;
```

`N` is deduced from the query and gated against the carrier's cyclic order, so the propagation fires exactly at the true period. Same trait-lifting shape as #718's HSP propagation (carrier trait ⇒ derived-carrier trait).

`OrbitSequence<T, Op>` derives the `IsSequence` shape from `Path<T>` (distinct type so the propagation has something to key on; the orbit `n ↦ Opⁿ(gen)` is computed in the generator lambda).

## Witness (Modular<6>)

```cpp
STATIC_CHECK(is_periodic_v<Modular<6>, +>);             // carrier premise
STATIC_CHECK(cyclic_order_v<Modular<6>, +> == 6);
STATIC_CHECK(IsPeriodicSequence<OrbitSequence<Modular<6>, +>, 6>);  // the bridge
STATIC_CHECK_FALSE(IsPeriodicSequence<..., 5>);         // wrong period rejects
STATIC_CHECK_FALSE(IsPeriodicSequence<..., 0>);         // degenerate guard
```

Plus a runtime check that the orbit values cycle with period 6.

## Why absorptive is NOT aligned the same way

Per the same design review: `is_absorptive_v` (lattice absorption `a∨(a∧b)=a`) and `is_absorptive_sequence_v` (eventual constancy) share the "operation collapses to a constant" intuition but have **no orbit-style theorem** linking them. Forcing a mechanical bridge there would be a naming coincidence dressed as a unification — so absorptive stays at the shared-name + duality-note level. (Periodic earns the bridge; absorptive doesn't.)

## Test plan

- [x] `make compile` — green
- [x] `make test` — 100% pass, 15/15 suites
- [x] Three TEST_CASEs: carrier premise, the bridge (+ wrong-period / degenerate rejects), runtime orbit cycling

## Refs

- Epic: #719 (Slice 1b, follow-up to Slice 1 / PR #729)
- Bridge pattern mirrors #718's HSP trait-propagation