### PR TITLE
feat(sequences): #703 Slice 3b — iota_view as a meet-semilattice (intersection)

### DIFF
--- a/src/main/modules/dedekind/sequences/ranges.cppm
+++ b/src/main/modules/dedekind/sequences/ranges.cppm
@@ -424,4 +424,86 @@ static_assert(detail::iota_bounds_of<D1andD2>::start ==
               "(start == bound after the clamp).");
 }  // namespace bridge_meet_witness
 
+/** @section ranges__Iota_Meet_Semilattice (#703 Slice 3b)
+ *
+ *  @brief @c std::ranges::iota_view as a Form-chain object: an
+ *         @c order::IsOrderMeetSemilattice under subset-inclusion, with
+ *         intersection as the meet.
+ *
+ *  @details Two @c iota_view values @c a, @c b can be intersected: their
+ *  meet is the iota_view @c [max(start), min(bound)) clamped to empty if
+ *  disjoint.  Intersection is associative, commutative, and idempotent —
+ *  the three trait registrations below make
+ *  @c IsOrderMeetSemilattice<iota_view<T,T>, IotaIntersection> fire.
+ *
+ *  @note @b Why @b meet-only @b and @b not @b a @b full @b lattice:
+ *  union of two iota_views is @b not in general an iota_view
+ *  (@c [0,3) @c ∪ @c [5,10) is not one interval), so iota_view's carrier
+ *  is @b not closed under join.  A full lattice on the intervals layer
+ *  requires moving to a richer carrier — finite unions of intervals, or
+ *  the @c Sub<> subobject lattice from #698 Slice 8.  Tracked as a
+ *  follow-up issue; this slice exhibits the honest meet-semilattice
+ *  fragment.
+ */
+
+/** @brief The meet (intersection) operator on @c std::ranges::iota_view
+ *         values: a callable that returns the iota_view of the common
+ *         tail, or an empty iota_view on disjoint inputs. */
+export struct IotaIntersection {
+  template <std::integral T>
+  constexpr std::ranges::iota_view<T, T> operator()(
+      const std::ranges::iota_view<T, T>& a,
+      const std::ranges::iota_view<T, T>& b) const {
+    if (a.empty()) return a;
+    if (b.empty()) return b;
+    const T a_start = *a.begin();
+    const T b_start = *b.begin();
+    const T a_bound = static_cast<T>(a_start + static_cast<T>(a.size()));
+    const T b_bound = static_cast<T>(b_start + static_cast<T>(b.size()));
+    const T new_start = a_start > b_start ? a_start : b_start;
+    const T raw_bound = a_bound < b_bound ? a_bound : b_bound;
+    // Clamp to empty on disjoint inputs (raw_bound < new_start) so size()
+    // doesn't underflow on unsigned T — same shape as to_iota_view's clamp.
+    const T new_bound = raw_bound < new_start ? new_start : raw_bound;
+    return std::ranges::views::iota(new_start, new_bound);
+  }
+};
+
+}  // namespace dedekind::sequences
+
+namespace dedekind::category {
+
+// IotaIntersection is the meet on iota_view<T,T>: associative,
+// commutative, idempotent — the trait triple that makes
+// IsOrderMeetSemilattice fire.
+template <std::integral T>
+inline constexpr bool is_associative_v<std::ranges::iota_view<T, T>,
+                                       dedekind::sequences::IotaIntersection> =
+    true;
+template <std::integral T>
+inline constexpr bool is_commutative_v<std::ranges::iota_view<T, T>,
+                                       dedekind::sequences::IotaIntersection> =
+    true;
+template <std::integral T>
+inline constexpr bool is_idempotent_v<std::ranges::iota_view<T, T>,
+                                      dedekind::sequences::IotaIntersection> =
+    true;
+
+}  // namespace dedekind::category
+
+namespace dedekind::sequences {
+
+// The Form-chain row-4-fragment witness: iota_view is an order-theoretic
+// meet-semilattice under intersection (codirected, but not filtered —
+// join doesn't fit iota_view; see the section note above).
+static_assert(dedekind::order::IsOrderMeetSemilattice<
+                  std::ranges::iota_view<int, int>, IotaIntersection>,
+              "iota_view<int,int> with IotaIntersection is an order-theoretic "
+              "meet-semilattice (associative + commutative + idempotent + the "
+              "magma surface meet(a,b) -> iota_view<T,T>).");
+static_assert(
+    dedekind::order::IsOrderMeetSemilattice<
+        std::ranges::iota_view<std::size_t, std::size_t>, IotaIntersection>,
+    "Same witness fires on the unsigned (size_t) carrier.");
+
 }  // namespace dedekind::sequences

--- a/src/main/modules/dedekind/sequences/ranges.cppm
+++ b/src/main/modules/dedekind/sequences/ranges.cppm
@@ -456,10 +456,18 @@ export struct IotaIntersection {
       const std::ranges::iota_view<T, T>& b) const {
     if (a.empty()) return a;
     if (b.empty()) return b;
+    // Read the iota_view's start and bound DIRECTLY from its iterators
+    // (operator* on iota_view's iterator just returns the stored value),
+    // not via @c start @c + @c size().  Computing the bound from the size
+    // narrows @c iv.size() (a @c range_size_t, typically @c size_t) back
+    // to @c T, which truncates and can trigger signed-overflow UB on huge
+    // ranges like @c [INT_MIN, INT_MAX).  Both iterators are well-formed
+    // for @c iota_view<T,T> per @c [range.iota.iterator] (no past-the-end
+    // dereference UB — the iterator stores @c value_ in itself).
     const T a_start = *a.begin();
     const T b_start = *b.begin();
-    const T a_bound = static_cast<T>(a_start + static_cast<T>(a.size()));
-    const T b_bound = static_cast<T>(b_start + static_cast<T>(b.size()));
+    const T a_bound = *a.end();
+    const T b_bound = *b.end();
     const T new_start = a_start > b_start ? a_start : b_start;
     const T raw_bound = a_bound < b_bound ? a_bound : b_bound;
     // Clamp to empty on disjoint inputs (raw_bound < new_start) so size()

--- a/src/test/cpp/modules/dedekind/sequences/halfspace_to_iota_test.cpp
+++ b/src/test/cpp/modules/dedekind/sequences/halfspace_to_iota_test.cpp
@@ -208,6 +208,44 @@ TEST_CASE("ranges:halfspace ↔ iota — disjoint meet produces an empty iota_vi
   REQUIRE(iv_size(iv_disjoint) == 0u);
 }
 
+TEST_CASE("ranges:iota — meet-semilattice law witnesses (#703 Slice 3b)",
+          "[ranges][iota][meet-semilattice]") {
+  // IotaIntersection: the meet operator on iota_view values.  The lattice
+  // laws (associative + commutative + idempotent) are registered as traits
+  // and pinned by static_assert in ranges.cppm; here we exhibit them on
+  // concrete value-level samples so the trait registrations agree with
+  // the actual operator behaviour.
+  constexpr IotaIntersection meet{};
+  const auto a = std::ranges::views::iota(2, 8);
+  const auto b = std::ranges::views::iota(5, 10);
+  const auto c = std::ranges::views::iota(3, 9);
+
+  // Idempotent: a ∧ a == a.
+  const auto a_meet_a = meet(a, a);
+  REQUIRE(iv_size(a_meet_a) == 6u);
+  REQUIRE(*a_meet_a.begin() == 2);
+
+  // Commutative: a ∧ b == b ∧ a (both = [5, 8)).
+  const auto ab = meet(a, b);
+  const auto ba = meet(b, a);
+  REQUIRE(iv_size(ab) == iv_size(ba));
+  REQUIRE(iv_size(ab) == 3u);
+  REQUIRE(*ab.begin() == 5);
+  REQUIRE(*ba.begin() == 5);
+
+  // Associative: (a ∧ b) ∧ c == a ∧ (b ∧ c).
+  const auto abc_left = meet(meet(a, b), c);
+  const auto abc_right = meet(a, meet(b, c));
+  REQUIRE(iv_size(abc_left) == iv_size(abc_right));
+  REQUIRE(*abc_left.begin() == *abc_right.begin());
+
+  // Disjoint ⇒ empty (the codomain-closure that lets the trait
+  // registration stand uniformly).
+  const auto d = std::ranges::views::iota(20, 30);
+  const auto ad = meet(a, d);
+  REQUIRE(iv_size(ad) == 0u);
+}
+
 TEST_CASE(
     "ranges:iota→halfspace — round-trip across the four strictness "
     "combinations and across signed/unsigned carriers",

--- a/src/test/cpp/modules/dedekind/sequences/halfspace_to_iota_test.cpp
+++ b/src/test/cpp/modules/dedekind/sequences/halfspace_to_iota_test.cpp
@@ -17,6 +17,7 @@
 
 #include <algorithm>
 #include <catch2/catch_test_macros.hpp>
+#include <climits>
 #include <iterator>
 #include <ranges>
 #include <type_traits>
@@ -244,6 +245,25 @@ TEST_CASE("ranges:iota — meet-semilattice law witnesses (#703 Slice 3b)",
   const auto d = std::ranges::views::iota(20, 30);
   const auto ad = meet(a, d);
   REQUIRE(iv_size(ad) == 0u);
+}
+
+TEST_CASE("ranges:iota — meet handles huge signed ranges (overflow regression)",
+          "[ranges][iota][meet-semilattice][overflow]") {
+  // Regression for the signed-overflow bug where computing the bound via
+  // start + (T)size() narrowed a huge size_t to T and tripped UB.  The
+  // fix reads the bound directly from iota_view's end iterator — no size
+  // arithmetic — so a huge range like [INT_MIN, INT_MAX) intersected with
+  // a small range stays the small range.
+  constexpr IotaIntersection meet{};
+  const auto huge = std::ranges::views::iota(INT_MIN, INT_MAX);
+  const auto small_range = std::ranges::views::iota(3, 8);
+  const auto m1 = meet(huge, small_range);
+  REQUIRE(iv_size(m1) == 5u);
+  REQUIRE(*m1.begin() == 3);
+  // Commute the operands too, since meet is commutative.
+  const auto m2 = meet(small_range, huge);
+  REQUIRE(iv_size(m2) == 5u);
+  REQUIRE(*m2.begin() == 3);
 }
 
 TEST_CASE(


### PR DESCRIPTION
## Summary

The honest fragment of "`iota_view` as a Form-chain object": **`iota_view` is an order-theoretic meet-semilattice** under subset-inclusion + intersection — codirected, but **not** filtered (the deeper full-lattice question goes to a follow-up).

- **`IotaIntersection`** — the meet operator on `iota_view<T,T>` values, returning `[max(start), min(bound))` clamped to empty on disjoint inputs (same shape as `to_iota_view`'s clamp, so no underflow on unsigned `T`).
- Registered as **associative + commutative + idempotent** on `(iota_view<T,T>, IotaIntersection)`. `static_assert`s in `ranges.cppm` pin **`IsOrderMeetSemilattice<iota_view<int,int>, IotaIntersection>`** *and* `<iota_view<size_t,size_t>, IotaIntersection>`.
- Test exhibits the three laws on concrete value-level samples (idempotent, commutative, associative) and the disjoint→empty closure that lets the trait registrations stand uniformly.

### Honest scope (per your steer)
This is the **meet-semilattice** reading only — not a full lattice. Union of two `iota_view`s is **not in general an `iota_view`** (`[0,3) ∪ [5,10)` isn't one interval), so the carrier isn't closed under join. Claiming `IsLatticeCategory<iota_view, ...>` would over-reach. The full-lattice claim needs a richer carrier (finite unions of intervals, or `Sub<iota_view>` from #698 Slice 8). **Documented as follow-up issue #741** with options and a recommended path.

## Test plan

- [x] `make test` — all 15 suites green
- [x] `make format` clean
- [ ] CI green