### PR TITLE
feat(optimization, sets): #747 halfspace meets as real :expressions Set DSL

### DIFF
--- a/src/main/modules/dedekind/optimization/lp.cppm
+++ b/src/main/modules/dedekind/optimization/lp.cppm
@@ -422,9 +422,14 @@ constexpr auto lp_extract(Polytope2D<T, cx, cy, Hs...>) {
 export template <typename T, T a, T b, T c>
 struct Halfspace2DPredicate {
   using Domain = dedekind::linear_algebra::Vec2V<T>;
-  // Countable: ℚ² is countable, so a halfspace over Vec2V<Rat> sits at
-  // ℵ_0 — matches `Set`'s own default and feeds the `Set::operator&`
-  // dispatch on `cardinality_type` cleanly.
+  // `cardinality_type` here matches `Set`'s own default (`ℵ_0`) so the
+  // `Set::operator&` dispatch on `requires { typename Result::cardinality_type;
+  // }` resolves cleanly without substitution failure when the structured result
+  // is wrapped back into a Set.  The tag is a typed defaulting choice for the
+  // DSL dispatch, NOT a paper claim about the cardinality of `Vec2V<T>` for
+  // arbitrary `T` (e.g. uncountable for `T = double`); sharper carrier-axis
+  // bounds (#622) are tracked through the
+  // `:sets:cardinality` ladder rather than at the predicate site.
   using cardinality_type = dedekind::sets::ℵ_0;
 
   constexpr bool operator()(const Domain& p) const {

--- a/src/main/modules/dedekind/optimization/lp.cppm
+++ b/src/main/modules/dedekind/optimization/lp.cppm
@@ -80,8 +80,10 @@ module;
 export module dedekind.optimization:lp;
 
 import dedekind.algebra;        // HasRingOperators constraint
+import dedekind.category;       // ClassicalLogic — Set's logic species (#747)
 import dedekind.numbers;        // Rational<Z>
 import dedekind.linear_algebra; // Invertible2x2, Vec2
+import dedekind.sets;           // Set — DSL participants (#747)
 
 namespace dedekind::optimization {
 
@@ -380,95 +382,119 @@ constexpr auto lp_extract(Polytope2D<T, cx, cy, Hs...>) {
   return Polytope2D<T, cx, cy, Hs...>::extract();
 }
 
-/** @section lp__Structural_Slice  Typed halfspace meets for §5.
+/** @section lp__Set_DSL_Slice  Halfspace meets as real `:expressions` Set DSL.
  *
- *  Structurally-typed carriers that let the §5 LP exhibit read in the
- *  textbook frame `F : ℚ×ℚ, U : F→ℚ, G ⊆ F, opt = argmax(G, U)`, with
- *  `G` literally carrying its halfspace pack at the type level:
+ *  The §5 LP exhibit reads in the textbook frame
+ *  `F : ℚ×ℚ, U : F→ℚ, G ⊆ F, opt = argmax(G, U)`, with `G` being a
+ *  genuine `:expressions::Set<Vec2V<T>, ClassicalLogic, P>` instance —
+ *  the same DSL §3 builds out of bound-scout comprehensions, applied
+ *  to the 2D LP carrier:
  *
  *      constexpr auto G = halfspace_set(H1{}) & halfspace_set(H2{})
  *                       & halfspace_set(H3{}) & halfspace_set(H4{});
  *      constexpr LinearFunctional<Rat, Rat{3L}, Rat{2L}> U{};
  *      constexpr auto opt = argmax(G, U);   //  Vec2<Rat, Rat{2L}, Rat{2L}>
- *      static_assert(G.contains(opt));      //  opt ∈ G, pointwise check
+ *      static_assert(G.contains(opt));      //  opt ∈ G via the Set DSL
  *
- *  @par What this is — and is not.
- *  These carriers have the @em surface of a Set DSL participant
- *  ( @c Domain typedef, @c contains(v) method, @c operator& for meet),
- *  which is enough for @ref argmax to dispatch on G's type and extract
- *  the halfspace pack.  They are however @b not @c :expressions @c Set
- *  instances: this file does not import @c dedekind.sets, the @c & here
- *  is defined in @c :optimization (not @c Set::operator& ), and no
- *  @c NaturalLogic / @c ClassicalLogic / @c Lawvere comprehension
- *  machinery is involved.  The §3 Set DSL is shape-compatible with
- *  what's here but does not (yet) do the structural work.
+ *  The integration with `:expressions` rides on the existing
+ *  @c structured_and customization point (the same one @c :order:halfspace
+ *  uses to collapse one-dimensional halfspace meets to singletons /
+ *  intervals / empty).  @c :expressions::Set::operator& discovers our
+ *  @c structured_and overloads via ADL on the predicate types and
+ *  produces a structurally-typed Set:
  *
- *  @par What's tracked in #747.
- *  The proper Set-DSL integration — making @c Halfspace2DPredicate<T, a, b, c>
- *  a real @c :expressions predicate, lifting these carriers into
- *  @c Set<Vec2V<T>, ClassicalLogic, Halfspace2DPredicate<...>> instances,
- *  and specialising @c :expressions::Set::operator& for halfspace pairs
- *  so the FIXME #365 direction (structural lattice-law rewriting on Set
- *  intersections) actually closes for the 2D case — is tracked there.
- *  The carriers in this section are the structural-typing seed that
- *  migration sits on top of.
+ *      Set<Vec2V<T>, ClassicalLogic,
+ *          Polytope2DPredicate<T, H1, H2, H3, H4>>
+ *
+ *  carrying the halfspace pack inside the predicate's template parameter
+ *  list — exactly what @c argmax extracts to call the kernel.  Closes
+ *  FIXME(#365) in the 2D-halfspace case: the meet is no longer a lambda
+ *  fall-through, it's a structural reduction the DSL recognises.
  */
 
-/** @brief A typed carrier over a single NTTP halfspace, shape-compatible
- *  with the Set DSL surface ( @c Domain + @c contains ) but not a
- *  @c :expressions @c Set instance.  Carries the halfspace as a type
- *  parameter so @c & can preserve the pack rather than collapsing to a
- *  lambda. */
-export template <typename Hs2D>
-struct Halfspace2DSet {
-  using scalar_type = typename Hs2D::scalar_type;
-  using Domain = dedekind::linear_algebra::Vec2V<scalar_type>;
+/** @brief @c :expressions predicate for one 2D halfspace `a·x + b·y ≤ c`.
+ *
+ *  Carries `(a, b, c)` as NTTPs (structural) and exposes a stateless
+ *  @c operator() — the predicate Set DSL participants are built from.
+ *  ADL through this type's namespace (`:optimization`) lets the
+ *  @c structured_and overloads below intercept halfspace meets inside
+ *  @c :expressions::Set::operator& . */
+export template <typename T, T a, T b, T c>
+struct Halfspace2DPredicate {
+  using Domain = dedekind::linear_algebra::Vec2V<T>;
+  // Countable: ℚ² is countable, so a halfspace over Vec2V<Rat> sits at
+  // ℵ_0 — matches `Set`'s own default and feeds the `Set::operator&`
+  // dispatch on `cardinality_type` cleanly.
+  using cardinality_type = dedekind::sets::ℵ_0;
 
-  constexpr bool contains(const Domain& p) const {
-    return Hs2D::contains_value(p.x, p.y);
+  constexpr bool operator()(const Domain& p) const {
+    return !(c < a * p.x + b * p.y);
   }
 };
 
-/** @brief Lift a @ref Halfspace2D NTTP value into its typed carrier. */
-export template <typename T, T a, T b, T c>
-constexpr auto halfspace_set(Halfspace2D<T, a, b, c>) {
-  return Halfspace2DSet<Halfspace2D<T, a, b, c>>{};
-}
-
-/** @brief Structural meet of typed halfspaces: a polytope carrying its
- *  halfspace pack at the type level.  Has @c contains(v) for direct
- *  pointwise membership query (the conjunction of every halfspace's
- *  @c contains_value); the type-level pack is what @ref argmax extracts
- *  to call the kernel. */
+/** @brief @c :expressions predicate for the @em meet of N 2D halfspaces:
+ *  a polytope as a single conjunctive predicate, with the halfspace
+ *  pack carried at the type level so downstream combinators
+ *  (@ref argmax , and anything else dispatching on the polytope's
+ *  structure) can extract it. */
 export template <typename T, typename... Hs>
-struct Polytope2DSet {
-  using scalar_type = T;
+struct Polytope2DPredicate {
   using Domain = dedekind::linear_algebra::Vec2V<T>;
+  using cardinality_type = dedekind::sets::ℵ_0;
 
-  constexpr bool contains(const Domain& p) const {
+  constexpr bool operator()(const Domain& p) const {
     return (Hs::contains_value(p.x, p.y) && ...);
   }
 };
 
-/** @brief @c Halfspace2DSet & @c Halfspace2DSet — the structural meet
- *  that preserves the halfspace pack at the type level.  Returns a
- *  @ref Polytope2DSet carrying both halfspaces.  Defined here in
- *  @c :optimization (not via @c :expressions::Set::operator& , which
- *  would today fall through to an opaque lambda meet — tracked at the
- *  FIXME #365 direction and in #747). */
-export template <typename T, T a1, T b1, T c1, T a2, T b2, T c2>
-constexpr auto operator&(Halfspace2DSet<Halfspace2D<T, a1, b1, c1>>,
-                         Halfspace2DSet<Halfspace2D<T, a2, b2, c2>>) {
-  return Polytope2DSet<T, Halfspace2D<T, a1, b1, c1>,
-                       Halfspace2D<T, a2, b2, c2>>{};
+/** @brief Lift a @ref Halfspace2D NTTP value into a `:expressions` Set
+ *  whose predicate carries the halfspace structurally. */
+export template <typename T, T a, T b, T c>
+constexpr auto halfspace_set(Halfspace2D<T, a, b, c>) {
+  return dedekind::sets::Set<dedekind::linear_algebra::Vec2V<T>,
+                             dedekind::category::ClassicalLogic,
+                             Halfspace2DPredicate<T, a, b, c>>{
+      Halfspace2DPredicate<T, a, b, c>{}};
 }
 
-/** @brief Chained meet: @c Polytope2DSet & @c Halfspace2DSet appends
- *  the new halfspace to the pack. */
+/** @section lp__structured_and_overloads
+ *
+ *  Customization point: when @c :expressions::Set::operator& meets two
+ *  predicates, it tries @c structured_and(p1, p2) via ADL before
+ *  falling back to a lambda meet.  Our overloads here let the DSL
+ *  recognise halfspace + halfspace, polytope + halfspace, and halfspace
+ *  + polytope meets as structural reductions producing a
+ *  @ref Polytope2DPredicate that carries the union of the two
+ *  halfspace packs.
+ *
+ *  Parallels @c :order:halfspace::structured_and on 1D halfspaces; the
+ *  difference is that 1D meets land in `Singleton` / `OrderInterval` /
+ *  empty (the lattice for 1D), whereas 2D halfspace meets land in
+ *  `Polytope2DPredicate` (no cardinality-1 short circuit at this layer —
+ *  the optimum-as-typed-constant collapse happens further down in
+ *  @ref argmax via @ref maximize ).
+ */
+
+/** @brief Halfspace + halfspace → polytope of two halfspaces. */
+export template <typename T, T a1, T b1, T c1, T a2, T b2, T c2>
+constexpr auto structured_and(Halfspace2DPredicate<T, a1, b1, c1>,
+                              Halfspace2DPredicate<T, a2, b2, c2>) {
+  return Polytope2DPredicate<T, Halfspace2D<T, a1, b1, c1>,
+                             Halfspace2D<T, a2, b2, c2>>{};
+}
+
+/** @brief Polytope + halfspace → polytope with the halfspace appended. */
 export template <typename T, typename... Hs, T a, T b, T c>
-constexpr auto operator&(Polytope2DSet<T, Hs...>,
-                         Halfspace2DSet<Halfspace2D<T, a, b, c>>) {
-  return Polytope2DSet<T, Hs..., Halfspace2D<T, a, b, c>>{};
+constexpr auto structured_and(Polytope2DPredicate<T, Hs...>,
+                              Halfspace2DPredicate<T, a, b, c>) {
+  return Polytope2DPredicate<T, Hs..., Halfspace2D<T, a, b, c>>{};
+}
+
+/** @brief Halfspace + polytope → delegate to the canonical direction. */
+export template <typename T, T a, T b, T c, typename... Hs>
+constexpr auto structured_and(Halfspace2DPredicate<T, a, b, c>,
+                              Polytope2DPredicate<T, Hs...>) {
+  return Polytope2DPredicate<T, Halfspace2D<T, a, b, c>, Hs...>{};
 }
 
 /** @brief Linear functional `U : F → T` with NTTP-typed coefficients.
@@ -486,14 +512,20 @@ struct LinearFunctional {
   }
 };
 
-/** @brief @c argmax(G, U) on a structurally-typed polytope and a linear
- *  functional.  Extracts the halfspace pack from G's type and the
- *  objective coefficients from U's NTTPs, dispatches to the kernel via
- *  @ref maximize, and lifts the result to an NTTP @c Vec2.  This is a
- *  thin combinator on top of @c maximize ; the kernel itself is unchanged. */
-export template <typename T, typename... Hs, T cx, T cy>
+/** @brief @c argmax(G, U) on a polytope-Set and a linear functional.
+ *
+ *  @c G is a Set whose predicate is a @ref Polytope2DPredicate carrying
+ *  the halfspace pack; @c U is a @ref LinearFunctional carrying the
+ *  objective coefficients as NTTPs.  This combinator extracts both
+ *  packs from the type level and dispatches to the kernel via
+ *  @ref maximize , returning the optimum as an NTTP @c Vec2 .  Pure
+ *  type-level glue on top of @c maximize ; the kernel itself is unchanged. */
+export template <typename T, typename L, typename... Hs, T cx, T cy>
   requires(sizeof...(Hs) >= 2) && dedekind::algebra::HasRingOperators<T>
-constexpr auto argmax(Polytope2DSet<T, Hs...>, LinearFunctional<T, cx, cy>) {
+constexpr auto argmax(
+    const dedekind::sets::Set<dedekind::linear_algebra::Vec2V<T>, L,
+                              Polytope2DPredicate<T, Hs...>>&,
+    LinearFunctional<T, cx, cy>) {
   return maximize<T, cx, cy, Hs...>();
 }
 

--- a/src/main/modules/dedekind/optimization/lp.cppm
+++ b/src/main/modules/dedekind/optimization/lp.cppm
@@ -445,6 +445,10 @@ struct Halfspace2DPredicate {
 export template <typename T, typename... Hs>
 struct Polytope2DPredicate {
   using Domain = dedekind::linear_algebra::Vec2V<T>;
+  // Same typed-defaulting rationale as @ref Halfspace2DPredicate :
+  // matches `Set`'s own default so the `Set::operator&` dispatch on
+  // `cardinality_type` resolves cleanly; not a paper claim about the
+  // cardinality of `Vec2V<T>` for arbitrary `T`.
   using cardinality_type = dedekind::sets::ℵ_0;
 
   constexpr bool operator()(const Domain& p) const {

--- a/src/main/modules/dedekind/optimization/lp.cppm
+++ b/src/main/modules/dedekind/optimization/lp.cppm
@@ -433,7 +433,7 @@ struct Halfspace2DPredicate {
   using cardinality_type = dedekind::sets::ℵ_0;
 
   constexpr bool operator()(const Domain& p) const {
-    return !(c < a * p.x + b * p.y);
+    return Halfspace2D<T, a, b, c>::contains_value(p.x, p.y);
   }
 };
 
@@ -504,6 +504,17 @@ export template <typename T, T a, T b, T c, typename... Hs>
 constexpr auto structured_and(Halfspace2DPredicate<T, a, b, c>,
                               Polytope2DPredicate<T, Hs...>) {
   return Polytope2DPredicate<T, Halfspace2D<T, a, b, c>, Hs...>{};
+}
+
+/** @brief Polytope + polytope → concatenate the halfspace packs.  Without
+ *  this overload, a right-associative meet `(H1 & H2) & (H3 & H4)` would
+ *  fall through to the lambda meet in @c :expressions::Set::operator& ;
+ *  the whole point of @c structured_and is that the structural collapse
+ *  must not depend on how the source bracketed the meet. */
+export template <typename T, typename... Hs1, typename... Hs2>
+constexpr auto structured_and(Polytope2DPredicate<T, Hs1...>,
+                              Polytope2DPredicate<T, Hs2...>) {
+  return Polytope2DPredicate<T, Hs1..., Hs2...>{};
 }
 
 /** @brief Linear functional `U : F → T` with NTTP-typed coefficients.

--- a/src/main/modules/dedekind/optimization/lp.cppm
+++ b/src/main/modules/dedekind/optimization/lp.cppm
@@ -422,14 +422,32 @@ constexpr auto lp_extract(Polytope2D<T, cx, cy, Hs...>) {
 export template <typename T, T a, T b, T c>
 struct Halfspace2DPredicate {
   using Domain = dedekind::linear_algebra::Vec2V<T>;
-  // `cardinality_type` here matches `Set`'s own default (`ℵ_0`) so the
-  // `Set::operator&` dispatch on `requires { typename Result::cardinality_type;
-  // }` resolves cleanly without substitution failure when the structured result
-  // is wrapped back into a Set.  The tag is a typed defaulting choice for the
-  // DSL dispatch, NOT a paper claim about the cardinality of `Vec2V<T>` for
-  // arbitrary `T` (e.g. uncountable for `T = double`); sharper carrier-axis
-  // bounds (#622) are tracked through the
-  // `:sets:cardinality` ladder rather than at the predicate site.
+  // `cardinality_type` here serves @em two purposes for the
+  // `:expressions::Set::operator&` dispatch on the structured result
+  // (see `:expressions::expressions.cppm:708-715`):
+  //
+  //   1. Required for substitution well-formedness.  The Finite-elevation
+  //      branch is spelled
+  //          `requires { typename Result::cardinality_type; } &&
+  //           std::same_as<typename Result::cardinality_type, Finite>`
+  //      and the `&&` short-circuits at @em evaluation but NOT at
+  //      @em substitution: the `std::same_as<typename Result::…, Finite>`
+  //      operand is type-checked regardless of the `requires`'s truth
+  //      value.  Empirically: removing this typedef yields a hard
+  //      `no type named 'cardinality_type'` error at that line.
+  //      (FIXME on the `:expressions` side: lift the second clause into a
+  //      nested `if constexpr` so the requires guard is sufficient on its
+  //      own.)
+  //   2. Classification: matches `Set`'s own default (`ℵ_0`) so the
+  //      structured polytope ends up wrapped via the generic
+  //      `Set<T, L, Result>{…}` path rather than elevated as a Finite
+  //      result.  The right answer for the 2D polytope case.
+  //
+  // The `ℵ_0` tag is a typed defaulting choice for the DSL dispatch —
+  // NOT a paper claim about the cardinality of `Vec2V<T>` for arbitrary
+  // `T` (e.g. uncountable for `T = double`); sharper carrier-axis bounds
+  // (#622) belong on the `:sets:cardinality` ladder, not at the predicate
+  // site.
   using cardinality_type = dedekind::sets::ℵ_0;
 
   constexpr bool operator()(const Domain& p) const {
@@ -445,10 +463,13 @@ struct Halfspace2DPredicate {
 export template <typename T, typename... Hs>
 struct Polytope2DPredicate {
   using Domain = dedekind::linear_algebra::Vec2V<T>;
-  // Same typed-defaulting rationale as @ref Halfspace2DPredicate :
-  // matches `Set`'s own default so the `Set::operator&` dispatch on
-  // `cardinality_type` resolves cleanly; not a paper claim about the
-  // cardinality of `Vec2V<T>` for arbitrary `T`.
+  // Same typed-defaulting rationale as @ref Halfspace2DPredicate (1)
+  // substitution well-formedness for `:expressions::Set::operator&`'s
+  // Finite-elevation branch (which references `Result::cardinality_type`
+  // outside a `requires` guard, so the typedef must exist for the body
+  // to type-check), and (2) classification — `ℵ_0` routes the structured
+  // polytope through the generic Set wrapping path.  Not a paper claim
+  // about the cardinality of `Vec2V<T>` for arbitrary `T`.
   using cardinality_type = dedekind::sets::ℵ_0;
 
   constexpr bool operator()(const Domain& p) const {

--- a/src/test/cpp/modules/dedekind/optimization/lp_test.cpp
+++ b/src/test/cpp/modules/dedekind/optimization/lp_test.cpp
@@ -12,6 +12,7 @@
 #include <vector>
 
 import dedekind.analysis; // Dual<F> (relocated from :numbers at PR #513)
+import dedekind.category; // ClassicalLogic — Set's logic species (#747)
 import dedekind.linear_algebra;
 import dedekind.numbers;
 import dedekind.optimization;
@@ -136,75 +137,75 @@ TEST_CASE("optimization:lp — axis-aligned corner is pruned away",
 }
 
 /**
- * @brief Structural bridge: the §5 LP in the textbook frame
+ * @brief Set DSL bridge (§3 ↔ §5): the §5 LP in the textbook frame
  *        ` F : ℚ×ℚ, U : F → ℚ, G ⊆ F, opt = argmax(G, U) `,
- *        with G as a structurally-typed meet of halfspaces.
+ *        with G a real `:expressions::Set` whose predicate carries the
+ *        halfspace pack at the type level (#747).
  *
  *   F = ℚ × ℚ            -- ambient field, operationally `Vec2V<Rat>`.
  *   U : F → ℚ            -- `LinearFunctional` carrying (3, 2) at the
  *                           type level.
- *   G ⊆ F                -- `halfspace_set(H1{}) & halfspace_set(H2{})
- *                           & halfspace_set(H3{}) & halfspace_set(H4{})`.
- *                           G's *type* IS
- *                           `Polytope2DSet<Rat, H1, H2, H3, H4>`,
- *                           carrying the halfspace pack at the type
- *                           level.  The `&` operator here is the
- *                           structural meet defined in `:optimization` —
- *                           shape-compatible with the `:expressions`
- *                           Set DSL surface, NOT actually a Set DSL
- *                           participant (see lp__Structural_Slice in
- *                           lp.cppm and #747).
- *   opt = argmax(G, U)   -- combinator that extracts G's pack from the
- *                           type, U's coefficients from its NTTPs, and
- *                           dispatches to the kernel.  Returns the
+ *   G ⊆ F                -- the meet `halfspace_set(H1{}) & ... &
+ * halfspace_set(H4{})`, where `halfspace_set` lifts each NTTP halfspace into a
+ * `Set<Vec2V<Rat>, ClassicalLogic, Halfspace2DPredicate<Rat, ...>>` and `&`
+ *                           routes through `:expressions::Set::operator&` →
+ *                           `structured_and` (ADL on our overloads in
+ *                           `:optimization`) → a Set whose predicate IS
+ *                           `Polytope2DPredicate<Rat, H1, H2, H3, H4>`.
+ *                           Closes FIXME(#365) for the 2D-halfspace case:
+ *                           the meet is a structural reduction, not a
+ *                           lambda fall-through.
+ *   opt = argmax(G, U)   -- combinator that extracts the halfspace pack
+ *                           from G's `Polytope2DPredicate` and U's
+ *                           NTTPs, dispatches to `maximize`, returns the
  *                           typed constant `Vec2<Rat, Rat{2L}, Rat{2L}>`.
  *
- * The bridge this exhibit supports is the *structural* one: G's *type*
- * IS the polytope's combinatorial data, so `argmax` can dispatch on it
- * without re-extracting halfspaces from a closure body.  The stronger
- * §3 ↔ §5 claim — that the @c :expressions Set DSL infrastructure
- * (Lawvere comprehension over @c Set<T, L, P>) does the work — requires
- * lifting these carriers into actual @c Set<...> instances with a
- * structural @c Halfspace2DPredicate ; tracked in #747.
+ * Every step in the textbook frame is realised through a real Set DSL
+ * object: G is a `:expressions::Set` instance, the meet goes through
+ * `Set::operator&`, the predicate carries the structure.  The §3
+ * comprehension View does the work for §5; the kernel itself is
+ * untouched.
  */
 TEST_CASE(
-    "optimization:lp — structural bridge: F = ℚ×ℚ, U : F → ℚ, "
-    "G = H1 & H2 & H3 & H4, opt = argmax(G, U) = Vec2<Rat, 2, 2> (#743)",
-    "[optimization][lp][structural][bridge][centrepiece]") {
-  // F = ℚ × ℚ.  Operationally `Vec2V<Rat>`.
+    "optimization:lp — Set DSL bridge: G = H1 & H2 & H3 & H4 as "
+    "Set<Vec2V<Rat>, ClassicalLogic, Polytope2DPredicate<...>>, "
+    "opt = argmax(G, U) = Vec2<Rat, 2, 2> (#747)",
+    "[optimization][lp][dsl][bridge][centrepiece]") {
   using F = dedekind::linear_algebra::Vec2V<Rat>;
   static_assert(F::dimension == 2);
   static_assert(std::same_as<typename F::scalar_type, Rat>);
 
-  // U : F → ℚ.  Linear functional carrying the §5 objective (3, 2) at
-  // the type level so `argmax` can route its coefficients into the
-  // NTTP-driven kernel without smuggling them through function params.
+  // U : F → ℚ.
   constexpr LinearFunctional<Rat, Rat{3L}, Rat{2L}> U{};
 
-  // G ⊆ F.  Structurally-typed meet of four halfspaces: `decltype(G)`
-  // IS `Polytope2DSet<Rat, H1, H2, H3, H4>`, carrying the pack at the
-  // type level.  The `&` here is the one in `:optimization`, not
-  // `:expressions::Set::operator&` — see lp__Structural_Slice for the
-  // honest read on what is and is not Set DSL participation.
+  // G ⊆ F.  The meet of four halfspace-Sets goes through
+  // `:expressions::Set::operator&`, which discovers our
+  // `structured_and` overloads via ADL on `Halfspace2DPredicate` /
+  // `Polytope2DPredicate` and reduces structurally.
   constexpr auto G = halfspace_set(H1{}) & halfspace_set(H2{}) &
                      halfspace_set(H3{}) & halfspace_set(H4{});
-  static_assert(
-      std::same_as<decltype(G), const Polytope2DSet<Rat, H1, H2, H3, H4>>);
 
-  // argmax(G, U).  The combinator extracts the halfspace pack from G's
-  // type, the (cx, cy) from U's NTTPs, dispatches to `maximize`, and
-  // returns the optimum as the typed constant.
+  // `decltype(G)` IS a real `:expressions::Set` instance — the §3 DSL —
+  // whose predicate carries the halfspace pack at the type level.  This
+  // is what closes FIXME(#365) for the 2D-halfspace case: not a lambda,
+  // a structural predicate.
+  using ExpectedG =
+      dedekind::sets::Set<F, dedekind::category::ClassicalLogic,
+                          Polytope2DPredicate<Rat, H1, H2, H3, H4>>;
+  static_assert(std::same_as<decltype(G), const ExpectedG>);
+
+  // argmax(G, U).  Extracts the halfspace pack from G's predicate and
+  // (cx, cy) from U's NTTPs; dispatches to `maximize`.
   constexpr auto opt = argmax(G, U);
   static_assert(std::same_as<decltype(opt), const Vec2<Rat, Rat{2L}, Rat{2L}>>);
 
-  // The witnesses: the kernel's answer lies in G (pointwise `.contains`
-  // on the structurally-typed carrier), and U evaluates to the textbook
-  // value 10 on it.
+  // The witnesses: opt ∈ G via the Set DSL's `contains`; U(opt) is the
+  // textbook value 10.  Everything decided at translation time.
   constexpr F opt_v{opt.first, opt.second};
   STATIC_CHECK(G.contains(opt_v));
   STATIC_CHECK(U(opt_v) == Rat{10L});
 
-  // Negative witnesses on the structurally-typed carrier.
+  // Negative witnesses through the Set DSL contract.
   STATIC_CHECK_FALSE(G.contains(F{Rat{3L}, Rat{3L}}));   // x + y = 6 > 4
   STATIC_CHECK_FALSE(G.contains(F{Rat{-1L}, Rat{0L}}));  // x < 0
 }

--- a/src/test/cpp/modules/dedekind/optimization/lp_test.cpp
+++ b/src/test/cpp/modules/dedekind/optimization/lp_test.cpp
@@ -146,8 +146,10 @@ TEST_CASE("optimization:lp — axis-aligned corner is pruned away",
  *   U : F → ℚ            -- `LinearFunctional` carrying (3, 2) at the
  *                           type level.
  *   G ⊆ F                -- the meet `halfspace_set(H1{}) & ... &
- * halfspace_set(H4{})`, where `halfspace_set` lifts each NTTP halfspace into a
- * `Set<Vec2V<Rat>, ClassicalLogic, Halfspace2DPredicate<Rat, ...>>` and `&`
+ *                           halfspace_set(H4{})`, where `halfspace_set`
+ *                           lifts each NTTP halfspace into a Set
+ *                           `Set<Vec2V<Rat>, ClassicalLogic,
+ *                            Halfspace2DPredicate<Rat, ...>>` and `&`
  *                           routes through `:expressions::Set::operator&` →
  *                           `structured_and` (ADL on our overloads in
  *                           `:optimization`) → a Set whose predicate IS

--- a/src/test/cpp/modules/dedekind/optimization/lp_test.cpp
+++ b/src/test/cpp/modules/dedekind/optimization/lp_test.cpp
@@ -210,6 +210,16 @@ TEST_CASE(
   // Negative witnesses through the Set DSL contract.
   STATIC_CHECK_FALSE(G.contains(F{Rat{3L}, Rat{3L}}));   // x + y = 6 > 4
   STATIC_CHECK_FALSE(G.contains(F{Rat{-1L}, Rat{0L}}));  // x < 0
+
+  // Bracketing invariance: `(H1 & H2) & (H3 & H4)` (polytope × polytope)
+  // must collapse to the same `Polytope2DPredicate` as the left-folded
+  // form above.  Without the polytope × polytope `structured_and`
+  // overload, the Set DSL would fall through to a lambda meet here and
+  // `decltype(G2)` would not match — so the static_assert is the
+  // mechanical guard against that regression.
+  constexpr auto G2 = (halfspace_set(H1{}) & halfspace_set(H2{})) &
+                      (halfspace_set(H3{}) & halfspace_set(H4{}));
+  static_assert(std::same_as<decltype(G2), decltype(G)>);
 }
 
 TEST_CASE("optimization:lp — infeasible polytope reports no optimum",


### PR DESCRIPTION
## Summary

Closes #747 — lift the §5 LP polytope into a genuine `:expressions::Set` instance whose predicate carries the halfspace pack at the type level. Closes the structurally-typed-vs-actually-Set-DSL gap left open by #746's `[structural][bridge]` exhibit.

**The Set DSL is now doing the structural work.** `lp.cppm` imports `dedekind.sets`. `halfspace_set(Halfspace2D<T, a, b, c>)` returns a `Set<Vec2V<T>, ClassicalLogic, Halfspace2DPredicate<T, a, b, c>>`. The meet `H1_set & H2_set & H3_set & H4_set` routes through `:expressions::Set::operator&`, which discovers our `structured_and` overloads via ADL on `Halfspace2DPredicate` / `Polytope2DPredicate` and reduces structurally — no lambda fall-through. Closes FIXME #365 in the 2D-halfspace case, paralleling the existing `:order:halfspace` structural reductions (`Singleton` / `OrderInterval` / `Ø`) for 1D halfspaces.

**Before / after.** #746 had standalone `Halfspace2DSet<Hs2D>` and `Polytope2DSet<T, Hs...>` structs with a parallel `operator&` in `:optimization`; they had the *surface* of a Set DSL participant but were not `:expressions::Set` instances. This PR removes them and replaces with:

- `Halfspace2DPredicate<T, a, b, c>` — a real `:expressions` predicate (`Domain`, `operator()`, `cardinality_type = ℵ_0`).
- `Polytope2DPredicate<T, Hs...>` — the meet predicate; halfspace pack as template args.
- `structured_and` overloads in `:optimization` for halfspace × halfspace and polytope × halfspace (+ symmetric).
- `argmax(Set<Vec2V<T>, L, Polytope2DPredicate<T, Hs...>>, LinearFunctional<T, cx, cy>)` extracts the pack via the new Set type and dispatches to the unchanged kernel.

The `[dsl][bridge]` test (renamed from `[structural][bridge]`) witnesses real Set DSL participation:

```cpp
using ExpectedG = Set<Vec2V<Rat>, ClassicalLogic,
                      Polytope2DPredicate<Rat, H1, H2, H3, H4>>;
static_assert(std::same_as<decltype(G), const ExpectedG>);
```

## Public surface change

Removed: `Halfspace2DSet<Hs2D>`, `Polytope2DSet<T, Hs...>`, the namespace-scoped `operator&` overloads on them.

Added: `Halfspace2DPredicate<T, a, b, c>`, `Polytope2DPredicate<T, Hs...>`, `structured_and` overloads.

Changed: `halfspace_set`'s return type, `argmax`'s parameter type (now takes a `:expressions::Set`).

The §5 source-level idiom `halfspace_set(H1{}) & halfspace_set(H2{}) & ... ; argmax(G, U);` is unchanged — only the underlying types are now real Set DSL participants. Per [[feedback_experimental_api_breaks]] the structural cleanup is taken; no forwarding shims.

## Test plan

- [x] `make compile` clean
- [x] `make test` — 15 ctest suites pass (LP: 11 C++ test cases / 51 assertions)
- [x] `make ir-fixture-check` — 8 IR fixtures, all semantic-sanity green (the runtime IR fixture exercises the kernel directly, not the DSL surface, so unaffected)

Companion paper edit (separate PR for #744): §6.1's vertex-enumeration-as-Compiler-Wall framing comes out — the wall no longer manifests at the §5 algorithmic choice; the relevant compile-time costs are elsewhere (instantiation depth, `constexpr` step caps).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
