### PR TITLE
docs(paper): #744 Phase B §5 + §6 rewrite under Set-as-output framing

### DIFF
--- a/docs/paper/paper.tex
+++ b/docs/paper/paper.tex
@@ -1675,37 +1675,31 @@ review catching the claim.}
 \label{sec:linalg}
 % ============================================================
 
-\subsection{Linear Programming: The Optimum as a Typed Constant}
+\subsection{Linear Programming: \texorpdfstring{$\operatorname{argmax} : \mathbf{Set} \to \mathbf{Set}$}{argmax: Set → Set}}
 \label{sec:lp-centrepiece}
 
-Stare at a linear program for a moment. The polytope is an intersection
-of halfspaces---a set, in exactly the comprehension sense of
-Section~\ref{sec:sets-rules}. The objective is a linear functional. The
-optimum is the one vertex of the polytope at which the objective is
-largest.
+Stare at a linear program for a moment.
+The polytope is an intersection of halfspaces --- a set, in exactly the comprehension sense of Section~\ref{sec:sets-rules}.
+The objective is a linear functional $U : F \to \mathbb{Q}$ on the ambient $F = \mathbb{Q}^2$.
+The optimum is also a set --- a singleton when there is a unique optimal vertex, the empty set when the polytope is infeasible, an unbounded ray when the objective is unbounded over the polytope, a face when the objective is parallel to an edge.
+The textbook signature of $\operatorname{argmax}$ is therefore $\mathbf{Set} \to \mathbf{Set}$.
 
-The previous section's reductions collapsed a set to a simpler set. An
-optimum is also a collapse: it reduces a set to a single point. The move
-of this section is to lift that collapse into the type system. If every
-halfspace and every objective coefficient is named at the type level,
-the compiler has enough information to enumerate the vertices, run the
-feasibility checks, compare the objective values, and emit the winner
-as a literal. The LP solver is the C++ compiler.
+In a library where the input polytope is already a Set in the set-comprehension DSL (Section~\ref{sec:sets-rules}), the honest output type is also a Set; the regime --- singleton, empty, ray, face --- is encoded in the output Set's predicate type.
+The move of this section is to lift that arrow into the type system.
+If every halfspace and every objective coefficient is named at the type level, the compiler has enough information to enumerate the vertex candidates, run the feasibility checks, compare objective values, and emit the optimum Set whose predicate carries the regime.
 
-\paragraph{Showcase~9 (centrepiece).} Consider a textbook LP:
+The cases shipped at the time of writing are the singleton (a unique optimal vertex) and the empty Set (infeasible polytope); ray-valued and face-valued outputs are deferred to a follow-up.
+When the LP has a face of optima --- the objective parallel to a feasible edge --- the kernel tie-breaks to a single vertex of that face and the output Set is the corresponding singleton; the §5 strict form makes this scope explicit at the type level.
+
+\paragraph{Showcase~9 (centrepiece).} Consider the textbook LP:
 \begin{align*}
   \text{maximise} \quad & 3x + 2y \\
   \text{subject to} \quad & x + y \leq 4 \\
                           & 2x + y \leq 6 \\
                           & x, y \geq 0
 \end{align*}
-The feasible region is a polygon in $\mathbb{Q}^2$
-(Figure~\ref{fig:lp-polytope}); the optimum is the vertex
-$(2, 2)$ where the non-axis-aligned constraints $x + y = 4$ and
-$2x + y = 6$ are simultaneously binding (objective value $10$). In
-\texttt{dedekind.optimization:lp}, constraints are NTTPs and the
-reduction is a variadic template whose output carries the vertex at the
-type level:
+The feasible region is a polygon in $\mathbb{Q}^2$ (Figure~\ref{fig:lp-polytope}); the optimum is the singleton $\{(2, 2)\}$ where the non-axis-aligned constraints $x + y = 4$ and $2x + y = 6$ are simultaneously binding (objective value $10$).
+In \texttt{dedekind.optimization:lp}, constraints are NTTPs lifted into halfspace Sets, the polytope $G$ is their meet under \cppinline{operator&}, the objective $U$ is a NTTP-typed \cppinline{LinearFunctional}, and \cppinline{argmax(G, U)} returns the optimum Set whose predicate type pins the regime:
 
 \begin{figure}[htbp]
 \centering
@@ -1769,24 +1763,40 @@ using H2 = Halfspace2D<Rat, Rat{2}, Rat{1}, Rat{6}>;     // 2x +  y <= 6
 using H3 = Halfspace2D<Rat, Rat{-1}, Rat{0}, Rat{0}>;    //  x      >= 0
 using H4 = Halfspace2D<Rat, Rat{0}, Rat{-1}, Rat{0}>;    //       y >= 0
 
-using Optimum = decltype(maximize<Rat, Rat{3}, Rat{2}, H1, H2, H3, H4>());
-static_assert(std::same_as<Optimum, Vec2<Rat, Rat{2}, Rat{2}>>);
+// Input: polytope G ⊆ ℚ² as the meet of halfspace Sets in the §3 DSL.
+constexpr auto G = halfspace_set(H1{}) & halfspace_set(H2{})
+                 & halfspace_set(H3{}) & halfspace_set(H4{});
+// Objective: U : F → ℚ, coefficients (3, 2) at the type level.
+constexpr LinearFunctional<Rat, Rat{3}, Rat{2}> U{};
+// Output: a Set whose predicate type encodes the regime.  Here it is
+// the singleton {(2, 2)}, with the coordinates pinned at NTTPs.
+using Optimum = std::remove_cvref_t<decltype(argmax(G, U))>;
+using OptPred = std::remove_cvref_t<decltype(std::declval<Optimum>().predicate())>;
+static_assert(std::same_as<OptPred, Singleton2DPredicate<Rat, Rat{2}, Rat{2}>>);
 \end{cpp}
 \end{listing}
 
-The reduction enumerates vertex candidates at compile time (all
-$\binom{4}{2} = 6$ pairs of binding constraints), solves each $2 \times 2$
-active-set system via \texttt{Invertible2x2}'s closed-form Cramer
-inverse (exact over $\mathbb{Q}$), filters by feasibility against the
-non-active constraints, and picks the objective-maximising feasible
-vertex. Every step is a template specialisation; no runtime iteration
-survives.
+The reduction enumerates vertex candidates at compile time (all $\binom{4}{2} = 6$ pairs of binding constraints), solves each $2 \times 2$ active-set system via \texttt{Invertible2x2}'s closed-form Cramer inverse (exact over $\mathbb{Q}$), filters by feasibility against the non-active constraints, and picks the objective-maximising feasible vertex.
+Every step is a template specialisation; no runtime iteration survives.
 
-\paragraph{IR witness.} The paper's claim is not prose; it is
-translation-time mechanics. Two \texttt{extern "C"} functions in the
-fixture return the numerator of the optimum's $x$- and $y$-coordinates.
-At \texttt{-O2}, \texttt{clang}'s optimiser folds the entire LP
-reduction to literal integers:
+\paragraph{Two kernels under one combinator.}
+A separate concern arises when the polytope happens to be signed-unimodular and axis-aligned: coefficients in $\{-1, 0, +1\}$ with at most one nonzero per halfspace.
+In that scope, the Cramer determinants are all $\pm 1$, the active-set divisions degenerate to sign flips, and the vertex coordinates are simply the relevant axis bounds; the active-set enumeration collapses to per-axis bracketing and a sign-driven select.
+The library ships both kernels and lets the type system pick.
+The dispatch is one \cppinline{if constexpr} over a conjunction of concepts on the halfspace pack and the carrier:
+\cppinline{HasUnitRangeEntries<Hs...>} (every coefficient lies in $\{-1, 0, +1\}$), \cppinline{IsAxisAlignedPolytope<Hs...>} (at least one coefficient is zero per halfspace), and \cppinline{SuitableForAxisAlignedFastPath<T>} (the carrier admits the bit-ops kernel's signedness convention).
+When all three hold, \cppinline{argmax(G, U)} routes to the bit-ops kernel; otherwise to the generic Cramer kernel.
+The non-taken branch is removed from the template instantiation by \cppinline{if constexpr}; no run-time dispatch survives.
+
+\paragraph{Bridge: same source, two evaluation modes.}
+The compile-time path described above takes constraints at the type level.
+The same kernel runs at runtime when the constraints arrive as a \cppinline{std::span} --- the shape Python callers see through the project's \texttt{nanobind} facade.
+The runtime entry \cppinline{maximize_with_values<T>(span, cx, cy)} performs the same structural classification at runtime, routes to the same kernel, and returns the same Set carrier --- with the regime now encoded at the value level (via the predicate's \cppinline{(point, feasible)} state) instead of the type level.
+The bridge is mechanical: the kernel is one \cppinline{constexpr} function, and the call site selects the evaluation mode by the constexpr-ness of its arguments.
+
+\paragraph{IR witness.} The paper's claim is not prose; it is translation-time mechanics.
+On the NTTP path, two \texttt{extern "C"} witness functions in the fixture return the optimum's $x$- and $y$-coordinates --- extracted from the output Set's predicate at the type level.
+At \texttt{-O2}, \texttt{clang}'s optimiser folds the entire LP reduction to literal integers:
 
 % Source: src/test/cpp/modules/dedekind/python/showcase_09_lp_vertex_typed_constant.ll
 \begin{listing}[htbp]
@@ -1804,24 +1814,30 @@ define noundef i64 @witness_lp_optimum_y() ... {
 \end{cpp}
 \end{listing}
 
-The IR is checked into the repository as a fixture
-(\texttt{showcase\_09\_lp\_vertex\_typed\_constant.ll}); a build-time
-gate (\texttt{make ir-fixture-check}) fails CI if optimiser drift ever
-loses the collapse. The binary contains no LP solver; no simplex
-tableau; no active-set machinery. More precisely: the vertex's
-coordinates are non-type template parameters of the result type
-(\cppinline{Vec2<Rat, Rat{2}, Rat{2}>}), so the C++23 NTTP machinery
-is what carries the answer through to type-level. The input is a
-constexpr value passed as NTTP; the output is a type whose NTTPs
-encode the coordinates; the runtime call returning a coordinate
-collapses to a literal load in the emitted IR.  Because the reduction
-lands in \texttt{Rational<...>} rather than IEEE floating point, the
-\cppinline{ret i64 2} output is bit-identical across ARM and x86
-back-ends and host floating-point ABIs --- the typed constant has
-no rounding mode to disagree about.  This is the embedded /
-cross-platform-determinism guarantee the paper has been claiming
-throughout, made concrete by the absence of any \texttt{double}-typed
-reduction in the IR.
+The IR is checked into the repository as a fixture (\texttt{showcase\_09\_lp\_vertex\_typed\_constant.ll}); a build-time gate (\texttt{make ir-fixture-check}) fails CI if optimiser drift ever loses the collapse.
+The binary contains no LP solver; no simplex tableau; no active-set machinery.
+More precisely: the vertex's coordinates are non-type template parameters of the output Set's predicate (\cppinline{Singleton2DPredicate<Rat, Rat{2}, Rat{2}>}), so the C++23 NTTP machinery is what carries the answer through to the type level.
+The input is a constexpr Set passed under \cppinline{argmax(G, U)}; the output is a Set whose predicate type's NTTPs encode the coordinates; the runtime witness extracting a coordinate collapses to a literal load in the emitted IR.
+Because the reduction lands in \texttt{Rational<...>} rather than IEEE floating point, the \cppinline{ret i64 2} output is bit-identical across ARM and x86 back-ends and host floating-point ABIs --- the typed constant has no rounding mode to disagree about.
+
+\paragraph{Runtime IR: two kernels, two signatures.}
+The complementary direction is to call the same kernels with runtime data and look at the residual IR.
+The library exposes \cppinline{maximize_axis_aligned_with_values<T>} and \cppinline{maximize_cramer_with_values<T>} as explicit power-user entries (the IR microscope on each kernel in isolation); the default \cppinline{maximize_with_values<T>} dispatches mechanically between them.
+The fixtures \texttt{showcase\_09b\_lp\_runtime\_residual.ll} and \texttt{showcase\_12b\_lp\_unimodular\_runtime.ll} pin the two kernels' signatures: the Cramer kernel retains its $2 \times 2$ \texttt{fdiv} / \texttt{fmuladd} active-set arithmetic and the loop's \texttt{phi} accumulators; the bit-ops kernel retains the loop's \texttt{phi} accumulators and the sign-driven \texttt{select} but emits no \texttt{mul} / \texttt{sdiv} / \texttt{udiv} on the integer carrier.
+The semantic-sanity checker enforces both shapes (\texttt{pruning-ir-fixture.py}).
+
+\paragraph{Strict close.}
+The previous paragraphs are the rough form; the strict form is mechanical.
+A \cppinline{static_assert} on the project's \cppinline{IsSet} concept (the ETCS-grade Set contract from Section~\ref{sec:sets-rules}) confirms that the input polytope, the singleton output, the empty output, and the runtime-discriminated output are all Sets in the same sense --- not merely structurally-similar wrappers but carriers of \cppinline{HasETCSAxioms} and \cppinline{IsCartesianClosed<CanonicalSetCCC<Ambient>>}.
+A further \cppinline{static_assert} on \cppinline{IsFAlgebra} confirms the catamorphism \emph{shape} on the output side: the output Set carries a structure map $F\langle X\rangle \to X$ for the identity endofunctor on its ambient category, with the active-set step closing over the halfspace pack.\footnote{The shape witness is mechanical.
+The catamorphism's uniqueness clause --- that \cppinline{argmax(G, U)} is the unique morphism into the output algebra from the initial halfspace-list F-algebra for $F(X) = 1 + \text{Halfspace} \times X$ --- is the engineer's honesty obligation per Pierce~\cite{pierce2002tapl} §5.4; the project's \cppinline{:f_algebra} partition reifies this as an opt-in \cppinline{is_initial_f_algebra_v} trait, deliberately defaulted to false here.
+The halfspace-list endofunctor's full \cppinline{IsEndofunctor} instantiation ($\Sigma_\text{cat}$, \cppinline{Shape}, $\varphi$) is a separate categorical task; see also Meijer-Fokkinga-Paterson's classical functional reading of fold under polynomial functors, and Bird's \emph{Algebra of Programming} for the textbook treatment.}
+
+% TODO (listings in follow-up commits to this PR):
+%   - Listing: regime × dispatch trigger × predicate × IR signature table.
+%   - Listing: showcase_09b vs showcase_12b abbreviated IR side-by-side.
+%   - Listing: static_assert(IsSet<...>) chain on input and three output regimes.
+%   - Listing: static_assert(IsFAlgebra<...>) inline witness extract.
 
 \subsection{Forward-Mode AD as a Sibling Realisation of Compile-Time Derivatives}
 \label{sec:ad-elliott}

--- a/docs/paper/paper.tex
+++ b/docs/paper/paper.tex
@@ -1826,6 +1826,54 @@ The library exposes \cppinline{maximize_axis_aligned_with_values<T>} and \cppinl
 The fixtures \texttt{showcase\_09b\_lp\_runtime\_residual.ll} and \texttt{showcase\_12b\_lp\_unimodular\_runtime.ll} pin the two kernels' signatures: the Cramer kernel retains its $2 \times 2$ \texttt{fdiv} / \texttt{fmuladd} active-set arithmetic and the loop's \texttt{phi} accumulators; the bit-ops kernel retains the loop's \texttt{phi} accumulators and the sign-driven \texttt{select} but emits no \texttt{mul} / \texttt{sdiv} / \texttt{udiv} on the integer carrier.
 The semantic-sanity checker enforces both shapes (\texttt{pruning-ir-fixture.py}).
 
+% Source excerpts: showcase_09b_lp_runtime_residual.ll, showcase_12b_lp_unimodular_runtime.ll
+\begin{listing}[htbp]
+\caption{Abbreviated runtime IR for the two LP kernels.
+Excerpts from \texttt{showcase\_09b\_lp\_runtime\_residual.ll} (generic Cramer over \texttt{double}) and \texttt{showcase\_12b\_lp\_unimodular\_runtime.ll} (bit-ops fast path over \texttt{int}).
+Cramer emits floating-point divide / multiply / fused-multiply-add inside an active-set loop; the fast path emits per-axis integer compares, \texttt{llvm.smin}, and a sign-driven \texttt{select}, with \texttt{mul} / \texttt{sdiv} / \texttt{udiv} absent on the integer carrier.
+Both fixtures are pinned by \texttt{pruning-ir-fixture.py}.}
+\label{lst:lp-runtime-ir-side-by-side}
+\noindent
+\begin{minipage}[t]{0.48\linewidth}
+\textbf{Generic Cramer (\texttt{showcase\_09b}):}
+\begin{cpp}
+
+; per active-set pair: 2x2 Cramer solve
+%33 = fneg double %32
+%34 = fmul double %22, %33
+%35 = call double @llvm.fmuladd.f64(
+        double %20, double %31, double %34)
+; numerators elided ...
+%44 = fdiv double %43, %35   ; x_num/det
+%47 = fdiv double %46, %35   ; y_num/det
+; per-constraint feasibility check:
+%59 = fmul double %47, %58
+%60 = call double @llvm.fmuladd.f64(
+        double %56, double %44, double %59)
+; outer: C(n,2) pairs; inner: m feasibility;
+; argmax phi over the surviving vertex.
+\end{cpp}
+\end{minipage}\hfill
+\begin{minipage}[t]{0.48\linewidth}
+\textbf{Bit-ops fast path (\texttt{showcase\_12b}):}
+\begin{cpp}
+
+; per halfspace: per-axis bracketing
+%17 = load i32, ptr %16, align 4   ; coeff_x
+%18 = add  i32 %17, 1
+%19 = icmp ult i32 %18, 3       ; in {-1,0,1}?
+; per-axis dispatch (y-branch elided):
+%41 = call i32 @llvm.smin.i32(
+        i32 %31, i32 %12)
+%42 = select i1 %40, i32 %41, i32 %31
+; phi i8 / phi i32 carry axis bounds and
+; bound-present flags across the loop;
+; no mul / sdiv / udiv on the carrier
+; appears anywhere in this function.
+\end{cpp}
+\end{minipage}
+\end{listing}
+
 \begin{table}[htbp]
 \centering
 \caption{\textbf{Kernel $\times$ evaluation mode $\times$ output predicate $\times$ IR signature for \cppinline{argmax(G, U)}.}
@@ -1856,7 +1904,6 @@ A more elegant compile-time kernel is available in principle: Fourier-Motzkin el
 We leave the Fourier-Motzkin kernel to follow-up.
 
 % TODO (listings in follow-up commits to this PR):
-%   - Listing: showcase_09b vs showcase_12b abbreviated IR side-by-side.
 %   - Listing: static_assert(IsSet<...>) chain on input and three output regimes.
 %   - Listing: static_assert(IsFAlgebra<...>) inline witness extract.
 

--- a/docs/paper/paper.tex
+++ b/docs/paper/paper.tex
@@ -1897,15 +1897,69 @@ A \cppinline{static_assert} on the project's \cppinline{IsSet} concept (the ETCS
 A further \cppinline{static_assert} on \cppinline{IsFAlgebra} confirms the catamorphism \emph{shape} on the output side: the output Set carries a structure map $F\langle X\rangle \to X$ for the identity endofunctor on its ambient category, with the active-set step closing over the halfspace pack.\footnote{The shape witness is mechanical.
 The catamorphism's uniqueness clause --- that \cppinline{argmax(G, U)} is the unique morphism into the output algebra from the initial halfspace-list F-algebra for $F(X) = 1 + \text{Halfspace} \times X$ --- is the engineer's honesty obligation per Pierce~\cite{pierce2002tapl} §5.4; the project's \cppinline{:f_algebra} partition reifies this as an opt-in \cppinline{is_initial_f_algebra_v} trait, deliberately defaulted to false here.}
 
+% Source: src/test/cpp/modules/dedekind/optimization/lp_test.cpp (TEST_CASE "both argmax input and output satisfy IsSet")
+\begin{listing}[htbp]
+\caption{Mechanical \cppinline{IsSet} witness for the input polytope and the three output regimes. From \texttt{lp\_test.cpp} (TEST\_CASE ``both argmax input and output satisfy IsSet'').}
+\label{lst:lp-is-set-chain}
+\begin{cpp}
+
+using F = Vec2V<Rat>;
+using L = ClassicalLogic;
+
+// Input polytope: G ⊆ F via the §3 set-comprehension DSL.
+using PolyG = Set<F, L, Polytope2DPredicate<Rat, H1, H2, H3, H4>>;
+static_assert(IsSet<PolyG>);
+
+// Three output regimes, all over the same ambient F:
+//   (a) NTTP feasible:    Singleton2DPredicate<x*, y*>
+//   (b) NTTP infeasible:  EmptyPredicate<F>
+//   (c) runtime:          LPSolutionPredicate (point, feasible)
+using SingOut    = Set<F, L, Singleton2DPredicate<Rat, Rat{2L}, Rat{2L}>>;
+using EmptyOut   = Set<F, L, EmptyPredicate<F>>;
+using RuntimeOut = Set<F, L, LPSolutionPredicate<Rat>>;
+static_assert(IsSet<SingOut>);
+static_assert(IsSet<EmptyOut>);
+static_assert(IsSet<RuntimeOut>);
+\end{cpp}
+\end{listing}
+
+% Source: src/test/cpp/modules/dedekind/optimization/lp_test.cpp (TEST_CASE "output Set is an F-algebra")
+\begin{listing}[htbp]
+\caption{Mechanical \cppinline{IsFAlgebra} shape witness for the output Set. The active-set step is the structure map $F\langle X\rangle \to X$ on $X = $\cppinline{OutputSet}; the initial-F-algebra opt-in is deliberately false, naming the universal-property clause as the engineer's honesty obligation. From \texttt{lp\_test.cpp} (TEST\_CASE ``output Set is an F-algebra'').}
+\label{lst:lp-is-falgebra}
+\begin{cpp}
+
+using OutputSet     = Set<Vec2V<Rat>, ClassicalLogic,
+                          LPSolutionPredicate<Rat>>;
+using LPSolutionCat = DiscreteCategory<OutputSet>;
+using LPSolutionIdF = identity_functor<LPSolutionCat>;
+
+// Active-set step: endomap on OutputSet.  At F-algebra shape
+// level the step is independent of any particular halfspace;
+// concrete LP folds compose chains of these, each closing
+// over one halfspace internally.
+constexpr auto step = arrow(
+    [](const OutputSet& s) { return s; });
+using StepArrow = std::decay_t<decltype(step)>;
+
+// Catamorphism shape: F<X> → X for F = identity_functor on
+// the ambient category, X = OutputSet, structure map = step.
+static_assert(IsFAlgebra<OutputSet, StepArrow, LPSolutionIdF>);
+
+// Initial-F-algebra opt-in deliberately false: the universal-
+// property clause is the engineer's honesty obligation, not
+// mechanically witnessed here.
+static_assert(!is_initial_f_algebra_v<LPSolutionIdF,
+                                      OutputSet, StepArrow>);
+\end{cpp}
+\end{listing}
+
 \paragraph{Algorithmic scope.}
 The vertex-enumeration kernel is $O(\binom{m}{n})$ in the halfspace count --- the bubble sort of LP, well-suited to the small $m$ §5 exhibits and to compile-time enumeration generally, not to industrial constraint counts.
 The halfspace pack lives in NTTP space; §\ref{sec:compiler-wall} names this as the Compiler Wall, so the inner solver's choice does not move the wall it caps.
 A more elegant compile-time kernel is available in principle: Fourier-Motzkin elimination~\cite{schrijver1986theory} §12.2 reduces the polytope dimension by dimension, surfacing the singleton, empty, face, and ray regimes uniformly from the shape of the resulting interval, and is a catamorphism on the halfspace pack proper rather than the identity-functor shape recorded above.
 We leave the Fourier-Motzkin kernel to follow-up.
 
-% TODO (listings in follow-up commits to this PR):
-%   - Listing: static_assert(IsSet<...>) chain on input and three output regimes.
-%   - Listing: static_assert(IsFAlgebra<...>) inline witness extract.
 
 \subsection{Forward-Mode AD as a Sibling Realisation of Compile-Time Derivatives}
 \label{sec:ad-elliott}

--- a/docs/paper/paper.tex
+++ b/docs/paper/paper.tex
@@ -1830,6 +1830,12 @@ A \cppinline{static_assert} on the project's \cppinline{IsSet} concept (the ETCS
 A further \cppinline{static_assert} on \cppinline{IsFAlgebra} confirms the catamorphism \emph{shape} on the output side: the output Set carries a structure map $F\langle X\rangle \to X$ for the identity endofunctor on its ambient category, with the active-set step closing over the halfspace pack.\footnote{The shape witness is mechanical.
 The catamorphism's uniqueness clause --- that \cppinline{argmax(G, U)} is the unique morphism into the output algebra from the initial halfspace-list F-algebra for $F(X) = 1 + \text{Halfspace} \times X$ --- is the engineer's honesty obligation per Pierce~\cite{pierce2002tapl} §5.4; the project's \cppinline{:f_algebra} partition reifies this as an opt-in \cppinline{is_initial_f_algebra_v} trait, deliberately defaulted to false here.}
 
+\paragraph{Algorithmic scope.}
+The vertex-enumeration kernel is $O(\binom{m}{n})$ in the halfspace count --- the bubble sort of LP, well-suited to the small $m$ §5 exhibits and to compile-time enumeration generally, not to industrial constraint counts.
+The halfspace pack lives in NTTP space; §\ref{sec:compiler-wall} names this as the Compiler Wall, so the inner solver's choice does not move the wall it caps.
+A more elegant compile-time kernel is available in principle: Fourier-Motzkin elimination~\cite{schrijver1986theory} §12.2 reduces the polytope dimension by dimension, surfacing the singleton, empty, face, and ray regimes uniformly from the shape of the resulting interval, and is a catamorphism on the halfspace pack proper rather than the identity-functor shape recorded above.
+We leave the Fourier-Motzkin kernel to follow-up.
+
 % TODO (listings in follow-up commits to this PR):
 %   - Listing: regime × dispatch trigger × predicate × IR signature table.
 %   - Listing: showcase_09b vs showcase_12b abbreviated IR side-by-side.

--- a/docs/paper/paper.tex
+++ b/docs/paper/paper.tex
@@ -1829,13 +1829,8 @@ The reduction enumerates vertex candidates at compile time (all $\binom{4}{2} = 
 Every step is a template specialisation; no runtime iteration survives.
 
 \paragraph{Two kernels under one combinator.}
-A separate concern arises when the polytope happens to be signed-unimodular and axis-aligned: coefficients in $\{-1, 0, +1\}$ with at most one nonzero per halfspace.
-In that scope, the Cramer determinants are all $\pm 1$, the active-set divisions degenerate to sign flips, and the vertex coordinates are simply the relevant axis bounds; the active-set enumeration collapses to per-axis bracketing and a sign-driven select.
-The library ships both kernels and lets the type system pick.
-The dispatch is one \cppinline{if constexpr} over a conjunction of concepts on the halfspace pack and the carrier:
-\cppinline{HasUnitRangeEntries<Hs...>} (every coefficient lies in $\{-1, 0, +1\}$), \cppinline{IsAxisAlignedPolytope<Hs...>} (at least one coefficient is zero per halfspace), and \cppinline{SuitableForAxisAlignedFastPath<T>} (the carrier admits the bit-ops kernel's signedness convention).
-When all three hold, \cppinline{argmax(G, U)} routes to the bit-ops kernel; otherwise to the generic Cramer kernel.
-The non-taken branch is removed from the template instantiation by \cppinline{if constexpr}; no run-time dispatch survives.
+A separate concern arises when the polytope happens to be signed-unimodular and axis-aligned: in that scope the Cramer determinants are all $\pm 1$, the active-set divisions degenerate to sign flips, and the enumeration collapses to per-axis bracketing and a sign-driven select.
+The library ships both kernels and lets the type system pick (Table~\ref{tab:lp-regime-dispatch}); the dispatch is a single \cppinline{if constexpr} over three concepts on the halfspace pack and carrier, and the non-taken branch is removed from the template instantiation.
 
 \paragraph{Bridge: same source, two evaluation modes.}
 The compile-time path described above takes constraints at the type level.
@@ -1843,9 +1838,8 @@ The same kernel runs at runtime when the constraints arrive as a \cppinline{std:
 The runtime entry \cppinline{maximize_with_values<T>(span, cx, cy)} performs the same structural classification at runtime, routes to the same kernel, and returns the same Set carrier --- with the regime now encoded at the value level (via the predicate's \cppinline{(point, feasible)} state) instead of the type level.
 The bridge is mechanical: the kernel is one \cppinline{constexpr} function, and the call site selects the evaluation mode by the constexpr-ness of its arguments.
 
-\paragraph{IR witness.} The paper's claim is not prose; it is translation-time mechanics.
-On the NTTP path, two \texttt{extern "C"} witness functions in the fixture return the optimum's $x$- and $y$-coordinates --- extracted from the output Set's predicate at the type level.
-At \texttt{-O2}, \texttt{clang}'s optimiser folds the entire LP reduction to literal integers:
+\paragraph{IR witness.} The claim is translation-time mechanics.
+Two \texttt{extern "C"} fixture functions extract the optimum's $x$- and $y$-coordinates from the output Set's predicate; at \texttt{-O2}, \texttt{clang} folds the entire reduction to literal integers:
 
 % Source: src/test/cpp/modules/dedekind/python/showcase_09_lp_vertex_typed_constant.ll
 \begin{listing}[htbp]
@@ -1863,17 +1857,14 @@ define noundef i64 @witness_lp_optimum_y() ... {
 \end{cpp}
 \end{listing}
 
-The IR is checked into the repository as a fixture (\texttt{showcase\_09\_lp\_vertex\_typed\_constant.ll}); a build-time gate (\texttt{make ir-fixture-check}) fails CI if optimiser drift ever loses the collapse.
-The binary contains no LP solver; no simplex tableau; no active-set machinery.
-More precisely: the vertex's coordinates are non-type template parameters of the output Set's predicate (\cppinline{Singleton2DPredicate<Rat, Rat{2}, Rat{2}>}), so the C++23 NTTP machinery is what carries the answer through to the type level.
-The input is a constexpr Set passed under \cppinline{argmax(G, U)}; the output is a Set whose predicate type's NTTPs encode the coordinates; the runtime witness extracting a coordinate collapses to a literal load in the emitted IR.
-Because the reduction lands in \texttt{Rational<...>} rather than IEEE floating point, the \cppinline{ret i64 2} output is bit-identical across ARM and x86 back-ends and host floating-point ABIs --- the typed constant has no rounding mode to disagree about.
+The IR is checked in as \texttt{showcase\_09\_lp\_vertex\_typed\_constant.ll}; \texttt{make ir-fixture-check} fails CI on optimiser drift.
+The binary contains no LP solver, no simplex tableau, no active-set machinery: the vertex's coordinates ride as NTTPs of \cppinline{Singleton2DPredicate<Rat, Rat{2}, Rat{2}>}, and the witness extracting a coordinate collapses to a literal load.
+Because the reduction lands in \texttt{Rational<...>} rather than IEEE floating point, the output is bit-identical across ARM and x86 back-ends --- the typed constant has no rounding mode to disagree about.
 
 \paragraph{Runtime IR: two kernels, two signatures.}
-The complementary direction is to call the same kernels with runtime data and look at the residual IR.
-The library exposes \cppinline{maximize_axis_aligned_with_values<T>} and \cppinline{maximize_cramer_with_values<T>} as explicit power-user entries (the IR microscope on each kernel in isolation); the default \cppinline{maximize_with_values<T>} dispatches mechanically between them.
-The fixtures \texttt{showcase\_09b\_lp\_runtime\_residual.ll} and \texttt{showcase\_12b\_lp\_unimodular\_runtime.ll} pin the two kernels' signatures: the Cramer kernel retains its $2 \times 2$ \texttt{fdiv} / \texttt{fmuladd} active-set arithmetic and the loop's \texttt{phi} accumulators; the bit-ops kernel retains the loop's \texttt{phi} accumulators and the sign-driven \texttt{select} but emits no \texttt{mul} / \texttt{sdiv} / \texttt{udiv} on the integer carrier.
-The semantic-sanity checker enforces both shapes (\texttt{pruning-ir-fixture.py}).
+The complementary direction is to call the same kernels with runtime data.
+The power-user entries \cppinline{maximize_axis_aligned_with_values<T>} and \cppinline{maximize_cramer_with_values<T>} are the IR microscope on each kernel in isolation; the default \cppinline{maximize_with_values<T>} dispatches mechanically between them.
+Both signatures are pinned by fixtures (Listing~\ref{lst:lp-runtime-ir-side-by-side}, Table~\ref{tab:lp-regime-dispatch}) and enforced by \texttt{pruning-ir-fixture.py}.
 
 % Source excerpts: showcase_09b_lp_runtime_residual.ll, showcase_12b_lp_unimodular_runtime.ll
 \begin{listing}[htbp]
@@ -1942,8 +1933,7 @@ Generic Cramer & \cppinline{std::span} & \cppinline{LPSolutionPredicate} & $\bin
 \end{tabular}
 \end{table}
 
-A \cppinline{static_assert} on the project's \cppinline{IsSet} concept (the ETCS-grade Set contract from Section~\ref{sec:sets-rules}) confirms that the input polytope, the singleton output, the empty output, and the runtime-discriminated output are all Sets in the same sense --- not merely structurally-similar wrappers but carriers of \cppinline{HasETCSAxioms} and \cppinline{IsCartesianClosed<CanonicalSetCCC<Ambient>>}.
-A further \cppinline{static_assert} on \cppinline{IsFAlgebra} confirms the catamorphism \emph{shape} on the output side: the output Set carries a structure map $F\langle X\rangle \to X$ for the identity endofunctor on its ambient category, with the active-set step closing over the halfspace pack.\footnote{The shape witness is mechanical.
+Two \cppinline{static_assert} chains close the section: \cppinline{IsSet} (the ETCS-grade Set contract of Section~\ref{sec:sets-rules}) holds for the input polytope and all three output regimes (Listing~\ref{lst:lp-is-set-chain}); \cppinline{IsFAlgebra} holds for the output Set under the identity endofunctor (Listing~\ref{lst:lp-is-falgebra}), witnessing the catamorphism \emph{shape} with the active-set step as the structure map.\footnote{The shape witness is mechanical.
 The catamorphism's uniqueness clause --- that \cppinline{argmax(G, U)} is the unique morphism into the output algebra from the initial halfspace-list F-algebra for $F(X) = 1 + \text{Halfspace} \times X$ --- is the engineer's honesty obligation per Pierce~\cite{pierce2002tapl} §5.4; the project's \cppinline{:f_algebra} partition reifies this as an opt-in \cppinline{is_initial_f_algebra_v} trait, deliberately defaulted to false here.}
 
 % Source: src/test/cpp/modules/dedekind/optimization/lp_test.cpp (TEST_CASE "both argmax input and output satisfy IsSet")

--- a/docs/paper/paper.tex
+++ b/docs/paper/paper.tex
@@ -2064,7 +2064,427 @@ static_assert(as_matrix2x2(eps) * as_matrix2x2(eps) == zero_matrix2x2_v<Rat>);
 \end{cpp}
 \end{listing}
 
-\subsection{From Cardinality Pruning to Type-Directed Collapse}
+% ============================================================
+\section{Discussion}
+\label{sec:discussion}
+% ============================================================
+
+
+\subsection{The Compiler Wall: Where This Stops}
+\label{sec:compiler-wall}
+
+Treating \texttt{clang++} as a poor man's theorem prover is useful
+precisely because the compiler is bounded, predictable, and cheap. It
+is also, for the same reason, incapable of doing everything a real
+proof assistant would. The purpose of this subsection is to be honest
+about the wall and to name the \texttt{clang} knobs that push it back
+by a constant factor but cannot remove it.
+
+\paragraph{Compile-time budgets.}
+Every reduction in this paper is a variadic template, so two
+\texttt{clang} budgets matter: \emph{instantiation depth} (default
+$1024$, raised to $2048$ on the affected translation units; concepts
+and NTTP lambdas each add frames so the limit hits earlier than the
+naive count suggests) and \emph{\cppinline{constexpr} steps} (default
+$\sim\!10^6$, capping a single \cppinline{constexpr} evaluation).  A
+$2\times 2$ LP with four constraints is comfortably under both; a
+$2\times 2$ LP with thirty constraints ($\binom{30}{2} = 435$ active
+sets and nontrivial metadata) starts approaching the step limit.
+Raising the caps is possible (\cppinline{-ftemplate-depth=N},
+\cppinline{-fconstexpr-steps=N}) but trades compile time and resident
+memory for reach; the more principled answer is to stop at the
+boundary and hand off to a runtime solver --- which is exactly the
+case our centrepiece is \emph{not}.
+
+\paragraph{Combinatorial blowup is the pessimistic bound.}
+Compile-time vertex enumeration over $n$ halfspaces is, in the worst
+case, $\binom{n}{d}$ active-set solves for a $d$-dimensional LP
+(six for $n = 4$, $190$ for $n = 20$, nearly half a million for
+$n = 1000$).  Two facts soften this substantially in practice.  By
+the fundamental theorem of linear programming, the optimum of a
+$d$-dimensional LP is attained at a vertex with at most $d$ binding
+constraints, and on a handwritten polytope most of the syntactic
+constraint list is slack or redundant; the $\binom{n}{d}$ figure
+counts enumeration cost, not what any one vertex actually witnesses.
+Many of those redundancies are also \emph{statically} removable: the
+library's \cppinline{structured_and} dispatch already collapses
+linearly-dependent or contradictory halfspaces at compile time
+(Showcases~3 and~4), so the combinatorial term tracks the pruned
+count rather than the raw
+one.\footnote{Concretely:
+\cppinline{x > 5 && x > 7} collapses to \cppinline{x > 7} (stricter
+pivot wins); \cppinline{x > 5 && x < 2} collapses to $\varnothing$
+(contradiction); \cppinline{x > 3 && x < 5} over an integral carrier
+collapses to \cppinline{Singleton<4>}.  The 2D extension --- pruning
+halfspaces whose normals are linearly dependent --- follows the same
+dispatch pattern.}
+The instance regime this paper targets --- MPC steps with a handful
+of physical constraints, sensor-fusion guards, parametric
+configuration LPs --- rarely exceeds a few dozen raw constraints
+before pruning, and remains comfortably tractable.  Industrial-scale
+LP is emphatically not in scope; we do not claim it is.
+
+\paragraph{Active-set hints as the user-side escape valve.}
+Even within the compile-time regime, a user with domain knowledge of
+\emph{which} halfspaces bind at the optimum can short-circuit the
+$\binom{n}{d}$ enumeration entirely: because the constraint pack is
+already an NTTP list, instantiating
+\cppinline{maximize<T, cx, cy, H_i, H_j>()} with just the binding
+pair (instead of the full pack) is exactly the active-set hint, and
+the library evaluates only that single Cramer solve.  An explicit
+\cppinline{with_active_set<...>} API that takes the hint as a separate
+template argument and verifies feasibility against the full pack
+without re-enumerating is a natural successor surface, but the
+underlying NTTP-pack-as-hint mechanism is available today: dropping
+slack constraints from the syntactic list is the user's prerogative,
+and the combinatorial term then tracks the hinted count rather than
+the raw one.
+
+\subsection{Boundary Observations: An Axiom~\texorpdfstring{$\to$}{->}~Theorem Chain}
+\label{sec:boundary-observations}
+
+The preceding sections present the technique in an empirical sort of way: through worked showcases, IR artefacts, and concrete diagnostics.
+The library admits a stricter framing whose structural
+parallel is Wadler's \emph{Theorems for Free!}~\cite{wadler1989theorems}:
+parametricity gives the typed-lambda calculus theorems from type
+signatures alone; the dedekind library extends the move into
+\emph{algebraic} territory, where a carrier's axiomatic profile
+(declared via opt-in traits and concept witnesses) discharges
+carrier-level theorems at the type level. The empirical artefacts of
+the showcases are then \emph{realisations} of an underlying
+axiom~$\to$~theorem chain rather than the substance of the chain
+itself.
+
+\paragraph{Axioms as the engineer's honesty obligation.}
+A carrier's algebraic profile is asserted explicitly. Where the
+proof of an axiom is beyond what C++ concepts can quantify, the claim
+is made via an opt-in trait specialisation, and the engineer who
+declares the trait carries Wadler's
+\emph{propositions-as-types}~\cite{wadler2015propositions}
+obligation under the NSPE Code of Ethics canons III and IV (truthful
+public statements; faithful agency). The library ships several such
+opt-in surfaces:
+\cppinline{is_monic_arrow_v} for monomorphism declarations,
+\cppinline{is_initial_ring_v} for the initial-object reading of
+$\mathbb{Z}$, \cppinline{is_grothendieck_group_v} for the
+free-abelian-group reading, \cppinline{is_initial_f_algebra_v} for the
+NNO-as-initial-F-algebra reading, and a family of axiom-shape concepts
+including \cppinline{IsRing}, \cppinline{IsField},
+\cppinline{IsTotallyOrdered}, \cppinline{IsArchimedean}, and
+\cppinline{IsCyclicGroup}. Each is the engineer's claim, not a
+machine-discharged proof; the structural shape (signatures, closure,
+opt-in trait set to \texttt{true}) is what the type system can pin
+mechanically.
+
+\subsection{Related Work}
+\paragraph{Functional and dependently-typed approaches.}
+Agda~\cite{norell2007towards} and Coq provide dependent type systems in which set-membership
+proofs are first-class terms.  The expressiveness is greater than C++23, but the
+runtime model differs fundamentally: proof terms are erased at runtime, whereas
+\texttt{dedekind}'s structural pruning targets machine-code generation in a
+systems-programming context.
+Haskell~\cite{GHC2024} supports type-class-based structural reasoning, and libraries
+such as \texttt{algebra} encode ring and field hierarchies.  C++ templates differ in that
+they operate on concrete machine types (with hardware-level algebraic imperfections)
+rather than erased polymorphic dictionaries.
+
+\paragraph{Exact arithmetic.}
+The GNU Multiple Precision library (GMP) and \texttt{mpfr} support arbitrary-precision
+arithmetic at runtime.  \texttt{iRRAM}~\cite{mueller2001irram} and similar libraries
+implement computable real arithmetic.
+\texttt{dedekind} is complementary: exact reals (Dedekind cuts) are modelled
+\emph{intensionally as types}, and realization to a specific arithmetic backend is
+an explicit programmer choice.
+
+\paragraph{Set-builder type systems.}
+Refinement types~\cite{freeman1991refinement} attach predicates to types, enabling
+a form of set-builder representation in ML-family languages.
+Liquid Haskell~\cite{vazou2014refinement} extends Haskell with SMT-backed
+refinement predicates.
+\texttt{dedekind} achieves a subset of this functionality in standard C++23 without
+a custom type checker, using NTTP-embedded lambdas as the predicate carrier.
+
+\paragraph{Linear programming.}
+The standard LP toolchain---simplex~\cite{dantzig1963simplex} and
+interior-point methods~\cite{karmarkar1984interior} as implemented in
+Gurobi, CPLEX, GLPK, and related solvers---treats the problem instance
+as runtime data: the objective vector, constraint matrix, and right-hand
+side are passed to a solver that iterates to a vertex. \texttt{dedekind}
+sits orthogonally: problem instances whose size and coefficients are
+\emph{compile-time data} reduce via type-level vertex enumeration to
+the optimum as a typed constant (Section~\ref{sec:lp-centrepiece}), with
+the entire solver collapsing out of the emitted binary. This is not a
+replacement for runtime LP---for large, data-dependent instances the
+classical pipeline remains indispensable---but a complement for
+instances that appear during code generation (problem-shape metadata,
+compile-time configuration polytopes, template-parametric optimizer
+settings). Exact-rational arithmetic over $\mathbb{Q}$ connects the
+approach to the exact-LP literature~\cite{gleixner2016exact}; the
+specific contribution is the realisation at translation time with
+zero runtime overhead, witnessed in the emitted LLVM~IR fixtures.
+
+\paragraph{Automatic differentiation.}
+Runtime AD libraries such as Ceres~\cite{ceres-solver},
+Adept~\cite{hogan2014adept}, Sacado, dco/c++, and
+CasADi~\cite{andersson2019casadi} provide forward- and reverse-mode AD
+via expression templates or operator overloading on a specialised
+arithmetic type. The theoretical view taken by
+Elliott~\cite{elliott2018simple}---that forward-mode AD is the
+$(\text{value}, \text{tangent})$ product with chain-rule composition,
+not the dual-number object \emph{per se}---clarifies why the same
+reduction that solves the LP also computes its sensitivities when
+instantiated over the right ring (Section~\ref{sec:ad-elliott}).
+\texttt{dedekind}'s contribution is not a new AD algorithm but the
+observation that a single compile-time reduction, written once over an
+\texttt{HasRingOperators} carrier, serves as LP solver over $\mathbb{Q}$ and
+as forward-mode AD engine over $\mathbb{Q}[\varepsilon]/(\varepsilon^2)$
+with no extra code path.
+
+\paragraph{Embedded machine-learning runtimes and edge computing.}
+The embedded / edge-computing~\cite{shi2016edge} landscape has a
+mature runtime ecosystem that \texttt{dedekind} deliberately sits
+\emph{beside} rather than competes with. TensorFlow Lite
+Micro~\cite{david2021tflm} compiles models to a small-footprint
+interpreter targeted at microcontroller-class devices; ONNX Runtime
+and microTVM generate target-specific code from a model graph; the
+Eigen linear-algebra library is the de facto substrate for embedded
+numerics. These runtimes take the model as input and the target as
+fixed; they do not treat the hosting application's algebraic
+invariants as proof obligations for the C++ compiler to discharge.
+
+A deliberate choice on the linear-algebra backend is worth flagging
+here, since it connects the library's position to the
+abstract-naturals-versus-IEEE-numerics tension of
+Section~\ref{sec:numeric-tension}. Eigen~\cite{eigen2010} is
+mature, widely deployed, and excellent at what it targets---but it
+is also \emph{carrier-opinionated}: its matrix types default to
+\texttt{float} or \texttt{double} and its optimisations assume a
+field-like IEEE carrier. A natural path for \texttt{dedekind}'s
+runtime linear-algebra layer is instead toward
+GraphBLAS~\cite{kepner2011graphalgs, davis2019graphblas}, whose
+explicit \emph{(carrier, $+$, $\times$)} semiring parameterisation
+makes the ring-over-which-matrices-live a first-class configurable
+property. That matches the discipline this paper argues for:
+matrices over \cppinline{bool} (with OR/AND) are perfectly
+well-defined objects when inversion is not required, matrices over
+\cppinline{char} are useful for quantised embedded inference, and
+both sit naturally inside the \cppinline{HasRingOperators} /
+\cppinline{HasSemiringOperators} concept hierarchy. The cost of this
+generality is library complexity rather than carrier simplicity.
+The trade we advocate is correctness-and-performance (tight control
+over the ring structure) at the price of implementation effort,
+against Eigen's opposite trade---an ergonomic default carrier
+whose optimisations are largely locked to floating-point semantics.
+
+\texttt{dedekind} addresses a different surface: the \emph{inline}
+numerical primitives (Kalman filters, pose-estimation math, MPC
+steps, parametric optimisation) a robotics, automotive, or
+instrumentation engineer writes directly in their control loop. For
+these, a fixed-topology LP, a compile-specialised Kalman update,
+or an exact-rational sensor-fusion step expressed against
+\texttt{HasRingOperators} concepts exhibits three properties the
+model-runtime path does not aim at: a binary with no
+interpreter, a dependency graph no heavier than the system's
+\texttt{clang++}, and bit-for-bit deterministic arithmetic across
+platforms when the carrier is $\mathbb{Q}$. We see this as a
+complement to the runtime ecosystem, not a replacement: model-driven
+inference continues to belong to TFLite Micro and its siblings, while
+the numerical glue around such inference---the Kalman front-end, the
+control-loop LP, the gradient for online adaptation---is where
+Axiomatic Systems Programming is strongest.
+
+\paragraph{Data-pipeline DSLs.}
+Apache Spark, Flink, and the Python \texttt{pandas}/\texttt{polars} ecosystem
+provide declarative data pipelines with runtime domain checks. None of these
+ground their APIs in formal set theory, so intersections and filters are
+runtime pipeline operations rather than compile-time type invariants.
+\texttt{dedekind} is positioned one layer down: it is a systems-programming
+library that could in principle back such pipelines, but the contribution
+we demonstrate here is the compile-time reduction at the C++ layer itself.
+
+\paragraph{C++ template metaprogramming lineage.}
+Compile-time computation in C++ has a long tradition that
+\texttt{dedekind} builds on rather than supplants. Boost.Hana
+~\cite{chagnon2016hana} and \texttt{mp11}~\cite{pdimov2017mp11} provide
+compile-time heterogeneous containers and type-level algorithm
+support; Hana in particular already demonstrates concept-based
+structural dispatch at compile time and would be a natural
+lower-layer substrate for several of our combinators.
+CTRE~\cite{dusikova2018ctre} shows that serious computation
+(regular-expression matching, compiled to a type-level automaton)
+can live entirely inside the type system and emit optimised
+machine code; the shape of that reduction---intensional description
+to a named extensional object at translation time---is close kin to
+our halfspace and LP reductions, differing in subject matter but
+not in mechanism. Expression-template AD libraries including
+ENOKI~\cite{jakob2019enoki} and the runtime AD systems
+Ceres~\cite{ceres-solver}, Adept~\cite{hogan2014adept},
+and CasADi~\cite{andersson2019casadi} have carried pieces of the
+dual-number story into production workloads.
+
+\texttt{dedekind}'s position relative to this lineage is specific
+and narrow: it targets \emph{algebraic-semantic} content---ring
+homomorphisms, structural cardinality, ordering laws, the
+$(f, f')$ product as an Elliott~\cite{elliott2018simple} sibling---rather
+than the syntactic structure manipulation that is the traditional focus
+of TMP libraries. The contribution is not another metaprogramming
+trick but the claim, supported by worked reductions, that the
+\emph{discipline} of treating mainstream C++23 as a structural-gate
+theorem prover (Axiomatic Systems Programming) is now coherent enough
+to practise end-to-end.
+% ============================================================
+\section{Conclusion}
+\label{sec:conclusion}
+% ============================================================
+
+The thesis of this paper, once more: \emph{named algebraic structure
+at the type level, discharged by the compiler, narrows the gap
+between abstract mathematics and machine code without a separate
+proof assistant.} \texttt{dedekind} is the existence proof. Sets are
+rules rather than buckets; intensional descriptions defer
+materialisation to explicit boundaries; the LLVM backend carries
+discharged proofs through to object-code optimisation. The
+centrepiece existential proof (Section~\ref{sec:lp-centrepiece}) shows
+a textbook linear-programming instance reducing at compile time to
+its optimal vertex as a typed constant---the six candidate solves,
+six feasibility checks, and six objective comparisons vanish in the
+emitted IR. The same reduction over the dual-number ring recovers
+exact forward-mode sensitivities (Section~\ref{sec:ad-elliott}); at
+the linear-algebra layer it certifies the ring homomorphisms
+$\mathbb{C}, \mathbb{D} \hookrightarrow M_2(\mathbb{Q})$ as
+compile-time facts (Section~\ref{sec:lin-alg-embedding}). The
+companion repository's polynomial-calculus partitions discharge the
+Fundamental Theorem of Calculus at translation time on the same
+discipline. In every case the binary contains only literals.
+
+\paragraph{Axiomatic Systems Programming as a practised discipline.}
+The viewpoint we name in Section~\ref{sec:introduction}---treating
+\texttt{clang++} as a poor man's theorem prover, and the
+\texttt{HasRingOperators} concept as a proof obligation the carrier must
+discharge---is the paper's intended export. Taken seriously, it
+turns each algebraic invariant into a structural gate the compiler
+polices; taken habitually, it shifts the library author's default
+from ``runtime check'' to ``type-level obligation''. Three axes of
+type-directed collapse remain open (Section~\ref{sec:gap}): carrier
+tightening, smooth optimization, and lattice-law rewriting; each
+sits on the same NTTP-plus-concepts foundation as the halfspace and
+LP reductions demonstrated here.
+We leave them as worked targets for successor libraries that adopt
+the same discipline.
+
+\paragraph{An absent failure mode worth reporting.}
+A practical observation, offered honestly: across this library's
+development we did not encounter the two failure modes mainstream
+C++ template programming is famed for --- \emph{template
+instantiation explosion} (compile times that grow super-linearly
+with template depth) and \emph{template error hell} (diagnostics
+buried inside long substitution-failure cascades, far from the
+call site that triggered them).  Neither was a recurring concern.
+This is not nothing: both phenomena are well-documented hazards
+in production C++ template programming.  The disciplined fragment
+of §\ref{sec:axiomatic} (Table~\ref{tab:admissibility-rules})
+appears to rule out, by construction, the mechanisms that produce
+each.  The concept-constrained-template machinery fails at
+\emph{constraint-evaluation} time --- before template-body
+instantiation, with named-axiom diagnostics --- so the SFINAE-
+cascade error path is excluded.  Uniform parametric polymorphism
+(System-F-style; no specialisation-driven branching admitted in the
+public surface) keeps the set of compiled code paths linear in the
+number of callsites rather than combinatorial in the type tuples.
+And the bounded-instantiation-depth admissibility rule (capped at
+the carrier-lattice's three axes in the current surface) prevents
+the recursively-unfolding template-metaprogramming pattern that
+produces the explosion.  Whether this implies a \emph{formal}
+result --- a theorem that the disciplined fragment lies inside a
+decidable type-checking regime --- the paper does not claim.  The
+fragment is small enough that decidability is plausible
+(Lambek--Scott~\cite{lambek1988introduction} maps the constructive
+half to a CCC fragment; the propositions-as-types
+reading~\cite{wadler2015propositions} restricts to inhabited
+propositional types), but a proof would have to argue against
+the full C++ overload-resolution and ADL machinery and lies outside
+the scope of this engineering existence-proof.  We report the
+observation; the explanation we leave to the type-systems
+literature.
+
+\paragraph{A forward claim, in its weakest defensible form.}
+As numerical workloads saturate available hardware, the marginal
+returns of brute-force optimisation are diminishing, and the lever
+with a different cost curve is specialisation at translation time
+rather than run time. That lever also has a sustainability
+dimension: cycles not spent at run time are watt-hours not drawn
+from the grid, and the machine-learning research community has begun
+to measure its compute footprint in exactly those
+terms~\cite{schwartz2020greenai}. The operating point at which the
+lever compounds most visibly is not the data centre but the edge:
+CPU-first and embedded machine-learning
+deployments~\cite{shi2016edge, david2021tflm}, where the problem
+topology is fixed, the runtime footprint is under hard constraint,
+and the toolchain of least resistance is the system's
+\texttt{clang++}. We do not prove here
+that axiomatic discipline applied at library scale yields a
+meaningful fraction of cycles back at either end of the spectrum;
+we claim only that the ingredients---compile-time verification,
+structural optimisation, ring-aware code generation, exact
+arithmetic carriers---are now assembled in mainstream C++23, and
+that the discipline is worth practising precisely because its
+payoffs accrue at scales larger than any single library. If even a
+small fraction of the arithmetic done in contemporary edge
+deployments---model-predictive control in vehicles, Kalman-style
+sensor fusion in robotics, gradient evaluations in micro-inference
+loops---ran against libraries whose algebraic invariants had been
+discharged upstream, the compounded effect would be difficult to
+dismiss. The shape of that opportunity is what Axiomatic Systems
+Programming claims. Whether the shape materialises into the numbers
+it suggests is an engineering question, and one the next decade of
+library authors will answer.
+
+\paragraph{Reproducibility under heterogeneous tooling.}
+The discipline this paper names is, deliberately, falsifiable.  The
+constraints under which it stays honest---textbook-anchored
+vocabulary, a named-module dependency graph, structural assertions
+discharged at translation time, a CI-policed test suite---do not
+depend on which agent typed any particular line of code, nor on the
+specific host language.  As Section~\ref{sec:axiomatic} notes, the
+technique transfers with modest adjustment to any
+strongly-typed-and-tested substrate whose type system can name a
+predicate over compile-time data and check it mechanically: Scala
+under refined types and a strict build, C\# with constrained
+generics under Roslyn analysers, Java with sealed types, strictly-
+typed Python under \texttt{mypy} or \texttt{pyright}.  C++23 is the
+worked example here---chosen because of the LLVM lever from
+discharged proof to optimised object code---but the discipline does
+not turn on it.  A practitioner adopting the same constraints and a
+comparable toolchain in 2026 should be able to produce comparable
+artefacts on comparable timescales, irrespective of host language or
+of how the keystrokes were generated.  The discipline is meant to
+outlast any particular generation of authoring tool---and,
+increasingly, of programming language.
+
+% ============================================================
+\section*{Acknowledgements}
+\label{sec:acknowledgements}
+% ============================================================
+
+The development of \texttt{dedekind} relied substantively on AI assistance throughout, and the writing of this paper did so as well.
+The disclosure here is the concrete instance of the cost-benefit-calculus claim in §\ref{sec:introduction}: that paragraph names the shift in the abstract; this one names how it shifted on this artefact.
+Per the ‹Programming› journal's policy on AI tools~\cite{programming_journal_ai_policy}, the use of these tools is acknowledged and disclosed; the AI systems named below are tools whose contribution is recorded here as assistance, not authorship.
+The author is a single human person, named in the byline, who bears full responsibility for content, scope, correctness, and editorial judgement.
+
+The primary assistant was Anthropic's \emph{Claude} family (Sonnet and Opus across the project's lifetime; the 1M-context Opus 4.7 variant for the most recent slices, where reproducibility against extended-context interactions matters), invoked through the Claude Code CLI.
+Google's Gemini was used for second-opinion structural critique on substantive mathematical claims (size-restriction notation, adjunction-encoding feasibility, foundational-vs-mechanical disentanglement).
+GitHub Copilot's pull-request reviewer was invoked on every PR for scope-vs-claim consistency checks at the prose / table / listing level.
+The assistance covered draft generation (prose, code, listings, tabular structured elements), structural refactoring (concept naming, partition placement, hub-and-spoke dispatch shape), test scaffolding, review-thread response drafting, and CI / GitHub workflow scaffolding.
+
+The pattern is visible at commit-level granularity in the public repository at \url{https://github.com/vincentk/dedekind}: every commit message, every pull-request review thread, and the public CI build log compose into a complete audit trail.
+Reviewers can inspect the assistance pattern at any commit.
+``Assisted'' rather than ``co-authored'' is the operative voice throughout, both for this paper and for the codebase it documents.
+
+\printbibliography
+
+\appendix
+
+\section{From Cardinality Pruning to Type-Directed Collapse}
 \label{sec:gap}
 
 Step back from the showcases for a moment. What is the pattern? In every
@@ -2516,425 +2936,6 @@ demonstrate that the library realises the axiom~$\to$~theorem
 discipline in C++23 today, on the carriers in the Rosetta tables of
 Section~\ref{sec:carrier-rosetta}.
 
-% ============================================================
-\section{Discussion}
-\label{sec:discussion}
-% ============================================================
-
-
-\subsection{The Compiler Wall: Where This Stops}
-\label{sec:compiler-wall}
-
-Treating \texttt{clang++} as a poor man's theorem prover is useful
-precisely because the compiler is bounded, predictable, and cheap. It
-is also, for the same reason, incapable of doing everything a real
-proof assistant would. The purpose of this subsection is to be honest
-about the wall and to name the \texttt{clang} knobs that push it back
-by a constant factor but cannot remove it.
-
-\paragraph{Compile-time budgets.}
-Every reduction in this paper is a variadic template, so two
-\texttt{clang} budgets matter: \emph{instantiation depth} (default
-$1024$, raised to $2048$ on the affected translation units; concepts
-and NTTP lambdas each add frames so the limit hits earlier than the
-naive count suggests) and \emph{\cppinline{constexpr} steps} (default
-$\sim\!10^6$, capping a single \cppinline{constexpr} evaluation).  A
-$2\times 2$ LP with four constraints is comfortably under both; a
-$2\times 2$ LP with thirty constraints ($\binom{30}{2} = 435$ active
-sets and nontrivial metadata) starts approaching the step limit.
-Raising the caps is possible (\cppinline{-ftemplate-depth=N},
-\cppinline{-fconstexpr-steps=N}) but trades compile time and resident
-memory for reach; the more principled answer is to stop at the
-boundary and hand off to a runtime solver --- which is exactly the
-case our centrepiece is \emph{not}.
-
-\paragraph{Combinatorial blowup is the pessimistic bound.}
-Compile-time vertex enumeration over $n$ halfspaces is, in the worst
-case, $\binom{n}{d}$ active-set solves for a $d$-dimensional LP
-(six for $n = 4$, $190$ for $n = 20$, nearly half a million for
-$n = 1000$).  Two facts soften this substantially in practice.  By
-the fundamental theorem of linear programming, the optimum of a
-$d$-dimensional LP is attained at a vertex with at most $d$ binding
-constraints, and on a handwritten polytope most of the syntactic
-constraint list is slack or redundant; the $\binom{n}{d}$ figure
-counts enumeration cost, not what any one vertex actually witnesses.
-Many of those redundancies are also \emph{statically} removable: the
-library's \cppinline{structured_and} dispatch already collapses
-linearly-dependent or contradictory halfspaces at compile time
-(Showcases~3 and~4), so the combinatorial term tracks the pruned
-count rather than the raw
-one.\footnote{Concretely:
-\cppinline{x > 5 && x > 7} collapses to \cppinline{x > 7} (stricter
-pivot wins); \cppinline{x > 5 && x < 2} collapses to $\varnothing$
-(contradiction); \cppinline{x > 3 && x < 5} over an integral carrier
-collapses to \cppinline{Singleton<4>}.  The 2D extension --- pruning
-halfspaces whose normals are linearly dependent --- follows the same
-dispatch pattern.}
-The instance regime this paper targets --- MPC steps with a handful
-of physical constraints, sensor-fusion guards, parametric
-configuration LPs --- rarely exceeds a few dozen raw constraints
-before pruning, and remains comfortably tractable.  Industrial-scale
-LP is emphatically not in scope; we do not claim it is.
-
-\paragraph{Active-set hints as the user-side escape valve.}
-Even within the compile-time regime, a user with domain knowledge of
-\emph{which} halfspaces bind at the optimum can short-circuit the
-$\binom{n}{d}$ enumeration entirely: because the constraint pack is
-already an NTTP list, instantiating
-\cppinline{maximize<T, cx, cy, H_i, H_j>()} with just the binding
-pair (instead of the full pack) is exactly the active-set hint, and
-the library evaluates only that single Cramer solve.  An explicit
-\cppinline{with_active_set<...>} API that takes the hint as a separate
-template argument and verifies feasibility against the full pack
-without re-enumerating is a natural successor surface, but the
-underlying NTTP-pack-as-hint mechanism is available today: dropping
-slack constraints from the syntactic list is the user's prerogative,
-and the combinatorial term then tracks the hinted count rather than
-the raw one.
-
-\subsection{Boundary Observations: An Axiom~\texorpdfstring{$\to$}{->}~Theorem Chain}
-\label{sec:boundary-observations}
-
-The preceding sections present the technique in an empirical sort of way: through worked showcases, IR artefacts, and concrete diagnostics.
-The library admits a stricter framing whose structural
-parallel is Wadler's \emph{Theorems for Free!}~\cite{wadler1989theorems}:
-parametricity gives the typed-lambda calculus theorems from type
-signatures alone; the dedekind library extends the move into
-\emph{algebraic} territory, where a carrier's axiomatic profile
-(declared via opt-in traits and concept witnesses) discharges
-carrier-level theorems at the type level. The empirical artefacts of
-the showcases are then \emph{realisations} of an underlying
-axiom~$\to$~theorem chain rather than the substance of the chain
-itself.
-
-\paragraph{Axioms as the engineer's honesty obligation.}
-A carrier's algebraic profile is asserted explicitly. Where the
-proof of an axiom is beyond what C++ concepts can quantify, the claim
-is made via an opt-in trait specialisation, and the engineer who
-declares the trait carries Wadler's
-\emph{propositions-as-types}~\cite{wadler2015propositions}
-obligation under the NSPE Code of Ethics canons III and IV (truthful
-public statements; faithful agency). The library ships several such
-opt-in surfaces:
-\cppinline{is_monic_arrow_v} for monomorphism declarations,
-\cppinline{is_initial_ring_v} for the initial-object reading of
-$\mathbb{Z}$, \cppinline{is_grothendieck_group_v} for the
-free-abelian-group reading, \cppinline{is_initial_f_algebra_v} for the
-NNO-as-initial-F-algebra reading, and a family of axiom-shape concepts
-including \cppinline{IsRing}, \cppinline{IsField},
-\cppinline{IsTotallyOrdered}, \cppinline{IsArchimedean}, and
-\cppinline{IsCyclicGroup}. Each is the engineer's claim, not a
-machine-discharged proof; the structural shape (signatures, closure,
-opt-in trait set to \texttt{true}) is what the type system can pin
-mechanically.
-
-\subsection{Related Work}
-\paragraph{Functional and dependently-typed approaches.}
-Agda~\cite{norell2007towards} and Coq provide dependent type systems in which set-membership
-proofs are first-class terms.  The expressiveness is greater than C++23, but the
-runtime model differs fundamentally: proof terms are erased at runtime, whereas
-\texttt{dedekind}'s structural pruning targets machine-code generation in a
-systems-programming context.
-Haskell~\cite{GHC2024} supports type-class-based structural reasoning, and libraries
-such as \texttt{algebra} encode ring and field hierarchies.  C++ templates differ in that
-they operate on concrete machine types (with hardware-level algebraic imperfections)
-rather than erased polymorphic dictionaries.
-
-\paragraph{Exact arithmetic.}
-The GNU Multiple Precision library (GMP) and \texttt{mpfr} support arbitrary-precision
-arithmetic at runtime.  \texttt{iRRAM}~\cite{mueller2001irram} and similar libraries
-implement computable real arithmetic.
-\texttt{dedekind} is complementary: exact reals (Dedekind cuts) are modelled
-\emph{intensionally as types}, and realization to a specific arithmetic backend is
-an explicit programmer choice.
-
-\paragraph{Set-builder type systems.}
-Refinement types~\cite{freeman1991refinement} attach predicates to types, enabling
-a form of set-builder representation in ML-family languages.
-Liquid Haskell~\cite{vazou2014refinement} extends Haskell with SMT-backed
-refinement predicates.
-\texttt{dedekind} achieves a subset of this functionality in standard C++23 without
-a custom type checker, using NTTP-embedded lambdas as the predicate carrier.
-
-\paragraph{Linear programming.}
-The standard LP toolchain---simplex~\cite{dantzig1963simplex} and
-interior-point methods~\cite{karmarkar1984interior} as implemented in
-Gurobi, CPLEX, GLPK, and related solvers---treats the problem instance
-as runtime data: the objective vector, constraint matrix, and right-hand
-side are passed to a solver that iterates to a vertex. \texttt{dedekind}
-sits orthogonally: problem instances whose size and coefficients are
-\emph{compile-time data} reduce via type-level vertex enumeration to
-the optimum as a typed constant (Section~\ref{sec:lp-centrepiece}), with
-the entire solver collapsing out of the emitted binary. This is not a
-replacement for runtime LP---for large, data-dependent instances the
-classical pipeline remains indispensable---but a complement for
-instances that appear during code generation (problem-shape metadata,
-compile-time configuration polytopes, template-parametric optimizer
-settings). Exact-rational arithmetic over $\mathbb{Q}$ connects the
-approach to the exact-LP literature~\cite{gleixner2016exact}; the
-specific contribution is the realisation at translation time with
-zero runtime overhead, witnessed in the emitted LLVM~IR fixtures.
-
-\paragraph{Automatic differentiation.}
-Runtime AD libraries such as Ceres~\cite{ceres-solver},
-Adept~\cite{hogan2014adept}, Sacado, dco/c++, and
-CasADi~\cite{andersson2019casadi} provide forward- and reverse-mode AD
-via expression templates or operator overloading on a specialised
-arithmetic type. The theoretical view taken by
-Elliott~\cite{elliott2018simple}---that forward-mode AD is the
-$(\text{value}, \text{tangent})$ product with chain-rule composition,
-not the dual-number object \emph{per se}---clarifies why the same
-reduction that solves the LP also computes its sensitivities when
-instantiated over the right ring (Section~\ref{sec:ad-elliott}).
-\texttt{dedekind}'s contribution is not a new AD algorithm but the
-observation that a single compile-time reduction, written once over an
-\texttt{HasRingOperators} carrier, serves as LP solver over $\mathbb{Q}$ and
-as forward-mode AD engine over $\mathbb{Q}[\varepsilon]/(\varepsilon^2)$
-with no extra code path.
-
-\paragraph{Embedded machine-learning runtimes and edge computing.}
-The embedded / edge-computing~\cite{shi2016edge} landscape has a
-mature runtime ecosystem that \texttt{dedekind} deliberately sits
-\emph{beside} rather than competes with. TensorFlow Lite
-Micro~\cite{david2021tflm} compiles models to a small-footprint
-interpreter targeted at microcontroller-class devices; ONNX Runtime
-and microTVM generate target-specific code from a model graph; the
-Eigen linear-algebra library is the de facto substrate for embedded
-numerics. These runtimes take the model as input and the target as
-fixed; they do not treat the hosting application's algebraic
-invariants as proof obligations for the C++ compiler to discharge.
-
-A deliberate choice on the linear-algebra backend is worth flagging
-here, since it connects the library's position to the
-abstract-naturals-versus-IEEE-numerics tension of
-Section~\ref{sec:numeric-tension}. Eigen~\cite{eigen2010} is
-mature, widely deployed, and excellent at what it targets---but it
-is also \emph{carrier-opinionated}: its matrix types default to
-\texttt{float} or \texttt{double} and its optimisations assume a
-field-like IEEE carrier. A natural path for \texttt{dedekind}'s
-runtime linear-algebra layer is instead toward
-GraphBLAS~\cite{kepner2011graphalgs, davis2019graphblas}, whose
-explicit \emph{(carrier, $+$, $\times$)} semiring parameterisation
-makes the ring-over-which-matrices-live a first-class configurable
-property. That matches the discipline this paper argues for:
-matrices over \cppinline{bool} (with OR/AND) are perfectly
-well-defined objects when inversion is not required, matrices over
-\cppinline{char} are useful for quantised embedded inference, and
-both sit naturally inside the \cppinline{HasRingOperators} /
-\cppinline{HasSemiringOperators} concept hierarchy. The cost of this
-generality is library complexity rather than carrier simplicity.
-The trade we advocate is correctness-and-performance (tight control
-over the ring structure) at the price of implementation effort,
-against Eigen's opposite trade---an ergonomic default carrier
-whose optimisations are largely locked to floating-point semantics.
-
-\texttt{dedekind} addresses a different surface: the \emph{inline}
-numerical primitives (Kalman filters, pose-estimation math, MPC
-steps, parametric optimisation) a robotics, automotive, or
-instrumentation engineer writes directly in their control loop. For
-these, a fixed-topology LP, a compile-specialised Kalman update,
-or an exact-rational sensor-fusion step expressed against
-\texttt{HasRingOperators} concepts exhibits three properties the
-model-runtime path does not aim at: a binary with no
-interpreter, a dependency graph no heavier than the system's
-\texttt{clang++}, and bit-for-bit deterministic arithmetic across
-platforms when the carrier is $\mathbb{Q}$. We see this as a
-complement to the runtime ecosystem, not a replacement: model-driven
-inference continues to belong to TFLite Micro and its siblings, while
-the numerical glue around such inference---the Kalman front-end, the
-control-loop LP, the gradient for online adaptation---is where
-Axiomatic Systems Programming is strongest.
-
-\paragraph{Data-pipeline DSLs.}
-Apache Spark, Flink, and the Python \texttt{pandas}/\texttt{polars} ecosystem
-provide declarative data pipelines with runtime domain checks. None of these
-ground their APIs in formal set theory, so intersections and filters are
-runtime pipeline operations rather than compile-time type invariants.
-\texttt{dedekind} is positioned one layer down: it is a systems-programming
-library that could in principle back such pipelines, but the contribution
-we demonstrate here is the compile-time reduction at the C++ layer itself.
-
-\paragraph{C++ template metaprogramming lineage.}
-Compile-time computation in C++ has a long tradition that
-\texttt{dedekind} builds on rather than supplants. Boost.Hana
-~\cite{chagnon2016hana} and \texttt{mp11}~\cite{pdimov2017mp11} provide
-compile-time heterogeneous containers and type-level algorithm
-support; Hana in particular already demonstrates concept-based
-structural dispatch at compile time and would be a natural
-lower-layer substrate for several of our combinators.
-CTRE~\cite{dusikova2018ctre} shows that serious computation
-(regular-expression matching, compiled to a type-level automaton)
-can live entirely inside the type system and emit optimised
-machine code; the shape of that reduction---intensional description
-to a named extensional object at translation time---is close kin to
-our halfspace and LP reductions, differing in subject matter but
-not in mechanism. Expression-template AD libraries including
-ENOKI~\cite{jakob2019enoki} and the runtime AD systems
-Ceres~\cite{ceres-solver}, Adept~\cite{hogan2014adept},
-and CasADi~\cite{andersson2019casadi} have carried pieces of the
-dual-number story into production workloads.
-
-\texttt{dedekind}'s position relative to this lineage is specific
-and narrow: it targets \emph{algebraic-semantic} content---ring
-homomorphisms, structural cardinality, ordering laws, the
-$(f, f')$ product as an Elliott~\cite{elliott2018simple} sibling---rather
-than the syntactic structure manipulation that is the traditional focus
-of TMP libraries. The contribution is not another metaprogramming
-trick but the claim, supported by worked reductions, that the
-\emph{discipline} of treating mainstream C++23 as a structural-gate
-theorem prover (Axiomatic Systems Programming) is now coherent enough
-to practise end-to-end.
-% ============================================================
-\section{Conclusion}
-\label{sec:conclusion}
-% ============================================================
-
-The thesis of this paper, once more: \emph{named algebraic structure
-at the type level, discharged by the compiler, narrows the gap
-between abstract mathematics and machine code without a separate
-proof assistant.} \texttt{dedekind} is the existence proof. Sets are
-rules rather than buckets; intensional descriptions defer
-materialisation to explicit boundaries; the LLVM backend carries
-discharged proofs through to object-code optimisation. The
-centrepiece existential proof (Section~\ref{sec:lp-centrepiece}) shows
-a textbook linear-programming instance reducing at compile time to
-its optimal vertex as a typed constant---the six candidate solves,
-six feasibility checks, and six objective comparisons vanish in the
-emitted IR. The same reduction over the dual-number ring recovers
-exact forward-mode sensitivities (Section~\ref{sec:ad-elliott}); at
-the linear-algebra layer it certifies the ring homomorphisms
-$\mathbb{C}, \mathbb{D} \hookrightarrow M_2(\mathbb{Q})$ as
-compile-time facts (Section~\ref{sec:lin-alg-embedding}). The
-companion repository's polynomial-calculus partitions discharge the
-Fundamental Theorem of Calculus at translation time on the same
-discipline. In every case the binary contains only literals.
-
-\paragraph{Axiomatic Systems Programming as a practised discipline.}
-The viewpoint we name in Section~\ref{sec:introduction}---treating
-\texttt{clang++} as a poor man's theorem prover, and the
-\texttt{HasRingOperators} concept as a proof obligation the carrier must
-discharge---is the paper's intended export. Taken seriously, it
-turns each algebraic invariant into a structural gate the compiler
-polices; taken habitually, it shifts the library author's default
-from ``runtime check'' to ``type-level obligation''. Three axes of
-type-directed collapse remain open (Section~\ref{sec:gap}): carrier
-tightening, smooth optimization, and lattice-law rewriting; each
-sits on the same NTTP-plus-concepts foundation as the halfspace and
-LP reductions demonstrated here.
-We leave them as worked targets for successor libraries that adopt
-the same discipline.
-
-\paragraph{An absent failure mode worth reporting.}
-A practical observation, offered honestly: across this library's
-development we did not encounter the two failure modes mainstream
-C++ template programming is famed for --- \emph{template
-instantiation explosion} (compile times that grow super-linearly
-with template depth) and \emph{template error hell} (diagnostics
-buried inside long substitution-failure cascades, far from the
-call site that triggered them).  Neither was a recurring concern.
-This is not nothing: both phenomena are well-documented hazards
-in production C++ template programming.  The disciplined fragment
-of §\ref{sec:axiomatic} (Table~\ref{tab:admissibility-rules})
-appears to rule out, by construction, the mechanisms that produce
-each.  The concept-constrained-template machinery fails at
-\emph{constraint-evaluation} time --- before template-body
-instantiation, with named-axiom diagnostics --- so the SFINAE-
-cascade error path is excluded.  Uniform parametric polymorphism
-(System-F-style; no specialisation-driven branching admitted in the
-public surface) keeps the set of compiled code paths linear in the
-number of callsites rather than combinatorial in the type tuples.
-And the bounded-instantiation-depth admissibility rule (capped at
-the carrier-lattice's three axes in the current surface) prevents
-the recursively-unfolding template-metaprogramming pattern that
-produces the explosion.  Whether this implies a \emph{formal}
-result --- a theorem that the disciplined fragment lies inside a
-decidable type-checking regime --- the paper does not claim.  The
-fragment is small enough that decidability is plausible
-(Lambek--Scott~\cite{lambek1988introduction} maps the constructive
-half to a CCC fragment; the propositions-as-types
-reading~\cite{wadler2015propositions} restricts to inhabited
-propositional types), but a proof would have to argue against
-the full C++ overload-resolution and ADL machinery and lies outside
-the scope of this engineering existence-proof.  We report the
-observation; the explanation we leave to the type-systems
-literature.
-
-\paragraph{A forward claim, in its weakest defensible form.}
-As numerical workloads saturate available hardware, the marginal
-returns of brute-force optimisation are diminishing, and the lever
-with a different cost curve is specialisation at translation time
-rather than run time. That lever also has a sustainability
-dimension: cycles not spent at run time are watt-hours not drawn
-from the grid, and the machine-learning research community has begun
-to measure its compute footprint in exactly those
-terms~\cite{schwartz2020greenai}. The operating point at which the
-lever compounds most visibly is not the data centre but the edge:
-CPU-first and embedded machine-learning
-deployments~\cite{shi2016edge, david2021tflm}, where the problem
-topology is fixed, the runtime footprint is under hard constraint,
-and the toolchain of least resistance is the system's
-\texttt{clang++}. We do not prove here
-that axiomatic discipline applied at library scale yields a
-meaningful fraction of cycles back at either end of the spectrum;
-we claim only that the ingredients---compile-time verification,
-structural optimisation, ring-aware code generation, exact
-arithmetic carriers---are now assembled in mainstream C++23, and
-that the discipline is worth practising precisely because its
-payoffs accrue at scales larger than any single library. If even a
-small fraction of the arithmetic done in contemporary edge
-deployments---model-predictive control in vehicles, Kalman-style
-sensor fusion in robotics, gradient evaluations in micro-inference
-loops---ran against libraries whose algebraic invariants had been
-discharged upstream, the compounded effect would be difficult to
-dismiss. The shape of that opportunity is what Axiomatic Systems
-Programming claims. Whether the shape materialises into the numbers
-it suggests is an engineering question, and one the next decade of
-library authors will answer.
-
-\paragraph{Reproducibility under heterogeneous tooling.}
-The discipline this paper names is, deliberately, falsifiable.  The
-constraints under which it stays honest---textbook-anchored
-vocabulary, a named-module dependency graph, structural assertions
-discharged at translation time, a CI-policed test suite---do not
-depend on which agent typed any particular line of code, nor on the
-specific host language.  As Section~\ref{sec:axiomatic} notes, the
-technique transfers with modest adjustment to any
-strongly-typed-and-tested substrate whose type system can name a
-predicate over compile-time data and check it mechanically: Scala
-under refined types and a strict build, C\# with constrained
-generics under Roslyn analysers, Java with sealed types, strictly-
-typed Python under \texttt{mypy} or \texttt{pyright}.  C++23 is the
-worked example here---chosen because of the LLVM lever from
-discharged proof to optimised object code---but the discipline does
-not turn on it.  A practitioner adopting the same constraints and a
-comparable toolchain in 2026 should be able to produce comparable
-artefacts on comparable timescales, irrespective of host language or
-of how the keystrokes were generated.  The discipline is meant to
-outlast any particular generation of authoring tool---and,
-increasingly, of programming language.
-
-% ============================================================
-\section*{Acknowledgements}
-\label{sec:acknowledgements}
-% ============================================================
-
-The development of \texttt{dedekind} relied substantively on AI assistance throughout, and the writing of this paper did so as well.
-The disclosure here is the concrete instance of the cost-benefit-calculus claim in §\ref{sec:introduction}: that paragraph names the shift in the abstract; this one names how it shifted on this artefact.
-Per the ‹Programming› journal's policy on AI tools~\cite{programming_journal_ai_policy}, the use of these tools is acknowledged and disclosed; the AI systems named below are tools whose contribution is recorded here as assistance, not authorship.
-The author is a single human person, named in the byline, who bears full responsibility for content, scope, correctness, and editorial judgement.
-
-The primary assistant was Anthropic's \emph{Claude} family (Sonnet and Opus across the project's lifetime; the 1M-context Opus 4.7 variant for the most recent slices, where reproducibility against extended-context interactions matters), invoked through the Claude Code CLI.
-Google's Gemini was used for second-opinion structural critique on substantive mathematical claims (size-restriction notation, adjunction-encoding feasibility, foundational-vs-mechanical disentanglement).
-GitHub Copilot's pull-request reviewer was invoked on every PR for scope-vs-claim consistency checks at the prose / table / listing level.
-The assistance covered draft generation (prose, code, listings, tabular structured elements), structural refactoring (concept naming, partition placement, hub-and-spoke dispatch shape), test scaffolding, review-thread response drafting, and CI / GitHub workflow scaffolding.
-
-The pattern is visible at commit-level granularity in the public repository at \url{https://github.com/vincentk/dedekind}: every commit message, every pull-request review thread, and the public CI build log compose into a complete audit trail.
-Reviewers can inspect the assistance pattern at any commit.
-``Assisted'' rather than ``co-authored'' is the operative voice throughout, both for this paper and for the codebase it documents.
-
-\printbibliography
-
-\appendix
 
 \section{Continuous Iteration towards the Faithful Translation}
 \label{sec:eventually}

--- a/docs/paper/paper.tex
+++ b/docs/paper/paper.tex
@@ -1996,8 +1996,6 @@ static_assert(!is_initial_f_algebra_v<LPSolutionIdF,
 \paragraph{Algorithmic scope.}
 The vertex-enumeration kernel is $O(\binom{m}{n})$ in the halfspace count --- the bubble sort of LP, well-suited to the small $m$ §5 exhibits and to compile-time enumeration generally, not to industrial constraint counts.
 The halfspace pack lives in NTTP space; §\ref{sec:compiler-wall} names this as the Compiler Wall, so the inner solver's choice does not move the wall it caps.
-A more elegant compile-time kernel is available in principle: Fourier-Motzkin elimination~\cite{schrijver1986theory} §12.2 reduces the polytope dimension by dimension, surfacing the singleton, empty, face, and ray regimes uniformly from the shape of the resulting interval, and is a catamorphism on the halfspace pack proper rather than the identity-functor shape recorded above.
-We leave the Fourier-Motzkin kernel to follow-up.
 
 
 \subsection{Forward-Mode AD as a Sibling Realisation of Compile-Time Derivatives}
@@ -2135,6 +2133,13 @@ underlying NTTP-pack-as-hint mechanism is available today: dropping
 slack constraints from the syntactic list is the user's prerogative,
 and the combinatorial term then tracks the hinted count rather than
 the raw one.
+
+\paragraph{Total dual integrality as the generalising forward-pointer.}
+The shipped §\ref{sec:lp-centrepiece} fast-path is a totally-unimodular sub-case: axis-aligned rows with entries in $\{-1, 0, +1\}$, so every square submatrix has determinant in $\{-1, 0, +1\}$ and the polytope is integer for every integer $b$ (Hoffman--Kruskal characterisation~\cite{schrijver1986theory} §19).
+The generalising theory is \emph{total dual integrality} (TDI): a system $Ax \leq b$ is TDI when the dual LP has an integer optimum for every integer objective, and TDI plus integer $b$ implies an integer polyhedron (Edmonds--Giles theorem~\cite{schrijver1986theory} §22).
+TUM is a TDI sub-case; the §5 fast-path is a sub-case of a sub-case.
+A construction-time \cppinline{IsTDI<Hs..., b>} concept would gate a richer kernel family at compile time, with box-TDI and network-matrix sub-classes as the practical landing where a network-Simplex variant carries a strongly-polynomial guarantee --- the corner of LP solving where the construction-time gate and polynomial Simplex coexist today.
+We do not pursue this generalisation in the paper; the shipped axis-aligned fast-path remains the cleaner structural exhibit of the smaller TUM sub-case it occupies, and the TDI gate is named here as the textbook-shaped forward direction rather than a slated implementation.
 
 \subsection{Boundary Observations: An Axiom~\texorpdfstring{$\to$}{->}~Theorem Chain}
 \label{sec:boundary-observations}

--- a/docs/paper/paper.tex
+++ b/docs/paper/paper.tex
@@ -1678,7 +1678,7 @@ review catching the claim.}
 \subsection{Linear Programming: \texorpdfstring{$\operatorname{argmax} : \mathbf{Set} \to \mathbf{Set}$}{argmax: Set → Set}}
 \label{sec:lp-centrepiece}
 
-Stare at a linear program for a moment.
+Look at a linear program for a moment.
 The polytope is an intersection of halfspaces --- a set, in exactly the comprehension sense of Section~\ref{sec:sets-rules}.
 The objective is a linear functional $U : F \to \mathbb{Q}$ on the ambient $F = \mathbb{Q}^2$.
 The optimum is also a set --- a singleton when there is a unique optimal vertex, the empty set when the polytope is infeasible, an unbounded ray when the objective is unbounded over the polytope, a face when the objective is parallel to an edge.
@@ -1826,12 +1826,9 @@ The library exposes \cppinline{maximize_axis_aligned_with_values<T>} and \cppinl
 The fixtures \texttt{showcase\_09b\_lp\_runtime\_residual.ll} and \texttt{showcase\_12b\_lp\_unimodular\_runtime.ll} pin the two kernels' signatures: the Cramer kernel retains its $2 \times 2$ \texttt{fdiv} / \texttt{fmuladd} active-set arithmetic and the loop's \texttt{phi} accumulators; the bit-ops kernel retains the loop's \texttt{phi} accumulators and the sign-driven \texttt{select} but emits no \texttt{mul} / \texttt{sdiv} / \texttt{udiv} on the integer carrier.
 The semantic-sanity checker enforces both shapes (\texttt{pruning-ir-fixture.py}).
 
-\paragraph{Strict close.}
-The previous paragraphs are the rough form; the strict form is mechanical.
 A \cppinline{static_assert} on the project's \cppinline{IsSet} concept (the ETCS-grade Set contract from Section~\ref{sec:sets-rules}) confirms that the input polytope, the singleton output, the empty output, and the runtime-discriminated output are all Sets in the same sense --- not merely structurally-similar wrappers but carriers of \cppinline{HasETCSAxioms} and \cppinline{IsCartesianClosed<CanonicalSetCCC<Ambient>>}.
 A further \cppinline{static_assert} on \cppinline{IsFAlgebra} confirms the catamorphism \emph{shape} on the output side: the output Set carries a structure map $F\langle X\rangle \to X$ for the identity endofunctor on its ambient category, with the active-set step closing over the halfspace pack.\footnote{The shape witness is mechanical.
-The catamorphism's uniqueness clause --- that \cppinline{argmax(G, U)} is the unique morphism into the output algebra from the initial halfspace-list F-algebra for $F(X) = 1 + \text{Halfspace} \times X$ --- is the engineer's honesty obligation per Pierce~\cite{pierce2002tapl} §5.4; the project's \cppinline{:f_algebra} partition reifies this as an opt-in \cppinline{is_initial_f_algebra_v} trait, deliberately defaulted to false here.
-The halfspace-list endofunctor's full \cppinline{IsEndofunctor} instantiation ($\Sigma_\text{cat}$, \cppinline{Shape}, $\varphi$) is a separate categorical task; see also Meijer-Fokkinga-Paterson's classical functional reading of fold under polynomial functors, and Bird's \emph{Algebra of Programming} for the textbook treatment.}
+The catamorphism's uniqueness clause --- that \cppinline{argmax(G, U)} is the unique morphism into the output algebra from the initial halfspace-list F-algebra for $F(X) = 1 + \text{Halfspace} \times X$ --- is the engineer's honesty obligation per Pierce~\cite{pierce2002tapl} §5.4; the project's \cppinline{:f_algebra} partition reifies this as an opt-in \cppinline{is_initial_f_algebra_v} trait, deliberately defaulted to false here.}
 
 % TODO (listings in follow-up commits to this PR):
 %   - Listing: regime × dispatch trigger × predicate × IR signature table.

--- a/docs/paper/paper.tex
+++ b/docs/paper/paper.tex
@@ -1670,7 +1670,7 @@ of \cite{nspe_ethics} are about; the type system's refusal to accept the
 \cppinline{IsRing<int>} witness is the mechanical analogue of an external
 review catching the claim.}
 
-\paragraph{$\mathbb{C}$ and $\mathbb{D}$ as Subrings of $M_2(\mathbb{Q})$.}
+\subsection{\texorpdfstring{$\mathbb{C}$ and $\mathbb{D}$}{ℂ and 𝔻} as Subrings of \texorpdfstring{$M_2(\mathbb{Q})$}{M₂(ℚ)}}
 \label{sec:lin-alg-embedding}
 
 The classical regular representations

--- a/docs/paper/paper.tex
+++ b/docs/paper/paper.tex
@@ -1826,6 +1826,25 @@ The library exposes \cppinline{maximize_axis_aligned_with_values<T>} and \cppinl
 The fixtures \texttt{showcase\_09b\_lp\_runtime\_residual.ll} and \texttt{showcase\_12b\_lp\_unimodular\_runtime.ll} pin the two kernels' signatures: the Cramer kernel retains its $2 \times 2$ \texttt{fdiv} / \texttt{fmuladd} active-set arithmetic and the loop's \texttt{phi} accumulators; the bit-ops kernel retains the loop's \texttt{phi} accumulators and the sign-driven \texttt{select} but emits no \texttt{mul} / \texttt{sdiv} / \texttt{udiv} on the integer carrier.
 The semantic-sanity checker enforces both shapes (\texttt{pruning-ir-fixture.py}).
 
+\begin{table}[htbp]
+\centering
+\caption{\textbf{Kernel $\times$ evaluation mode $\times$ output predicate $\times$ IR signature for \cppinline{argmax(G, U)}.}
+The kernel branch is selected by \cppinline{if constexpr} on three concepts over the halfspace pack and carrier (\cppinline{HasUnitRangeEntries}, \cppinline{IsAxisAlignedPolytope}, \cppinline{SuitableForAxisAlignedFastPath}); the evaluation mode is selected by the constexpr-ness of the call site.
+The four rows are exhibited by \texttt{showcase\_12}, \texttt{showcase\_12b}, \texttt{showcase\_09}, and \texttt{showcase\_09b} respectively, with their LLVM IR checked into the repository as fixtures.}
+\label{tab:lp-regime-dispatch}
+\small
+\begin{tabular}{@{}l l l l@{}}
+\toprule
+\textbf{Kernel} & \textbf{Mode} & \textbf{Output predicate} & \textbf{IR signature at \texttt{-O2}} \\
+\midrule
+Fast path & NTTP & \cppinline{Singleton2DPredicate} & \texttt{ret i64 K} (full fold) \\
+Fast path & \cppinline{std::span} & \cppinline{LPSolutionPredicate} & loop \texttt{phi} + sign-driven \texttt{select}; no \texttt{mul}/\texttt{sdiv}/\texttt{udiv} \\
+Generic Cramer & NTTP & \cppinline{Singleton2DPredicate} \emph{or} \cppinline{EmptyPredicate} & \texttt{ret i64 K} \emph{or} \texttt{static\_assert} refusal \\
+Generic Cramer & \cppinline{std::span} & \cppinline{LPSolutionPredicate} & $\binom{m}{n}$ active-set fold; $2{\times}2$ \texttt{fdiv} / \texttt{fmuladd} + \texttt{phi} \\
+\bottomrule
+\end{tabular}
+\end{table}
+
 A \cppinline{static_assert} on the project's \cppinline{IsSet} concept (the ETCS-grade Set contract from Section~\ref{sec:sets-rules}) confirms that the input polytope, the singleton output, the empty output, and the runtime-discriminated output are all Sets in the same sense --- not merely structurally-similar wrappers but carriers of \cppinline{HasETCSAxioms} and \cppinline{IsCartesianClosed<CanonicalSetCCC<Ambient>>}.
 A further \cppinline{static_assert} on \cppinline{IsFAlgebra} confirms the catamorphism \emph{shape} on the output side: the output Set carries a structure map $F\langle X\rangle \to X$ for the identity endofunctor on its ambient category, with the active-set step closing over the halfspace pack.\footnote{The shape witness is mechanical.
 The catamorphism's uniqueness clause --- that \cppinline{argmax(G, U)} is the unique morphism into the output algebra from the initial halfspace-list F-algebra for $F(X) = 1 + \text{Halfspace} \times X$ --- is the engineer's honesty obligation per Pierce~\cite{pierce2002tapl} §5.4; the project's \cppinline{:f_algebra} partition reifies this as an opt-in \cppinline{is_initial_f_algebra_v} trait, deliberately defaulted to false here.}
@@ -1837,7 +1856,6 @@ A more elegant compile-time kernel is available in principle: Fourier-Motzkin el
 We leave the Fourier-Motzkin kernel to follow-up.
 
 % TODO (listings in follow-up commits to this PR):
-%   - Listing: regime × dispatch trigger × predicate × IR signature table.
 %   - Listing: showcase_09b vs showcase_12b abbreviated IR side-by-side.
 %   - Listing: static_assert(IsSet<...>) chain on input and three output regimes.
 %   - Listing: static_assert(IsFAlgebra<...>) inline witness extract.

--- a/docs/paper/paper.tex
+++ b/docs/paper/paper.tex
@@ -2034,23 +2034,28 @@ bound by $\varepsilon$ (replace $x + y \leq 4$ with
 $x + y \leq 4 + \varepsilon$). The active set is unchanged for
 infinitesimal perturbation; the Cramer solve now runs over duals:
 
-% Source: src/test/cpp/modules/dedekind/optimization/lp_test.cpp
+% Source: src/test/cpp/modules/dedekind/optimization/lp_test.cpp (TEST_CASE "parametric LP over Dual<ℚ>")
 \begin{listing}[htbp]
-\caption{Parametric LP over \texttt{Dual<Rat>}. From \texttt{lp\_test.cpp}.}
+\caption{Parametric LP over \texttt{Dual<Rat>}: optimum + first-order sensitivity as one typed constant. The runtime entry \cppinline{maximize_with_values<D>} folds at translation time when its arguments are \cppinline{constexpr} (the bridge of §\ref{sec:lp-centrepiece}); instantiating at $T = $\cppinline{Dual<Rat>} discharges sensitivity through the chain rule of the ring laws. From \texttt{lp\_test.cpp} (TEST\_CASE ``parametric LP over Dual<ℚ>'').}
 \label{lst:lp-dual}
 \begin{cpp}
 
 using D = Dual<Rat>;
-using H1P = Halfspace2D<D, D{Rat{1L}}, D{Rat{1L}},
-                        D{Rat{4L}, Rat{1L}}>;  // bound = 4 + epsilon
-using H2D = Halfspace2D<D, D{Rat{2L}}, D{Rat{1L}}, D{Rat{6L}}>;
-using H3D = Halfspace2D<D, D{Rat{-1L}}, D{Rat{0L}}, D{Rat{0L}}>;
-using H4D = Halfspace2D<D, D{Rat{0L}}, D{Rat{-1L}}, D{Rat{0L}}>;
+constexpr std::array<HalfspaceTriple<D>, 4> polytope = {{
+    {D{Rat{1L}}, D{Rat{1L}}, D{Rat{4L}, Rat{1L}}}, // H1: x + y <= 4 + ε
+    {D{Rat{2L}}, D{Rat{1L}}, D{Rat{6L}}},          // H2: 2x + y <= 6
+    {D{Rat{-1L}}, D{Rat{0L}}, D{Rat{0L}}},         // H3: x >= 0
+    {D{Rat{0L}}, D{Rat{-1L}}, D{Rat{0L}}},         // H4:     y >= 0
+}};
+constexpr auto v = maximize_with_values<D>(
+    std::span<const HalfspaceTriple<D>>(polytope),
+    D{Rat{3L}}, D{Rat{2L}});
 
-constexpr auto v = maximize_value<D, D{Rat{3L}}, D{Rat{2L}},
-                                  H1P, H2D, H3D, H4D>();
-static_assert(v.x.val == Rat{2L}  && v.x.der == Rat{-1L});
-static_assert(v.y.val == Rat{2L}  && v.y.der == Rat{2L});
+// Optimum: x* = 2 − ε, y* = 2 + 2ε.  Set membership over Dual<Rat>
+// encodes primal AND first-order sensitivity in one compile-time check.
+constexpr auto opt = Vec2V<D>{D{Rat{2L}, Rat{-1L}},
+                              D{Rat{2L}, Rat{ 2L}}};
+static_assert(v.contains(opt));
 \end{cpp}
 \end{listing}
 

--- a/docs/paper/paper.tex
+++ b/docs/paper/paper.tex
@@ -1916,7 +1916,8 @@ Both fixtures are pinned by \texttt{pruning-ir-fixture.py}.}
 
 \begin{table}[htbp]
 \centering
-\caption{\textbf{Kernel $\times$ evaluation mode $\times$ output predicate $\times$ IR signature for \cppinline{argmax(G, U)}.}
+\caption{\textbf{Kernel $\times$ evaluation mode $\times$ output predicate $\times$ IR signature for the §\ref{sec:lp-centrepiece} LP combinator.}
+NTTP rows are reached through \cppinline{argmax(G, U)} (input polytope as a Set, output Set with NTTP-coordinate predicate); runtime rows through \cppinline{maximize_with_values<T>(span, cx, cy)} (input as \cppinline{std::span<HalfspaceTriple<T>>}, output Set with value-level predicate).
 The kernel branch is selected by \cppinline{if constexpr} on three concepts over the halfspace pack and carrier (\cppinline{HasUnitRangeEntries}, \cppinline{IsAxisAlignedPolytope}, \cppinline{SuitableForAxisAlignedFastPath}); the evaluation mode is selected by the constexpr-ness of the call site.
 The four rows are exhibited by \texttt{showcase\_12}, \texttt{showcase\_12b}, \texttt{showcase\_09}, and \texttt{showcase\_09b} respectively, with their LLVM IR checked into the repository as fixtures.}
 \label{tab:lp-regime-dispatch}
@@ -2122,17 +2123,17 @@ LP is emphatically not in scope; we do not claim it is.
 Even within the compile-time regime, a user with domain knowledge of
 \emph{which} halfspaces bind at the optimum can short-circuit the
 $\binom{n}{d}$ enumeration entirely: because the constraint pack is
-already an NTTP list, instantiating
-\cppinline{maximize<T, cx, cy, H_i, H_j>()} with just the binding
-pair (instead of the full pack) is exactly the active-set hint, and
-the library evaluates only that single Cramer solve.  An explicit
-\cppinline{with_active_set<...>} API that takes the hint as a separate
-template argument and verifies feasibility against the full pack
-without re-enumerating is a natural successor surface, but the
-underlying NTTP-pack-as-hint mechanism is available today: dropping
-slack constraints from the syntactic list is the user's prerogative,
-and the combinatorial term then tracks the hinted count rather than
-the raw one.
+already a meet of halfspace Sets, instantiating
+\cppinline{argmax(halfspace_set(H_i{}) & halfspace_set(H_j{}), U)} with
+just the binding pair (instead of the full pack) is exactly the
+active-set hint, and the library evaluates only that single Cramer
+solve.  An explicit \cppinline{with_active_set<...>} API that takes
+the hint as a separate template argument and verifies feasibility
+against the full pack without re-enumerating is a natural successor
+surface, but the underlying meet-as-hint mechanism is available today:
+dropping slack constraints from the syntactic meet is the user's
+prerogative, and the combinatorial term then tracks the hinted count
+rather than the raw one.
 
 \paragraph{Total dual integrality as the generalising forward-pointer.}
 The shipped §\ref{sec:lp-centrepiece} fast-path is a totally-unimodular sub-case: axis-aligned rows with entries in $\{-1, 0, +1\}$, so every square submatrix has determinant in $\{-1, 0, +1\}$ and the polytope is integer for every integer $b$ (Hoffman--Kruskal characterisation~\cite{schrijver1986theory} §19).
@@ -2724,10 +2725,11 @@ sketches that do not.
     under \#363.
   \item \textbf{Linear programming} (demonstrated in
     Section~\ref{sec:lp-centrepiece} and Section~\ref{sec:ad-elliott}).
-    \cppinline{maximize(c, polytope)} reduces, for compile-time-sized LPs, to
-    a typed vertex via type-level active-set enumeration, and the same
-    reduction over a dual-number carrier yields sensitivity analysis
-    with no extra code path: the solver is the compiler.
+    \cppinline{argmax(G, U)} reduces, for compile-time-sized LPs, to a
+    Set whose predicate type encodes the regime (singleton, empty, \ldots)
+    via type-level active-set enumeration; the same reduction over a
+    dual-number carrier yields sensitivity analysis with no extra code
+    path: the solver is the compiler.
   \item \textbf{Lattice-law rewriting.} Distributivity and
     absorption applied at the type level rewrite
     $(A \cup B) \cap \lnot A$ to $B \cap \lnot A$ \emph{before} local

--- a/docs/paper/paper.tex
+++ b/docs/paper/paper.tex
@@ -1670,6 +1670,55 @@ of \cite{nspe_ethics} are about; the type system's refusal to accept the
 \cppinline{IsRing<int>} witness is the mechanical analogue of an external
 review catching the claim.}
 
+\paragraph{$\mathbb{C}$ and $\mathbb{D}$ as Subrings of $M_2(\mathbb{Q})$.}
+\label{sec:lin-alg-embedding}
+
+The classical regular representations
+$a + bi \mapsto
+\bigl(\begin{smallmatrix} a & -b \\ b & a \end{smallmatrix}\bigr)$
+and
+$a + b\varepsilon \mapsto
+\bigl(\begin{smallmatrix} a & b \\ 0 & a \end{smallmatrix}\bigr)$
+are ring monomorphisms $\mathbb{C}, \mathbb{D} \hookrightarrow
+M_2(\mathbb{Q})$ (see, e.g., Lang~\cite{lang2002algebra}). The
+library claims both identities at the type level over
+\cppinline{Rational<SignedExtensionalCardinal<>>} and the compiler
+discharges them as bit-perfect \texttt{static\_assert}s, with the
+defining relation $\varepsilon^2 = 0$ lifting to
+$\bigl(\begin{smallmatrix} 0 & 1 \\ 0 & 0 \end{smallmatrix}\bigr)^2
+= 0$ on the matrix side.
+
+In the HSP vocabulary of §\ref{sec:axiomatic}, both embeddings are
+components of a single natural-transformation schema
+$\operatorname{Cplx}, \operatorname{Dual} \Rightarrow
+\operatorname{End}_R \circ \operatorname{Free}_2$ — composing an H
+operation (quotient by $(i^2+1)$ or $(\varepsilon^2)$) with a P
+operation ($\operatorname{Free}_2$) and the internal-hom
+$\operatorname{End}_R$ — with target $M_2(R) =
+\operatorname{End}_R(R^2)$.  The worked instance ships at $R =
+\mathbb{Q}$; the listing below discharges
+$\operatorname{Cplx}(\mathbb{Q}), \operatorname{Dual}(\mathbb{Q})
+\hookrightarrow M_2(\mathbb{Q})$ mechanically.
+
+% Source: src/test/cpp/modules/dedekind/linear_algebra/embeddings_test.cpp
+\begin{listing}[htbp]
+\caption{Matrix embeddings of complex and dual numbers over $\mathbb{Q}$.}
+\label{lst:lin-alg-embeddings}
+\begin{cpp}
+
+using Rat = Rational<SignedExtensionalCardinal<>>;
+constexpr Complex<Rat> z{Rat{1}, Rat{2}}, w{Rat{3}, Rat{-5}};
+constexpr Dual<Rat>    d{Rat{2}, Rat{3}}, e{Rat{-1}, Rat{5}};
+static_assert(as_matrix2x2(z + w) == as_matrix2x2(z) + as_matrix2x2(w));
+static_assert(as_matrix2x2(z * w) == as_matrix2x2(z) * as_matrix2x2(w));
+static_assert(as_matrix2x2(d + e) == as_matrix2x2(d) + as_matrix2x2(e));
+static_assert(as_matrix2x2(d * e) == as_matrix2x2(d) * as_matrix2x2(e));
+constexpr Dual<Rat> eps{Rat{0}, Rat{1}};
+static_assert(as_matrix2x2(eps) * as_matrix2x2(eps) == zero_matrix2x2_v<Rat>);
+\end{cpp}
+\end{listing}
+
+
 % ============================================================
 \section{Linear Algebra}
 \label{sec:linalg}
@@ -2015,54 +2064,6 @@ side effect of the ring laws. The same
 $\mathtt{Dual}\circ\mathtt{Complex}\circ\mathtt{Rational}$ layering
 extends to holomorphic automatic differentiation at compile time;
 we leave its application to a follow-up.
-
-\subsection{Linear Algebra: \texorpdfstring{$\mathbb{C}$ and $\mathbb{D}$}{ℂ and 𝔻} as Subrings of \texorpdfstring{$M_2(\mathbb{Q})$}{M₂(ℚ)}}
-\label{sec:lin-alg-embedding}
-
-The classical regular representations
-$a + bi \mapsto
-\bigl(\begin{smallmatrix} a & -b \\ b & a \end{smallmatrix}\bigr)$
-and
-$a + b\varepsilon \mapsto
-\bigl(\begin{smallmatrix} a & b \\ 0 & a \end{smallmatrix}\bigr)$
-are ring monomorphisms $\mathbb{C}, \mathbb{D} \hookrightarrow
-M_2(\mathbb{Q})$ (see, e.g., Lang~\cite{lang2002algebra}). The
-library claims both identities at the type level over
-\cppinline{Rational<SignedExtensionalCardinal<>>} and the compiler
-discharges them as bit-perfect \texttt{static\_assert}s, with the
-defining relation $\varepsilon^2 = 0$ lifting to
-$\bigl(\begin{smallmatrix} 0 & 1 \\ 0 & 0 \end{smallmatrix}\bigr)^2
-= 0$ on the matrix side.
-
-In the HSP vocabulary of §\ref{sec:axiomatic}, both embeddings are
-components of a single natural-transformation schema
-$\operatorname{Cplx}, \operatorname{Dual} \Rightarrow
-\operatorname{End}_R \circ \operatorname{Free}_2$ — composing an H
-operation (quotient by $(i^2+1)$ or $(\varepsilon^2)$) with a P
-operation ($\operatorname{Free}_2$) and the internal-hom
-$\operatorname{End}_R$ — with target $M_2(R) =
-\operatorname{End}_R(R^2)$.  The worked instance ships at $R =
-\mathbb{Q}$; the listing below discharges
-$\operatorname{Cplx}(\mathbb{Q}), \operatorname{Dual}(\mathbb{Q})
-\hookrightarrow M_2(\mathbb{Q})$ mechanically.
-
-% Source: src/test/cpp/modules/dedekind/linear_algebra/embeddings_test.cpp
-\begin{listing}[htbp]
-\caption{Matrix embeddings of complex and dual numbers over $\mathbb{Q}$.}
-\label{lst:lin-alg-embeddings}
-\begin{cpp}
-
-using Rat = Rational<SignedExtensionalCardinal<>>;
-constexpr Complex<Rat> z{Rat{1}, Rat{2}}, w{Rat{3}, Rat{-5}};
-constexpr Dual<Rat>    d{Rat{2}, Rat{3}}, e{Rat{-1}, Rat{5}};
-static_assert(as_matrix2x2(z + w) == as_matrix2x2(z) + as_matrix2x2(w));
-static_assert(as_matrix2x2(z * w) == as_matrix2x2(z) * as_matrix2x2(w));
-static_assert(as_matrix2x2(d + e) == as_matrix2x2(d) + as_matrix2x2(e));
-static_assert(as_matrix2x2(d * e) == as_matrix2x2(d) * as_matrix2x2(e));
-constexpr Dual<Rat> eps{Rat{0}, Rat{1}};
-static_assert(as_matrix2x2(eps) * as_matrix2x2(eps) == zero_matrix2x2_v<Rat>);
-\end{cpp}
-\end{listing}
 
 % ============================================================
 \section{Discussion}

--- a/docs/paper/references.bib
+++ b/docs/paper/references.bib
@@ -250,6 +250,15 @@
   isbn      = {9780262162098}
 }
 
+@book{schrijver1986theory,
+  author    = {Schrijver, Alexander},
+  title     = {Theory of Linear and Integer Programming},
+  series    = {Wiley-Interscience Series in Discrete Mathematics and Optimization},
+  publisher = {Wiley},
+  year      = {1986},
+  isbn      = {9780471982326}
+}
+
 @article{cardelli1996typesystems,
   author    = {Cardelli, Luca},
   title     = {Type systems},


### PR DESCRIPTION
## Summary

Phase B (#744) — rewrite of §5 under the Set-as-output framing landed in PR #751 (`d29d3798`).
Eleven docs-only commits across §5.1 (LP centrepiece), §5.2 (AD sibling migration), §5.3 (relocated to §4), §5.4 (relocated to appendix as §A), §5.1 prose trim, and §6.1 TDI forward-pointer.

## What landed

| Slice | Commit(s) | Effect |
|---|---|---|
| **1A** §5.1 prose | `e4d21b03` `52f70991` | Set-as-output rewrite; Listing 1 migrated to `argmax(G, U)` form; scope honesty on singleton/empty/ray/face |
| **1B** §5.1 close | `17ce5177` | "Algorithmic scope" paragraph; Schrijver bib entry |
| **1C** §5.1 structured elements | `c5715990` `56415a94` `258c9abb` | Dispatch table (kernel × mode × predicate × IR); side-by-side runtime IR listing; `IsSet` + `IsFAlgebra` static_assert listings |
| **2A** §5.4 → appendix | `f8b3983b` | Type-Directed Collapse subsection (lattice + 1D theorem + N-D conjecture + cross-cutting friction notes) moved wholesale to appendix as §A |
| **2B** §5.3 → §4 | `c763732d` | ℂ/𝔻 ↪ M₂(ℚ) matrix embedding moved to end of §4 (Algebraic Lattice) as paragraph block |
| **2C** §5.2 listing migration | `8c60537a` | `lst:lp-dual` migrated from defunct `maximize_value<>` → `maximize_with_values<D>(span, ...)` in constexpr context, matching `lp_test.cpp` verbatim |
| **2.5** §5.1 prose trim | `e4a3effa` | First delete-style commit; −10 net lines, −1pp main body; four duplication zones cut against the new structured elements |
| **2.6** TDI forward-pointer | `774d3d22` | Cut FM from §5.1 (off-axis recommendation per textbook factoring); add TDI generalising paragraph to §6.1 Compiler Wall (Hoffman–Kruskal + Edmonds–Giles; Schrijver §19 + §22) |

## Net effect

| | Pre-PR (main) | After this PR | Δ |
|---|:-:|:-:|:-:|
| Total PDF | 59pp | 61pp | +2pp |
| Main body | ~46pp | ~36pp | **−10pp** |
| Appendix | ~13pp | ~25pp | +12pp |
| §5 substantive content | §5.1 + §5.2 + §5.3 + §5.4 | §5.1 + §5.2 (others relocated) | — |

§5 reads cleanly as **§5.1 (LP centrepiece) + §5.2 (AD sibling)**; every abstract claim maps to one of these two.

## Deferred (separate slices)

- **Slice 3+**: §3 reshape, §1 + §2 refresh under Set-as-output, §6 + §7 polish — separate PRs.
- **Phase C** (#744): final restructure to ‹Programming›'s 22pp main + appendices budget.
- **Phase D** (#745): pre-submission QA — anti-AI-slop checklist, Acknowledgements, refs cleanup, editor pre-email.

## Test plan

- [x] Single-pass `lualatex -halt-on-error` builds clean (61pp; no undefined refs/cites/labels)
- [x] §5.1 + §5.2 read coherent end-to-end after trim + listing migration
- [x] Cross-references §5↔§6, §5↔§A (appendix), §5↔§4 all resolve
- [ ] CI green on `build-and-deploy`, `Analyze (actions/c-cpp/python)`, `CodeQL`, `codecov/patch`, `codecov/project` (in progress on slice 2.6 push)

🤖 Generated with [Claude Code](https://claude.com/claude-code)