### PR TITLE
feat(numbers): #719 Mandelbrot leverages the sequence-shape API (DivergencePath is absorptive)

### DIFF
--- a/src/main/modules/dedekind/numbers/mandelbrot.cppm
+++ b/src/main/modules/dedekind/numbers/mandelbrot.cppm
@@ -100,7 +100,39 @@ constexpr auto mandelbrot_orbit(const Complex<R>& c) {
 // ─────────────────────────────────────
 
 /**
- * The divergence spectrum of an orbit: a monotone Path<Ternary>.
+ * @class DivergencePath
+ * @brief The escape signal of a Mandelbrot orbit, tagged as a sequence-shape
+ *        witness: a monotone @c {Unknown,True}-valued @c Path<Ternary> that
+ *        is @b structurally absorptive for every parameter @c c.
+ *
+ * @details The divergence path of @c orbit_divergence_path is eventually
+ * constant regardless of @c c:
+ *
+ *   - @b Escaping @c c (outside @f$M@f$): the path is @c Unknown until the
+ *     escape index, then @c True forever (@c True is the absorbing element
+ *     of Kleene OR — @c §sequences::IsAbsorptiveSequence's "tail factors
+ *     through a singleton @f$\{z\}@f$" with @f$z = @c True@f$).
+ *   - @b Bounded @c c (inside @f$M@f$): the path is the constant @c Unknown
+ *     sequence — eventually-constant from index 0, the degenerate absorptive
+ *     case (@f$z = @c Unknown@f$).
+ *
+ * So the @c IsAbsorptiveSequence shape holds at the @b type level for the
+ * carrier as a whole, independently of the (value-level, undecidable)
+ * membership question for any individual @c c.  This is the honest leverage
+ * the sequence API affords Mandelbrot: per-@c c boundedness
+ * (@c IsBoundedSequence ⟺ @f$c \in M@f$) is value-dependent and cannot be
+ * type-witnessed, but "the escape indicator is an absorptive sequence" @b is.
+ *
+ * @see dedekind::sequences::IsAbsorptiveSequence
+ */
+export template <IsComplexScalar R>
+struct DivergencePath : Path<Ternary> {
+  constexpr explicit DivergencePath(Path<Ternary> p)
+      : Path<Ternary>{std::move(p)} {}
+};
+
+/**
+ * The divergence spectrum of an orbit: a monotone @c DivergencePath<R>.
  *
  *   orbit_divergence_path(orbit, p)(n)
  *     = True    if ∃ k ≤ n : p(z_k)   (escape witnessed)
@@ -109,6 +141,9 @@ constexpr auto mandelbrot_orbit(const Complex<R>& c) {
  * Monotonicity: True is the absorbing element of Kleene OR, so once the
  * path reaches True it stays there.  A monotone {Unknown,True}-valued path
  * is isomorphic to ℕ∞ — its information content is exactly the escape time.
+ * The result type @c DivergencePath<R> carries the
+ * @c sequences::IsAbsorptiveSequence shape (eventually constant for every
+ * @c c — see the class doc), making the eventual-constancy a type-level fact.
  *
  * This is the Layer 1 intensional object; orbit_escape_time() is the
  * efficient materialization.
@@ -117,13 +152,13 @@ export template <IsComplexScalar R, typename EscapeCriterion>
   requires IsEscapeCriterion<EscapeCriterion, Complex<R>>
 constexpr auto orbit_divergence_path(const OrbitPath<R>& orbit,
                                      EscapeCriterion criterion)
-    -> Path<Ternary> {
-  return scan(
+    -> DivergencePath<R> {
+  return DivergencePath<R>{scan(
       [criterion](const FinitePath<Complex<R>>& p) -> Ternary {
         return exists(p, classify<Complex<R>>(criterion).χ) ? Ternary::True
                                                             : Ternary::Unknown;
       },
-      orbit);
+      orbit)};
 }
 
 /**
@@ -236,5 +271,36 @@ constexpr auto M_tower(EscapeCriterion criterion,
     return M_N<R>(n, criterion, policy);
   };
 }
+
+}  // namespace dedekind::numbers
+
+namespace dedekind::sequences {
+
+/** @brief Opt-in: every @c DivergencePath<R> is absorptive (eventually
+ *         constant — @c True after escape, or the degenerate constant
+ *         @c Unknown when bounded).  The eventual-constancy is structural,
+ *         holding for all @c c, so it is a sound type-level registration.
+ *         See @c dedekind::numbers::DivergencePath. */
+export template <dedekind::numbers::IsComplexScalar R>
+inline constexpr bool
+    is_absorptive_sequence_v<dedekind::numbers::DivergencePath<R>> = true;
+
+}  // namespace dedekind::sequences
+
+namespace dedekind::numbers {
+
+/** @section mandelbrot__Formal_Verification
+ *  Sequence-API leverage pinned at the type level (#719). */
+
+// The raw orbit n ↦ z_n is a bona-fide sequence (ℕ → Complex<R>).
+static_assert(dedekind::sequences::IsSequence<OrbitPath<double>>,
+              "A Mandelbrot orbit is an IsSequence (ℕ → Complex).");
+
+// The escape indicator is a typed absorptive sequence — eventual-constancy
+// for every c, independent of the value-level membership question.
+static_assert(
+    dedekind::sequences::IsAbsorptiveSequence<DivergencePath<double>>,
+    "The Mandelbrot divergence path is an absorptive sequence: eventually "
+    "constant (True after escape, else the degenerate constant Unknown).");
 
 }  // namespace dedekind::numbers

--- a/src/main/modules/dedekind/numbers/mandelbrot.cppm
+++ b/src/main/modules/dedekind/numbers/mandelbrot.cppm
@@ -110,8 +110,8 @@ constexpr auto mandelbrot_orbit(const Complex<R>& c) {
  *
  *   - @b Escaping @c c (outside @f$M@f$): the path is @c Unknown until the
  *     escape index, then @c True forever (@c True is the absorbing element
- *     of Kleene OR — @c §sequences::IsAbsorptiveSequence's "tail factors
- *     through a singleton @f$\{z\}@f$" with @f$z = @c True@f$).
+ *     of Kleene OR — the @c IsAbsorptiveSequence tail factors through a
+ *     singleton @f$\{z\}@f$ with @f$z@f$ = @c True).
  *   - @b Bounded @c c (inside @f$M@f$): the path is the constant @c Unknown
  *     sequence — eventually-constant from index 0, the degenerate absorptive
  *     case (@f$z = @c Unknown@f$).
@@ -123,12 +123,28 @@ constexpr auto mandelbrot_orbit(const Complex<R>& c) {
  * (@c IsBoundedSequence ⟺ @f$c \in M@f$) is value-dependent and cannot be
  * type-witnessed, but "the escape indicator is an absorptive sequence" @b is.
  *
+ * @note Construction is restricted to @c orbit_divergence_path (the only
+ *       friend): the absorptive invariant is enforced @b by @b construction,
+ *       not merely promised by the trait opt-in.  No public constructor from
+ *       an arbitrary @c Path<Ternary> exists, so a @c DivergencePath can only
+ *       arise from the factory that guarantees eventual-constancy.  (The
+ *       @c .generator / @c .extent members inherited from @c Path remain
+ *       writable — preserving eventual-constancy under in-place mutation is
+ *       the residual honesty obligation, as for every tagged @c Path.)
+ *
  * @see dedekind::sequences::IsAbsorptiveSequence
  */
 export template <IsComplexScalar R>
 struct DivergencePath : Path<Ternary> {
+ private:
   constexpr explicit DivergencePath(Path<Ternary> p)
       : Path<Ternary>{std::move(p)} {}
+
+  template <IsComplexScalar R2, typename EscapeCriterion>
+    requires IsEscapeCriterion<EscapeCriterion, Complex<R2>>
+  friend constexpr auto orbit_divergence_path(const OrbitPath<R2>& orbit,
+                                              EscapeCriterion criterion)
+      -> DivergencePath<R2>;
 };
 
 /**

--- a/src/test/cpp/modules/dedekind/numbers/mandelbrot_stress_test.cpp
+++ b/src/test/cpp/modules/dedekind/numbers/mandelbrot_stress_test.cpp
@@ -113,6 +113,8 @@ TEST_CASE("Sets: Mandelbrot set-builder stress test", "[sets][mandelbrot]") {
         mandelbrot_orbit(ComplexPoint{2.0, 0.0}), criterion);
 
     static_assert(IsSequence<decltype(divergence)>);
+    // The escape signal is a typed absorptive sequence (eventually constant).
+    static_assert(IsAbsorptiveSequence<DivergencePath<double>>);
     REQUIRE(divergence.at(0) == Ternary::Unknown);  // z_0=0, inside ball
     REQUIRE(divergence.at(1) == Ternary::Unknown);  // z_1=2, |2|²=4 not >4
     REQUIRE(divergence.at(2) == Ternary::True);     // z_2=6, |6|²=36>4

--- a/src/test/cpp/modules/dedekind/numbers/mandelbrot_stress_test.cpp
+++ b/src/test/cpp/modules/dedekind/numbers/mandelbrot_stress_test.cpp
@@ -1,8 +1,10 @@
 #include <catch2/catch_test_macros.hpp>
 #include <chrono>
 #include <complex>
+#include <concepts>
 #include <cstdint>
 #include <string>
+#include <type_traits>
 
 import dedekind.category;
 import dedekind.sets;
@@ -113,7 +115,10 @@ TEST_CASE("Sets: Mandelbrot set-builder stress test", "[sets][mandelbrot]") {
         mandelbrot_orbit(ComplexPoint{2.0, 0.0}), criterion);
 
     static_assert(IsSequence<decltype(divergence)>);
-    // The escape signal is a typed absorptive sequence (eventually constant).
+    // The factory wires the new API: its return type is exactly
+    // DivergencePath<double>, a typed absorptive sequence (eventually const).
+    static_assert(std::same_as<std::remove_cvref_t<decltype(divergence)>,
+                               DivergencePath<double>>);
     static_assert(IsAbsorptiveSequence<DivergencePath<double>>);
     REQUIRE(divergence.at(0) == Ternary::Unknown);  // z_0=0, inside ball
     REQUIRE(divergence.at(1) == Ternary::Unknown);  // z_1=2, |2|²=4 not >4


### PR DESCRIPTION
## Summary

Wires the Mandelbrot module into the new `:sequences` shape API (#719 Slice 1).

The honest leverage point: the escape signal `orbit_divergence_path` is **structurally eventually-constant for every parameter `c`** — `True` once escape is witnessed (the absorbing element of Kleene OR), else the degenerate constant `Unknown` sequence when bounded. That eventual-constancy is the `sequences::IsAbsorptiveSequence` shape, and it holds at the **type level** regardless of the value-level (undecidable) membership of any individual `c`.

- New tagged carrier `DivergencePath<R> : Path<Ternary>`; `orbit_divergence_path` now returns it.
- Registers `is_absorptive_sequence_v<DivergencePath<R>> = true` in `dedekind::sequences`.
- `static_assert`s pin the shape in the module (`IsSequence<OrbitPath<double>>`, `IsAbsorptiveSequence<DivergencePath<double>>`) and in the stress test.

Per-`c` boundedness (`IsBoundedSequence ⟺ c ∈ M`) is value-dependent and undecidable, so it is deliberately **not** type-witnessed — only the structural fact is. Type-checks instead of prose.

## Test plan

- [x] `make test` — all 15 suites green
- [x] `make format` clean (pre-push hook)
- [ ] CI build-and-deploy + Analyze trio + CodeQL green

🤖 Generated with [Claude Code](https://claude.com/claude-code)