### PR TITLE
feat(sequences): #719 Slice 4 — `IsSeries`/`IsSummable`/`IsAbsolutelyConvergent` + partial_sums

### DIFF
--- a/src/main/modules/dedekind/sequences/convergence.cppm
+++ b/src/main/modules/dedekind/sequences/convergence.cppm
@@ -158,6 +158,71 @@ concept IsOrderConvergent =
     is_order_convergent_v<Seq>;
 
 // ===========================================================================
+// Series concepts (#719 Slice 4): a series is a sequence carrying the
+// additive partial-sum structure.  Form-chain rows 6c–6e.
+//
+// A @b series @f$\sum a_n@f$ is determined by its term sequence
+// @f$(a_n)@f$; its convergence is the convergence of the partial-sum
+// sequence @f$S_n = \sum_{k\le n} a_k@f$ (materialised by
+// @c partial_sums below).  The carrier gate uses the @b additive shape
+// (@c a @c + @c a well-formed) rather than a registered algebraic
+// concept, exactly the deliberate choice @c IsCauchySequence makes for
+// its subtraction shape: it admits @c double and user-defined additive
+// carriers alike, lifting the monoid/Banach reasoning to the engineer's
+// honesty obligation.
+// ===========================================================================
+
+/**
+ * @concept IsSeries
+ * @brief A sequence whose @c Codomain carries the additive structure
+ *        needed to form partial sums @f$S_n = \sum_{k\le n} a_k@f$.
+ *
+ * @details The load-bearing structural gate: a carrier with no @c +
+ *          cannot host a series and is honestly rejected.  @c IsSummable
+ *          / @c IsAbsolutelyConvergent refine this with opt-in traits.
+ *          See @c partial_sums for the partial-sum materialisation.
+ */
+export template <typename Seq>
+concept IsSeries = IsSequence<Seq> && requires(typename Seq::Codomain a) {
+  { a + a } -> std::convertible_to<typename Seq::Codomain>;
+};
+
+/** @brief Opt-in: the series @f$\sum a_n@f$ is @b summable — its
+ *         partial-sum sequence converges.  The actual convergence (and
+ *         the carrier completeness it presumes) is the engineer's
+ *         honesty obligation, as for @c IsConvergentSequence. */
+export template <typename Seq>
+inline constexpr bool is_summable_v = false;
+
+/** @concept IsSummable
+ *  @brief A convergent series.  Necessary condition (the engineer's
+ *         obligation to respect): summable @c ⇒ @c a_n @c → @c 0.  The
+ *         runtime numerical hooks @c ratio_test_converges,
+ *         @c root_test_converges, @c comparison_test_converges, and
+ *         @c converges_series_partial_sums (below) are the operational
+ *         counterparts that decide summability for concrete float
+ *         carriers. */
+export template <typename Seq>
+concept IsSummable = IsSeries<Seq> && is_summable_v<Seq>;
+
+/** @brief Opt-in: the series @f$\sum a_n@f$ is @b absolutely convergent
+ *         — the series of norms @f$\sum \lVert a_n\rVert@f$ is summable. */
+export template <typename Seq>
+inline constexpr bool is_absolutely_convergent_v = false;
+
+/** @concept IsAbsolutelyConvergent
+ *  @brief An absolutely convergent series.  @b Refines @c IsSummable:
+ *         in a complete (Banach) carrier absolute convergence implies
+ *         convergence, so an @c IsAbsolutelyConvergent witness is also
+ *         @c IsSummable — the same refinement shape as
+ *         @c IsConvergentSequence over @c IsCauchySequence.  Carrier
+ *         completeness is the honesty obligation that makes the
+ *         implication sound; the witness opts into @b both traits. */
+export template <typename Seq>
+concept IsAbsolutelyConvergent =
+    IsSummable<Seq> && is_absolutely_convergent_v<Seq>;
+
+// ===========================================================================
 // Sequence-shape concepts (#719 Slice 1).
 //
 // Boundedness, monotonicity, periodicity, absorptivity, and the
@@ -398,6 +463,32 @@ constexpr bool in_closed_euclidean_ball(R center, R point, R radius) {
 }
 
 }  // namespace detail
+
+/**
+ * @brief The partial-sum series @f$S_n = \sum_{k\le n} a_k@f$ of a term
+ *        path, materialised via the co-Kleisli @c scan.
+ *
+ * @details @c partial_sums(terms)(n) folds @c + over the first @c n+1
+ * terms (the additive identity @c T{} seeds the fold).  This is the
+ * carrier on which @c IsSummable / @c IsAbsolutelyConvergent are judged:
+ * the series @f$\sum a_n@f$ converges iff @c partial_sums(terms) does.
+ * Requires the @c IsSeries additive shape on @c T.
+ */
+export template <typename T>
+  requires requires(T a) {
+    { a + a } -> std::convertible_to<T>;
+  }
+constexpr Path<T> partial_sums(const Path<T>& terms) {
+  return scan(
+      [](const FinitePath<T>& prefix_terms) -> T {
+        T acc{};
+        for (std::size_t i = 0; i < prefix_terms.size(); ++i) {
+          acc = acc + prefix_terms.at(i);
+        }
+        return acc;
+      },
+      terms);
+}
 
 /**
  * @brief Build a geometric-series term path: a_n = r^n.

--- a/src/main/modules/dedekind/sequences/convergence.cppm
+++ b/src/main/modules/dedekind/sequences/convergence.cppm
@@ -469,10 +469,21 @@ constexpr bool in_closed_euclidean_ball(R center, R point, R radius) {
  *        path, materialised via the co-Kleisli @c scan.
  *
  * @details @c partial_sums(terms)(n) folds @c + over the first @c n+1
- * terms (the additive identity @c T{} seeds the fold).  This is the
- * carrier on which @c IsSummable / @c IsAbsolutelyConvergent are judged:
- * the series @f$\sum a_n@f$ converges iff @c partial_sums(terms) does.
- * Requires the @c IsSeries additive shape on @c T.
+ * terms, @b seeded @b from @b the @b first @b term (index 0) and
+ * accumulating from index 1 — so no additive identity / default
+ * constructor is needed, only the @c IsSeries additive shape (@c +).
+ * The @c scan prefix is always non-empty (element @c i sees the first
+ * @c i+1 terms), so the seed @c prefix_terms.at(0) is always valid.
+ * This is the carrier on which @c IsSummable / @c IsAbsolutelyConvergent
+ * are judged: the series @f$\sum a_n@f$ converges iff @c partial_sums
+ * does.
+ *
+ * @note @b Complexity: this is a @b lazy / intensional series (like
+ * @c scan itself) — each @c at(n) recomputes the fold, so it is
+ * @f$O(n)@f$ per access and @f$O(N^2)@f$ to sample the first @c N
+ * partial sums.  For hot-path numerical convergence checks prefer the
+ * eager single-pass @c converges_series_partial_sums below, which caches
+ * the running sum.
  */
 export template <typename T>
   requires requires(T a) {
@@ -481,8 +492,8 @@ export template <typename T>
 constexpr Path<T> partial_sums(const Path<T>& terms) {
   return scan(
       [](const FinitePath<T>& prefix_terms) -> T {
-        T acc{};
-        for (std::size_t i = 0; i < prefix_terms.size(); ++i) {
+        T acc = prefix_terms.at(0);
+        for (std::size_t i = 1; i < prefix_terms.size(); ++i) {
           acc = acc + prefix_terms.at(i);
         }
         return acc;

--- a/src/test/cpp/modules/dedekind/sequences/series_concepts_test.cpp
+++ b/src/test/cpp/modules/dedekind/sequences/series_concepts_test.cpp
@@ -1,0 +1,104 @@
+/** @file dedekind/sequences/series_concepts_test.cpp
+ *
+ * Unit coverage for the series concepts (#719 Slice 4): @c IsSeries,
+ * @c IsSummable, @c IsAbsolutelyConvergent, and the @c partial_sums
+ * primitive.
+ *
+ * A series Σaₙ is a sequence carrying the additive partial-sum
+ * structure; its convergence is the convergence of the partial-sum
+ * sequence Sₙ = Σ_{k≤n} aₖ.  The concepts gate on the additive shape of
+ * the carrier (load-bearing) plus opt-in traits (the engineer's honesty
+ * obligation for actual convergence + carrier completeness).
+ *
+ * Coverage:
+ *  - IsSeries fires on an additive carrier (double), rejects a
+ *    non-additive carrier.
+ *  - partial_sums materialises Sₙ correctly (geometric series).
+ *  - IsSummable fires on a tagged opt-in witness; rejects without opt-in.
+ *  - IsAbsolutelyConvergent refines IsSummable: a witness opting into
+ *    BOTH traits fires; a witness opting only into absolute-convergence
+ *    (not summable) is honestly rejected — the refinement is load-bearing.
+ */
+
+#include <catch2/catch_test_macros.hpp>
+#include <cstddef>
+
+import dedekind.sequences;
+
+using namespace dedekind::sequences;
+
+namespace series_witnesses {
+
+struct no_add {};  // no operator+ : not a series carrier
+
+/** @brief Tagged term-path opting into summability only. */
+struct summable_path : Path<double> {
+  using Path<double>::Path;
+};
+/** @brief Tagged term-path opting into BOTH summable + abs-convergent. */
+struct abs_convergent_path : Path<double> {
+  using Path<double>::Path;
+};
+/** @brief Tagged term-path opting into abs-convergent ONLY (no summable):
+ *         must be rejected by IsAbsolutelyConvergent (refines IsSummable). */
+struct abs_only_path : Path<double> {
+  using Path<double>::Path;
+};
+
+}  // namespace series_witnesses
+
+namespace dedekind::sequences {
+template <>
+inline constexpr bool is_summable_v<series_witnesses::summable_path> = true;
+
+template <>
+inline constexpr bool is_summable_v<series_witnesses::abs_convergent_path> =
+    true;
+template <>
+inline constexpr bool
+    is_absolutely_convergent_v<series_witnesses::abs_convergent_path> = true;
+
+template <>
+inline constexpr bool
+    is_absolutely_convergent_v<series_witnesses::abs_only_path> = true;
+}  // namespace dedekind::sequences
+
+TEST_CASE("sequences:series — IsSeries gates on the additive carrier shape",
+          "[sequences][series]") {
+  STATIC_CHECK(IsSeries<Path<double>>);
+  STATIC_CHECK(IsSeries<Path<int>>);
+  // A carrier with no operator+ cannot host a series.
+  STATIC_CHECK_FALSE(IsSeries<Path<series_witnesses::no_add>>);
+}
+
+TEST_CASE("sequences:series — partial_sums materialises Sₙ = Σ_{k≤n} aₖ",
+          "[sequences][series][partial-sums]") {
+  // Geometric series with ratio 1/2: aₙ = (1/2)ⁿ, Sₙ = 2 - (1/2)ⁿ.
+  const auto terms = geometric_series_terms<double>(0.5);
+  const auto sums = partial_sums(terms);
+  STATIC_CHECK(IsSequence<decltype(sums)>);
+  REQUIRE(sums.at(0) == 1.0);    // S₀ = 1
+  REQUIRE(sums.at(1) == 1.5);    // S₁ = 1 + 1/2
+  REQUIRE(sums.at(2) == 1.75);   // S₂ = 1 + 1/2 + 1/4
+  REQUIRE(sums.at(3) == 1.875);  // S₃
+}
+
+TEST_CASE("sequences:series — IsSummable fires on the tagged opt-in witness",
+          "[sequences][series][summable]") {
+  STATIC_CHECK(IsSummable<series_witnesses::summable_path>);
+  // No opt-in ⇒ honest reject (a plain double series is not claimed
+  // summable just because the carrier is additive).
+  STATIC_CHECK_FALSE(IsSummable<Path<double>>);
+}
+
+TEST_CASE("sequences:series — IsAbsolutelyConvergent refines IsSummable",
+          "[sequences][series][absolute]") {
+  // Opts into both traits ⇒ fires.
+  STATIC_CHECK(IsAbsolutelyConvergent<series_witnesses::abs_convergent_path>);
+  // Opts into absolute-convergence ONLY (not summable) ⇒ rejected: the
+  // refinement IsAbsolutelyConvergent ⊑ IsSummable is load-bearing
+  // (absolute convergence implies convergence — the witness must carry
+  // both, encoding the Banach-space implication as the obligation).
+  STATIC_CHECK_FALSE(IsAbsolutelyConvergent<series_witnesses::abs_only_path>);
+  STATIC_CHECK_FALSE(IsSummable<series_witnesses::abs_only_path>);
+}

--- a/src/test/cpp/modules/dedekind/sequences/series_concepts_test.cpp
+++ b/src/test/cpp/modules/dedekind/sequences/series_concepts_test.cpp
@@ -20,8 +20,11 @@
  *    (not summable) is honestly rejected — the refinement is load-bearing.
  */
 
+#include <catch2/catch_approx.hpp>
 #include <catch2/catch_test_macros.hpp>
 #include <cstddef>
+
+using Catch::Approx;
 
 import dedekind.sequences;
 
@@ -77,10 +80,10 @@ TEST_CASE("sequences:series — partial_sums materialises Sₙ = Σ_{k≤n} aₖ
   const auto terms = geometric_series_terms<double>(0.5);
   const auto sums = partial_sums(terms);
   STATIC_CHECK(IsSequence<decltype(sums)>);
-  REQUIRE(sums.at(0) == 1.0);    // S₀ = 1
-  REQUIRE(sums.at(1) == 1.5);    // S₁ = 1 + 1/2
-  REQUIRE(sums.at(2) == 1.75);   // S₂ = 1 + 1/2 + 1/4
-  REQUIRE(sums.at(3) == 1.875);  // S₃
+  REQUIRE(sums.at(0) == Approx(1.0));    // S₀ = 1
+  REQUIRE(sums.at(1) == Approx(1.5));    // S₁ = 1 + 1/2
+  REQUIRE(sums.at(2) == Approx(1.75));   // S₂ = 1 + 1/2 + 1/4
+  REQUIRE(sums.at(3) == Approx(1.875));  // S₃
 }
 
 TEST_CASE("sequences:series — IsSummable fires on the tagged opt-in witness",


### PR DESCRIPTION
## Summary

Adds the **series** concept tower (#719 Slice 4). A series Σaₙ is a sequence carrying the additive partial-sum structure; its convergence is the convergence of the partial-sum sequence `Sₙ = Σ_{k≤n} aₖ`.

- **`partial_sums(terms)`** — materialises `Sₙ` via the co-Kleisli `scan` (folds `+` over each prefix). The reusable carrier on which summability is judged.
- **`IsSeries`** — structural gate on the additive shape of the `Codomain` (`{a+a}` well-formed). This is the same deliberate loose-shape choice `IsCauchySequence` makes for subtraction: it admits `double` and user-defined additive carriers, lifting monoid/Banach reasoning to the engineer's honesty obligation. A non-additive carrier is honestly rejected.
- **`is_summable_v` + `IsSummable`** — opt-in (partial sums converge). The runtime `ratio_test_converges` / `root_test_converges` / `comparison_test_converges` / `converges_series_partial_sums` hooks already in this file are the operational counterparts for concrete float carriers.
- **`is_absolutely_convergent_v` + `IsAbsolutelyConvergent`** — **refines `IsSummable`**: absolute convergence ⇒ convergence in a Banach carrier, the same refinement shape as `IsConvergentSequence` over `IsCauchySequence`. Carrier completeness is the honesty obligation; the witness opts into both traits.

### Type-checks instead of prose
- `IsSeries` fires on `double`/`int`, rejects a `no operator+` carrier.
- `partial_sums` matches the geometric-series `Sₙ` (1, 1.5, 1.75, 1.875, …).
- `IsSummable` fires on opt-in, rejects without.
- `IsAbsolutelyConvergent` fires when both traits are set; honestly rejected when only absolute-convergence is claimed (the `IsSummable` refinement is load-bearing).

## Test plan

- [x] `make test` — all 15 suites green
- [x] `make format` clean
- [ ] CI green