### PR TITLE
feat(sequences): #703 Slice 1 — OrderInterval→iota_view bridge (halfspace ↔ ranges)

### DIFF
--- a/src/main/modules/dedekind/sequences/ranges.cppm
+++ b/src/main/modules/dedekind/sequences/ranges.cppm
@@ -41,10 +41,13 @@ module;
 #include <concepts>
 #include <cstddef>
 #include <cstdint>
+#include <ranges>
 
 export module dedekind.sequences:ranges;
 
 import dedekind.category;
+import dedekind.order; // OrderInterval / Halfspace — the halfspace→iota_view
+                       // bridge for #703 Slice 1
 import dedekind.sets;
 import dedekind.topology;
 import :net;
@@ -228,5 +231,46 @@ static_assert(dedekind::topology::IsConvex<IntegerInterval<int>>,
 static_assert(
     IsConvexEnumerable<IntegerInterval<int>>,
     "IntegerInterval must satisfy IsConvexEnumerable (convex + terminal set).");
+
+/**
+ * @section ranges__Halfspace_To_Iota_View_Bridge (#703 Slice 1)
+ *
+ * @brief The typed→runtime half of the halfspace ↔ iota_view isomorphism:
+ *        convert a compile-time-bounded @c order::OrderInterval into the
+ *        equivalent @c std::ranges::iota_view (closed-open boundary).
+ *
+ * @details An @c order::OrderInterval<T, Lo, Hi, SL, SU> is the meet of two
+ * opposing halfspaces — a typed-Δ⁰₁ predicate.  @c std::ranges::iota_view
+ * is its range view: the same set of integers, accessed as a view rather
+ * than as a predicate.  This adapter maps the typed predicate to a
+ * runtime-bounded iota_view, normalising the four (SL, SU) strictness
+ * combinations to iota_view's canonical @c [start, bound) shape:
+ *
+ *   - lower @c Strict     ⇒ @c start = Lo + 1   (predicate @c x > Lo)
+ *   - lower @c NonStrict  ⇒ @c start = Lo       (predicate @c x ≥ Lo)
+ *   - upper @c Strict     ⇒ @c bound = Hi       (predicate @c x < Hi)
+ *   - upper @c NonStrict  ⇒ @c bound = Hi + 1   (predicate @c x ≤ Hi)
+ *
+ * The reverse direction (@c from_iota_view) requires an explicit typed
+ * target because @c iota_view's bounds are runtime data while
+ * @c OrderInterval's are template parameters — deferred to Slice 2 along
+ * with the @c IsIsomorphism witness for the pair.  Deeper Form-chain
+ * witnessing of @c iota_view as an object (subobject-of-ambient lattice
+ * shape) is the Slice 3+ direction.
+ */
+export template <std::integral T, T Lo, T Hi, dedekind::order::Strictness SL,
+                 dedekind::order::Strictness SU, typename L>
+constexpr std::ranges::iota_view<T, T> to_iota_view(
+    const dedekind::order::OrderInterval<T, Lo, Hi, SL, SU, L>&) {
+  constexpr T start =
+      (SL == dedekind::order::Strictness::Strict) ? static_cast<T>(Lo + 1) : Lo;
+  constexpr T raw_bound =
+      (SU == dedekind::order::Strictness::Strict) ? Hi : static_cast<T>(Hi + 1);
+  // Clamp: an empty OrderInterval (e.g. {x : 5 < x < 5}) must produce an
+  // empty iota_view, not a wrapped one — iota(start, bound<start) is
+  // ill-formed and would compute a wrapped size on unsigned T.
+  constexpr T bound = raw_bound < start ? start : raw_bound;
+  return std::ranges::views::iota(start, bound);
+}
 
 }  // namespace dedekind::sequences

--- a/src/main/modules/dedekind/sequences/ranges.cppm
+++ b/src/main/modules/dedekind/sequences/ranges.cppm
@@ -41,6 +41,7 @@ module;
 #include <concepts>
 #include <cstddef>
 #include <cstdint>
+#include <limits>
 #include <ranges>
 
 export module dedekind.sequences:ranges;
@@ -258,17 +259,48 @@ static_assert(
  * witnessing of @c iota_view as an object (subobject-of-ambient lattice
  * shape) is the Slice 3+ direction.
  */
-export template <std::integral T, T Lo, T Hi, dedekind::order::Strictness SL,
-                 dedekind::order::Strictness SU, typename L>
+export template <std::integral T, auto Lo, auto Hi,
+                 dedekind::order::Strictness SL, dedekind::order::Strictness SU,
+                 typename L>
+  requires std::convertible_to<decltype(Lo), T> &&
+           std::convertible_to<decltype(Hi), T>
 constexpr std::ranges::iota_view<T, T> to_iota_view(
     const dedekind::order::OrderInterval<T, Lo, Hi, SL, SU, L>&) {
-  constexpr T start =
-      (SL == dedekind::order::Strictness::Strict) ? static_cast<T>(Lo + 1) : Lo;
-  constexpr T raw_bound =
-      (SU == dedekind::order::Strictness::Strict) ? Hi : static_cast<T>(Hi + 1);
-  // Clamp: an empty OrderInterval (e.g. {x : 5 < x < 5}) must produce an
-  // empty iota_view, not a wrapped one — iota(start, bound<start) is
-  // ill-formed and would compute a wrapped size on unsigned T.
+  // OrderInterval's pivots are NTTPs of possibly distinct integral types
+  // (e.g. int pivots for a size_t carrier); narrow each to the carrier
+  // type before arithmetic.  No wider arithmetic type works uniformly
+  // here — int64_t can't represent size_t's max — so the overflow corners
+  // are kept in T and ruled out at compile time below.
+  constexpr T lo_t = static_cast<T>(Lo);
+  constexpr T hi_t = static_cast<T>(Hi);
+  constexpr T tmax = std::numeric_limits<T>::max();
+
+  // Honest-Rejection at compile time for the corners where the iota_view's
+  // bounds cannot be represented in T: lower-Strict at T's max would need
+  // start = max+1, and upper-NonStrict at T's max would need bound = max+1
+  // (iota's exclusive upper bound has no way to encode "include max").
+  static_assert(SL != dedekind::order::Strictness::Strict || lo_t != tmax,
+                "to_iota_view: lower-Strict at T's max would need start = "
+                "max+1, which is not representable in T.  Use a different "
+                "lower boundary, or a wider carrier.");
+  static_assert(SU != dedekind::order::Strictness::NonStrict || hi_t != tmax,
+                "to_iota_view: upper-NonStrict at T's max would need bound = "
+                "max+1 (iota's exclusive upper), which is not representable "
+                "in T.  Use upper-Strict (predicate x < max), or a wider "
+                "carrier.");
+
+  // The strictness ±1 is now safe in T (the overflow corners are excluded
+  // above, so the increment cannot UB on signed T nor wrap on unsigned T).
+  constexpr T start = (SL == dedekind::order::Strictness::Strict)
+                          ? static_cast<T>(lo_t + 1)
+                          : lo_t;
+  constexpr T raw_bound = (SU == dedekind::order::Strictness::Strict)
+                              ? hi_t
+                              : static_cast<T>(hi_t + 1);
+  // Empty intervals (e.g. {x : 5 < x < 5}) yield bound < start under the
+  // strictness normalisation; std::views::iota(start, bound<start) would
+  // iterate on a wrapped range and size() would underflow on unsigned T.
+  // Clamp so the resulting iota_view is honestly empty.
   constexpr T bound = raw_bound < start ? start : raw_bound;
   return std::ranges::views::iota(start, bound);
 }

--- a/src/test/cpp/modules/dedekind/sequences/halfspace_to_iota_test.cpp
+++ b/src/test/cpp/modules/dedekind/sequences/halfspace_to_iota_test.cpp
@@ -103,6 +103,28 @@ TEST_CASE(
 }
 
 TEST_CASE(
+    "ranges:halfspace→iota — unsigned carrier: pivots cross types, and the "
+    "empty case does not wrap",
+    "[ranges][halfspace][iota][unsigned]") {
+  // Pivots are int (3, 7); carrier is std::size_t — exercises the
+  // auto-NTTP / convertible-to-T pivot deduction.
+  using OI_us = OrderInterval<std::size_t, 3, 7, Strictness::NonStrict,
+                              Strictness::Strict>;
+  const auto iv = to_iota_view(OI_us{});
+  STATIC_CHECK(
+      std::is_same_v<std::remove_cvref_t<decltype(iv)>,
+                     std::ranges::iota_view<std::size_t, std::size_t>>);
+  REQUIRE(iv_size(iv) == 4u);  // {3,4,5,6}
+
+  // Empty after strictness normalisation on an unsigned carrier: the clamp
+  // must produce an empty iota_view, not an underflowed (size_t)-1.
+  using OI_us_empty =
+      OrderInterval<std::size_t, 5, 5, Strictness::Strict, Strictness::Strict>;
+  const auto iv_empty = to_iota_view(OI_us_empty{});
+  REQUIRE(iv_size(iv_empty) == 0u);
+}
+
+TEST_CASE(
     "ranges:halfspace→iota — the image plugs into IsFiniteSequence via "
     "from_range",
     "[ranges][halfspace][iota][sequence-bridge]") {

--- a/src/test/cpp/modules/dedekind/sequences/halfspace_to_iota_test.cpp
+++ b/src/test/cpp/modules/dedekind/sequences/halfspace_to_iota_test.cpp
@@ -1,0 +1,119 @@
+/** @file dedekind/sequences/halfspace_to_iota_test.cpp
+ *
+ * Unit coverage for the typed→runtime half of the halfspace ↔ iota_view
+ * isomorphism (#703 Slice 1): @c to_iota_view, the adapter from
+ * @c order::OrderInterval (a compile-time typed-Δ⁰₁ predicate) to
+ * @c std::ranges::iota_view (its range view).
+ *
+ * Coverage:
+ *  - The four (lower, upper) strictness combinations normalise to
+ *    iota_view's canonical [start, bound) shape with the correct bounds.
+ *  - The image iota_view's elements all satisfy the source OrderInterval
+ *    predicate (the iso's defining property — value-level agreement).
+ *  - Cardinalities agree: OrderInterval::size() == iota_view's element count.
+ *  - The image flows into the library's IsFiniteSequence concept via the
+ *    existing from_range adapter — the bridge plugs into the sequence layer.
+ */
+
+#include <catch2/catch_test_macros.hpp>
+#include <ranges>
+#include <type_traits>
+
+import dedekind.sequences;
+import dedekind.order;
+import dedekind.category;
+
+using namespace dedekind::sequences;
+using dedekind::order::OrderInterval;
+using dedekind::order::Strictness;
+
+namespace {
+
+template <typename Iv>
+constexpr std::size_t iv_size(const Iv& iv) {
+  // iota_view<T,T> with integral T has a size() member.
+  return static_cast<std::size_t>(iv.size());
+}
+
+}  // namespace
+
+TEST_CASE(
+    "ranges:halfspace→iota — [Lo, Hi) (lower NonStrict, upper Strict): "
+    "the canonical iota_view shape",
+    "[ranges][halfspace][iota]") {
+  // OrderInterval<int, 3, 8, NonStrict, Strict> = {x : 3 ≤ x < 8} = [3, 8).
+  using OI =
+      OrderInterval<int, 3, 8, Strictness::NonStrict, Strictness::Strict>;
+  constexpr OI predicate{};
+  const auto iv = to_iota_view(predicate);
+
+  STATIC_CHECK(std::is_same_v<std::remove_cvref_t<decltype(iv)>,
+                              std::ranges::iota_view<int, int>>);
+  REQUIRE(*iv.begin() == 3);
+  REQUIRE(iv_size(iv) == 5u);
+  REQUIRE(iv_size(iv) == predicate.size());
+  // Every element of the iota_view satisfies the source predicate.
+  for (const int x : iv) {
+    REQUIRE(predicate(x));
+  }
+}
+
+TEST_CASE(
+    "ranges:halfspace→iota — strictness combinations normalise to "
+    "[start, bound)",
+    "[ranges][halfspace][iota][strictness]") {
+  // (Strict, NonStrict): {x : Lo < x ≤ Hi} = [Lo+1, Hi+1) = [4, 9) for
+  // Lo=3,Hi=8
+  using OI_SN =
+      OrderInterval<int, 3, 8, Strictness::Strict, Strictness::NonStrict>;
+  const auto iv_sn = to_iota_view(OI_SN{});
+  REQUIRE(*iv_sn.begin() == 4);
+  REQUIRE(iv_size(iv_sn) == 5u);
+
+  // (Strict, Strict): {x : Lo < x < Hi} = [Lo+1, Hi) = [4, 8)
+  using OI_SS =
+      OrderInterval<int, 3, 8, Strictness::Strict, Strictness::Strict>;
+  const auto iv_ss = to_iota_view(OI_SS{});
+  REQUIRE(*iv_ss.begin() == 4);
+  REQUIRE(iv_size(iv_ss) == 4u);
+
+  // (NonStrict, NonStrict): {x : Lo ≤ x ≤ Hi} = [Lo, Hi+1) = [3, 9)
+  using OI_NN =
+      OrderInterval<int, 3, 8, Strictness::NonStrict, Strictness::NonStrict>;
+  const auto iv_nn = to_iota_view(OI_NN{});
+  REQUIRE(*iv_nn.begin() == 3);
+  REQUIRE(iv_size(iv_nn) == 6u);
+
+  // Cardinality agreement on each shape:
+  REQUIRE(iv_size(iv_sn) == OI_SN{}.size());
+  REQUIRE(iv_size(iv_ss) == OI_SS{}.size());
+  REQUIRE(iv_size(iv_nn) == OI_NN{}.size());
+}
+
+TEST_CASE(
+    "ranges:halfspace→iota — empty interval round-trips to an empty "
+    "iota_view",
+    "[ranges][halfspace][iota][empty]") {
+  // Empty under (Strict, Strict): {x : 5 < x < 5} = ∅
+  using OI_empty =
+      OrderInterval<int, 5, 5, Strictness::Strict, Strictness::Strict>;
+  const auto iv = to_iota_view(OI_empty{});
+  REQUIRE(iv_size(iv) == 0u);
+  REQUIRE(iv_size(iv) == OI_empty{}.size());
+}
+
+TEST_CASE(
+    "ranges:halfspace→iota — the image plugs into IsFiniteSequence via "
+    "from_range",
+    "[ranges][halfspace][iota][sequence-bridge]") {
+  // The whole point of routing through iota_view: the library's sequence
+  // layer already lifts ranges via from_range, so to_iota_view gets us
+  // straight into IsFiniteSequence territory.
+  using OI =
+      OrderInterval<int, 0, 4, Strictness::NonStrict, Strictness::Strict>;
+  const auto fp = from_range(to_iota_view(OI{}));
+  STATIC_CHECK(IsFiniteSequence<std::remove_cvref_t<decltype(fp)>>);
+  REQUIRE(fp.size() == 4u);
+  REQUIRE(fp.at(0) == 0);
+  REQUIRE(fp.at(3) == 3);
+}


### PR DESCRIPTION
## Summary

First slice of #703 (`std::ranges` + halfspaces). Lands the **typed→runtime half of the halfspace ↔ iota_view isomorphism**: convert a compile-time `order::OrderInterval` (the meet of two halfspaces — a typed-Δ⁰₁ predicate) into the equivalent `std::ranges::iota_view`, normalising the four strictness combinations to iota_view's canonical `[start, bound)` shape.

- **`to_iota_view(OrderInterval<T, Lo, Hi, SL, SU, L>) → std::ranges::iota_view<T,T>`** in `:sequences:ranges` (which now imports `dedekind.order`). Empty intervals (`start > bound`) are clamped so the iota_view is empty rather than wrapping on unsigned `T`.
- Bridge lives next to `IntegerInterval`, the sister carrier that already owns the range-view + `IsConvexEnumerable` + `IsFiniteSequence` integration here.

### Type-checks instead of prose
- The four `(SL, SU)` combinations land at the right `[start, bound)`.
- Every iota_view element satisfies the source `OrderInterval` predicate (the iso's defining property).
- Cardinalities agree: `OrderInterval::size() == iota_view`'s element count.
- The empty case round-trips to an empty iota_view.
- The image plugs into `IsFiniteSequence` via the existing `from_range` adapter — the bridge connects all the way into the sequence layer.

### Honest deferrals (per #703)
- **`from_iota_view` + `IsIsomorphism` witness** — needs an explicit typed target because iota_view's bounds are runtime data and OrderInterval's are template parameters. Slice 2.
- **Form-chain witnessing of iota_view as a Form-chain object** — needs the subobject-of-ambient lattice reading designed first (iota_view-as-type doesn't naturally carry the lattice ordering; the meaningful order is the subobject inclusion on iota_view *values*). Slice 3+.
- Co-design with #708's non-integral `HeytingExponential` specialisations to follow once consumers surface here.

Per your steer: this is the **Iso** encoding (Halfspace and iota_view stay distinct types, bridged by an explicit arrow), not a literal-equality merge.

## Test plan

- [x] `make test` — all 15 suites green
- [x] `make format` clean
- [ ] CI green