### PR TITLE
feat(sequences): #719 Slice 2 — IsStreamComonad + tails (δ) on Path

### DIFF
--- a/src/main/modules/dedekind/sequences/path.cppm
+++ b/src/main/modules/dedekind/sequences/path.cppm
@@ -370,6 +370,63 @@ constexpr auto drop(const Path<T, Cardinality>& path, std::size_t n) {
   }};
 }
 
+/**
+ * @brief δ (duplicate / comultiplication) of the stream comonad — the
+ *        stream of all suffixes.
+ *
+ * @details For an infinite stream @f$s : \mathbb{N} \to T@f$,
+ * @f[
+ *   \mathrm{tails}(s)\,(n) \;=\; \mathrm{drop}(s, n) \;=\; \lambda i.\, s(n+i),
+ * @f]
+ * so @c tails(s) is the @f$\mathbb{N} \to (\mathbb{N} \to T)@f$ stream whose
+ * @f$n@f$-th element is the @f$n@f$-shifted tail of @c s.  This is the
+ * Uustalu–Vene comultiplication @f$\delta@f$ for the stream comonad; paired
+ * with the head counit @f$\varepsilon(s) = s(0)@f$ it satisfies the comonad
+ * laws (witnessed in @c stream_comonad_test.cpp):
+ *
+ *   - left  counit: @f$\varepsilon(\delta\,s) = s@f$           (head of tails)
+ *   - right counit: @f$(\mathrm{map}\,\varepsilon)(\delta\,s) = s@f$
+ *   - coassoc:      @f$\delta(\delta\,s) = (\mathrm{map}\,\delta)(\delta\,s)@f$
+ *
+ * @see operator<<= — the co-Kleisli @c extend; @c δ(s) == s <<= identity.
+ */
+export template <typename T, typename Cardinality>
+  requires(!dedekind::sets::IsFinite<Cardinality>)
+constexpr auto tails(const Path<T, Cardinality>& s)
+    -> Path<Path<T, Cardinality>, Cardinality> {
+  return Path<Path<T, Cardinality>, Cardinality>{
+      [s](std::size_t n) { return drop(s, n); }};
+}
+
+/**
+ * @concept IsStreamComonad
+ * @brief \emph{Operational} duck-typed check that @c W carries the
+ *        Uustalu–Vene stream-comonad shape on an @b infinite sequence
+ *        @f$\mathbb{N} \to A@f$: @c ε (head @c w.at(0)), @c δ
+ *        (@c tails(w)), and @c extend (@c w @c <<= @c f).
+ *
+ * @details This is the sequence-axis operational counterpart of the
+ * axiomatic @c dedekind::category::IsComonad — the same complementary
+ * pairing the project uses for @c IsCyclic vs @c IsCyclicGroup.  The
+ * heavy categorical concept demands an @c IsEndofunctor with reified
+ * @c ε / @c δ natural transformations; this one asks only that the
+ * carrier exposes the operational shape, which @c Path already does
+ * via @c counit_witness (ε) and @c tails (δ).  The third leg, @c extend
+ * (@c operator<<=), is the derived @f$\mathrm{map}\,f \circ \delta@f$ and
+ * is separately certified by the @c IsCoKleisliExtension witness below.
+ *
+ * Finiteness is excluded on purpose: the comonad of @b infinite streams
+ * (with @c δ = @c tails) is a different beast from the non-empty-list
+ * comonad on finite carriers, so a @c FinitePath is honestly rejected.
+ */
+export template <typename W>
+concept IsStreamComonad =
+    IsSequence<W> && !dedekind::sets::IsFinite<typename W::cardinality_type> &&
+    requires(const W& w) {
+      { w.at(0) } -> std::same_as<typename W::Codomain>;
+      { tails(w) };
+    };
+
 export template <typename T, typename Step>
   requires std::invocable<const std::decay_t<Step>&, const T&> &&
            std::same_as<
@@ -694,6 +751,17 @@ static_assert(IsCoKleisliExtension<path_functor<int>, int, long>,
 static_assert(
     IsFrobenius<path_functor<int>, int, long>,
     "Path must satisfy the Frobenius witness (Kleisli + co-Kleisli).");
+
+// Stream comonad (Uustalu–Vene): the infinite Path carries the operational
+// ε / δ / extend triple; the finite Path is honestly rejected (the stream
+// comonad with δ = tails is not the non-empty-list comonad).
+static_assert(IsStreamComonad<Path<int>>,
+              "An infinite Path is an operational stream comonad: head (ε), "
+              "tails (δ), and extend (<<=).");
+static_assert(!IsStreamComonad<FinitePath<int>>,
+              "A FinitePath is NOT a stream comonad — δ = tails is the "
+              "infinite-stream structure, distinct from the non-empty-list "
+              "comonad on finite carriers.");
 
 // ---------------------------------------------------------------------------
 // Categorical anchor: Path<T> as a morphism out of the NNO (#602).

--- a/src/main/modules/dedekind/sequences/path.cppm
+++ b/src/main/modules/dedekind/sequences/path.cppm
@@ -403,8 +403,13 @@ constexpr auto tails(const Path<T, Cardinality>& s)
  * @concept IsStreamComonad
  * @brief \emph{Operational} duck-typed check that @c W carries the
  *        Uustalu–Vene stream-comonad shape on an @b infinite sequence
- *        @f$\mathbb{N} \to A@f$: @c ε (head @c w.at(0)), @c δ
- *        (@c tails(w)), and @c extend (@c w @c <<= @c f).
+ *        @f$\mathbb{N} \to A@f$.  The concept body checks the two
+ *        primitive legs — @c ε (head @c w.at(0)) and @c δ
+ *        (@c tails(w)) — only; the third leg @c extend (@c w @c <<= @c f)
+ *        is the derived @f$\mathrm{map}\,f \circ \delta@f$ and is
+ *        certified separately by the @c IsCoKleisliExtension witness
+ *        (pinned beside the @c IsStreamComonad<Path<int>> assertion
+ *        below), not re-checked here.
  *
  * @details This is the @b extension presentation of the stream comonad
  * (counit @c ε + coextension @c <<=), the dual of Manes' Kleisli-triple

--- a/src/main/modules/dedekind/sequences/path.cppm
+++ b/src/main/modules/dedekind/sequences/path.cppm
@@ -388,7 +388,8 @@ constexpr auto drop(const Path<T, Cardinality>& path, std::size_t n) {
  *   - right counit: @f$(\mathrm{map}\,\varepsilon)(\delta\,s) = s@f$
  *   - coassoc:      @f$\delta(\delta\,s) = (\mathrm{map}\,\delta)(\delta\,s)@f$
  *
- * @see operator<<= — the co-Kleisli @c extend; @c δ(s) == s <<= identity.
+ * @see operator<<= — the co-Kleisli @c extend; @c δ(s) is @c extend with
+ *      the context-identity, i.e.\ @c s @c <<= @c std::identity{}.
  */
 export template <typename T, typename Cardinality>
   requires(!dedekind::sets::IsFinite<Cardinality>)
@@ -418,13 +419,18 @@ constexpr auto tails(const Path<T, Cardinality>& s)
  * Finiteness is excluded on purpose: the comonad of @b infinite streams
  * (with @c δ = @c tails) is a different beast from the non-empty-list
  * comonad on finite carriers, so a @c FinitePath is honestly rejected.
+ *
+ * The @c δ leg constrains @c tails(w) to be indexable with elements of
+ * type @c W (a stream of @c W tails), not merely well-formed — this pins
+ * the comultiplication shape @f$W \Rightarrow W \circ W@f$ and rejects an
+ * unrelated ADL-found @c tails returning some other type.
  */
 export template <typename W>
 concept IsStreamComonad =
     IsSequence<W> && !dedekind::sets::IsFinite<typename W::cardinality_type> &&
-    requires(const W& w) {
+    requires(const W& w, std::size_t n) {
       { w.at(0) } -> std::same_as<typename W::Codomain>;
-      { tails(w) };
+      { tails(w).at(n) } -> std::same_as<W>;
     };
 
 export template <typename T, typename Step>

--- a/src/main/modules/dedekind/sequences/path.cppm
+++ b/src/main/modules/dedekind/sequences/path.cppm
@@ -406,15 +406,27 @@ constexpr auto tails(const Path<T, Cardinality>& s)
  *        @f$\mathbb{N} \to A@f$: @c ε (head @c w.at(0)), @c δ
  *        (@c tails(w)), and @c extend (@c w @c <<= @c f).
  *
- * @details This is the sequence-axis operational counterpart of the
- * axiomatic @c dedekind::category::IsComonad — the same complementary
- * pairing the project uses for @c IsCyclic vs @c IsCyclicGroup.  The
- * heavy categorical concept demands an @c IsEndofunctor with reified
- * @c ε / @c δ natural transformations; this one asks only that the
- * carrier exposes the operational shape, which @c Path already does
- * via @c counit_witness (ε) and @c tails (δ).  The third leg, @c extend
- * (@c operator<<=), is the derived @f$\mathrm{map}\,f \circ \delta@f$ and
- * is separately certified by the @c IsCoKleisliExtension witness below.
+ * @details This is the @b extension presentation of the stream comonad
+ * (counit @c ε + coextension @c <<=), the dual of Manes' Kleisli-triple
+ * theorem.  It is @b equivalent to — not weaker than — the
+ * comultiplication presentation @f$(W, \varepsilon, \delta)@f$ of
+ * @c dedekind::category::IsComonad: the two determine each other, with
+ * @c δ recovered as @c tails (@c s @c <<= @c std::identity{}).  The
+ * pairing mirrors @c IsCyclic vs @c IsCyclicGroup.
+ *
+ * Why the @b extension presentation rather than @c IsComonad directly:
+ * @c IsComonad refines @c IsEndofunctor (@c Σ_cat @c == @c Τ_cat), and
+ * @b no non-identity type-constructor in the library is an endofunctor —
+ * every reified functor maps @c Set<T> @c → @c Set<F<T>> (so
+ * @c maybe_functor and @c tuple_functor are @c IsFunctor but @b not
+ * @c IsEndofunctor; the only @c IsComonad witness in the codebase is
+ * @c identity_functor).  @c Path is no exception, so the co-Kleisli
+ * layer is the level on which the comonad is actually certified — see
+ * the @c path__Why_The_Kleisli_Layer_And_Not_IsComonad note on
+ * @c path_functor.  The @c extend leg here is the derived
+ * @f$\mathrm{map}\,f \circ \delta@f$, separately certified by the
+ * @c IsCoKleisliExtension witness pinned beside the
+ * @c IsStreamComonad<Path<int>> assertion below.
  *
  * Finiteness is excluded on purpose: the comonad of @b infinite streams
  * (with @c δ = @c tails) is a different beast from the non-empty-list
@@ -601,33 +613,50 @@ namespace dedekind::category {
  * @c maybe_functor / @c vec2_functor / @c matrix2x2_functor Hubs in
  * other partitions.
  *
- * @section path__Functor_Limitation
- * Unlike @c maybe_functor — which DOES satisfy
- * @c dedekind::category::IsFunctor — @c path_functor deliberately
- * does NOT.  Reason: @c Path<T> is itself an Arrow at the type level
- * (carries @c Domain @c = @c std::size_t and @c Codomain @c = @c T,
- * realising the textbook reading @c Path: @c ℕ @c → @c T).  This
- * makes @c Morphism<Path<T>, Path<T>, ...> fail @c IsSpokeArrow
- * (because @c Path<T> is an @c IsArrow domain), which in turn makes
- * @c Set<Path<T>>::operator>>(Arrow, Arrow) — needed by
- * @c IsSmallCategory<Set<Path<T>>> — not resolve cleanly.  The standard
- * Functor-on-Set machinery does not apply.  This is structural to
- * Path's "is itself an arrow" nature and not a defect to be papered
- * over.
+ * @section path__Why_The_Kleisli_Layer_And_Not_IsComonad
+ * Path's (co)monadic structure is certified at the Kleisli-witness
+ * layer (@c :kleisli — @c unit_witness, @c counit_witness,
+ * @c IsKleisliExtension, @c IsCoKleisliExtension, @c IsFrobenius), @b not
+ * via the strict @c dedekind::category::IsComonad / @c IsMonad.  This is
+ * a deliberate, textbook-sanctioned choice, not a Path-specific defect:
+ *
+ *   - The two presentations are @b equivalent.  A comonad
+ *     @f$(W, \varepsilon, \delta)@f$ and a co-Kleisli triple
+ *     (object-map @c Shape, counit @c ε, coextension @c <<=) determine
+ *     each other (the dual of Manes' Kleisli-triple theorem).  The
+ *     @c :kleisli layer is the @b extension presentation; @c :monad's
+ *     @c IsComonad is the @b comultiplication presentation.  Path lives
+ *     in the former.
+ *
+ *   - The strict @c IsComonad cannot bite @b any non-identity
+ *     type-constructor here, Path included.  @c IsComonad refines
+ *     @c IsEndofunctor, which demands @c Σ_cat @c == @c Τ_cat.  Every
+ *     reified functor in the library maps @c Set<T> @c → @c Set<F<T>>
+ *     (@c maybe_functor, @c tuple_functor), so @c Σ_cat @c ≠ @c Τ_cat
+ *     and none of them are endofunctors — the @b only @c IsEndofunctor /
+ *     @c IsComonad witness in the codebase is @c identity_functor.
+ *     (Confirmed mechanically: @c maybe_functor and @c tuple_functor are
+ *     @c IsFunctor but @b not @c IsEndofunctor.)  So reifying @c φ on
+ *     @c path_functor would buy @c IsFunctor at best — never
+ *     @c IsComonad — because @c Path<T> changes the object type
+ *     @c Set<T> @c → @c Set<Path<T>> exactly as @c maybe_functor does.
+ *
+ *   - @c path_functor therefore reifies only the object-action
+ *     (@c Shape) the Kleisli registry consumes; @c φ (= @c map) is
+ *     recoverable but left unreified because the @c :kleisli layer is
+ *     the level on which the equivalence is actually witnessed for
+ *     non-identity carriers.
  *
  * @section path__Frobenius_Reading
  * Path is @b Frobenius — it carries both monadic and comonadic
- * structure (per the partition's header note).  Under the categorical
- * reading at the Kleisli-witness level:
- *   * @c path_functor is the Hub-tag for the underlying functor T,
- *     namely the type-constructor @c Path<·> on objects (no @c φ
- *     reified at this level for the structural reason above).
+ * structure (per the partition's header note).  At the Kleisli-witness
+ * level:
+ *   * @c path_functor is the Hub-tag for the type-constructor
+ *     @c Path<·> on objects (object-action only; see above).
  *   * @c unit_witness<path_functor<T>, T> is the @c T-component of
- *     the natural transformation @c η: @c Id @c ⇒ @c T (constant
- *     path @c λn.x).
- *   * @c counit_witness<path_functor<T>, T> is the @c T-component
- *     of the natural transformation @c ε: @c T @c ⇒ @c Id (head
- *     sampling @c p.at(0)).
+ *     @c η: @c Id @c ⇒ @c T (constant path @c λn.x).
+ *   * @c counit_witness<path_functor<T>, T> is the @c T-component of
+ *     @c ε: @c T @c ⇒ @c Id (head sampling @c p.at(0)).
  *   * The downstream @c IsFrobenius<path_functor<int>, int, long>
  *     static_assert witnesses the Kleisli-side bracket shape
  *     mechanically — that's the right level to certify on Path.
@@ -758,16 +787,45 @@ static_assert(
     IsFrobenius<path_functor<int>, int, long>,
     "Path must satisfy the Frobenius witness (Kleisli + co-Kleisli).");
 
-// Stream comonad (Uustalu–Vene): the infinite Path carries the operational
-// ε / δ / extend triple; the finite Path is honestly rejected (the stream
-// comonad with δ = tails is not the non-empty-list comonad).
+// ---------------------------------------------------------------------------
+// Stream comonad (Uustalu–Vene), in the extension presentation.
+//
+// The three assertions below are ONE comonad seen at one level — the
+// co-Kleisli / extension presentation — pinned mechanically so the
+// equivalence is load-bearing rather than narrative:
+//
+//   (1) IsCoKleisliExtension<path_functor<int>, …>  — the categorical
+//       co-Kleisli triple (ε via counit_witness + coextension <<=) in
+//       :kleisli; this is the upstream comonad witness Path reuses.
+//   (2) IsStreamComonad<Path<int>>                   — the sequence-axis
+//       operational shape (head ε + tails δ) built ON (1); δ = tails is
+//       s <<= std::identity{}, so (2) is a specialisation of (1).
+//
+// Equivalence to the comultiplication presentation (W, ε, δ) of
+// category::IsComonad holds by the dual Kleisli-triple theorem, but is
+// NOT asserted here because IsComonad refines IsEndofunctor (Σ_cat ==
+// Τ_cat) and no non-identity type-constructor in the library is an
+// endofunctor (maybe_functor / tuple_functor are IsFunctor but not
+// IsEndofunctor; only identity_functor is).  path_functor is therefore
+// deliberately left below endofunctor level — the assertion pins that as
+// a Sollbruchstelle: if a future change reifies path_functor up to an
+// endofunctor, this fires and forces the IsComonad-vs-:kleisli story
+// (see path__Why_The_Kleisli_Layer_And_Not_IsComonad) to be revisited.
+static_assert(!IsEndofunctor<path_functor<int>>,
+              "Sollbruchstelle: path_functor is intentionally NOT reified "
+              "to endofunctor level (Path changes Set<T> → Set<Path<T>>, so "
+              "Σ_cat ≠ Τ_cat — same as maybe_functor).  Path's comonad is "
+              "certified in the :kleisli extension presentation instead.  If "
+              "this fails, revisit whether category::IsComonad now applies.");
+
 static_assert(IsStreamComonad<Path<int>>,
               "An infinite Path is an operational stream comonad: head (ε), "
-              "tails (δ), and extend (<<=).");
+              "tails (δ), and extend (<<=), built on the co-Kleisli witness.");
 static_assert(!IsStreamComonad<FinitePath<int>>,
               "A FinitePath is NOT a stream comonad — δ = tails is the "
               "infinite-stream structure, distinct from the non-empty-list "
               "comonad on finite carriers.");
+// ---------------------------------------------------------------------------
 
 // ---------------------------------------------------------------------------
 // Categorical anchor: Path<T> as a morphism out of the NNO (#602).

--- a/src/test/cpp/modules/dedekind/sequences/stream_comonad_test.cpp
+++ b/src/test/cpp/modules/dedekind/sequences/stream_comonad_test.cpp
@@ -1,0 +1,111 @@
+/** @file dedekind/sequences/stream_comonad_test.cpp
+ *
+ * Unit coverage for the stream-comonad surface on @c Path (#719 Slice 2):
+ * the operational @c IsStreamComonad concept and the @c tails (δ /
+ * duplicate) primitive, with the three Uustalu–Vene comonad laws
+ * verified pointwise on a sample stream.
+ *
+ * The counit is the head @f$\varepsilon(s) = s(0)@f$ (the project's
+ * @c counit_witness); the comultiplication is @c tails (δ), the stream
+ * of all suffixes; @c extend is @c operator<<=.  The laws:
+ *
+ *   - left  counit:  ε(δ s)            = s          head of tails
+ *   - right counit:  (map ε)(δ s)      = s          sampling each tail's head
+ *   - coassoc:       δ(δ s)            = (map δ)(δ s)
+ *
+ * Path generators are @c std::function-backed, so the laws cannot be
+ * @c static_assert-ed (no constexpr std::function); they are exercised
+ * pointwise at runtime on a finite window of indices.
+ */
+
+#include <catch2/catch_test_macros.hpp>
+#include <cstddef>
+
+import dedekind.sequences;
+
+using namespace dedekind::sequences;
+
+namespace {
+
+/** @brief The naturals 0,1,2,… as an infinite stream. */
+Path<int> naturals() {
+  return Path<int>{[](std::size_t n) { return static_cast<int>(n); }};
+}
+
+constexpr std::size_t window = 6;
+
+}  // namespace
+
+TEST_CASE(
+    "sequences:comonad — Path carries the operational stream-comonad shape",
+    "[sequences][comonad][stream]") {
+  STATIC_CHECK(IsStreamComonad<Path<int>>);
+  // The infinite-stream comonad (δ = tails) is not the non-empty-list
+  // comonad on finite carriers, so a FinitePath is honestly rejected.
+  STATIC_CHECK_FALSE(IsStreamComonad<FinitePath<int>>);
+}
+
+TEST_CASE("sequences:comonad — tails(s)(n) is the n-shifted tail (= drop)",
+          "[sequences][comonad][tails]") {
+  const auto s = naturals();
+  const auto ts = tails(s);
+  for (std::size_t n = 0; n < window; ++n) {
+    const auto tail_n = ts.at(n);
+    for (std::size_t i = 0; i < window; ++i) {
+      REQUIRE(tail_n.at(i) == static_cast<int>(n + i));
+      REQUIRE(tail_n.at(i) == drop(s, n).at(i));
+    }
+  }
+}
+
+TEST_CASE("sequences:comonad — left counit: ε(δ s) = s (head of tails)",
+          "[sequences][comonad][law]") {
+  const auto s = naturals();
+  const auto head_of_tails = tails(s).at(0);  // ε(δ s) = (δ s)(0) = drop(s,0)
+  for (std::size_t i = 0; i < window; ++i) {
+    REQUIRE(head_of_tails.at(i) == s.at(i));
+  }
+}
+
+TEST_CASE("sequences:comonad — right counit: (map ε)(δ s) = s",
+          "[sequences][comonad][law]") {
+  const auto s = naturals();
+  const auto ts = tails(s);
+  // map ε over the stream of tails: n ↦ head(tails(s)(n)) = (tails s)(n).at(0)
+  for (std::size_t n = 0; n < window; ++n) {
+    REQUIRE(ts.at(n).at(0) == s.at(n));
+  }
+}
+
+TEST_CASE("sequences:comonad — coassociativity: δ(δ s) = (map δ)(δ s)",
+          "[sequences][comonad][law]") {
+  const auto s = naturals();
+  const auto ts = tails(s);
+  const auto lhs = tails(ts);  // δ(δ s) : stream of tails-of-(stream of tails)
+  // (map δ)(δ s) : n ↦ tails((δ s)(n)) = tails(drop(s, n))
+  for (std::size_t n = 0; n < window; ++n) {
+    const auto lhs_n = lhs.at(n);  // a stream of streams
+    const auto rhs_n = tails(ts.at(n));
+    for (std::size_t j = 0; j < window; ++j) {
+      for (std::size_t i = 0; i < window; ++i) {
+        REQUIRE(lhs_n.at(j).at(i) == rhs_n.at(j).at(i));
+      }
+    }
+  }
+}
+
+TEST_CASE("sequences:comonad — extend (<<=) agrees with mapping over tails",
+          "[sequences][comonad][extend]") {
+  const auto s = naturals();
+  // A context-aware extension: the first forward difference s(n+1) - s(n).
+  const auto fwd_diff = [](const Path<int>& ctx) {
+    return ctx.at(1) - ctx.at(0);
+  };
+  const auto extended = s <<= fwd_diff;
+  // extend f == map (f) . tails, so extended(n) == f(tails(s)(n)).
+  const auto ts = tails(s);
+  for (std::size_t n = 0; n < window; ++n) {
+    REQUIRE(extended.at(n) == 1);  // naturals: constant +1
+    REQUIRE(extended.at(n) == fwd_diff(ts.at(n)));
+  }
+}


### PR DESCRIPTION
## Summary

Names the Uustalu–Vene **stream comonad** shape that `Path` already carries (#719 Slice 2), and makes Path's comonad story honest end-to-end.

Path's comonad infrastructure already exists (`operator<<=` = extend, `counit_witness` = head/ε, `drop` = shift, `IsCoKleisliExtension`/`IsFrobenius` witnesses). This PR adds the missing **named operational concept** + the comultiplication primitive, then corrects the surrounding rationale.

### Stream comonad
- **`tails(s)`** — the δ (duplicate/comultiplication): the stream of all suffixes, `tails(s)(n) = drop(s, n)`.
- **`IsStreamComonad<W>`** — operational shape concept (infinite sequence + head ε + `tails` δ), the sequence-axis counterpart of axiomatic `category::IsComonad` (the `IsCyclic` vs `IsCyclicGroup` pairing). The δ leg is type-pinned to `tails(w).at(n) -> same_as<W>` (shape `W ⇒ W∘W`, ADL-safe).
- Honest-Rejection of `FinitePath`; the three comonad laws verified pointwise at runtime in `stream_comonad_test.cpp`.

### Comonad-honesty pass (follow-up review)
A throwaway spike confirmed mechanically that `maybe_functor`/`tuple_functor` are `IsFunctor` but **not** `IsEndofunctor` (they map `Set<T> → Set<F<T>>`, so `Σ_cat ≠ Τ_cat`), so the strict `category::IsComonad` — which refines `IsEndofunctor` — admits **only** `identity_functor`. Path is no exception. So:
- Replaced `path_functor`'s stale `path__Functor_Limitation` note (it cited a #525 `IsSpokeArrow` obstruction the same file later asserts is gone) with `path__Why_The_Kleisli_Layer_And_Not_IsComonad`: the comonad is certified in the co-Kleisli/**extension** presentation (`:kleisli`), equivalent to `(W,ε,δ)` by the dual Kleisli-triple theorem.
- Named that equivalence in `IsStreamComonad`'s doc (δ = tails = `s <<= std::identity{}`).
- Made the lineage load-bearing: co-located `IsCoKleisliExtension` + `IsStreamComonad` as one comonad at one level, plus a **Sollbruchstelle** `static_assert(!IsEndofunctor<path_functor<int>>)` that fires if the witness is ever reified to endofunctor level.

## Test plan

- [x] `make test` — all 15 suites green
- [x] `make format` clean
- [x] Spike (`!IsEndofunctor<maybe_functor>` / `<tuple_functor>`) confirmed, then reverted
- [ ] CI green