### PR TITLE
feat(sequences): #719 Slice 5 — logical-collapse upgrade + Bolzano–Weierstrass crown

### DIFF
--- a/src/main/modules/dedekind/sequences/convergence.cppm
+++ b/src/main/modules/dedekind/sequences/convergence.cppm
@@ -19,10 +19,14 @@ module;
 
 export module dedekind.sequences:convergence;
 
-import dedekind.category; // is_periodic_v / cyclic_order_v — the orbit bridge
+import dedekind.category; // is_periodic_v / cyclic_order_v — the orbit bridge;
+                          // ClassicalLogic — the classical regime tag
 import dedekind.order;    // IsOrderMeetSemilattice / IsOrderJoinSemilattice —
                           // the lattice prerequisite for order-convergence
                           // (#719 Slice 3)
+import dedekind.sets;     // NaturalLogic — the carrier-axis cardinality cut
+                          // (countable→Classical, uncountable→Ternary) gating
+                          // the Cauchy⇒convergent collapse (#719 Slice 5)
 
 import :net;  // IsSequence (Form-chain row 4) — #719 Slice 0
 import :path;
@@ -100,6 +104,43 @@ export template <typename Seq>
 concept IsConvergentSequence = IsCauchySequence<Seq> && requires(Seq s) {
   { limit(s) } -> std::same_as<typename Seq::Codomain>;
 };
+
+/** @brief The logic regime governing @c Seq's limit-collapse, read off
+ *         the carrier's cardinality via the @c :sets cardinality cut
+ *         (@c NaturalLogic): a @b countable @c Codomain (@c ℵ_0 /
+ *         @c Finite) lands in @c ClassicalLogic, an @b uncountable one
+ *         (the continuum, or a non-cardinality'd primitive) in
+ *         @c TernaryLogic. */
+export template <typename Seq>
+using convergence_logic =
+    typename dedekind::sets::NaturalLogic<typename Seq::Codomain>::species;
+
+/**
+ * @concept IsClassicallyConvergent
+ * @brief A Cauchy sequence whose carrier sits in the @b classical logic
+ *        regime, so the Cauchy @c ⇒ convergent collapse (limit
+ *        extraction) fires honestly.
+ *
+ * @details The LEM-flavoured step "every Cauchy sequence converges" is
+ * the completeness axiom; constructively it is @b blocked — Specker
+ * exhibits a computable Cauchy sequence of rationals whose limit is not
+ * computable.  The carrier-axis cardinality cut (#622/#696) decides the
+ * regime via @c convergence_logic: a @b countable @c Codomain lands in
+ * @c ClassicalLogic and the collapse fires; an @b uncountable carrier
+ * (the continuum, or a non-cardinality'd primitive like @c double — the
+ * float↔ℝ gap) lands in @c TernaryLogic and the collapse is honestly
+ * rejected.  The @b existence of the limit is then the classical theorem
+ * / the engineer's honesty obligation; this concept gates only the
+ * Cauchy shape and the regime, matching the project's
+ * concept-names-the-role discipline.
+ *
+ * Form-chain row 7 of #719; the convergence half of the logical-collapse
+ * crown that @c WitnessesBolzanoWeierstrass completes.
+ */
+export template <typename Seq>
+concept IsClassicallyConvergent =
+    IsCauchySequence<Seq> &&
+    std::same_as<convergence_logic<Seq>, dedekind::category::ClassicalLogic>;
 
 /** @brief Opt-in: @c Seq order-converges — its liminf and limsup
  *         coincide.  The order-@b completeness of the carrier (so the
@@ -355,6 +396,33 @@ concept IsSubsequence =
     IsSequence<Sub> && IsSequence<Sup> &&
     std::same_as<typename Sub::Codomain, typename Sup::Codomain> &&
     is_subsequence_v<Sub, Sup>;
+
+/**
+ * @concept WitnessesBolzanoWeierstrass
+ * @brief The Bolzano–Weierstrass crown: @c Sub witnesses that the
+ *        bounded sequence @c Sup has a convergent subsequence.
+ *
+ * @details Holds when @c Sup is order-bounded (@c IsBoundedSequence),
+ * @c Sub is a subsequence of @c Sup (@c IsSubsequence), and @c Sub is
+ * @c IsClassicallyConvergent.  This is Bolzano–Weierstrass read as a
+ * @b logical-collapse theorem: "every bounded sequence has a convergent
+ * subsequence" is classically true but constructively false (it needs
+ * sequential compactness / a LEM-grade choice).  The classical collapse
+ * fires exactly when the carrier is in the @c ClassicalLogic regime
+ * (countable cardinality cut); over a @c TernaryLogic carrier the
+ * witness is honestly rejected — no type-level guarantee of a convergent
+ * subsequence (Specker / non-computable limit).
+ *
+ * The convergent subsequence itself (the strictly-increasing index map
+ * and the limit) is the @b existential witness the engineer supplies via
+ * @c is_subsequence_v + the carrier's classical regime; this concept
+ * certifies that a supplied @c (Sub, Sup) pair has the
+ * Bolzano–Weierstrass shape.  Crown of #719 (Form-chain row 7).
+ */
+export template <typename Sub, typename Sup>
+concept WitnessesBolzanoWeierstrass =
+    IsBoundedSequence<Sup> && IsSubsequence<Sub, Sup> &&
+    IsClassicallyConvergent<Sub>;
 
 // ===========================================================================
 // The orbit bridge (#719 Slice 1b): carrier-axis periodicity ⇒

--- a/src/main/modules/dedekind/sequences/convergence.cppm
+++ b/src/main/modules/dedekind/sequences/convergence.cppm
@@ -15,6 +15,7 @@ module;
 #include <cmath>
 #include <concepts>
 #include <cstddef>
+#include <type_traits>
 #include <vector>
 
 export module dedekind.sequences:convergence;
@@ -112,8 +113,8 @@ concept IsConvergentSequence = IsCauchySequence<Seq> && requires(Seq s) {
  *         (the continuum, or a non-cardinality'd primitive) in
  *         @c TernaryLogic. */
 export template <typename Seq>
-using convergence_logic =
-    typename dedekind::sets::NaturalLogic<typename Seq::Codomain>::species;
+using convergence_logic = typename dedekind::sets::NaturalLogic<
+    typename std::remove_cvref_t<Seq>::Codomain>::type;
 
 /**
  * @concept IsClassicallyConvergent

--- a/src/test/cpp/modules/dedekind/sequences/bolzano_weierstrass_test.cpp
+++ b/src/test/cpp/modules/dedekind/sequences/bolzano_weierstrass_test.cpp
@@ -1,0 +1,138 @@
+/** @file dedekind/sequences/bolzano_weierstrass_test.cpp
+ *
+ * The crown of the sequences categorification (#719 Slice 5): the
+ * logical-collapse upgrade @c IsClassicallyConvergent and the
+ * Bolzano–Weierstrass witness @c WitnessesBolzanoWeierstrass, exhibited
+ * as an @b existence demonstration with the LEM gate visible at the type
+ * level.
+ *
+ * The Cauchy⇒convergent collapse, and hence Bolzano–Weierstrass
+ * ("every bounded sequence has a convergent subsequence"), is classically
+ * true but constructively blocked (Specker).  The carrier-axis
+ * cardinality cut (NaturalLogic) decides the regime:
+ *
+ *   - countable carrier (cardinality_type = ℵ_0) → ClassicalLogic → the
+ *     collapse fires, BW witness holds;
+ *   - Ternary carrier (a non-cardinality'd primitive like double — the
+ *     float↔ℝ gap) → TernaryLogic → the collapse is honestly rejected,
+ *     BW witness fails.
+ *
+ * This is an existence demonstration, NOT a guarantee: it exhibits one
+ * (bounded Sup, convergent Sub) pair that witnesses BW classically, and
+ * the dual Ternary pair that is honestly rejected.
+ */
+
+#include <catch2/catch_test_macros.hpp>
+#include <type_traits>
+
+import dedekind.sequences;
+import dedekind.sets;
+import dedekind.category;
+
+using namespace dedekind::sequences;
+
+namespace bw_witnesses {
+
+/** @brief A countable real-ish carrier: cardinality_type = ℵ_0 places it
+ *         in the ClassicalLogic regime; operator- gives it the Cauchy
+ *         subtraction shape. */
+struct CountableReal {
+  using cardinality_type = dedekind::sets::ℵ_0;
+  double v = 0.0;
+  friend constexpr CountableReal operator-(CountableReal a, CountableReal b) {
+    return CountableReal{a.v - b.v};
+  }
+};
+
+// --- Classical side: countable carrier ---
+struct bw_super : Path<CountableReal> {
+  using Path<CountableReal>::Path;
+};
+struct bw_sub : Path<CountableReal> {
+  using Path<CountableReal>::Path;
+};
+
+// --- Ternary side: double (no cardinality_type ⇒ TernaryLogic) ---
+struct bw_super_ternary : Path<double> {
+  using Path<double>::Path;
+};
+struct bw_sub_ternary : Path<double> {
+  using Path<double>::Path;
+};
+
+}  // namespace bw_witnesses
+
+namespace dedekind::sequences {
+// Sup is order-bounded on both sides…
+template <>
+inline constexpr bool is_bounded_sequence_v<bw_witnesses::bw_super> = true;
+template <>
+inline constexpr bool is_bounded_sequence_v<bw_witnesses::bw_super_ternary> =
+    true;
+// …and Sub is a subsequence of Sup on both sides.
+template <>
+inline constexpr bool
+    is_subsequence_v<bw_witnesses::bw_sub, bw_witnesses::bw_super> = true;
+template <>
+inline constexpr bool is_subsequence_v<bw_witnesses::bw_sub_ternary,
+                                       bw_witnesses::bw_super_ternary> = true;
+}  // namespace dedekind::sequences
+
+TEST_CASE(
+    "sequences:collapse — convergence_logic reads the carrier regime off "
+    "the cardinality cut",
+    "[sequences][convergence][collapse]") {
+  STATIC_CHECK(
+      std::is_same_v<convergence_logic<Path<bw_witnesses::CountableReal>>,
+                     dedekind::category::ClassicalLogic>);
+  // double has no cardinality_type ⇒ NaturalLogic defaults to Ternary.
+  STATIC_CHECK(std::is_same_v<convergence_logic<Path<double>>,
+                              dedekind::category::TernaryLogic>);
+}
+
+TEST_CASE(
+    "sequences:collapse — IsClassicallyConvergent fires only in the "
+    "classical regime (Specker honest-rejection under Ternary)",
+    "[sequences][convergence][collapse]") {
+  // Countable carrier ⇒ classical regime ⇒ the Cauchy⇒convergent collapse
+  // fires.
+  STATIC_CHECK(IsClassicallyConvergent<Path<bw_witnesses::CountableReal>>);
+  // double is Cauchy-shaped but sits in the Ternary regime, so the
+  // collapse is honestly rejected even though the subtraction shape holds.
+  STATIC_CHECK(IsCauchySequence<Path<double>>);
+  STATIC_CHECK_FALSE(IsClassicallyConvergent<Path<double>>);
+}
+
+TEST_CASE("sequences:crown — Bolzano–Weierstrass witness holds classically",
+          "[sequences][convergence][bolzano-weierstrass]") {
+  // Bounded Sup + subsequence Sub + Sub classically convergent ⇒ the
+  // (Sub, Sup) pair witnesses Bolzano–Weierstrass.  Existence
+  // demonstration over a countable carrier.
+  STATIC_CHECK(WitnessesBolzanoWeierstrass<bw_witnesses::bw_sub,
+                                           bw_witnesses::bw_super>);
+}
+
+TEST_CASE(
+    "sequences:crown — Bolzano–Weierstrass is honestly rejected under "
+    "the Ternary regime (the LEM gate is load-bearing)",
+    "[sequences][convergence][bolzano-weierstrass][honest-rejection]") {
+  // Same shape (bounded Sup, subsequence Sub) but over a Ternary carrier:
+  // the convergent-subsequence collapse is Specker-blocked, so the witness
+  // fails — BW is exhibited as a logical-collapse theorem, not a guarantee.
+  STATIC_CHECK(IsBoundedSequence<bw_witnesses::bw_super_ternary>);
+  STATIC_CHECK(IsSubsequence<bw_witnesses::bw_sub_ternary,
+                             bw_witnesses::bw_super_ternary>);
+  STATIC_CHECK_FALSE(
+      WitnessesBolzanoWeierstrass<bw_witnesses::bw_sub_ternary,
+                                  bw_witnesses::bw_super_ternary>);
+}
+
+TEST_CASE("sequences:crown — the boundedness gate is load-bearing",
+          "[sequences][convergence][bolzano-weierstrass]") {
+  // A classically-convergent subsequence of an UNbounded super does not
+  // witness BW: with no is_bounded_sequence_v opt-in on Path<CountableReal>,
+  // the Sup leg fails.  (bw_sub is a registered subsequence of bw_super,
+  // not of a bare Path, so we check the bounded gate directly.)
+  STATIC_CHECK_FALSE(IsBoundedSequence<Path<bw_witnesses::CountableReal>>);
+  STATIC_CHECK(IsClassicallyConvergent<bw_witnesses::bw_sub>);
+}


### PR DESCRIPTION
## Summary

The crown of the sequences categorification (#719): **Bolzano–Weierstrass exhibited as a logical-collapse theorem**, with the LEM gate visible at the type level.

- **`convergence_logic<Seq>`** — the carrier's logic regime, read off the cardinality cut (`sets::NaturalLogic`): a countable `Codomain` (`ℵ_0`/`Finite`) → `ClassicalLogic`; an uncountable / non-cardinality'd one (`double`, the float↔ℝ gap) → `TernaryLogic`.
- **`IsClassicallyConvergent<Seq>`** = `IsCauchySequence<Seq>` ∧ the carrier sits in `ClassicalLogic`. The Cauchy⇒convergent collapse (completeness axiom) is classical; constructively it is Specker-blocked. The limit's *existence* is the classical theorem / engineer's honesty obligation — the concept gates only the Cauchy shape and the regime (the project's concept-names-the-role discipline).
- **`WitnessesBolzanoWeierstrass<Sub, Sup>`** = `IsBoundedSequence<Sup>` ∧ `IsSubsequence<Sub, Sup>` ∧ `IsClassicallyConvergent<Sub>`. "Every bounded sequence has a convergent subsequence" — classically true, constructively false; the witness fires exactly in the `ClassicalLogic` regime, Honest-Rejected under Ternary.

### Existence demonstration, not a guarantee
The test exhibits one `(bounded Sup, convergent Sub)` pair over a countable carrier that witnesses BW classically, and the dual pair over `double` that is honestly rejected — making the LEM gate load-bearing. Also pins `convergence_logic`'s regime read and the boundedness gate.

Grounded by a throwaway spike that established: `IsConvergentSequence<Path<double>>` is `false` today (`HasLimit<double>` fails `order::IsArchimedean`), and raw primitives sit uniformly in the Ternary regime — so the classical side is reached via countable-`cardinality_type` carriers. This **resolves the Slice-0 deferral**: the positive classical-convergence witness lands here with the `ClassicalLogic` / `Ternary` gating set up coherently.

This is paper-crown material — happy to draft a paper listing for it in the dedicated paper-editing pass.

## Test plan

- [x] `make test` — all 15 suites green
- [x] `make format` clean
- [ ] CI green