### PR TITLE
feat(sequences): #719 Slice 3 — IsOrderConvergent (lattice-theoretic convergence)

### DIFF
--- a/src/main/modules/dedekind/sequences/convergence.cppm
+++ b/src/main/modules/dedekind/sequences/convergence.cppm
@@ -20,6 +20,9 @@ module;
 export module dedekind.sequences:convergence;
 
 import dedekind.category; // is_periodic_v / cyclic_order_v — the orbit bridge
+import dedekind.order;    // IsOrderMeetSemilattice / IsOrderJoinSemilattice —
+                          // the lattice prerequisite for order-convergence
+                          // (#719 Slice 3)
 
 import :net;  // IsSequence (Form-chain row 4) — #719 Slice 0
 import :path;
@@ -97,6 +100,62 @@ export template <typename Seq>
 concept IsConvergentSequence = IsCauchySequence<Seq> && requires(Seq s) {
   { limit(s) } -> std::same_as<typename Seq::Codomain>;
 };
+
+/** @brief Opt-in: @c Seq order-converges — its liminf and limsup
+ *         coincide.  The order-@b completeness of the carrier (so the
+ *         inf/sup of the @b infinite tails exist) and the
+ *         @c liminf @c = @c limsup equality itself are the engineer's
+ *         honesty obligation, exactly as metric-completeness is for
+ *         @c IsCauchySequence. */
+export template <typename Seq>
+inline constexpr bool is_order_convergent_v = false;
+
+/**
+ * @concept IsOrderConvergent
+ * @brief A sequence that converges in the @b order sense:
+ *        @f$\liminf_n s(n) = \limsup_n s(n)@f$, with
+ *        @f$\liminf = \bigsqcup_n \bigsqcap_{k\ge n} s(k)@f$ and
+ *        @f$\limsup = \bigsqcap_n \bigsqcup_{k\ge n} s(k)@f$.
+ *
+ * @details The carrier must be an order @b lattice — both an
+ * @c order::IsOrderMeetSemilattice (for the @c ⊓ / inf of tails) and an
+ * @c order::IsOrderJoinSemilattice (for the @c ⊔ / sup) — so that
+ * @c liminf and @c limsup are even @b definable.  This is the
+ * load-bearing @c :order::lattice cross-reference: a carrier with no
+ * meet/join cannot host order-convergence and is honestly rejected
+ * regardless of any trait opt-in.  Order-@b completeness (the inf/sup
+ * of the @b infinite tails actually existing) and the
+ * @c liminf @c = @c limsup equality are the engineer's honesty
+ * obligation, mirroring how metric-completeness is the obligation for
+ * @c IsCauchySequence.
+ *
+ * @section convergence__Order_vs_Metric Order vs metric convergence
+ * Order-convergence is the @b lattice-theoretic, metric-free notion and
+ * is @b constructive (no LEM): in a Dedekind-complete carrier a
+ * @b bounded @b monotone sequence order-converges to the sup/inf of its
+ * image — the order-theoretic monotone convergence theorem, which needs
+ * no choice principle.  This contrasts with the metric
+ * @c IsConvergentSequence, whose @c limit(s) extraction from a Cauchy
+ * sequence is the LEM-flavoured collapse gated in #719 Slice 5.
+ *
+ * The monotone-convergence propagation itself
+ * (@c is_bounded_sequence_v @c ∧ @c is_monotone_sequence_v over a
+ * @c order::IsDedekindComplete carrier @c ⇒ order-convergent) is a named
+ * follow-up rather than a baked-in concept disjunction: the only
+ * @c IsDedekindComplete carrier in the library, @c ExactReal, lives
+ * downstream of @c :sequences, so the propagation is best witnessed in a
+ * downstream test alongside that carrier (cf.\ the orbit bridge, whose
+ * propagation is witnessed downstream in @c :morphologies).
+ *
+ * Anchor: Birkhoff, @em Lattice @em Theory §X.9 (order convergence).
+ * Form-chain row 6b of #719.
+ */
+export template <typename Seq>
+concept IsOrderConvergent =
+    IsSequence<Seq> &&
+    dedekind::order::IsOrderMeetSemilattice<typename Seq::Codomain> &&
+    dedekind::order::IsOrderJoinSemilattice<typename Seq::Codomain> &&
+    is_order_convergent_v<Seq>;
 
 // ===========================================================================
 // Sequence-shape concepts (#719 Slice 1).

--- a/src/test/cpp/modules/dedekind/sequences/order_convergence_concepts_test.cpp
+++ b/src/test/cpp/modules/dedekind/sequences/order_convergence_concepts_test.cpp
@@ -1,0 +1,83 @@
+/** @file dedekind/sequences/order_convergence_concepts_test.cpp
+ *
+ * Unit coverage for the order-convergence concept (#719 Slice 3):
+ * @c IsOrderConvergent — lattice-theoretic (metric-free) convergence,
+ * @c liminf = limsup.
+ *
+ * The concept gates on three things: @c IsSequence, the carrier being an
+ * order @b lattice (both @c order::IsOrderMeetSemilattice and
+ * @c order::IsOrderJoinSemilattice — so liminf/limsup are definable),
+ * and the opt-in @c is_order_convergent_v trait (the engineer's honesty
+ * obligation for completeness + the liminf=limsup equality).
+ *
+ * Coverage:
+ *  - Fires on a tagged lattice-carrier witness that opts in.
+ *  - Honestly rejects a plain (non-opted-in) lattice sequence.
+ *  - Honestly rejects a non-lattice carrier (std::complex has no
+ *    meet/join) EVEN WITH the opt-in — the :order::lattice gate is
+ *    load-bearing, not advisory.
+ */
+
+#include <catch2/catch_test_macros.hpp>
+#include <complex>
+#include <cstddef>
+
+import dedekind.sequences;
+import dedekind.order;
+
+using namespace dedekind::sequences;
+
+namespace order_conv_witnesses {
+
+/** @brief Tagged toy path over @c int (an order lattice under min/max);
+ *         the opt-in below marks it as order-convergent. */
+struct convergent_int_path : Path<int> {
+  using Path<int>::Path;
+};
+
+/** @brief Tagged toy path over @c std::complex<double> — NOT an order
+ *         lattice (no operator< ⇒ no min/max meet/join).  Opts in below
+ *         to prove the carrier gate overrides the trait. */
+struct tagged_complex_path : Path<std::complex<double>> {
+  using Path<std::complex<double>>::Path;
+};
+
+}  // namespace order_conv_witnesses
+
+namespace dedekind::sequences {
+template <>
+inline constexpr bool
+    is_order_convergent_v<order_conv_witnesses::convergent_int_path> = true;
+template <>
+inline constexpr bool
+    is_order_convergent_v<order_conv_witnesses::tagged_complex_path> = true;
+}  // namespace dedekind::sequences
+
+TEST_CASE(
+    "sequences:order-convergence — IsOrderConvergent fires on the tagged "
+    "lattice witness",
+    "[sequences][convergence][order]") {
+  STATIC_CHECK(IsOrderConvergent<order_conv_witnesses::convergent_int_path>);
+  // No opt-in ⇒ honest reject, even though int is a lattice carrier.
+  STATIC_CHECK_FALSE(IsOrderConvergent<Path<int>>);
+}
+
+TEST_CASE(
+    "sequences:order-convergence — the :order::lattice gate is "
+    "load-bearing (non-lattice carrier rejected despite opt-in)",
+    "[sequences][convergence][order][honest-rejection]") {
+  // std::complex<double> has no meet/join, so liminf/limsup are not even
+  // definable — IsOrderConvergent rejects regardless of the trait opt-in.
+  STATIC_CHECK_FALSE(
+      dedekind::order::IsOrderMeetSemilattice<std::complex<double>>);
+  STATIC_CHECK_FALSE(
+      IsOrderConvergent<order_conv_witnesses::tagged_complex_path>);
+}
+
+TEST_CASE(
+    "sequences:order-convergence — int is the lattice carrier the "
+    "witness relies on",
+    "[sequences][convergence][order][lattice]") {
+  STATIC_CHECK(dedekind::order::IsOrderMeetSemilattice<int>);
+  STATIC_CHECK(dedekind::order::IsOrderJoinSemilattice<int>);
+}


### PR DESCRIPTION
## Summary

Adds **order-convergence** (#719 Slice 3): a sequence order-converges when its liminf and limsup coincide, `liminf = ⊔ₙ ⊓_{k≥n} s(k)` and `limsup = ⊓ₙ ⊔_{k≥n} s(k)`.

- **`is_order_convergent_v`** opt-in trait + **`IsOrderConvergent`** concept, gating on `IsSequence` **and** the carrier being an order lattice — both `order::IsOrderMeetSemilattice` (⊓ / inf of tails) and `order::IsOrderJoinSemilattice` (⊔ / sup) — so liminf/limsup are even *definable*. This is the load-bearing **`:order::lattice` cross-reference**: a carrier with no meet/join is honestly rejected regardless of opt-in.
- Order-completeness and the liminf=limsup equality are the engineer's honesty obligation, mirroring metric-completeness for `IsCauchySequence`.

### Order vs metric convergence
Order-convergence is the lattice-theoretic, **metric-free** notion and is **constructive (no LEM)**: in a Dedekind-complete carrier a bounded monotone sequence order-converges to the sup/inf of its image — the order-theoretic monotone convergence theorem, no choice principle needed. This contrasts with the metric `IsConvergentSequence`, whose `limit(s)` extraction is the LEM-flavoured collapse gated in Slice 5.

The MCT propagation (`bounded ∧ monotone` over a Dedekind-complete carrier ⇒ order-convergent) is named as a follow-up: the only `IsDedekindComplete` carrier in the library, `ExactReal`, lives downstream of `:sequences`, so it is best witnessed there (cf. the orbit bridge, witnessed downstream in `:morphologies`).

### Type-checks instead of prose
- Fires on a tagged int-lattice witness that opts in.
- Rejects a non-opted-in lattice sequence.
- Rejects a non-lattice carrier (`std::complex`, no meet/join) **even with the opt-in** — proving the lattice gate is load-bearing, not advisory.

A short spike confirmed the carrier facts before fixing the gate: `IsDedekindComplete` is satisfied by `ExactReal` but not `double`/`int` (the order concepts rest on registered relational traits + member-extrema), whereas `bool`/`int` satisfy both order semilattices — hence the lattice (not Dedekind-complete) gate.

## Test plan

- [x] `make test` — all 15 suites green
- [x] `make format` clean
- [ ] CI green