### PR TITLE
feat(sequences): tail-equivalence congruence on Path<T> (sequences↔quotients cross-cutter)

### DIFF
--- a/src/main/modules/dedekind/sequences/sequences.cppm
+++ b/src/main/modules/dedekind/sequences/sequences.cppm
@@ -16,5 +16,6 @@ export import :net;
 export import :convergence;
 export import :limits;
 export import :path;
+export import :tail;
 export import :curve;
 export import :ranges;

--- a/src/main/modules/dedekind/sequences/tail_equivalence.cppm
+++ b/src/main/modules/dedekind/sequences/tail_equivalence.cppm
@@ -53,9 +53,11 @@
  */
 module;
 
+#include <algorithm>
 #include <cstddef>
 #include <functional>
 #include <limits>
+#include <numeric>
 
 export module dedekind.sequences:tail;
 
@@ -98,6 +100,95 @@ struct TailEquivalent {
     return true;
   }
 };
+
+/**
+ * @section tail__From_The_Undecidable_General_Case_To_A_Decidable_Bool
+ *
+ * Tail-equivalence is undecidable in general — deciding @c s ~ t means
+ * consuming the infinite tail, i.e.\ @b general @b recursion over a
+ * codata stream whose state space is unbounded; the honest verdict is
+ * @c Ternary::Unknown.  It collapses to a decidable @c bool exactly when
+ * both streams have a @b finite-state presentation — a @b lasso: a finite
+ * prefix followed by a cycle, @f$s(n) = s(n + C)\ \forall n \ge P@f$.
+ * On a lasso the decision is @b structural @b recursion over the finite
+ * @c (prefix, cycle) witness: past @c max(Pₛ,Pₜ) both streams factor
+ * through a common cycle of length @c lcm(Cₛ,Cₜ), so agreement on @b one
+ * full period is agreement forever — a @b provably @b sufficient,
+ * terminating check, not a sampled heuristic.
+ *
+ * This is the type-directed bridge from the general (Ternary) case to the
+ * decidable (Boolean) case: the finite-presentation witness
+ * @c IsEventuallyPeriodic is exactly what licenses structural recursion.
+ * It unifies the @c :convergence shape concepts as lasso shapes —
+ * @c IsAbsorptiveSequence is a prefix + @b 1-cycle (eventually constant),
+ * @c IsPeriodicSequence<N> is a @b 0-prefix + N-cycle — and coheres with
+ * the #719 Slice 5 collapse: a finite presentation is a countable /
+ * @c ClassicalLogic object (decidable), its absence is @c TernaryLogic.
+ */
+
+/** @brief Opt-in finite-state ("lasso") presentation of an
+ *         eventually-periodic sequence: a prefix of length @c pre_period
+ *         followed by a cycle of length @c period
+ *         (@c s(n) @c = @c s(n+period) for all @c n @c ≥ @c pre_period).
+ *         The primary carries no presentation; a witness specialises it
+ *         with the finite @c (pre_period, period) data — the engineer's
+ *         honesty obligation (the presentation cannot be computed in
+ *         general).  Absorptive ⇒ @c period @c = @c 1; periodic ⇒
+ *         @c pre_period @c = @c 0. */
+export template <typename Seq>
+struct lasso_presentation {};
+
+/**
+ * @concept IsEventuallyPeriodic
+ * @brief @c Seq has a finite-state (lasso) presentation: a
+ *        @c lasso_presentation specialisation giving a positive @c period
+ *        and a @c pre_period.  This is the @b finite-presentation witness
+ *        that licenses a decidable, structural-recursive tail-equivalence
+ *        test (see @c decide_tail_equivalence).
+ */
+export template <typename Seq>
+concept IsEventuallyPeriodic = IsSequence<Seq> && requires {
+  requires lasso_presentation<Seq>::period > 0;
+  { lasso_presentation<Seq>::pre_period } -> std::convertible_to<std::size_t>;
+};
+
+/**
+ * @brief Type-directed tail-equivalence decision: honest @c bool exactly
+ *        on the finite-presentation domain, @c Ternary::Unknown otherwise.
+ *
+ * @details If both @c S and @c T are @c IsEventuallyPeriodic, the verdict
+ * is computed by @b structural recursion over their lasso presentations —
+ * a comparison on the provably-sufficient window
+ * @c [max(Pₛ,Pₜ), max(Pₛ,Pₜ) + lcm(Cₛ,Cₜ)) — and returned as
+ * @c Ternary::True / @c Ternary::False.  Otherwise the decision would
+ * require @b general recursion over an unbounded tail, so it is honestly
+ * rejected as @c Ternary::Unknown.  Contrast @c TailEquivalent::operator()
+ * — the @c bool relation the congruence machinery consumes — whose
+ * fixed-window read is operational/sampled; this is the decidable,
+ * correct verdict where the type permits it.
+ */
+export template <typename S, typename T>
+  requires(IsSequence<S> && IsSequence<T> &&
+           std::same_as<typename S::Codomain, typename T::Codomain>)
+constexpr dedekind::category::Ternary decide_tail_equivalence(const S& s,
+                                                              const T& t) {
+  if constexpr (IsEventuallyPeriodic<S> && IsEventuallyPeriodic<T>) {
+    const std::size_t start = std::max(lasso_presentation<S>::pre_period,
+                                       lasso_presentation<T>::pre_period);
+    const std::size_t len =
+        std::lcm(lasso_presentation<S>::period, lasso_presentation<T>::period);
+    for (std::size_t k = 0; k < len; ++k) {
+      const std::size_t n =
+          start + k;  // start,len are small finite-presentation data
+      if (s.at(n) != t.at(n)) {
+        return dedekind::category::Ternary::False;
+      }
+    }
+    return dedekind::category::Ternary::True;
+  } else {
+    return dedekind::category::Ternary::Unknown;
+  }
+}
 
 }  // namespace dedekind::sequences
 
@@ -161,5 +252,13 @@ static_assert(
                                       std::plus<Path<double>>>,
     "Tail-equivalence over double must NOT be a congruence: double equality "
     "is not reflexive (NaN), mirroring the std::equal_to<double> policy.");
+
+// A bare Path has no finite (lasso) presentation, so the general→decidable
+// bridge does not fire — deciding tail-equivalence on it is general
+// recursion (Ternary::Unknown).  Witness-based positive cases (decidable
+// bool on lasso witnesses) live in the test, where the tagged carriers do.
+static_assert(!IsEventuallyPeriodic<Path<int>>,
+              "A bare Path<int> has no finite-state (lasso) presentation by "
+              "default; the decidable tail-equivalence bridge requires one.");
 
 }  // namespace dedekind::sequences

--- a/src/main/modules/dedekind/sequences/tail_equivalence.cppm
+++ b/src/main/modules/dedekind/sequences/tail_equivalence.cppm
@@ -1,0 +1,139 @@
+/**
+ * @file dedekind/sequences/tail_equivalence.cppm
+ * @partition :tail
+ * @brief Tail-equivalence of paths: the congruence of "agreeing
+ *        eventually", tying the sequence layer to the #718 quotient
+ *        machinery.
+ *
+ * @section tail__The_Germ_At_Infinity
+ * Two sequences are @b tail-equivalent when they agree from some index
+ * on:
+ * @f[
+ *   s \sim_{\mathrm{tail}} t \;\;\Longleftrightarrow\;\;
+ *     \exists N.\ \forall n \ge N.\ s(n) = t(n).
+ * @f]
+ * The equivalence class of @c s is its @b germ at infinity — everything
+ * about @c s except a finite prefix.  This is the relation under which
+ * the sequence-shape concepts become invariants: an
+ * @c IsAbsorptiveSequence (eventually constant) is exactly a sequence
+ * tail-equivalent to a constant path, and an eventually-periodic
+ * sequence is tail-equivalent to a periodic one.
+ *
+ * @section tail__A_Congruence_Not_Just_An_Equivalence
+ * Tail-equivalence is compatible with @c Path's pointwise addition: if
+ * @c s ~ s' (agree past @c N₁) and @c t ~ t' (agree past @c N₂) then
+ * @c s+t ~ s'+t' (agree past @c max(N₁,N₂)).  So it is a genuine
+ * @c dedekind::category::IsCongruence with respect to
+ * @c std::plus<Path<T>>, and the quotient @c Path<T>/~ inherits the
+ * additive structure — a well-defined @b quotient @b algebra (the same
+ * structural fact #718's @c IsCongruence machinery certifies for
+ * @c ℤ/Nℤ and @c Frac).  Reifying the quotient @b carrier (with chosen
+ * representatives) is deliberately deferred — the congruence is what
+ * makes the quotient well-defined; the carrier struct would be added
+ * only when a consumer needs representatives.
+ *
+ * @section tail__Honesty_Obligation
+ * The full relation quantifies over an infinite tail (@c ∀n≥N), so it is
+ * not decidable in general.  @c TailEquivalent's @c operator() therefore
+ * gives the @b operational reading — agreement on a sampled tail window
+ * — exactly as @c IsCauchySequence pins the operational subtraction
+ * shape and the convergence hooks sample a tail.  The full
+ * @c ∃N ∀n≥N criterion is the engineer's honesty obligation; the
+ * type-level @c is_congruence_v registration carries the structural
+ * claim that tail-equivalence @b is a congruence.
+ *
+ * @copyright 2026 The Dedekind Authors
+ * Licensed under the Apache License, Version 2.0.
+ *
+ * @note "Le silence éternel de ces espaces infinis m'effraie."
+ *       — Blaise Pascal, *Pensées* (1670).
+ *       [Trans: "The eternal silence of these infinite spaces frightens
+ *        me." — the tail of a sequence is precisely the part that lives
+ *        in those infinite spaces.]
+ */
+module;
+
+#include <cstddef>
+#include <functional>
+
+export module dedekind.sequences:tail;
+
+import dedekind.category; // IsCongruence / IsEquivalenceRelation + relation
+                          // and congruence opt-in traits (#718)
+import :path;             // Path + pointwise operator+
+
+namespace dedekind::sequences {
+
+/**
+ * @class TailEquivalent
+ * @brief The tail-equivalence relation on @c Path<T>: agreement on a
+ *        sampled tail window @c [start, start+span).
+ *
+ * @details Callable as a binary relation @c (Path<T>, Path<T>) → bool, so
+ * it satisfies @c dedekind::category::IsBinaryRelation.  The sampled
+ * window is the operational reading of the (undecidable) full relation
+ * @c ∃N ∀n≥N. s(n)=t(n); see the partition's
+ * @c tail__Honesty_Obligation note.  Reflexive, symmetric and transitive
+ * on the window (and as the full relation), and a congruence w.r.t.
+ * pointwise @c + — registered below.
+ */
+export template <typename T>
+struct TailEquivalent {
+  std::size_t window_start = 0;
+  std::size_t window_span = 64;
+
+  constexpr bool operator()(const Path<T>& s, const Path<T>& t) const {
+    for (std::size_t i = window_start; i < window_start + window_span; ++i) {
+      if (s.at(i) != t.at(i)) {
+        return false;
+      }
+    }
+    return true;
+  }
+};
+
+}  // namespace dedekind::sequences
+
+namespace dedekind::category {
+
+// Tail-equivalence is an equivalence relation: reflexive, symmetric and
+// transitive (true of the full ∃N∀n≥N relation, and of the sampled
+// window the operator() reads).
+template <typename T>
+inline constexpr bool
+    is_reflexive_relation_v<dedekind::sequences::TailEquivalent<T>> = true;
+template <typename T>
+inline constexpr bool
+    is_symmetric_relation_v<dedekind::sequences::TailEquivalent<T>> = true;
+template <typename T>
+inline constexpr bool
+    is_transitive_relation_v<dedekind::sequences::TailEquivalent<T>> = true;
+
+// …and a congruence with respect to Path's pointwise addition: agreeing
+// past N₁ and past N₂ ⇒ the sums agree past max(N₁,N₂).
+template <typename T>
+inline constexpr bool is_congruence_v<dedekind::sequences::TailEquivalent<T>,
+                                      dedekind::sequences::Path<T>,
+                                      std::plus<dedekind::sequences::Path<T>>> =
+    true;
+
+}  // namespace dedekind::category
+
+namespace dedekind::sequences {
+
+/** @section tail__Formal_Verification */
+
+// Tail-equivalence over Path<int> is an equivalence relation…
+static_assert(
+    dedekind::category::IsEquivalenceRelation<TailEquivalent<int>, Path<int>>,
+    "Tail-equivalence must be an equivalence relation on Path<int>.");
+
+// …and a congruence w.r.t. pointwise + — so Path<int>/~tail is a
+// well-defined quotient algebra (the #718 IsCongruence link).
+static_assert(
+    dedekind::category::IsCongruence<TailEquivalent<int>, Path<int>,
+                                     std::plus<Path<int>>>,
+    "Tail-equivalence must be a congruence w.r.t. pointwise + on Path<int>, "
+    "so the quotient Path<int>/~tail inherits the additive structure.");
+
+}  // namespace dedekind::sequences

--- a/src/main/modules/dedekind/sequences/tail_equivalence.cppm
+++ b/src/main/modules/dedekind/sequences/tail_equivalence.cppm
@@ -54,10 +54,12 @@
 module;
 
 #include <algorithm>
+#include <concepts>
 #include <cstddef>
 #include <functional>
 #include <limits>
 #include <numeric>
+#include <type_traits>
 
 export module dedekind.sequences:tail;
 
@@ -92,8 +94,11 @@ struct TailEquivalent {
         window_start > std::numeric_limits<std::size_t>::max() - window_span
             ? std::numeric_limits<std::size_t>::max()
             : window_start + window_span;
+    // Compare via the carrier's own equality (the registered policy), not a
+    // bare !=, so types providing only operator== participate too.
+    const std::equal_to<T> eq{};
     for (std::size_t i = window_start; i < end; ++i) {
-      if (s.at(i) != t.at(i)) {
+      if (!eq(s.at(i), t.at(i))) {
         return false;
       }
     }
@@ -148,8 +153,14 @@ struct lasso_presentation {};
  */
 export template <typename Seq>
 concept IsEventuallyPeriodic = IsSequence<Seq> && requires {
+  // Both members must be present and integral (so they are usable with
+  // std::gcd / std::lcm and index arithmetic) — a non-integral period
+  // could otherwise satisfy `> 0` yet break decide_tail_equivalence.
+  requires std::integral<
+      std::remove_cvref_t<decltype(lasso_presentation<Seq>::pre_period)>>;
+  requires std::integral<
+      std::remove_cvref_t<decltype(lasso_presentation<Seq>::period)>>;
   requires lasso_presentation<Seq>::period > 0;
-  { lasso_presentation<Seq>::pre_period } -> std::convertible_to<std::size_t>;
 };
 
 /**
@@ -172,19 +183,43 @@ export template <typename S, typename T>
            std::same_as<typename S::Codomain, typename T::Codomain>)
 constexpr dedekind::category::Ternary decide_tail_equivalence(const S& s,
                                                               const T& t) {
+  using dedekind::category::Ternary;
   if constexpr (IsEventuallyPeriodic<S> && IsEventuallyPeriodic<T>) {
-    const std::size_t start = std::max(lasso_presentation<S>::pre_period,
-                                       lasso_presentation<T>::pre_period);
-    const std::size_t len =
-        std::lcm(lasso_presentation<S>::period, lasso_presentation<T>::period);
+    constexpr auto max = std::numeric_limits<std::size_t>::max();
+    const std::size_t ps =
+        static_cast<std::size_t>(lasso_presentation<S>::pre_period);
+    const std::size_t pt =
+        static_cast<std::size_t>(lasso_presentation<T>::pre_period);
+    const std::size_t cs =
+        static_cast<std::size_t>(lasso_presentation<S>::period);
+    const std::size_t ct =
+        static_cast<std::size_t>(lasso_presentation<T>::period);
+    const std::size_t start = std::max(ps, pt);
+    // Compute lcm(cs, ct) without UB: lcm = cs/gcd * ct; bail to Unknown if
+    // that product — or the start+len window — would overflow size_t.
+    const std::size_t g = std::gcd(cs, ct);
+    if (g == 0) {
+      return Ternary::Unknown;
+    }
+    const std::size_t a = cs / g;
+    if (a > max / ct) {
+      return Ternary::Unknown;  // lcm overflow ⇒ undecidable within bounds
+    }
+    const std::size_t len = a * ct;
+    if (len == 0 || start > max - len) {
+      return Ternary::Unknown;  // window would overflow ⇒ undecidable here
+    }
+    // Compare on the IsArrow surface s(n) (IsSequence guarantees operator(),
+    // not necessarily .at()) via the carrier's equality.
+    const std::equal_to<typename S::Codomain> eq{};
     for (std::size_t k = 0; k < len; ++k) {
-      const std::size_t n =
-          start + k;  // start,len are small finite-presentation data
-      if (s.at(n) != t.at(n)) {
-        return dedekind::category::Ternary::False;
+      const std::size_t n = start + k;
+      if (!eq(s(static_cast<typename S::Domain>(n)),
+              t(static_cast<typename T::Domain>(n)))) {
+        return Ternary::False;
       }
     }
-    return dedekind::category::Ternary::True;
+    return Ternary::True;
   } else {
     return dedekind::category::Ternary::Unknown;
   }

--- a/src/main/modules/dedekind/sequences/tail_equivalence.cppm
+++ b/src/main/modules/dedekind/sequences/tail_equivalence.cppm
@@ -55,6 +55,7 @@ module;
 
 #include <cstddef>
 #include <functional>
+#include <limits>
 
 export module dedekind.sequences:tail;
 
@@ -83,7 +84,13 @@ struct TailEquivalent {
   std::size_t window_span = 64;
 
   constexpr bool operator()(const Path<T>& s, const Path<T>& t) const {
-    for (std::size_t i = window_start; i < window_start + window_span; ++i) {
+    // Overflow-safe end: a large window_start must not wrap the bound and
+    // make the loop vacuously report agreement.
+    const std::size_t end =
+        window_start > std::numeric_limits<std::size_t>::max() - window_span
+            ? std::numeric_limits<std::size_t>::max()
+            : window_start + window_span;
+    for (std::size_t i = window_start; i < end; ++i) {
       if (s.at(i) != t.at(i)) {
         return false;
       }
@@ -96,22 +103,31 @@ struct TailEquivalent {
 
 namespace dedekind::category {
 
-// Tail-equivalence is an equivalence relation: reflexive, symmetric and
-// transitive (true of the full ∃N∀n≥N relation, and of the sampled
-// window the operator() reads).
+// Tail-equivalence inherits each relational property from the carrier's
+// own equality: it is reflexive / symmetric / transitive exactly when
+// @c std::equal_to<T> is.  This mirrors the codebase's equality policy
+// (std::equal_to<V> is registered an equivalence only for reflexive
+// carriers — std::integral V), so IEEE floats are correctly excluded:
+// NaN ≠ NaN breaks reflexivity, so TailEquivalent<double> is NOT an
+// equivalence relation (and hence not a congruence).
 template <typename T>
+  requires is_reflexive_relation_v<std::equal_to<T>>
 inline constexpr bool
     is_reflexive_relation_v<dedekind::sequences::TailEquivalent<T>> = true;
 template <typename T>
+  requires is_symmetric_relation_v<std::equal_to<T>>
 inline constexpr bool
     is_symmetric_relation_v<dedekind::sequences::TailEquivalent<T>> = true;
 template <typename T>
+  requires is_transitive_relation_v<std::equal_to<T>>
 inline constexpr bool
     is_transitive_relation_v<dedekind::sequences::TailEquivalent<T>> = true;
 
-// …and a congruence with respect to Path's pointwise addition: agreeing
-// past N₁ and past N₂ ⇒ the sums agree past max(N₁,N₂).
+// …and a congruence with respect to Path's pointwise addition (agreeing
+// past N₁ and past N₂ ⇒ the sums agree past max(N₁,N₂)) — gated on the
+// carrier's equality being a bona fide equivalence, same policy.
 template <typename T>
+  requires IsEquivalenceRelation<std::equal_to<T>, T>
 inline constexpr bool is_congruence_v<dedekind::sequences::TailEquivalent<T>,
                                       dedekind::sequences::Path<T>,
                                       std::plus<dedekind::sequences::Path<T>>> =
@@ -135,5 +151,15 @@ static_assert(
                                      std::plus<Path<int>>>,
     "Tail-equivalence must be a congruence w.r.t. pointwise + on Path<int>, "
     "so the quotient Path<int>/~tail inherits the additive structure.");
+
+// Honest-Rejection: over an IEEE float carrier the carrier's own equality
+// is not reflexive (NaN ≠ NaN), so tail-equivalence is not an equivalence
+// relation and Path<double>/~tail is not certified a congruence quotient.
+// Same policy as std::equal_to<double>.
+static_assert(
+    !dedekind::category::IsCongruence<TailEquivalent<double>, Path<double>,
+                                      std::plus<Path<double>>>,
+    "Tail-equivalence over double must NOT be a congruence: double equality "
+    "is not reflexive (NaN), mirroring the std::equal_to<double> policy.");
 
 }  // namespace dedekind::sequences

--- a/src/test/cpp/modules/dedekind/sequences/tail_equivalence_test.cpp
+++ b/src/test/cpp/modules/dedekind/sequences/tail_equivalence_test.cpp
@@ -44,12 +44,12 @@ TEST_CASE("sequences:tail — the sampled relation detects eventual agreement",
   const auto b = ramp_then(7, 2, 3);    // 2,2,2,7,7,7,… — agrees from index 3
   const auto c = Path<int>{[](std::size_t n) { return static_cast<int>(n); }};
 
-  // a and b agree on the whole sampled tail (they differ only in [0,3),
-  // and the default window starts at 0) — so on a window STARTING past the
-  // prefix they are tail-equivalent.
+  // a and b differ only on [0,3) and agree from index 3 onward.  A window
+  // STARTING at 3 sees only the agreeing tail ⇒ tail-equivalent…
   const TailEquivalent<int> tail_from_3{.window_start = 3, .window_span = 64};
   REQUIRE(tail_from_3(a, b));
-  // On the full-from-zero window they differ in [0,3):
+  // …while the default window starts at 0 and so catches the differing
+  // prefix [0,3):
   REQUIRE_FALSE(tail_eq(a, b));
   // a is not tail-equivalent to the unbounded ramp c:
   REQUIRE_FALSE(tail_eq(a, c));
@@ -86,12 +86,19 @@ TEST_CASE(
   REQUIRE(tail_from_5(eventually_42, constant_42));
 }
 
-TEST_CASE("sequences:tail — the congruence fires at a second instantiation",
-          "[sequences][tail][congruence]") {
-  // Non-vacuous re-instantiation: the registration is a template over T,
-  // exercised here at Path<double> (the main-file static_assert pins
-  // Path<int>).
+TEST_CASE(
+    "sequences:tail — the congruence fires at a second (integral) "
+    "instantiation, and is honestly rejected over float",
+    "[sequences][tail][congruence][honest-rejection]") {
+  // Non-vacuous re-instantiation at Path<long> (the main-file static_assert
+  // pins Path<int>); long's equality is reflexive, so the congruence fires.
   STATIC_CHECK(
+      dedekind::category::IsCongruence<TailEquivalent<long>, Path<long>,
+                                       std::plus<Path<long>>>);
+  // Over double the carrier's equality is not reflexive (NaN), so
+  // tail-equivalence is not an equivalence relation and not a congruence —
+  // same policy as std::equal_to<double>.
+  STATIC_CHECK_FALSE(
       dedekind::category::IsCongruence<TailEquivalent<double>, Path<double>,
                                        std::plus<Path<double>>>);
 }

--- a/src/test/cpp/modules/dedekind/sequences/tail_equivalence_test.cpp
+++ b/src/test/cpp/modules/dedekind/sequences/tail_equivalence_test.cpp
@@ -17,6 +17,11 @@
  *    tail-equivalent to the constant path at its limit.
  *  - the congruence fires at a second integral instantiation (Path<long>)
  *    and is honestly rejected over float (Path<double>, NaN policy).
+ *  - the general→decidable bridge: IsEventuallyPeriodic (the lasso /
+ *    finite-presentation witness) and decide_tail_equivalence — a
+ *    decidable bool on lasso witnesses (structural recursion over the
+ *    provably-sufficient lcm-window), Ternary::Unknown otherwise (general
+ *    recursion / Honest-Rejection).
  */
 
 #include <catch2/catch_test_macros.hpp>
@@ -37,6 +42,52 @@ Path<int> ramp_then(int tail_value, int head_value, std::size_t prefix_len) {
 }
 
 }  // namespace
+
+namespace tail_lasso {
+
+// Eventually-periodic ("lasso") witnesses: a finite prefix then a 2-cycle.
+// pre=2: 7,7,0,1,0,1,…   (tail value n%2 from index 2)
+struct pre2_per2 : Path<int> {
+  pre2_per2()
+      : Path<int>{[](std::size_t n) {
+          return n >= 2 ? static_cast<int>(n % 2) : 7;
+        }} {}
+};
+// pre=3: 5,5,5,0,1,0,1,…  (tail value n%2 from index 3) — tail-equal to
+// pre2_per2.
+struct pre3_per2 : Path<int> {
+  pre3_per2()
+      : Path<int>{[](std::size_t n) {
+          return n >= 3 ? static_cast<int>(n % 2) : 5;
+        }} {}
+};
+// pre=2, opposite phase: 9,9,1,0,1,0,…  (tail (n+1)%2) — NOT tail-equal.
+struct pre2_per2_antiphase : Path<int> {
+  pre2_per2_antiphase()
+      : Path<int>{[](std::size_t n) {
+          return n >= 2 ? static_cast<int>((n + 1) % 2) : 9;
+        }} {}
+};
+
+}  // namespace tail_lasso
+
+namespace dedekind::sequences {
+template <>
+struct lasso_presentation<tail_lasso::pre2_per2> {
+  static constexpr std::size_t pre_period = 2;
+  static constexpr std::size_t period = 2;
+};
+template <>
+struct lasso_presentation<tail_lasso::pre3_per2> {
+  static constexpr std::size_t pre_period = 3;
+  static constexpr std::size_t period = 2;
+};
+template <>
+struct lasso_presentation<tail_lasso::pre2_per2_antiphase> {
+  static constexpr std::size_t pre_period = 2;
+  static constexpr std::size_t period = 2;
+};
+}  // namespace dedekind::sequences
 
 TEST_CASE("sequences:tail — the sampled relation detects eventual agreement",
           "[sequences][tail][relation]") {
@@ -102,4 +153,36 @@ TEST_CASE(
   STATIC_CHECK_FALSE(
       dedekind::category::IsCongruence<TailEquivalent<double>, Path<double>,
                                        std::plus<Path<double>>>);
+}
+
+TEST_CASE(
+    "sequences:tail — IsEventuallyPeriodic is the finite-presentation "
+    "witness (lasso) that gates decidability",
+    "[sequences][tail][lasso][decidable]") {
+  STATIC_CHECK(IsEventuallyPeriodic<tail_lasso::pre2_per2>);
+  STATIC_CHECK(IsEventuallyPeriodic<tail_lasso::pre3_per2>);
+  // A bare Path has no finite presentation ⇒ no decidability gate.
+  STATIC_CHECK_FALSE(IsEventuallyPeriodic<Path<int>>);
+}
+
+TEST_CASE(
+    "sequences:tail — decide_tail_equivalence: decidable bool on lasso "
+    "witnesses, Unknown (general recursion) otherwise",
+    "[sequences][tail][lasso][decidable][honest-rejection]") {
+  using dedekind::category::Ternary;
+  const tail_lasso::pre2_per2 s;  // 7,7,0,1,0,1,…
+  const tail_lasso::pre3_per2 t;  // 5,5,5,0,1,0,1,…  (tail-equal to s)
+  const tail_lasso::pre2_per2_antiphase u;  // 9,9,1,0,1,0,…    (NOT tail-equal)
+
+  // Both eventually-periodic ⇒ structural recursion over the
+  // provably-sufficient [max(pre), max(pre)+lcm(period)) window ⇒ a real
+  // verdict, not a sampled guess.
+  REQUIRE(decide_tail_equivalence(s, t) == Ternary::True);
+  REQUIRE(decide_tail_equivalence(s, u) == Ternary::False);
+
+  // No finite presentation on either side ⇒ deciding needs the infinite
+  // tail (general recursion) ⇒ honestly Unknown.
+  const Path<int> p{[](std::size_t n) { return static_cast<int>(n); }};
+  const Path<int> q{[](std::size_t n) { return static_cast<int>(n) + 1; }};
+  REQUIRE(decide_tail_equivalence(p, q) == Ternary::Unknown);
 }

--- a/src/test/cpp/modules/dedekind/sequences/tail_equivalence_test.cpp
+++ b/src/test/cpp/modules/dedekind/sequences/tail_equivalence_test.cpp
@@ -15,7 +15,8 @@
  *  - the congruence's computational content: s~s' ∧ t~t' ⇒ s+t ~ s'+t'.
  *  - the absorptive connection: an eventually-constant path is
  *    tail-equivalent to the constant path at its limit.
- *  - the congruence fires at a second instantiation (Path<double>).
+ *  - the congruence fires at a second integral instantiation (Path<long>)
+ *    and is honestly rejected over float (Path<double>, NaN policy).
  */
 
 #include <catch2/catch_test_macros.hpp>

--- a/src/test/cpp/modules/dedekind/sequences/tail_equivalence_test.cpp
+++ b/src/test/cpp/modules/dedekind/sequences/tail_equivalence_test.cpp
@@ -1,0 +1,97 @@
+/** @file dedekind/sequences/tail_equivalence_test.cpp
+ *
+ * Unit coverage for the tail-equivalence congruence on Path (the
+ * sequences↔quotients cross-cutter): @c TailEquivalent and its
+ * registration as an @c IsCongruence w.r.t. pointwise +.
+ *
+ * Tail-equivalence s ~ t ⟺ ∃N ∀n≥N. s(n)=t(n) — agreement past a finite
+ * prefix.  The runtime relation reads the operational window; the
+ * type-level congruence (asserted in tail_equivalence.cppm for Path<int>)
+ * is the structural claim.
+ *
+ * Coverage:
+ *  - the sampled relation: agreement past a prefix ⇒ tail-equivalent;
+ *    a difference inside the window ⇒ not; reflexivity.
+ *  - the congruence's computational content: s~s' ∧ t~t' ⇒ s+t ~ s'+t'.
+ *  - the absorptive connection: an eventually-constant path is
+ *    tail-equivalent to the constant path at its limit.
+ *  - the congruence fires at a second instantiation (Path<double>).
+ */
+
+#include <catch2/catch_test_macros.hpp>
+#include <cstddef>
+#include <functional>
+
+import dedekind.sequences;
+import dedekind.category;
+
+using namespace dedekind::sequences;
+
+namespace {
+
+// s and t differ only on the first `prefix_len` indices, then agree.
+Path<int> ramp_then(int tail_value, int head_value, std::size_t prefix_len) {
+  return Path<int>{
+      [=](std::size_t n) { return n < prefix_len ? head_value : tail_value; }};
+}
+
+}  // namespace
+
+TEST_CASE("sequences:tail — the sampled relation detects eventual agreement",
+          "[sequences][tail][relation]") {
+  const TailEquivalent<int> tail_eq{};  // default window [0, 64)
+  const auto a = ramp_then(7, 1, 3);    // 1,1,1,7,7,7,…
+  const auto b = ramp_then(7, 2, 3);    // 2,2,2,7,7,7,… — agrees from index 3
+  const auto c = Path<int>{[](std::size_t n) { return static_cast<int>(n); }};
+
+  // a and b agree on the whole sampled tail (they differ only in [0,3),
+  // and the default window starts at 0) — so on a window STARTING past the
+  // prefix they are tail-equivalent.
+  const TailEquivalent<int> tail_from_3{.window_start = 3, .window_span = 64};
+  REQUIRE(tail_from_3(a, b));
+  // On the full-from-zero window they differ in [0,3):
+  REQUIRE_FALSE(tail_eq(a, b));
+  // a is not tail-equivalent to the unbounded ramp c:
+  REQUIRE_FALSE(tail_eq(a, c));
+  // Reflexivity:
+  REQUIRE(tail_eq(c, c));
+}
+
+TEST_CASE("sequences:tail — congruence content: s~s' ∧ t~t' ⇒ s+t ~ s'+t'",
+          "[sequences][tail][congruence]") {
+  // s, s' agree from index 2; t, t' agree from index 4.
+  const auto s = ramp_then(10, 0, 2);
+  const auto s_prime = ramp_then(10, 99, 2);
+  const auto t = ramp_then(20, 0, 4);
+  const auto t_prime = ramp_then(20, 99, 4);
+
+  const auto sum = s + t;
+  const auto sum_prime = s_prime + t_prime;
+
+  // The sums agree from index max(2,4) = 4 onward — witness on a window
+  // starting at 4.
+  const TailEquivalent<int> tail_from_4{.window_start = 4, .window_span = 64};
+  REQUIRE(tail_from_4(sum, sum_prime));
+}
+
+TEST_CASE(
+    "sequences:tail — an eventually-constant path is tail-equivalent to "
+    "its constant (absorptive connection)",
+    "[sequences][tail][absorptive]") {
+  // Eventually constant at 42 from index 5; the absorptive shape's germ.
+  const auto eventually_42 = ramp_then(42, -1, 5);
+  const auto constant_42 = Path<int>{[](std::size_t) { return 42; }};
+
+  const TailEquivalent<int> tail_from_5{.window_start = 5, .window_span = 64};
+  REQUIRE(tail_from_5(eventually_42, constant_42));
+}
+
+TEST_CASE("sequences:tail — the congruence fires at a second instantiation",
+          "[sequences][tail][congruence]") {
+  // Non-vacuous re-instantiation: the registration is a template over T,
+  // exercised here at Path<double> (the main-file static_assert pins
+  // Path<int>).
+  STATIC_CHECK(
+      dedekind::category::IsCongruence<TailEquivalent<double>, Path<double>,
+                                       std::plus<Path<double>>>);
+}


### PR DESCRIPTION
## Summary

Quotients the sequence layer by "agreeing eventually", reusing the #718 quotient machinery — the two categorification epics (#718 quotients, #719 sequences) meet here — and turns the meeting into a **type-directed general→decidable bridge**.

### The congruence (sequences ↔ quotients)
- **`:tail` partition** with `TailEquivalent<T>`: the relation `s ~ t ⟺ ∃N ∀n≥N. s(n)=t(n)` — the germ at infinity. Registered as an `IsEquivalenceRelation` and an **`IsCongruence`** w.r.t. pointwise `std::plus<Path<T>>`, so `Path<T>/~tail` is a well-defined quotient algebra (the same fact #718 certifies for `ℤ/Nℤ`, `Frac`).
- Relation traits are gated on the **carrier's own equality** (reflexive/symmetric/transitive iff `std::equal_to<T>` is), so IEEE floats are honestly excluded — `!IsCongruence<TailEquivalent<double>, …>` (NaN ≠ NaN). Same policy as `std::equal_to<double>`.

### The general→decidable bridge (the structural payoff)
The relation `operator()` is, on its own, a sampled-window for-loop with no structural content. The real content is **when the undecidable general case collapses to a decidable `bool`** — and that is exactly *"does the stream have a finite-state presentation?"*, the structural-vs-general recursion split made type-directed:

- **`lasso_presentation<Seq>` + `IsEventuallyPeriodic<Seq>`** — the finite-state ("lasso") witness: a prefix `pre_period` then a cycle `period`. Unifies the `:convergence` shape concepts (absorptive = 1-cycle, periodic = 0-prefix) and is the same finite/countable presentation the Slice-5 `ClassicalLogic` collapse keys on.
- **`decide_tail_equivalence<S,T>(s,t) -> Ternary`** — when both are `IsEventuallyPeriodic`, **structural recursion** over the *provably-sufficient* window `[max(Pₛ,Pₜ), max + lcm(Cₛ,Cₜ))` yields a real `True`/`False` (past max-pre-period both factor through the common cycle, so one period's agreement is agreement forever — not a sampled guess). Otherwise the decision needs the infinite tail (**general recursion**) ⇒ `Ternary::Unknown` (Honest-Rejection).

This de-glorifies the relation: the decidable `bool` now comes from the finite presentation, and the general case is honestly `Unknown` rather than a fixed-window lie.

## Test plan

- [x] `make test` — all 15 suites green
- [x] `make format` clean
- [ ] CI green