### PR TITLE
feat(sequences): #703 Slice 2 — from_iota_view (verifying inverse) + value-level iso witness

### DIFF
--- a/src/main/modules/dedekind/sequences/ranges.cppm
+++ b/src/main/modules/dedekind/sequences/ranges.cppm
@@ -346,15 +346,29 @@ constexpr std::optional<OI> from_iota_view(
         iv) {
   using B = detail::iota_bounds_of<OI>;
   using T = typename OI::Domain;
-  const T actual_start = *iv.begin();
-  // Cast size to T explicitly to avoid -Wsign-conversion on signed T; a
-  // size that doesn't fit T can't be a valid from_iota_view target anyway.
-  const T actual_bound =
-      static_cast<T>(actual_start + static_cast<T>(iv.size()));
-  if (actual_start == B::start && actual_bound == B::bound) {
+  // Compare sizes first.  This is well-defined for any iota_view (including
+  // empty and very large) and avoids the @c actual_start @c + @c iv.size()
+  // arithmetic that could wrap for large ranges.
+  const std::size_t actual_size = static_cast<std::size_t>(iv.size());
+  const std::size_t expected_size =
+      static_cast<std::size_t>(B::bound - B::start);
+  if (actual_size != expected_size) {
+    return std::nullopt;
+  }
+  // Empty interval: both sides empty ⇒ accept (the unique empty interval
+  // per @c OI type; @c *iv.begin() is conventionally @c value_ even when
+  // @c begin() @c == @c end(), but skipping the read keeps the verifier
+  // unambiguously safe and the meaning honest — at the value level the iso
+  // identifies @c OI{Empty} with @b any empty iota_view).
+  if (actual_size == 0) {
     return OI{};
   }
-  return std::nullopt;
+  // Non-empty: dereferencing begin() is well-defined.
+  const T actual_start = *iv.begin();
+  if (actual_start != B::start) {
+    return std::nullopt;
+  }
+  return OI{};
 }
 
 /** @section ranges__Halfspace_Iota_Round_Trip

--- a/src/main/modules/dedekind/sequences/ranges.cppm
+++ b/src/main/modules/dedekind/sequences/ranges.cppm
@@ -42,6 +42,7 @@ module;
 #include <cstddef>
 #include <cstdint>
 #include <limits>
+#include <optional>
 #include <ranges>
 
 export module dedekind.sequences:ranges;
@@ -234,46 +235,56 @@ static_assert(
     "IntegerInterval must satisfy IsConvexEnumerable (convex + terminal set).");
 
 /**
- * @section ranges__Halfspace_To_Iota_View_Bridge (#703 Slice 1)
+ * @section ranges__Halfspace_To_Iota_View_Bridge (#703 Slices 1–2)
  *
- * @brief The typed→runtime half of the halfspace ↔ iota_view isomorphism:
- *        convert a compile-time-bounded @c order::OrderInterval into the
- *        equivalent @c std::ranges::iota_view (closed-open boundary).
+ * @brief The halfspace ↔ iota_view isomorphism — typed @c OrderInterval
+ *        ↔ runtime-bounded @c std::ranges::iota_view, witnessed at the
+ *        value level by a round-trip.
  *
  * @details An @c order::OrderInterval<T, Lo, Hi, SL, SU> is the meet of two
  * opposing halfspaces — a typed-Δ⁰₁ predicate.  @c std::ranges::iota_view
  * is its range view: the same set of integers, accessed as a view rather
- * than as a predicate.  This adapter maps the typed predicate to a
- * runtime-bounded iota_view, normalising the four (SL, SU) strictness
- * combinations to iota_view's canonical @c [start, bound) shape:
+ * than as a predicate.  The pair @c (to_iota_view, from_iota_view)
+ * normalises the four (SL, SU) strictness combinations to iota_view's
+ * canonical @c [start, bound) shape:
  *
  *   - lower @c Strict     ⇒ @c start = Lo + 1   (predicate @c x > Lo)
  *   - lower @c NonStrict  ⇒ @c start = Lo       (predicate @c x ≥ Lo)
  *   - upper @c Strict     ⇒ @c bound = Hi       (predicate @c x < Hi)
  *   - upper @c NonStrict  ⇒ @c bound = Hi + 1   (predicate @c x ≤ Hi)
  *
- * The reverse direction (@c from_iota_view) requires an explicit typed
- * target because @c iota_view's bounds are runtime data while
- * @c OrderInterval's are template parameters — deferred to Slice 2 along
- * with the @c IsIsomorphism witness for the pair.  Deeper Form-chain
- * witnessing of @c iota_view as an object (subobject-of-ambient lattice
- * shape) is the Slice 3+ direction.
+ * The iso is @b value-level: it relates the singleton @c OI{} to a
+ * specific @c iota_view value, not the @c OrderInterval @b type to the
+ * @c iota_view @b type.  @c OrderInterval's bounds are template
+ * parameters and @c iota_view's are runtime data, so @c from_iota_view
+ * must be told the target type and verifies the runtime bounds match
+ * what @c to_iota_view would produce — returning @c std::optional<OI>
+ * (Honest-Rejection on mismatch).  The round-trip
+ * @c from_iota_view<OI>(to_iota_view(OI{})) is the iso witness, pinned
+ * by @c static_assert below.  A heavier categorical @c IsIsomorphism
+ * reification (arrows-as-structs with @c inverse()) is intentionally
+ * not done: it would over-claim a type-level iso, which the
+ * typed/runtime asymmetry forbids.  Slice 3+: @c iota_view as a
+ * Form-chain object (subobject-of-ambient lattice shape).
  */
-export template <std::integral T, auto Lo, auto Hi,
-                 dedekind::order::Strictness SL, dedekind::order::Strictness SU,
-                 typename L>
+namespace detail {
+
+/** @brief The @c [start, bound) iota_view bounds an @c OrderInterval
+ *         normalises to (shared between @c to_iota_view and
+ *         @c from_iota_view).  Specialised on @c OrderInterval shape;
+ *         the overflow corners (lower-Strict / upper-NonStrict at T's
+ *         max) are forbidden at compile time. */
+template <typename OI>
+struct iota_bounds_of;
+
+template <std::integral T, auto Lo, auto Hi, dedekind::order::Strictness SL,
+          dedekind::order::Strictness SU, typename L>
   requires std::convertible_to<decltype(Lo), T> &&
            std::convertible_to<decltype(Hi), T>
-constexpr std::ranges::iota_view<T, T> to_iota_view(
-    const dedekind::order::OrderInterval<T, Lo, Hi, SL, SU, L>&) {
-  // OrderInterval's pivots are NTTPs of possibly distinct integral types
-  // (e.g. int pivots for a size_t carrier); narrow each to the carrier
-  // type before arithmetic.  No wider arithmetic type works uniformly
-  // here — int64_t can't represent size_t's max — so the overflow corners
-  // are kept in T and ruled out at compile time below.
-  constexpr T lo_t = static_cast<T>(Lo);
-  constexpr T hi_t = static_cast<T>(Hi);
-  constexpr T tmax = std::numeric_limits<T>::max();
+struct iota_bounds_of<dedekind::order::OrderInterval<T, Lo, Hi, SL, SU, L>> {
+  static constexpr T lo_t = static_cast<T>(Lo);
+  static constexpr T hi_t = static_cast<T>(Hi);
+  static constexpr T tmax = std::numeric_limits<T>::max();
 
   // Honest-Rejection at compile time for the corners where the iota_view's
   // bounds cannot be represented in T: lower-Strict at T's max would need
@@ -289,20 +300,76 @@ constexpr std::ranges::iota_view<T, T> to_iota_view(
                 "in T.  Use upper-Strict (predicate x < max), or a wider "
                 "carrier.");
 
-  // The strictness ±1 is now safe in T (the overflow corners are excluded
-  // above, so the increment cannot UB on signed T nor wrap on unsigned T).
-  constexpr T start = (SL == dedekind::order::Strictness::Strict)
-                          ? static_cast<T>(lo_t + 1)
-                          : lo_t;
-  constexpr T raw_bound = (SU == dedekind::order::Strictness::Strict)
-                              ? hi_t
-                              : static_cast<T>(hi_t + 1);
-  // Empty intervals (e.g. {x : 5 < x < 5}) yield bound < start under the
-  // strictness normalisation; std::views::iota(start, bound<start) would
-  // iterate on a wrapped range and size() would underflow on unsigned T.
-  // Clamp so the resulting iota_view is honestly empty.
-  constexpr T bound = raw_bound < start ? start : raw_bound;
-  return std::ranges::views::iota(start, bound);
+  // The strictness ±1 is now safe in T (overflow corners excluded above).
+  static constexpr T start = (SL == dedekind::order::Strictness::Strict)
+                                 ? static_cast<T>(lo_t + 1)
+                                 : lo_t;
+  static constexpr T raw_bound = (SU == dedekind::order::Strictness::Strict)
+                                     ? hi_t
+                                     : static_cast<T>(hi_t + 1);
+  // Empty intervals (e.g. {x : 5 < x < 5}) yield raw_bound < start; clamp so
+  // the resulting iota_view is honestly empty rather than wrapped.
+  static constexpr T bound = raw_bound < start ? start : raw_bound;
+};
+
+}  // namespace detail
+
+/** @brief The typed→runtime half of the iso: project an @c OrderInterval to
+ *         its canonical @c std::ranges::iota_view (the same set of integers
+ *         viewed as a range rather than a predicate). */
+export template <std::integral T, auto Lo, auto Hi,
+                 dedekind::order::Strictness SL, dedekind::order::Strictness SU,
+                 typename L>
+  requires std::convertible_to<decltype(Lo), T> &&
+           std::convertible_to<decltype(Hi), T>
+constexpr std::ranges::iota_view<T, T> to_iota_view(
+    const dedekind::order::OrderInterval<T, Lo, Hi, SL, SU, L>&) {
+  using B = detail::iota_bounds_of<
+      dedekind::order::OrderInterval<T, Lo, Hi, SL, SU, L>>;
+  return std::ranges::views::iota(B::start, B::bound);
 }
+
+/** @brief The runtime→typed half of the iso (verifying, partial): check
+ *         whether the runtime @c iota_view matches what @c to_iota_view
+ *         would produce for the target @c OI, and return @c OI{} on match,
+ *         @c std::nullopt otherwise.
+ *
+ *  @details The target @c OrderInterval is supplied at the type level
+ *  because its bounds are template parameters; @c iota_view's are runtime
+ *  data, so the inverse cannot reconstruct the type — it can only
+ *  @b verify the bounds.  This is the honest shape of the asymmetric iso:
+ *  bijection at the value level (between @c OI{} and a specific
+ *  @c iota_view value), partial-with-verification at the runtime level. */
+export template <typename OI>
+constexpr std::optional<OI> from_iota_view(
+    const std::ranges::iota_view<typename OI::Domain, typename OI::Domain>&
+        iv) {
+  using B = detail::iota_bounds_of<OI>;
+  using T = typename OI::Domain;
+  const T actual_start = *iv.begin();
+  // Cast size to T explicitly to avoid -Wsign-conversion on signed T; a
+  // size that doesn't fit T can't be a valid from_iota_view target anyway.
+  const T actual_bound =
+      static_cast<T>(actual_start + static_cast<T>(iv.size()));
+  if (actual_start == B::start && actual_bound == B::bound) {
+    return OI{};
+  }
+  return std::nullopt;
+}
+
+/** @section ranges__Halfspace_Iota_Round_Trip
+ *  The iso witness: a value-level round-trip on a representative
+ *  @c OrderInterval pins that @c from_iota_view ∘ @c to_iota_view is the
+ *  identity on @c OI{}.  The negative direction is exercised in the test
+ *  (a mismatched iota_view ⇒ nullopt). */
+namespace halfspace_iota_witness {
+using OI =
+    dedekind::order::OrderInterval<int, 3, 8,
+                                   dedekind::order::Strictness::NonStrict,
+                                   dedekind::order::Strictness::Strict>;
+static_assert(from_iota_view<OI>(to_iota_view(OI{})).has_value(),
+              "Iso witness: from_iota_view ∘ to_iota_view yields OI{} for the "
+              "canonical [3, 8) interval.");
+}  // namespace halfspace_iota_witness
 
 }  // namespace dedekind::sequences

--- a/src/test/cpp/modules/dedekind/sequences/halfspace_to_iota_test.cpp
+++ b/src/test/cpp/modules/dedekind/sequences/halfspace_to_iota_test.cpp
@@ -139,3 +139,51 @@ TEST_CASE(
   REQUIRE(fp.at(0) == 0);
   REQUIRE(fp.at(3) == 3);
 }
+
+TEST_CASE(
+    "ranges:iota→halfspace — from_iota_view rebuilds OI from a matching "
+    "iota_view, rejects a mismatched one (#703 Slice 2)",
+    "[ranges][halfspace][iota][inverse]") {
+  using OI =
+      OrderInterval<int, 3, 8, Strictness::NonStrict, Strictness::Strict>;
+  // Round-trip on a matching iota_view: from_iota_view sees the [3, 8)
+  // bounds and rebuilds OI{}.
+  const auto matched = from_iota_view<OI>(to_iota_view(OI{}));
+  REQUIRE(matched.has_value());
+
+  // Honest-Rejection: an iota_view with the wrong bounds yields nullopt —
+  // the iso is value-level, so only the SPECIFIC iota_view value
+  // to_iota_view(OI{}) corresponds to OI{}.
+  const auto wrong_bounds = from_iota_view<OI>(std::ranges::views::iota(0, 5));
+  REQUIRE_FALSE(wrong_bounds.has_value());
+
+  // Even a partial mismatch (correct start, wrong bound) is rejected.
+  const auto partial = from_iota_view<OI>(std::ranges::views::iota(3, 9));
+  REQUIRE_FALSE(partial.has_value());
+}
+
+TEST_CASE(
+    "ranges:iota→halfspace — round-trip across the four strictness "
+    "combinations and across signed/unsigned carriers",
+    "[ranges][halfspace][iota][inverse][round-trip]") {
+  using OI_SN =
+      OrderInterval<int, 3, 8, Strictness::Strict, Strictness::NonStrict>;
+  using OI_SS =
+      OrderInterval<int, 3, 8, Strictness::Strict, Strictness::Strict>;
+  using OI_NN =
+      OrderInterval<int, 3, 8, Strictness::NonStrict, Strictness::NonStrict>;
+  using OI_us = OrderInterval<std::size_t, 3, 7, Strictness::NonStrict,
+                              Strictness::Strict>;
+
+  REQUIRE(from_iota_view<OI_SN>(to_iota_view(OI_SN{})).has_value());
+  REQUIRE(from_iota_view<OI_SS>(to_iota_view(OI_SS{})).has_value());
+  REQUIRE(from_iota_view<OI_NN>(to_iota_view(OI_NN{})).has_value());
+  REQUIRE(from_iota_view<OI_us>(to_iota_view(OI_us{})).has_value());
+
+  // Empty interval round-trips to nullopt? No — to_iota_view produces an
+  // empty iota_view at the clamped bounds; from_iota_view should accept it
+  // since the bounds match the clamped construction.
+  using OI_empty =
+      OrderInterval<int, 5, 5, Strictness::Strict, Strictness::Strict>;
+  REQUIRE(from_iota_view<OI_empty>(to_iota_view(OI_empty{})).has_value());
+}


### PR DESCRIPTION
## Summary

Second slice of #703. Closes the **halfspace ↔ iota_view iso pair**: a runtime→typed half that verifies the iota_view's bounds against the target `OrderInterval`'s compile-time bounds and returns `OI{}` on match, `std::nullopt` otherwise. The round-trip `from_iota_view<OI>(to_iota_view(OI{}))` is pinned as a `static_assert` in main.

- **`detail::iota_bounds_of<OI>`** — shared `(start, bound)` computation, lifted out of `to_iota_view` so both halves of the iso stay in lock-step (the overflow-corner `static_assert`s now live in the helper).
- **`from_iota_view<OI>(iota_view) -> std::optional<OI>`** — verifying inverse. The target `OrderInterval` is named at the type level (its bounds are template params; iota_view's are runtime data — the asymmetry your iso-encoding choice acknowledged); the inverse is partial-with-verification.
- **Round-trip iso witness** pinned by `static_assert` in `ranges.cppm`: `from_iota_view<OI>(to_iota_view(OI{})).has_value()`.

### Type-checks instead of prose
- Round-trip succeeds on a matching iota_view; Honest-Rejection on mismatched bounds (wrong start, wrong bound, partial mismatch).
- Round-trip across all four `(SL, SU)` strictness combinations and across signed/unsigned carriers (`int`, `std::size_t`).
- Empty case round-trips correctly (the clamp is consistent across both halves).

### Honest non-deferral
A heavier categorical **`IsIsomorphism`** reification (arrows-as-structs with `inverse()`) is intentionally **not** added — it would over-claim a *type-level* iso, which the typed/runtime asymmetry forbids: `OrderInterval` is a singleton type, `iota_view<T,T>` has uncountably many values, and the iso is between one `OI{}` and one specific `iota_view` value. The value-level round-trip is the right witness for this pair.

Slice 3+ remains: `iota_view` as a Form-chain object under the subobject-of-ambient lattice reading.

## Test plan

- [x] `make test` — all 15 suites green
- [x] `make format` clean
- [ ] CI green