### PR TITLE
feat(category, sequences): #753 §3 page-2 named samples + n-ary iterate + Arrow>>lambda adapter

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -101,7 +101,16 @@ function(add_dedekind_layer LAYER_NAME DEPENDS_ON)
     file(GLOB TEST_SOURCES   CONFIGURE_DEPENDS "src/test/cpp/modules/dedekind/${LAYER_NAME}/*_test.cpp")
 
     add_library(${LIB_TARGET} STATIC)
-    set_target_properties(${LIB_TARGET} PROPERTIES CXX_SCAN_FOR_MODULES ON)
+    set_target_properties(${LIB_TARGET} PROPERTIES
+        CXX_SCAN_FOR_MODULES ON
+        # The dedekind_* static libs are linked into the Python bindings .so
+        # (CMakeFiles/_dedekind target).  Without -fPIC, COMDAT-emitted
+        # symbols from inline-variable dynamic-init (esp. closures large
+        # enough to defeat std::function SBO, where the Path destructor is
+        # not inlined) produce non-PIC relocations that fail the .so link.
+        # POSITION_INDEPENDENT_CODE ON makes the static libs PIC-compatible
+        # for both shared-library linkage and the test executables.
+        POSITION_INDEPENDENT_CODE ON)
     target_sources(${LIB_TARGET} PUBLIC FILE_SET CXX_MODULES BASE_DIRS src/main/modules FILES ${MODULE_SOURCES})
     target_compile_options(${LIB_TARGET} PRIVATE ${DEDEKIND_WARNING_FLAGS})
     if(DEDEKIND_RUNTIME_COVERAGE_BRIDGES)

--- a/src/main/modules/dedekind/category/morphism.cppm
+++ b/src/main/modules/dedekind/category/morphism.cppm
@@ -809,6 +809,31 @@ constexpr auto operator>>(F&& f, G&& g) {
                          A x) constexpr { return g(f(std::move(x))); });
 }
 
+/**
+ * @brief @c operator>> with a callable on the RHS — auto-wraps the lambda
+ *        as @c arrow<F::Codomain> .
+ *
+ * @details Convenience overload so call sites can chain a typed Arrow with
+ * an inline lambda without per-site @c arrow<B>(λ) ceremony.  The lambda's
+ * Domain is deduced from the LHS Arrow's Codomain; its Codomain is deduced
+ * from the lambda's invoke result.  Equivalent to
+ * @c std::forward<F>(f) @c >> @c arrow<B>(std::forward<G>(g)) where
+ * @c B @c = @c F::Codomain — but spelled inline.
+ *
+ * @note Symmetric (lambda @c >> @c Arrow) adapter is intentionally NOT
+ * shipped: a bare lambda LHS has no fixed Domain, and inferring it from
+ * the RHS's Domain is fragile when the lambda is polymorphic.  Wrap the
+ * lambda explicitly via @c arrow<A>(λ) for that direction.
+ */
+export template <typename F, typename G>
+  requires IsSpokeArrow<std::decay_t<F>> && (!IsArrow<std::decay_t<G>>) &&
+           std::invocable<std::decay_t<G>&,
+                          const typename std::decay_t<F>::Codomain&>
+constexpr auto operator>>(F&& f, G&& g) {
+  using B = typename std::decay_t<F>::Codomain;
+  return std::forward<F>(f) >> arrow<B>(std::forward<G>(g));
+}
+
 /** @section morphism__Categorical_2 Verification: The Unit Laws (f ∘ id = f =
  * id ∘ f) */
 

--- a/src/main/modules/dedekind/sequences/path.cppm
+++ b/src/main/modules/dedekind/sequences/path.cppm
@@ -63,12 +63,26 @@ using namespace dedekind::order;
  * @brief A Frobenius-aware sequence F: ℕ → T.
  *
  * @tparam T The Species being enumerated.
+ * @tparam Cardinality The cardinality tag (@c ℵ_0 for infinite, @c Finite
+ *                     for bounded).
+ * @tparam Index The carrier of the @c Domain — any @c IsRingIntegral
+ *               inhabitant, defaulting to @c std::size_t for back-compat
+ *               with all existing call sites.  The Form-shaped choices
+ *               are @c dedekind::sets::ExtensionalCardinal<> (the
+ *               algebraically-certified finite ℕ carrier) and
+ *               @c dedekind::sets::Cardinality (the variant ℕ Form).
+ *               Closes the Sollbruchstelle documented on this struct
+ *               historically (@c "Path::Domain currently @c std::size_t —
+ *               once generalised, @c Cardinality is what makes the
+ *               @c size_t choice principled rather than accidental").
  */
-export template <typename T, typename Cardinality = ℵ_0>
+export template <typename T, typename Cardinality = ℵ_0,
+                 dedekind::order::IsRingIntegral Index = std::size_t>
 struct Path {
-  using Domain = std::size_t;
+  using Domain = Index;
   using Codomain = T;
   using cardinality_type = Cardinality;
+  using index_type = Index;
 
   struct const_iterator {
     using iterator_concept = std::random_access_iterator_tag;
@@ -177,13 +191,13 @@ struct Path {
   };
 
   /** @brief The underlying mapping f(n). */
-  std::function<T(std::size_t)> generator;
+  std::function<T(Index)> generator;
   std::size_t extent = 0;
 
-  constexpr Codomain operator()(Domain i) const { return generator(i); }
+  constexpr Codomain operator()(Index i) const { return generator(i); }
 
   /** @section path__Sequence_Interface */
-  constexpr T at(std::size_t i) const { return generator(i); }
+  constexpr T at(Index i) const { return generator(i); }
 
   /** @section path__Pointwise_Operators
    *
@@ -197,7 +211,7 @@ struct Path {
    */
 
   friend constexpr Path operator+(Path const& a, Path const& b) {
-    auto gen = [a, b](std::size_t i) { return a.at(i) + b.at(i); };
+    auto gen = [a, b](Index i) { return a.at(i) + b.at(i); };
     if constexpr (dedekind::sets::IsFinite<Cardinality>) {
       return Path{gen, std::min(a.size(), b.size())};
     } else {
@@ -206,7 +220,7 @@ struct Path {
   }
 
   friend constexpr Path operator-(Path const& a, Path const& b) {
-    auto gen = [a, b](std::size_t i) { return a.at(i) - b.at(i); };
+    auto gen = [a, b](Index i) { return a.at(i) - b.at(i); };
     if constexpr (dedekind::sets::IsFinite<Cardinality>) {
       return Path{gen, std::min(a.size(), b.size())};
     } else {
@@ -215,7 +229,7 @@ struct Path {
   }
 
   friend constexpr Path operator-(Path const& a) {
-    auto gen = [a](std::size_t i) { return -a.at(i); };
+    auto gen = [a](Index i) { return -a.at(i); };
     if constexpr (dedekind::sets::IsFinite<Cardinality>) {
       return Path{gen, a.size()};
     } else {
@@ -224,7 +238,7 @@ struct Path {
   }
 
   friend constexpr Path operator*(T const& s, Path const& a) {
-    auto gen = [s, a](std::size_t i) { return s * a.at(i); };
+    auto gen = [s, a](Index i) { return s * a.at(i); };
     if constexpr (dedekind::sets::IsFinite<Cardinality>) {
       return Path{gen, a.size()};
     } else {
@@ -233,7 +247,7 @@ struct Path {
   }
 
   friend constexpr Path operator*(Path const& a, T const& s) {
-    auto gen = [s, a](std::size_t i) { return a.at(i) * s; };
+    auto gen = [s, a](Index i) { return a.at(i) * s; };
     if constexpr (dedekind::sets::IsFinite<Cardinality>) {
       return Path{gen, a.size()};
     } else {
@@ -250,14 +264,14 @@ struct Path {
     using ResultPath = std::invoke_result_t<F, T>;
     using U = typename ResultPath::Codomain;
 
-    auto bound_generator = [m, f = std::forward<F>(f)](std::size_t n) {
+    auto bound_generator = [m, f = std::forward<F>(f)](Index n) {
       return f(m.at(n)).at(n);
     };
 
     if constexpr (dedekind::sets::IsFinite<Cardinality>) {
-      return Path<U, Cardinality>{bound_generator, m.size()};
+      return Path<U, Cardinality, Index>{bound_generator, m.size()};
     } else {
-      return Path<U, Cardinality>{bound_generator};
+      return Path<U, Cardinality, Index>{bound_generator};
     }
   }
 
@@ -269,24 +283,25 @@ struct Path {
   friend constexpr auto operator<<=(const Path& w, F&& f) {
     // Symmetry: F now maps Path<T> -> U.
     // We wrap that U back into a Path<U>.
-    using U = std::invoke_result_t<F, Path<T>>;
+    using U = std::invoke_result_t<F, Path<T, Cardinality, Index>>;
 
-    auto extended_generator = [w, f = std::forward<F>(f)](std::size_t n) {
+    auto extended_generator = [w, f = std::forward<F>(f)](Index n) {
       // Create the "sub-path" (suffix) starting at n, preserving cardinality.
       if constexpr (dedekind::sets::IsFinite<Cardinality>) {
-        const std::size_t suffix_size = (n < w.size()) ? w.size() - n : 0;
-        return f(Path<T, Cardinality>{
-            [w, n](std::size_t i) { return w.at(n + i); }, suffix_size});
+        const std::size_t suffix_size =
+            (n < w.size()) ? w.size() - static_cast<std::size_t>(n) : 0u;
+        return f(Path<T, Cardinality, Index>{
+            [w, n](Index i) { return w.at(n + i); }, suffix_size});
       } else {
-        return f(Path<T, Cardinality>{
-            [w, n](std::size_t i) { return w.at(n + i); }});
+        return f(Path<T, Cardinality, Index>{
+            [w, n](Index i) { return w.at(n + i); }});
       }
     };
 
     if constexpr (dedekind::sets::IsFinite<Cardinality>) {
-      return Path<U, Cardinality>{extended_generator, w.size()};
+      return Path<U, Cardinality, Index>{extended_generator, w.size()};
     } else {
-      return Path<U, Cardinality>{extended_generator};
+      return Path<U, Cardinality, Index>{extended_generator};
     }
   }
 
@@ -340,13 +355,16 @@ constexpr auto from_range(R&& range) {
       values->size()};
 }
 
-export template <typename T, typename Cardinality>
-constexpr auto prefix(const Path<T, Cardinality>& path, std::size_t length) {
+export template <typename T, typename Cardinality, typename Index>
+constexpr auto prefix(const Path<T, Cardinality, Index>& path,
+                      std::size_t length) {
   if constexpr (dedekind::sets::IsFinite<Cardinality>) {
     const std::size_t clamped = std::min(length, path.size());
-    return FinitePath<T>{[path](std::size_t i) { return path.at(i); }, clamped};
+    return Path<T, Finite, Index>{[path](Index i) { return path.at(i); },
+                                  clamped};
   } else {
-    return FinitePath<T>{[path](std::size_t i) { return path.at(i); }, length};
+    return Path<T, Finite, Index>{[path](Index i) { return path.at(i); },
+                                  length};
   }
 }
 
@@ -363,13 +381,14 @@ constexpr auto prefix(const Path<T, Cardinality>& path, std::size_t length) {
  * @return An infinite path with the same cardinality, representing the shifted
  *         tail.
  */
-export template <typename T, typename Cardinality>
+export template <typename T, typename Cardinality, typename Index>
   requires(!dedekind::sets::IsFinite<Cardinality>)
-constexpr auto drop(const Path<T, Cardinality>& path, std::size_t n) {
-  return Path<T, Cardinality>{[path, n](std::size_t i) {
-    assert(i <= std::numeric_limits<std::size_t>::max() - n &&
+constexpr auto drop(const Path<T, Cardinality, Index>& path, std::size_t n) {
+  return Path<T, Cardinality, Index>{[path, n](Index i) {
+    const auto j = static_cast<std::size_t>(i);
+    assert(j <= std::numeric_limits<std::size_t>::max() - n &&
            "drop index overflow: n + i exceeds size_t");
-    return path.at(n + i);
+    return path.at(static_cast<Index>(n + j));
   }};
 }
 
@@ -415,24 +434,23 @@ constexpr auto drop(const Path<T, Cardinality>& path, std::size_t n) {
  * categorical identity "a sequence IS a countable set of pairs" is
  * thus type-system-discharged rather than asserted in prose.
  */
-export template <typename T, typename Cardinality>
+export template <typename T, typename Cardinality, typename Index>
   requires std::equality_comparable<T>
-constexpr auto as_relation(const Path<T, Cardinality>& path) {
-  // Use @c Path::Domain (currently @c std::size_t ) as the relation's
-  // index carrier.  @c IsSequence requires its @c Domain to satisfy
-  // @c IsRingIntegral (see @c :order:halfspace:96 ); that algebraic gate
-  // — broad enough to admit both @c std::size_t and the @f$\mathbb{N}@f$
-  // Form @c dedekind::sets::Cardinality once @c Path::Domain is later
-  // generalised — is what makes the size_t choice principled rather than
-  // accidental, in line with the project's Form-before-Carrier posture.
-  using Index = typename Path<T, Cardinality>::Domain;
+constexpr auto as_relation(const Path<T, Cardinality, Index>& path) {
+  // The relation's index column type IS the Path's @c Domain (i.e.\
+  // its @c Index template parameter), gated on @c IsRingIntegral via
+  // the @c IsSequence concept.  After the Path::Domain lift, the
+  // Form-shaped choice @c dedekind::sets::ExtensionalCardinal<> flows
+  // through here without a @c size_t cast at the entry point — only
+  // the finite-cardinality bound check needs a size_t conversion (to
+  // compare against @c path.size() which is a stdlib container size).
   using Pair = std::pair<Index, T>;
   auto graph_pred = [path](const Pair& p) -> bool {
-    const auto i = static_cast<std::size_t>(p.first);
     if constexpr (dedekind::sets::IsFinite<Cardinality>) {
-      if (i >= path.size()) return false;
+      const auto i_size = static_cast<std::size_t>(p.first);
+      if (i_size >= path.size()) return false;
     }
-    return p.second == path.at(i);
+    return p.second == path.at(p.first);
   };
   return Set<Pair, ClassicalLogic, decltype(graph_pred)>{graph_pred};
 }
@@ -469,12 +487,12 @@ constexpr auto as_relation(const Path<T, Cardinality>& path) {
  * @see operator<<= — the co-Kleisli @c extend; @c δ(s) is @c extend with
  *      the context-identity, i.e.\ @c s @c <<= @c std::identity{}.
  */
-export template <typename T, typename Cardinality>
+export template <typename T, typename Cardinality, typename Index>
   requires(!dedekind::sets::IsFinite<Cardinality>)
-constexpr auto tails(const Path<T, Cardinality>& s)
-    -> Path<Path<T, Cardinality>, Cardinality> {
-  return Path<Path<T, Cardinality>, Cardinality>{
-      [s](std::size_t n) { return drop(s, n); }};
+constexpr auto tails(const Path<T, Cardinality, Index>& s)
+    -> Path<Path<T, Cardinality, Index>, Cardinality, Index> {
+  return Path<Path<T, Cardinality, Index>, Cardinality, Index>{
+      [s](Index n) { return drop(s, static_cast<std::size_t>(n)); }};
 }
 
 /**
@@ -652,20 +670,29 @@ constexpr Path<T> iterate(Op op, T seed_0, Ts... more_seeds) {
   // the operational form of @c path_functor::φ at this call site (see
   // the Sollbruchstelle docstring below for why @c φ remains unreified
   // at the Hub level).
+  //
+  // FIXME: the returned Path has the default @c Index @c = @c
+  // std::size_t .  Propagating the user-chosen @c Index Form through
+  // here requires a generic projection from arbitrary @c IsRingIntegral
+  // carriers to @c std::size_t (so the inner @c window_path.at can be
+  // queried).  Deferred to a follow-up: the conversion-from-Form
+  // arrow lives in @c :numbers:natural (downstream of this partition).
   auto window_path = iterate(initial, window_step);
   return Path<T>{
       [window_path](std::size_t k) -> T { return window_path.at(k)[0]; }};
 }
 
-export template <typename T, typename Cardinality, typename Pred>
+export template <typename T, typename Cardinality, typename Index,
+                 typename Pred>
   requires dedekind::sets::IsFinite<Cardinality> &&
            std::predicate<const std::decay_t<Pred>&, const T&>
-constexpr std::size_t count_if(const Path<T, Cardinality>& path, Pred&& pred) {
+constexpr std::size_t count_if(const Path<T, Cardinality, Index>& path,
+                               Pred&& pred) {
   auto predicate = std::forward<Pred>(pred);
   std::size_t count = 0;
 
   for (std::size_t i = 0; i < path.size(); ++i) {
-    if (std::invoke(predicate, path.at(i))) ++count;
+    if (std::invoke(predicate, path.at(static_cast<Index>(i)))) ++count;
   }
 
   return count;
@@ -701,9 +728,10 @@ constexpr std::optional<std::size_t> first_where(const FinitePath<T>& path,
   return std::nullopt;
 }
 
-export template <typename T, typename Cardinality, typename Pred>
+export template <typename T, typename Cardinality, typename Index,
+                 typename Pred>
   requires LogicalMap<Pred, T>
-constexpr auto exists(const Path<T, Cardinality>& path, Pred&& pred) {
+constexpr auto exists(const Path<T, Cardinality, Index>& path, Pred&& pred) {
   using Omega = OmegaOf<Pred, T>;
   using Logic = LogicOf<Omega>;
 
@@ -713,7 +741,8 @@ constexpr auto exists(const Path<T, Cardinality>& path, Pred&& pred) {
     if constexpr (dedekind::sets::IsFinite<Cardinality>) {
       if (i >= path.size()) break;
     }
-    witness = Logic::OR(witness, std::invoke(predicate, path.at(i)));
+    witness = Logic::OR(witness,
+                        std::invoke(predicate, path.at(static_cast<Index>(i))));
     if (witness == Logic::True)
       break;  // short-circuit: absorbing element found
   }
@@ -737,23 +766,26 @@ constexpr auto exists(const Path<T, Cardinality>& path, Pred&& pred) {
  * @param path Source infinite path.
  * @return     Infinite Path<U> where element i == f(prefix(path, i+1)).
  */
-export template <typename T, typename F>
+export template <typename T, typename Index, typename F>
   requires std::copy_constructible<std::decay_t<F>> &&
-           std::invocable<const std::decay_t<F>&, const FinitePath<T>&>
-constexpr auto scan(F&& f, const Path<T>& path) -> Path<
-    std::invoke_result_t<const std::decay_t<F>&, const FinitePath<T>&>> {
+           std::invocable<const std::decay_t<F>&, const Path<T, Finite, Index>&>
+constexpr auto scan(F&& f, const Path<T, ℵ_0, Index>& path) -> Path<
+    std::invoke_result_t<const std::decay_t<F>&, const Path<T, Finite, Index>&>,
+    ℵ_0, Index> {
   using Fn = std::decay_t<F>;
-  using U = std::invoke_result_t<const Fn&, const FinitePath<T>&>;
-  return Path<U>{[f = Fn(std::forward<F>(f)), path](std::size_t i) {
-    assert(i < std::numeric_limits<std::size_t>::max() &&
+  using U = std::invoke_result_t<const Fn&, const Path<T, Finite, Index>&>;
+  return Path<U, ℵ_0, Index>{[f = Fn(std::forward<F>(f)), path](Index i) {
+    const auto j = static_cast<std::size_t>(i);
+    assert(j < std::numeric_limits<std::size_t>::max() &&
            "scan index overflow: i+1 exceeds size_t");
-    return std::invoke(f, prefix(path, i + 1));
+    return std::invoke(f, prefix(path, j + 1));
   }};
 }
 
-export template <typename T, typename Cardinality, typename Pred>
+export template <typename T, typename Cardinality, typename Index,
+                 typename Pred>
   requires LogicalMap<Pred, T>
-constexpr auto forall(const Path<T, Cardinality>& path, Pred&& pred) {
+constexpr auto forall(const Path<T, Cardinality, Index>& path, Pred&& pred) {
   using Omega = OmegaOf<Pred, T>;
   using Logic = LogicOf<Omega>;
 
@@ -763,7 +795,8 @@ constexpr auto forall(const Path<T, Cardinality>& path, Pred&& pred) {
     if constexpr (dedekind::sets::IsFinite<Cardinality>) {
       if (i >= path.size()) break;
     }
-    witness = Logic::AND(witness, std::invoke(predicate, path.at(i)));
+    witness = Logic::AND(
+        witness, std::invoke(predicate, path.at(static_cast<Index>(i))));
     if (witness == Logic::False)
       break;  // short-circuit: absorbing element found
   }

--- a/src/main/modules/dedekind/sequences/path.cppm
+++ b/src/main/modules/dedekind/sequences/path.cppm
@@ -30,6 +30,7 @@
 module;
 
 #include <algorithm>
+#include <array>
 #include <cassert>
 #include <compare>
 #include <concepts>
@@ -566,6 +567,79 @@ constexpr auto iterate(T seed, Step&& step, std::size_t length) {
         return (*values)[i];
       },
       length};
+}
+
+/**
+ * @brief @c iterate(op, @c seed_0, @c ... @c , @c seed_{n-1}) — n-ary
+ *        recurrence: a binary (or @em n-ary) operator applied repeatedly to a
+ *        sliding window of @c n previous values.
+ *
+ * @details Captures the structural pattern @em "binary @em op @em applied
+ * @em recursively" that recurs across the codebase's recurrence exhibits
+ * (Fibonacci, Lucas, Tribonacci, GCD-via-Euclid, linear recurrences of any
+ * order).  The state is a sliding window of @c n carriers; each step
+ * computes @c op(w_0, @c ..., @c w_{n-1}) , shifts the window left by one,
+ * and writes the result into the last slot.  The read-back semantics:
+ * @c path.at(k) for @c k @c < @c n returns @c seed_k ; for @c k @c >= @c n
+ * returns the canonical @c k -th sequence element.
+ *
+ * @section path__nary_iterate_Use
+ *
+ * @code
+ *   // Fibonacci:         F_0 = 0, F_1 = 1, F_{n+2} = F_n + F_{n+1}
+ *   auto fib = iterate(std::plus<size_t>{}, size_t{0}, size_t{1});
+ *   // Path<size_t>, at(0)=0, at(1)=1, at(2)=1, at(3)=2, ...
+ *
+ *   // Tribonacci:        T_{n+3} = T_n + T_{n+1} + T_{n+2}
+ *   auto tri = iterate([](size_t a, size_t b, size_t c) { return a + b + c; },
+ *                      size_t{0}, size_t{0}, size_t{1});
+ *
+ *   // Generic linear recurrence (e.g. Pell's: P_{n+1} = 2 P_n + P_{n-1}):
+ *   auto pell = iterate([](size_t a, size_t b) { return 2*b + a; },
+ *                       size_t{0}, size_t{1});
+ * @endcode
+ *
+ * @section path__nary_iterate_NNO_Reading
+ *
+ * For @c n @c = @c 1 this overload reduces to the standard NNO morphism
+ * @c iterate(op, @c seed) above (in argument-swapped form) — the
+ * categorical NNO universal property says there exists a unique morphism
+ * @c ℕ @c → @c carrier making the recursion diagram commute (Mac Lane
+ * @em CWM §V.5), and this is the @c n -dimensional analogue.  The
+ * existing 2-argument @c iterate(seed, @c step) form stays alongside this
+ * overload for back-compat; new code is encouraged to prefer the n-ary
+ * form for any recurrence of order @c >= @c 2 .
+ *
+ * @tparam Op  An @c n -ary callable on @c T @c × @c ... @c × @c T returning
+ *             @c T (where @c n @c = @c 1 @c + @c sizeof...(Ts) ).
+ * @tparam T   The carrier of the recurrence; the codomain of @c op .
+ * @tparam Ts  Additional seed types convertible to @c T .
+ *
+ * @complexity @c O(k) per @c path.at(k) call — the lazy form walks from
+ * the seeds on each random access, just like the binary @c iterate above.
+ * The eager bounded sibling is a separate slice deferred until a use case
+ * surfaces.
+ */
+export template <typename Op, typename T, typename... Ts>
+  requires(std::convertible_to<Ts, T> && ...) &&
+          std::invocable<Op&, T, Ts...> &&
+          std::same_as<std::remove_cvref_t<std::invoke_result_t<Op&, T, Ts...>>,
+                       T>
+constexpr Path<T> iterate(Op op, T seed_0, Ts... more_seeds) {
+  constexpr std::size_t N = 1 + sizeof...(Ts);
+  std::array<T, N> initial{seed_0, T(more_seeds)...};
+  return Path<T>{[op = std::move(op), initial](std::size_t k) -> T {
+    if (k < N) return initial[k];
+    std::array<T, N> window = initial;
+    for (std::size_t i = N; i <= k; ++i) {
+      T next = [&]<std::size_t... Is>(std::index_sequence<Is...>) {
+        return op(window[Is]...);
+      }(std::make_index_sequence<N>{});
+      for (std::size_t j = 0; j + 1 < N; ++j) window[j] = window[j + 1];
+      window[N - 1] = next;
+    }
+    return window[N - 1];
+  }};
 }
 
 export template <typename T, typename Cardinality, typename Pred>

--- a/src/main/modules/dedekind/sequences/path.cppm
+++ b/src/main/modules/dedekind/sequences/path.cppm
@@ -627,19 +627,34 @@ export template <typename Op, typename T, typename... Ts>
                        T>
 constexpr Path<T> iterate(Op op, T seed_0, Ts... more_seeds) {
   constexpr std::size_t N = 1 + sizeof...(Ts);
-  std::array<T, N> initial{seed_0, T(more_seeds)...};
-  return Path<T>{[op = std::move(op), initial](std::size_t k) -> T {
-    if (k < N) return initial[k];
-    std::array<T, N> window = initial;
-    for (std::size_t i = N; i <= k; ++i) {
-      T next = [&]<std::size_t... Is>(std::index_sequence<Is...>) {
-        return op(window[Is]...);
-      }(std::make_index_sequence<N>{});
-      for (std::size_t j = 0; j + 1 < N; ++j) window[j] = window[j + 1];
-      window[N - 1] = next;
-    }
-    return window[N - 1];
-  }};
+  using Window = std::array<T, N>;
+  Window initial{seed_0, T(more_seeds)...};
+
+  // The window-transition is itself a recurrence on @c Window — shift
+  // left by one, write @c op(w_0, @c ..., @c w_{N-1}) into the last
+  // slot.  @c std::apply unpacks the array via the tuple-like protocol;
+  // @c std::shift_left is the C++20 in-place left shift.  No hand-rolled
+  // index_sequence ceremony, no manual element-by-element copy.
+  auto window_step = [op = std::move(op)](Window w) -> Window {
+    T next = std::apply(op, w);
+    std::shift_left(w.begin(), w.end(), 1);
+    w[N - 1] = next;
+    return w;
+  };
+
+  // The recurrence @em walker IS the existing binary @c iterate primitive
+  // (above) — n-ary @c iterate is its functorial projection.  Window
+  // @c k holds @c (F_k, @c F_{k+1}, @c ..., @c F_{k+N-1}) , so the
+  // canonical @c k -th element is @c window_path.at(k)[0] uniformly for
+  // any @c k @c >= @c 0 (the initial window's seeds being
+  // @c (F_0, @c ..., @c F_{N-1}) ).  No new for-loop, no @c if @c (k @c <
+  // @c N) branch — the math is direct.  The head-projection lambda is
+  // the operational form of @c path_functor::φ at this call site (see
+  // the Sollbruchstelle docstring below for why @c φ remains unreified
+  // at the Hub level).
+  auto window_path = iterate(initial, window_step);
+  return Path<T>{
+      [window_path](std::size_t k) -> T { return window_path.at(k)[0]; }};
 }
 
 export template <typename T, typename Cardinality, typename Pred>

--- a/src/main/modules/dedekind/sequences/path.cppm
+++ b/src/main/modules/dedekind/sequences/path.cppm
@@ -92,6 +92,12 @@ struct Path {
     using reference = T;
 
     const Path* owner = nullptr;
+    // Iteration position counter is @c std::size_t — the natural counter
+    // type for a @c std::random_access_iterator (the @c difference_type
+    // is @c std::ptrdiff_t , its index is its unsigned-twin).  This is a
+    // SIZE-shaped role, not an INDEX-shaped one; the call to @c
+    // owner->at(index) below implicit-converts size_t back to the Path's
+    // @c Index via the algebraic gate.
     std::size_t index = 0;
 
     constexpr reference operator*() const {
@@ -640,9 +646,9 @@ constexpr auto iterate(T seed, Step&& step, std::size_t length) {
  */
 export template <typename Op, typename T, typename... Ts>
   requires(std::convertible_to<Ts, T> && ...) &&
-          std::invocable<Op&, T, Ts...> &&
-          std::same_as<std::remove_cvref_t<std::invoke_result_t<Op&, T, Ts...>>,
-                       T>
+          std::invocable<const Op&, T, Ts...> &&
+          std::same_as<
+              std::remove_cvref_t<std::invoke_result_t<const Op&, T, Ts...>>, T>
 constexpr Path<T> iterate(Op op, T seed_0, Ts... more_seeds) {
   constexpr std::size_t N = 1 + sizeof...(Ts);
   using Window = std::array<T, N>;

--- a/src/main/modules/dedekind/sequences/samples.cppm
+++ b/src/main/modules/dedekind/sequences/samples.cppm
@@ -17,15 +17,27 @@
  * @subsection The_Sample_Pair
  *  - @c is_even @c : @c Path<Boolean> — gives the join row a heterogeneous
  *    codomain (@c ℕ @c × @c 𝔹 @c × @c ℕ ), exhibiting tuples-not-lists.
- *  - @c fibonacci @c : @c Path<std::size_t> — the canonical recurrence,
- *    formulated as @c iterate(seed, @c step) on the @em categorical
- *    @em product carrier @c ℕ @c × @c ℕ .  Step is an @c O(1)
- *    endomorphism @c (a, @c b) @c ↦ @c (b, @c a+b) ; the @c iterate
- *    primitive is the unique NNO morphism @c ℕ @c → @c carrier making
- *    Lawvere's NNO recursion diagram commute (Mac Lane @em CWM §V.5).
+ *  - @c fibonacci_of<T> @c : @c Path<T> — the canonical recurrence,
+ *    parameterised on the same algebraic gate @c IsSequence imposes on
+ *    its @c Domain (@c :order:halfspace:IsRingIntegral , the gate used
+ *    by #755 ): any ring-integral carrier @c T whose seed @c T(0u)
+ *    and @c T(1u) are well-formed.  The named default
+ *    @c fibonacci @c = @c fibonacci_of<std::size_t> is what the paper
+ *    listing cites; alternative @c IsRingIntegral carriers
+ *    (@c unsigned, @c ExtensionalCardinal<N>, …) instantiate the same
+ *    recurrence at no extra cost.  The variant @c Cardinality /
+ *    @c SignedCardinality Forms require the
+ *    @c finite_cardinality(0) factory rather than brace-init and are a
+ *    Sollbruchstelle for a future arrow-based zero/one oracle (post
+ *    #602's set-level embeddings).
+ *
+ *    The step @c (a, @c b) @c ↦ @c (b, @c a+b) is an @c O(1)
+ *    endomorphism on the categorical product @c T @c × @c T ; the
+ *    @c iterate primitive is the unique NNO morphism @c ℕ @c → @c carrier
+ *    making Lawvere's NNO recursion diagram commute (Mac Lane @em CWM §V.5).
  *
  * @build_order 5
- * @dependency dedekind.category, dedekind.sequences:path
+ * @dependency dedekind.category, dedekind.order, dedekind.sequences:path
  *
  * @copyright 2026 The Dedekind Authors
  * Licensed under the Apache License, Version 2.0.
@@ -44,6 +56,7 @@ module;
 export module dedekind.sequences:samples;
 
 import dedekind.category;
+import dedekind.order;
 import :path;
 
 namespace dedekind::sequences {
@@ -64,10 +77,12 @@ export inline const auto is_even =
     Path<Boolean>{[](std::size_t n) -> Boolean { return Boolean{n % 2 == 0}; }};
 
 /**
- * @brief The Fibonacci recurrence state stream: @c iterate on @c ℕ @c × @c ℕ .
+ * @brief The Fibonacci recurrence state stream: @c iterate on @c T @c × @c T
+ *        for any @c IsRingIntegral carrier @c T whose seed @c T(0u),
+ *        @c T(1u) are well-formed.
  *
  * @details The state carrier is the @em categorical @em product
- * @c ℕ @c × @c ℕ — modelled by @c std::pair<std::size_t, @c std::size_t>
+ * @c T @c × @c T — modelled by @c std::pair<T, @c T>
  * (witnessed by the @c IsProduct static_assert below, exactly as
  * @c Rational<Z> certifies @c IsProduct<Rational<Z>, @c Z, @c Z> and
  * @c Complex<R> certifies @c IsProduct<Complex<R>, @c R, @c R> ).  The
@@ -75,27 +90,61 @@ export inline const auto is_even =
  * that product.  @c iterate(seed, @c step) is the unique morphism
  * @c ℕ @c → @c state-carrier making Lawvere's NNO recursion diagram
  * commute (Mac Lane @em CWM §V.5).
+ *
+ * @tparam T Any @c IsRingIntegral inhabitant constructible from the
+ *           unsigned literals @c 0u and @c 1u — i.e.\ @c std::integral
+ *           types and the @c ExtensionalCardinal<N> /
+ *           @c SignedExtensionalCardinal<N> ring-integral carriers.
+ *           The variant @c Cardinality / @c SignedCardinality Forms are
+ *           excluded by the brace-init requirement; they need
+ *           @c finite_cardinality factories rather than @c T(0u)
+ *           (a Sollbruchstelle named in the partition docstring above).
  */
 static_assert(
     dedekind::category::IsProduct<std::pair<std::size_t, std::size_t>,
                                   std::size_t, std::size_t>,
-    "fibonacci's recurrence state IS the categorical product ℕ × ℕ via "
-    ".first / .second as the canonical projections π₁ and π₂.");
+    "fibonacci's recurrence state IS the categorical product T × T via "
+    ".first / .second as the canonical projections π₁ and π₂ (witnessed "
+    "here at the named-default T = std::size_t).");
 
-export inline const auto fibonacci_state = iterate(
-    std::pair<std::size_t, std::size_t>{0u, 1u},
-    [](const auto& p) { return std::pair{p.second, p.first + p.second}; });
+export template <dedekind::order::IsRingIntegral T>
+  requires requires {
+    T(0u);
+    T(1u);
+  }
+inline const auto fibonacci_state_of =
+    iterate(std::pair<T, T>{T(0u), T(1u)}, [](const auto& p) {
+      return std::pair{p.second, p.first + p.second};
+    });
 
 /**
- * @brief @c fibonacci @c : @c ℕ @c → @c ℕ — the canonical Fibonacci
- *        sequence @c 0, @c 1, @c 1, @c 2, @c 3, @c 5, @c 8, @c 13, ... .
+ * @brief @c fibonacci_of<T> @c : @c ℕ @c → @c T — the canonical Fibonacci
+ *        sequence @c 0, @c 1, @c 1, @c 2, @c 3, @c 5, @c 8, @c 13, ... in
+ *        carrier @c T .
  *
- * @details Read off the canonical sequence by projecting @c π₁ from
- * @c fibonacci_state : @c fibonacci(n) @c = @c π₁(fibonacci_state.at(n)) .
- * The recurrence step lives in @c fibonacci_state ; this Path is just
- * the first-component readout.
+ * @details Read off by projecting @c π₁ from @c fibonacci_state_of<T> :
+ * @c fibonacci_of<T>(n) @c = @c π₁(fibonacci_state_of<T>.at(n)) .  The
+ * recurrence step lives in @c fibonacci_state_of<T> ; this Path is the
+ * first-component readout.
  */
-export inline const auto fibonacci = Path<std::size_t>{
-    [](std::size_t n) -> std::size_t { return fibonacci_state.at(n).first; }};
+export template <dedekind::order::IsRingIntegral T>
+  requires requires {
+    T(0u);
+    T(1u);
+  }
+inline const auto fibonacci_of = Path<T>{
+    [](std::size_t n) -> T { return fibonacci_state_of<T>.at(n).first; }};
+
+/**
+ * @brief @c fibonacci_state @c , @c fibonacci — named defaults at
+ *        @c T @c = @c std::size_t for paper citation.
+ *
+ * @details The §3 page-2 listing cites these names directly:
+ * @c fibonacci is the canonical operational instantiation, and the same
+ * recurrence lifts to any other @c IsRingIntegral carrier via
+ * @c fibonacci_of<T> .
+ */
+export inline const auto& fibonacci_state = fibonacci_state_of<std::size_t>;
+export inline const auto& fibonacci = fibonacci_of<std::size_t>;
 
 }  // namespace dedekind::sequences

--- a/src/main/modules/dedekind/sequences/samples.cppm
+++ b/src/main/modules/dedekind/sequences/samples.cppm
@@ -26,11 +26,12 @@
  *    same algebraic gate @c IsSequence imposes on its @c Domain
  *    (@c :order:halfspace:IsRingIntegral , the gate used by #755 ): any
  *    ring-integral carrier @c T whose seed @c T(0u) and @c T(1u) are
- *    well-formed.  The named default
- *    @c fibonacci @c = @c fibonacci_of<std::size_t> is what the paper
- *    listing cites; alternative @c IsRingIntegral carriers
- *    (@c unsigned, @c ExtensionalCardinal<N>, …) instantiate the same
- *    recurrence at no extra cost.  The variant @c Cardinality /
+ *    well-formed.  The named default @c fibonacci @c = @c
+ *    fibonacci_of<ℕ_Form> (@c ExtensionalCardinal<> at the carrier
+ *    role) is what the paper listing cites; alternative
+ *    @c IsRingIntegral carriers (@c std::size_t , @c unsigned,
+ *    @c ExtensionalCardinal<N>, …) instantiate the same recurrence at
+ *    no extra cost.  The variant @c Cardinality /
  *    @c SignedCardinality Forms require the
  *    @c finite_cardinality(0) factory rather than brace-init and are a
  *    Sollbruchstelle for a future arrow-based zero/one oracle (post
@@ -66,11 +67,21 @@ export module dedekind.sequences:samples;
 
 import dedekind.category;
 import dedekind.order;
+import dedekind.sets;
 import :path;
 
 namespace dedekind::sequences {
 
 using namespace dedekind::category;
+
+// The project's algebraically-certified finite ℕ-Form carrier; lives in
+// @c :sets:cardinality (upstream of @c :sequences ).  Used here as the
+// Form-shaped @c Index parameter on Path<...> so the §3 page-2 anchor
+// reads in Form vocabulary at both the Domain and the carrier of the
+// recurrence — closing the @c "size_t again and again" call-site
+// friction that the architectural lift of @c Path::Domain to
+// @c IsRingIntegral made addressable.
+using ℕ_Form = dedekind::sets::ExtensionalCardinal<>;
 
 /**
  * @brief @c is_even @c : @c ℕ @c → @c 𝔹 — the parity sequence as a
@@ -82,8 +93,8 @@ using namespace dedekind::category;
  * triple, not a list of one type.  The join's @em tuples-not-lists
  * character is the page-2 beat the paper prose lands on.
  */
-export inline const auto is_even =
-    Path<Boolean>{[](std::size_t n) -> Boolean { return Boolean{n % 2 == 0}; }};
+export inline const auto is_even = Path<Boolean, ℵ_0, ℕ_Form>{
+    [](ℕ_Form n) -> Boolean { return Boolean{n % ℕ_Form{2u} == ℕ_Form{0u}}; }};
 
 /**
  * @brief @c fibonacci_of<T> @c : @c ℕ @c → @c T — the canonical Fibonacci
@@ -116,14 +127,20 @@ export template <dedekind::order::IsRingIntegral T>
 inline const auto fibonacci_of = iterate(std::plus<T>{}, T(0u), T(1u));
 
 /**
- * @brief @c fibonacci — named default at @c T @c = @c std::size_t for
- *        paper citation.
+ * @brief @c fibonacci — named default at @c T @c = @c ℕ_Form
+ *        (@c ExtensionalCardinal<> ) for paper citation.
  *
  * @details The §3 page-2 listing cites this name directly:
- * @c fibonacci is the canonical operational instantiation, and the same
+ * @c fibonacci is the Form-shaped canonical instantiation at the
+ * @em carrier role (@c T @c = @c ExtensionalCardinal<> ); the same
  * recurrence lifts to any other @c IsRingIntegral carrier via
- * @c fibonacci_of<T> .
+ * @c fibonacci_of<T> .  The returned @c Path 's @c Index defaults to
+ * @c std::size_t because the n-ary @c iterate primitive doesn't yet
+ * propagate the @c Index Form (see the @c FIXME in @c :sequences:path
+ * around the n-ary @c iterate body).  @c is_even above carries
+ * @c ExtensionalCardinal<> at the Path's @c Index role directly,
+ * since it constructs its @c Path explicitly.
  */
-export inline const auto& fibonacci = fibonacci_of<std::size_t>;
+export inline const auto& fibonacci = fibonacci_of<ℕ_Form>;
 
 }  // namespace dedekind::sequences

--- a/src/main/modules/dedekind/sequences/samples.cppm
+++ b/src/main/modules/dedekind/sequences/samples.cppm
@@ -18,10 +18,15 @@
  *  - @c is_even @c : @c Path<Boolean> — gives the join row a heterogeneous
  *    codomain (@c ℕ @c × @c 𝔹 @c × @c ℕ ), exhibiting tuples-not-lists.
  *  - @c fibonacci_of<T> @c : @c Path<T> — the canonical recurrence,
- *    parameterised on the same algebraic gate @c IsSequence imposes on
- *    its @c Domain (@c :order:halfspace:IsRingIntegral , the gate used
- *    by #755 ): any ring-integral carrier @c T whose seed @c T(0u)
- *    and @c T(1u) are well-formed.  The named default
+ *    expressed via the n-ary @c iterate(op, @c seeds...) primitive in
+ *    @c :sequences:path .  Fibonacci is the
+ *    @c iterate(std::plus<T>{}, @c T(0u), @c T(1u)) instance — one
+ *    named primitive, one binary operator, two seeds, no fanout /
+ *    projection / explicit-product-type ceremony.  Parameterised on the
+ *    same algebraic gate @c IsSequence imposes on its @c Domain
+ *    (@c :order:halfspace:IsRingIntegral , the gate used by #755 ): any
+ *    ring-integral carrier @c T whose seed @c T(0u) and @c T(1u) are
+ *    well-formed.  The named default
  *    @c fibonacci @c = @c fibonacci_of<std::size_t> is what the paper
  *    listing cites; alternative @c IsRingIntegral carriers
  *    (@c unsigned, @c ExtensionalCardinal<N>, …) instantiate the same
@@ -31,10 +36,13 @@
  *    Sollbruchstelle for a future arrow-based zero/one oracle (post
  *    #602's set-level embeddings).
  *
- *    The step @c (a, @c b) @c ↦ @c (b, @c a+b) is an @c O(1)
- *    endomorphism on the categorical product @c T @c × @c T ; the
- *    @c iterate primitive is the unique NNO morphism @c ℕ @c → @c carrier
- *    making Lawvere's NNO recursion diagram commute (Mac Lane @em CWM §V.5).
+ *    The structural pattern @em "binary @em op @em applied @em
+ *    recursively" is captured by the n-ary @c iterate primitive
+ *    directly; Tribonacci is @c iterate(λ(a,b,c). @c a+b+c, @c ...) ,
+ *    GCD-via-Euclid is @c iterate(modulus, @c ...) , etc.  @c iterate is
+ *    the unique NNO morphism @c ℕ @c → @c carrier making Lawvere's NNO
+ *    recursion diagram commute (Mac Lane @em CWM §V.5), generalised to
+ *    @c n -dimensional state.
  *
  * @build_order 5
  * @dependency dedekind.category, dedekind.order, dedekind.sequences:path
@@ -51,6 +59,7 @@
 module;
 
 #include <cstddef>
+#include <functional>
 #include <utility>
 
 export module dedekind.sequences:samples;
@@ -77,19 +86,18 @@ export inline const auto is_even =
     Path<Boolean>{[](std::size_t n) -> Boolean { return Boolean{n % 2 == 0}; }};
 
 /**
- * @brief The Fibonacci recurrence state stream: @c iterate on @c T @c × @c T
- *        for any @c IsRingIntegral carrier @c T whose seed @c T(0u),
- *        @c T(1u) are well-formed.
+ * @brief @c fibonacci_of<T> @c : @c ℕ @c → @c T — the canonical Fibonacci
+ *        sequence @c 0, @c 1, @c 1, @c 2, @c 3, @c 5, @c 8, @c 13, ... in
+ *        any @c IsRingIntegral carrier @c T .
  *
- * @details The state carrier is the @em categorical @em product
- * @c T @c × @c T — modelled by @c std::pair<T, @c T>
- * (witnessed by the @c IsProduct static_assert below, exactly as
- * @c Rational<Z> certifies @c IsProduct<Rational<Z>, @c Z, @c Z> and
- * @c Complex<R> certifies @c IsProduct<Complex<R>, @c R, @c R> ).  The
- * step @c (a, @c b) @c ↦ @c (b, @c a+b) is an @c O(1) endomorphism on
- * that product.  @c iterate(seed, @c step) is the unique morphism
- * @c ℕ @c → @c state-carrier making Lawvere's NNO recursion diagram
- * commute (Mac Lane @em CWM §V.5).
+ * @details Expressed via the n-ary @c iterate primitive (in
+ * @c :sequences:path ): Fibonacci is the @c (op @c = @c +, @c seeds @c =
+ * @c (0, @c 1)) instance of the "binary op applied recursively" pattern.
+ * The carrier @c T is parameterised on the same algebraic gate
+ * @c IsSequence imposes on its @c Domain (@c IsRingIntegral at
+ * @c :order:halfspace:96 ); the @c requires-clause narrows to those
+ * carriers where the unsigned-literal brace-init @c T(0u), @c T(1u) is
+ * well-formed.
  *
  * @tparam T Any @c IsRingIntegral inhabitant constructible from the
  *           unsigned literals @c 0u and @c 1u — i.e.\ @c std::integral
@@ -100,51 +108,22 @@ export inline const auto is_even =
  *           @c finite_cardinality factories rather than @c T(0u)
  *           (a Sollbruchstelle named in the partition docstring above).
  */
-static_assert(
-    dedekind::category::IsProduct<std::pair<std::size_t, std::size_t>,
-                                  std::size_t, std::size_t>,
-    "fibonacci's recurrence state IS the categorical product T × T via "
-    ".first / .second as the canonical projections π₁ and π₂ (witnessed "
-    "here at the named-default T = std::size_t).");
-
 export template <dedekind::order::IsRingIntegral T>
   requires requires {
     T(0u);
     T(1u);
   }
-inline const auto fibonacci_state_of =
-    iterate(std::pair<T, T>{T(0u), T(1u)}, [](const auto& p) {
-      return std::pair{p.second, p.first + p.second};
-    });
+inline const auto fibonacci_of = iterate(std::plus<T>{}, T(0u), T(1u));
 
 /**
- * @brief @c fibonacci_of<T> @c : @c ℕ @c → @c T — the canonical Fibonacci
- *        sequence @c 0, @c 1, @c 1, @c 2, @c 3, @c 5, @c 8, @c 13, ... in
- *        carrier @c T .
+ * @brief @c fibonacci — named default at @c T @c = @c std::size_t for
+ *        paper citation.
  *
- * @details Read off by projecting @c π₁ from @c fibonacci_state_of<T> :
- * @c fibonacci_of<T>(n) @c = @c π₁(fibonacci_state_of<T>.at(n)) .  The
- * recurrence step lives in @c fibonacci_state_of<T> ; this Path is the
- * first-component readout.
- */
-export template <dedekind::order::IsRingIntegral T>
-  requires requires {
-    T(0u);
-    T(1u);
-  }
-inline const auto fibonacci_of = Path<T>{
-    [](std::size_t n) -> T { return fibonacci_state_of<T>.at(n).first; }};
-
-/**
- * @brief @c fibonacci_state @c , @c fibonacci — named defaults at
- *        @c T @c = @c std::size_t for paper citation.
- *
- * @details The §3 page-2 listing cites these names directly:
+ * @details The §3 page-2 listing cites this name directly:
  * @c fibonacci is the canonical operational instantiation, and the same
  * recurrence lifts to any other @c IsRingIntegral carrier via
  * @c fibonacci_of<T> .
  */
-export inline const auto& fibonacci_state = fibonacci_state_of<std::size_t>;
 export inline const auto& fibonacci = fibonacci_of<std::size_t>;
 
 }  // namespace dedekind::sequences

--- a/src/main/modules/dedekind/sequences/samples.cppm
+++ b/src/main/modules/dedekind/sequences/samples.cppm
@@ -1,0 +1,101 @@
+/**
+ * @file dedekind/sequences/samples.cppm
+ * @partition :samples
+ * @brief Named §3 page-2 sample sequences: @c is_even and @c fibonacci.
+ *
+ * @section samples__Purpose
+ *
+ * Paper §3 page-2 (the @em Sequences half of "Sets and Sequences") leans
+ * on two named, non-trivial @c Path<T> sequences whose graphs can be
+ * lifted via @c as_relation and joined relationally — the page-2 anchor
+ * for the @em θ-join @em via @em σ @em ∘ @em × beat.  Naming them in
+ * code (rather than inlining anonymous closures at the call sites) lets
+ * the paper prose cite them by their exported names, and lets downstream
+ * exhibits (the §3 page-2 listing, the §3 reshape PR) compose against a
+ * stable surface.
+ *
+ * @subsection The_Sample_Pair
+ *  - @c is_even @c : @c Path<Boolean> — gives the join row a heterogeneous
+ *    codomain (@c ℕ @c × @c 𝔹 @c × @c ℕ ), exhibiting tuples-not-lists.
+ *  - @c fibonacci @c : @c Path<std::size_t> — the canonical recurrence,
+ *    formulated as @c iterate(seed, @c step) on the @em categorical
+ *    @em product carrier @c ℕ @c × @c ℕ .  Step is an @c O(1)
+ *    endomorphism @c (a, @c b) @c ↦ @c (b, @c a+b) ; the @c iterate
+ *    primitive is the unique NNO morphism @c ℕ @c → @c carrier making
+ *    Lawvere's NNO recursion diagram commute (Mac Lane @em CWM §V.5).
+ *
+ * @build_order 5
+ * @dependency dedekind.category, dedekind.sequences:path
+ *
+ * @copyright 2026 The Dedekind Authors
+ * Licensed under the Apache License, Version 2.0.
+ *
+ * @note "Examples are the schoolmaster of fools."
+ *       — Edmund Burke, @em Reflections @em on @em the @em Revolution
+ *       @em in @em France (1790), turning the saw on its head: well-chosen
+ *       examples are the schoolmaster of the wise, too.
+ */
+
+module;
+
+#include <cstddef>
+#include <utility>
+
+export module dedekind.sequences:samples;
+
+import dedekind.category;
+import :path;
+
+namespace dedekind::sequences {
+
+using namespace dedekind::category;
+
+/**
+ * @brief @c is_even @c : @c ℕ @c → @c 𝔹 — the parity sequence as a
+ *        @c Path<Boolean> .
+ *
+ * @details Boolean codomain by design: the §3 page-2 join exhibit
+ * relationally joins @c is_even and @c fibonacci on the shared index
+ * column, producing rows of type @c (ℕ, @c 𝔹, @c ℕ) — a heterogeneous
+ * triple, not a list of one type.  The join's @em tuples-not-lists
+ * character is the page-2 beat the paper prose lands on.
+ */
+export inline const auto is_even =
+    Path<Boolean>{[](std::size_t n) -> Boolean { return Boolean{n % 2 == 0}; }};
+
+/**
+ * @brief The Fibonacci recurrence state stream: @c iterate on @c ℕ @c × @c ℕ .
+ *
+ * @details The state carrier is the @em categorical @em product
+ * @c ℕ @c × @c ℕ — modelled by @c std::pair<std::size_t, @c std::size_t>
+ * (witnessed by the @c IsProduct static_assert below, exactly as
+ * @c Rational<Z> certifies @c IsProduct<Rational<Z>, @c Z, @c Z> and
+ * @c Complex<R> certifies @c IsProduct<Complex<R>, @c R, @c R> ).  The
+ * step @c (a, @c b) @c ↦ @c (b, @c a+b) is an @c O(1) endomorphism on
+ * that product.  @c iterate(seed, @c step) is the unique morphism
+ * @c ℕ @c → @c state-carrier making Lawvere's NNO recursion diagram
+ * commute (Mac Lane @em CWM §V.5).
+ */
+static_assert(
+    dedekind::category::IsProduct<std::pair<std::size_t, std::size_t>,
+                                  std::size_t, std::size_t>,
+    "fibonacci's recurrence state IS the categorical product ℕ × ℕ via "
+    ".first / .second as the canonical projections π₁ and π₂.");
+
+export inline const auto fibonacci_state = iterate(
+    std::pair<std::size_t, std::size_t>{0u, 1u},
+    [](const auto& p) { return std::pair{p.second, p.first + p.second}; });
+
+/**
+ * @brief @c fibonacci @c : @c ℕ @c → @c ℕ — the canonical Fibonacci
+ *        sequence @c 0, @c 1, @c 1, @c 2, @c 3, @c 5, @c 8, @c 13, ... .
+ *
+ * @details Read off the canonical sequence by projecting @c π₁ from
+ * @c fibonacci_state : @c fibonacci(n) @c = @c π₁(fibonacci_state.at(n)) .
+ * The recurrence step lives in @c fibonacci_state ; this Path is just
+ * the first-component readout.
+ */
+export inline const auto fibonacci = Path<std::size_t>{
+    [](std::size_t n) -> std::size_t { return fibonacci_state.at(n).first; }};
+
+}  // namespace dedekind::sequences

--- a/src/main/modules/dedekind/sequences/sequences.cppm
+++ b/src/main/modules/dedekind/sequences/sequences.cppm
@@ -16,6 +16,7 @@ export import :net;
 export import :convergence;
 export import :limits;
 export import :path;
+export import :samples;
 export import :tail;
 export import :curve;
 export import :ranges;

--- a/src/main/modules/dedekind/sets/cardinality.cppm
+++ b/src/main/modules/dedekind/sets/cardinality.cppm
@@ -196,6 +196,19 @@ struct ExtensionalCardinal {
     limbs[0] = static_cast<limb_type>(value);
   }
 
+  /** @brief Explicit projection to @c std::size_t — reads the
+   *         least-significant limb.  Used by @c :sequences:path 's helper
+   *         functions (@c drop , @c scan , @c <<= , @c tails ,
+   *         @c as_relation ) when the user-chosen @c Index Form needs to
+   *         flow through a @c std::size_t -valued counter
+   *         (e.g.\ @c std::vector::size() bound checks).  Marked
+   *         @c explicit so the projection IS-A choice the call site
+   *         makes — it does not implicitly silently lose upper limbs.
+   *
+   *  For @c N @c = @c 1 this is the full value.  For @c N @c > @c 1 the
+   *  upper limbs are dropped; the call site must ensure the value fits. */
+  explicit constexpr operator std::size_t() const noexcept { return limbs[0]; }
+
   constexpr friend bool operator==(const ExtensionalCardinal&,
                                    const ExtensionalCardinal&) = default;
 
@@ -701,6 +714,14 @@ struct SignedExtensionalCardinal {
     }
     magnitude =
         magnitude_type{static_cast<typename magnitude_type::limb_type>(value)};
+  }
+
+  /** @brief Explicit projection to @c std::size_t — reads the magnitude's
+   *         least-significant limb (sign is dropped).  Sibling to
+   *         @c ExtensionalCardinal::operator @c std::size_t() ; used at the
+   *         same call sites in @c :sequences:path 's helpers. */
+  explicit constexpr operator std::size_t() const noexcept {
+    return static_cast<std::size_t>(magnitude);
   }
 
   constexpr friend bool operator==(

--- a/src/test/cpp/modules/dedekind/category/morphism_test.cpp
+++ b/src/test/cpp/modules/dedekind/category/morphism_test.cpp
@@ -151,3 +151,41 @@ TEST_CASE("Category: Algebraic Proofs (Runtime Witnesses)",
     STATIC_CHECK(!HasArrowComposeOperators<int, int>);
   }
 }
+
+TEST_CASE("operator>> auto-wraps an RHS lambda as an arrow",
+          "[category][morphism][operator_compose][lambda_adapter]") {
+  // Convenience overload: arrow<A, B>(f) >> [](const B& b) { ... }
+  // wraps the RHS lambda via arrow<B>(λ) implicitly, tightening call
+  // sites that would otherwise spell out the per-site arrow<>{ }
+  // wrapping.
+
+  SECTION("Arrow >> lambda type-checks and composes correctly") {
+    const auto plus_one = arrow<int, int>([](int x) { return x + 1; });
+    const auto chain = plus_one >> [](const int& x) { return x * 2; };
+
+    STATIC_CHECK(IsArrow<decltype(chain)>);
+    REQUIRE(chain(3) == 8);    // (3 + 1) * 2 = 8
+    REQUIRE(chain(10) == 22);  // (10 + 1) * 2 = 22
+  }
+
+  SECTION("Chained Arrow >> lambda >> lambda lifts both lambdas") {
+    // Both RHS positions are bare lambdas; the adapter fires twice.
+    const auto base = arrow<int, int>([](int x) { return x + 1; });
+    const auto chain = base >> [](const int& x) { return x * 2; } >>
+                       [](const int& x) { return x - 3; };
+
+    STATIC_CHECK(IsArrow<decltype(chain)>);
+    REQUIRE(chain(5) == 9);  // ((5 + 1) * 2) - 3 = 9
+  }
+
+  SECTION("RHS lambda's codomain can differ from its domain") {
+    // Arrow<int, int> chained with a bool-returning lambda.
+    const auto plus_one = arrow<int, int>([](int x) { return x + 1; });
+    const auto is_even =
+        plus_one >> [](const int& x) -> bool { return x % 2 == 0; };
+
+    STATIC_CHECK(IsArrow<decltype(is_even)>);
+    REQUIRE(is_even(1) == true);   // (1 + 1) % 2 == 0
+    REQUIRE(is_even(2) == false);  // (2 + 1) % 2 != 0
+  }
+}

--- a/src/test/cpp/modules/dedekind/sequences/path_test.cpp
+++ b/src/test/cpp/modules/dedekind/sequences/path_test.cpp
@@ -254,3 +254,76 @@ TEST_CASE("Sequences: The Path to Continuity",
     REQUIRE(right.at(2) == 6);
   }
 }
+
+TEST_CASE("n-ary iterate(op, seeds...): the recurrence primitive",
+          "[sequences][path][iterate][nary]") {
+  // Captures "binary op applied recursively to a sliding window" as a
+  // single named primitive.  Fibonacci is the canonical n=2 + plus
+  // instance; Tribonacci is n=3; n=1 reduces to the standard NNO
+  // morphism (in argument-swapped form vs the existing iterate(seed,
+  // step)).
+  using std::size_t;
+
+  SECTION("n=2, op=plus: Fibonacci 0, 1, 1, 2, 3, 5, 8, 13, 21, 34") {
+    const auto fib = iterate(std::plus<size_t>{}, size_t{0}, size_t{1});
+    static_assert(IsSequence<decltype(fib)>);
+    REQUIRE(fib.at(0) == 0u);
+    REQUIRE(fib.at(1) == 1u);
+    REQUIRE(fib.at(2) == 1u);
+    REQUIRE(fib.at(3) == 2u);
+    REQUIRE(fib.at(4) == 3u);
+    REQUIRE(fib.at(5) == 5u);
+    REQUIRE(fib.at(6) == 8u);
+    REQUIRE(fib.at(7) == 13u);
+    REQUIRE(fib.at(8) == 21u);
+    REQUIRE(fib.at(9) == 34u);
+  }
+
+  SECTION("n=3: Tribonacci 0, 0, 1, 1, 2, 4, 7, 13, 24") {
+    const auto tri =
+        iterate([](size_t a, size_t b, size_t c) { return a + b + c; },
+                size_t{0}, size_t{0}, size_t{1});
+    REQUIRE(tri.at(0) == 0u);
+    REQUIRE(tri.at(1) == 0u);
+    REQUIRE(tri.at(2) == 1u);
+    REQUIRE(tri.at(3) == 1u);
+    REQUIRE(tri.at(4) == 2u);
+    REQUIRE(tri.at(5) == 4u);
+    REQUIRE(tri.at(6) == 7u);
+    REQUIRE(tri.at(7) == 13u);
+    REQUIRE(tri.at(8) == 24u);
+  }
+
+  SECTION("n=2, Pell's recurrence P_{n+1} = 2 P_n + P_{n-1}") {
+    // P_0=0, P_1=1, P_2=2, P_3=5, P_4=12, P_5=29, P_6=70
+    const auto pell = iterate([](size_t a, size_t b) { return 2 * b + a; },
+                              size_t{0}, size_t{1});
+    REQUIRE(pell.at(0) == 0u);
+    REQUIRE(pell.at(1) == 1u);
+    REQUIRE(pell.at(2) == 2u);
+    REQUIRE(pell.at(3) == 5u);
+    REQUIRE(pell.at(4) == 12u);
+    REQUIRE(pell.at(5) == 29u);
+    REQUIRE(pell.at(6) == 70u);
+  }
+
+  SECTION(
+      "n=1 reduces to the unary NNO morphism (arg-swapped vs binary form)") {
+    // iterate(succ, 0) is the n=1 form of the n-ary overload; it should
+    // produce the same canonical sequence 0, 1, 2, 3, ... as the binary
+    // iterate(0, succ) form.
+    const auto naturals = iterate([](size_t n) { return n + 1; }, size_t{0});
+    REQUIRE(naturals.at(0) == 0u);
+    REQUIRE(naturals.at(1) == 1u);
+    REQUIRE(naturals.at(5) == 5u);
+    REQUIRE(naturals.at(42) == 42u);
+  }
+
+  SECTION("Op deduction works without explicit type parameter") {
+    // The carrier T deduces from the seeds; no explicit <T> ceremony at
+    // the call site (the page-2 paper §3 claim).
+    const auto fib_int = iterate(std::plus<int>{}, 0, 1);
+    REQUIRE(fib_int.at(7) == 13);
+    REQUIRE(fib_int.at(9) == 34);
+  }
+}

--- a/src/test/cpp/modules/dedekind/sequences/samples_test.cpp
+++ b/src/test/cpp/modules/dedekind/sequences/samples_test.cpp
@@ -23,27 +23,36 @@ using namespace dedekind::category;
 using namespace dedekind::sequences;
 using namespace dedekind::sets;
 
+// Use the same Form-shaped ℕ alias the samples partition exports —
+// @c ExtensionalCardinal<> is the algebraically-certified finite ℕ
+// carrier, and after #756's @c Path::Domain lift it flows through
+// at both the Index and the carrier roles on @c is_even and
+// @c fibonacci .  Test literals on the value side use this alias to
+// avoid the @c (unsigned @c int) @c vs @c (ExtensionalCardinal<>)
+// implicit-conversion ambiguity that bare @c 0u literals trigger.
+using ℕ_Form = ExtensionalCardinal<>;
+
 TEST_CASE("is_even pins the parity sequence on its first six indices",
           "[sequences][samples][is_even]") {
-  REQUIRE(is_even.at(0) == Boolean{true});
-  REQUIRE(is_even.at(1) == Boolean{false});
-  REQUIRE(is_even.at(2) == Boolean{true});
-  REQUIRE(is_even.at(3) == Boolean{false});
-  REQUIRE(is_even.at(4) == Boolean{true});
-  REQUIRE(is_even.at(5) == Boolean{false});
+  REQUIRE(is_even.at(ℕ_Form{0u}) == Boolean{true});
+  REQUIRE(is_even.at(ℕ_Form{1u}) == Boolean{false});
+  REQUIRE(is_even.at(ℕ_Form{2u}) == Boolean{true});
+  REQUIRE(is_even.at(ℕ_Form{3u}) == Boolean{false});
+  REQUIRE(is_even.at(ℕ_Form{4u}) == Boolean{true});
+  REQUIRE(is_even.at(ℕ_Form{5u}) == Boolean{false});
 }
 
 TEST_CASE("fibonacci pins the canonical sequence 0, 1, 1, 2, 3, 5, 8, 13",
           "[sequences][samples][fibonacci]") {
   // Canonical Fibonacci F_0 = 0, F_1 = 1, F_{n+2} = F_n + F_{n+1}.
-  REQUIRE(fibonacci.at(0) == 0u);
-  REQUIRE(fibonacci.at(1) == 1u);
-  REQUIRE(fibonacci.at(2) == 1u);
-  REQUIRE(fibonacci.at(3) == 2u);
-  REQUIRE(fibonacci.at(4) == 3u);
-  REQUIRE(fibonacci.at(5) == 5u);
-  REQUIRE(fibonacci.at(6) == 8u);
-  REQUIRE(fibonacci.at(7) == 13u);
+  REQUIRE(fibonacci.at(0) == ℕ_Form{0u});
+  REQUIRE(fibonacci.at(1) == ℕ_Form{1u});
+  REQUIRE(fibonacci.at(2) == ℕ_Form{1u});
+  REQUIRE(fibonacci.at(3) == ℕ_Form{2u});
+  REQUIRE(fibonacci.at(4) == ℕ_Form{3u});
+  REQUIRE(fibonacci.at(5) == ℕ_Form{5u});
+  REQUIRE(fibonacci.at(6) == ℕ_Form{8u});
+  REQUIRE(fibonacci.at(7) == ℕ_Form{13u});
 }
 
 TEST_CASE("fibonacci_of<T> is Form-generic across IsRingIntegral carriers",
@@ -65,25 +74,30 @@ TEST_CASE("fibonacci_of<T> is Form-generic across IsRingIntegral carriers",
 TEST_CASE("as_relation(is_even) graph membership",
           "[sequences][samples][as_relation]") {
   const auto rel = as_relation(is_even);
-  // On-graph pairs: (n, is_even(n)).
-  REQUIRE(rel(std::pair<std::size_t, Boolean>{0u, Boolean{true}}));
-  REQUIRE(rel(std::pair<std::size_t, Boolean>{3u, Boolean{false}}));
-  REQUIRE(rel(std::pair<std::size_t, Boolean>{42u, Boolean{true}}));
+  // On-graph pairs: (n, is_even(n)).  Pair index column is ℕ (Form-
+  // shaped) because @c is_even now carries @c ExtensionalCardinal<>
+  // at its Path's @c Index role.
+  REQUIRE(rel(std::pair<ℕ_Form, Boolean>{ℕ_Form{0u}, Boolean{true}}));
+  REQUIRE(rel(std::pair<ℕ_Form, Boolean>{ℕ_Form{3u}, Boolean{false}}));
+  REQUIRE(rel(std::pair<ℕ_Form, Boolean>{ℕ_Form{42u}, Boolean{true}}));
   // Off-graph (wrong value at the index): rejected.
-  REQUIRE_FALSE(rel(std::pair<std::size_t, Boolean>{0u, Boolean{false}}));
-  REQUIRE_FALSE(rel(std::pair<std::size_t, Boolean>{3u, Boolean{true}}));
+  REQUIRE_FALSE(rel(std::pair<ℕ_Form, Boolean>{ℕ_Form{0u}, Boolean{false}}));
+  REQUIRE_FALSE(rel(std::pair<ℕ_Form, Boolean>{ℕ_Form{3u}, Boolean{true}}));
 }
 
 TEST_CASE("as_relation(fibonacci) graph membership",
           "[sequences][samples][as_relation]") {
   const auto rel = as_relation(fibonacci);
-  // On-graph: (n, F_n).
-  REQUIRE(rel(std::pair<std::size_t, std::size_t>{0u, 0u}));
-  REQUIRE(rel(std::pair<std::size_t, std::size_t>{7u, 13u}));
-  REQUIRE(rel(std::pair<std::size_t, std::size_t>{10u, 55u}));
+  // On-graph: (n, F_n).  Both pair components carry ℕ — index because
+  // @c fibonacci 's Path Index is @c std::size_t (n-ary @c iterate
+  // FIXME), value because @c fibonacci 's carrier @c T is
+  // @c ExtensionalCardinal<> .
+  REQUIRE(rel(std::pair<std::size_t, ℕ_Form>{0u, ℕ_Form{0u}}));
+  REQUIRE(rel(std::pair<std::size_t, ℕ_Form>{7u, ℕ_Form{13u}}));
+  REQUIRE(rel(std::pair<std::size_t, ℕ_Form>{10u, ℕ_Form{55u}}));
   // Off-graph (wrong value): rejected.
-  REQUIRE_FALSE(rel(std::pair<std::size_t, std::size_t>{7u, 14u}));
-  REQUIRE_FALSE(rel(std::pair<std::size_t, std::size_t>{10u, 21u}));
+  REQUIRE_FALSE(rel(std::pair<std::size_t, ℕ_Form>{7u, ℕ_Form{14u}}));
+  REQUIRE_FALSE(rel(std::pair<std::size_t, ℕ_Form>{10u, ℕ_Form{21u}}));
 }
 
 TEST_CASE("θ-join via σ∘× on (is_even, fibonacci) exhibits a heterogeneous row",
@@ -93,46 +107,57 @@ TEST_CASE("θ-join via σ∘× on (is_even, fibonacci) exhibits a heterogeneous 
   // pairs whose index columns agree.  This is Codd's general θ-join
   // shape, the same posture by which natural_join / zip / LIMIT are
   // not separately named (per #753).  The output row's type is
-  //   pair<pair<ℕ, 𝔹>, pair<ℕ, ℕ>>
+  //   pair<pair<ℕ_Form, 𝔹>, pair<ℕ_Form, ℕ>>
   // — heterogeneous in the Boolean column, a tuple-of-tuples, NOT a
   // list of one type.  That heterogeneity is the page-2 beat the
   // paper §3 listing exhibits.
-  using EvenPair = std::pair<std::size_t, Boolean>;
-  using FibPair = std::pair<std::size_t, std::size_t>;
+  // Note on the @em heterogeneity of the row's index columns: after
+  // PR #756's @c Path::Domain lift, @c is_even 's index column is
+  // @c ℕ (@c ExtensionalCardinal<> ) while @c fibonacci 's index
+  // column is @c std::size_t (the n-ary @c iterate FIXME).  The θ
+  // predicate compares them via @c ExtensionalCardinal<> 's implicit
+  // ctor from @c std::unsigned_integral .
+  using EvenPair = std::pair<ℕ_Form, Boolean>;
+  using FibPair = std::pair<std::size_t, ℕ_Form>;
   using JoinedRow = std::pair<EvenPair, FibPair>;
 
   const auto rel_even = as_relation(is_even);
   const auto rel_fib = as_relation(fibonacci);
 
-  const auto joined = select(cartesian_product(rel_even, rel_fib),
-                             [](const JoinedRow& row) -> bool {
-                               return row.first.first == row.second.first;
-                             });
+  const auto joined = select(
+      cartesian_product(rel_even, rel_fib), [](const JoinedRow& row) -> bool {
+        // Compare via the ℕ-Form: lift size_t
+        // through ExtensionalCardinal's implicit
+        // ctor and use the defaulted ==.
+        return row.first.first == ℕ_Form{row.second.first};
+      });
 
   SECTION("Diagonal row at n=7: (7, false, 13) is in the join") {
     // is_even(7) = false, fibonacci(7) = 13 — the canonical paper-citable
     // row that exhibits the heterogeneous (ℕ, 𝔹, ℕ) shape.
-    REQUIRE(joined(JoinedRow{EvenPair{7u, Boolean{false}}, FibPair{7u, 13u}}));
+    REQUIRE(joined(JoinedRow{EvenPair{ℕ_Form{7u}, Boolean{false}},
+                             FibPair{7u, ℕ_Form{13u}}}));
   }
 
   SECTION("Diagonal row at n=8: (8, true, 21) is in the join") {
     // is_even(8) = true, fibonacci(8) = 21 — a second on-diagonal row,
     // pinning that the join is not a coincidence at n=7 only.
-    REQUIRE(joined(JoinedRow{EvenPair{8u, Boolean{true}}, FibPair{8u, 21u}}));
+    REQUIRE(joined(JoinedRow{EvenPair{ℕ_Form{8u}, Boolean{true}},
+                             FibPair{8u, ℕ_Form{21u}}}));
   }
 
   SECTION("Off-diagonal row (mismatched indices) is rejected") {
     // is_even(7) = false, fibonacci(8) = 21 — but the indices disagree
     // (7 ≠ 8), so the θ-predicate vetoes the row.
-    REQUIRE_FALSE(
-        joined(JoinedRow{EvenPair{7u, Boolean{false}}, FibPair{8u, 21u}}));
+    REQUIRE_FALSE(joined(JoinedRow{EvenPair{ℕ_Form{7u}, Boolean{false}},
+                                   FibPair{8u, ℕ_Form{21u}}}));
   }
 
   SECTION("Off-graph row (wrong fibonacci value) is rejected") {
     // The source-predicate veto from as_relation(fibonacci) fires:
     // fibonacci(7) ≠ 99, so even with matched indices, (7, false, 99)
     // is off the fibonacci graph.
-    REQUIRE_FALSE(
-        joined(JoinedRow{EvenPair{7u, Boolean{false}}, FibPair{7u, 99u}}));
+    REQUIRE_FALSE(joined(JoinedRow{EvenPair{ℕ_Form{7u}, Boolean{false}},
+                                   FibPair{7u, ℕ_Form{99u}}}));
   }
 }

--- a/src/test/cpp/modules/dedekind/sequences/samples_test.cpp
+++ b/src/test/cpp/modules/dedekind/sequences/samples_test.cpp
@@ -46,6 +46,22 @@ TEST_CASE("fibonacci pins the canonical sequence 0, 1, 1, 2, 3, 5, 8, 13",
   REQUIRE(fibonacci.at(7) == 13u);
 }
 
+TEST_CASE("fibonacci_of<T> is Form-generic across IsRingIntegral carriers",
+          "[sequences][samples][fibonacci][parametric]") {
+  // The §3-page-2 algebraic-genericity beat: the recurrence is parameterised
+  // on the same IsRingIntegral gate that IsSequence imposes on its Domain
+  // (per :order:halfspace and the #755 substrate PR).  Instantiating
+  // fibonacci_of<T> at a non-default T (here unsigned int) gives the same
+  // canonical sequence — mechanical witness that the named `fibonacci`
+  // is just the T = std::size_t instantiation of a Form-generic recurrence,
+  // not a carrier-specific exhibit.
+  const auto& fib_unsigned = fibonacci_of<unsigned int>;
+  REQUIRE(fib_unsigned.at(0) == 0u);
+  REQUIRE(fib_unsigned.at(1) == 1u);
+  REQUIRE(fib_unsigned.at(5) == 5u);
+  REQUIRE(fib_unsigned.at(7) == 13u);
+}
+
 TEST_CASE(
     "fibonacci_state's recurrence step is the categorical product algebra",
     "[sequences][samples][fibonacci][nno]") {

--- a/src/test/cpp/modules/dedekind/sequences/samples_test.cpp
+++ b/src/test/cpp/modules/dedekind/sequences/samples_test.cpp
@@ -25,11 +25,11 @@ using namespace dedekind::sets;
 
 // Use the same Form-shaped ℕ alias the samples partition exports —
 // @c ExtensionalCardinal<> is the algebraically-certified finite ℕ
-// carrier, and after #756's @c Path::Domain lift it flows through
-// at both the Index and the carrier roles on @c is_even and
-// @c fibonacci .  Test literals on the value side use this alias to
-// avoid the @c (unsigned @c int) @c vs @c (ExtensionalCardinal<>)
-// implicit-conversion ambiguity that bare @c 0u literals trigger.
+// carrier, and Path's @c Index template parameter carries it at both
+// the Index and the carrier roles on @c is_even and @c fibonacci .
+// Test literals on the value side use this alias to avoid the
+// @c (unsigned @c int) @c vs @c (ExtensionalCardinal<>) implicit-
+// conversion ambiguity that bare @c 0u literals trigger.
 using ℕ_Form = ExtensionalCardinal<>;
 
 TEST_CASE("is_even pins the parity sequence on its first six indices",
@@ -111,10 +111,10 @@ TEST_CASE("θ-join via σ∘× on (is_even, fibonacci) exhibits a heterogeneous 
   // — heterogeneous in the Boolean column, a tuple-of-tuples, NOT a
   // list of one type.  That heterogeneity is the page-2 beat the
   // paper §3 listing exhibits.
-  // Note on the @em heterogeneity of the row's index columns: after
-  // PR #756's @c Path::Domain lift, @c is_even 's index column is
-  // @c ℕ (@c ExtensionalCardinal<> ) while @c fibonacci 's index
-  // column is @c std::size_t (the n-ary @c iterate FIXME).  The θ
+  // Note on the @em heterogeneity of the row's index columns:
+  // @c is_even 's index column is @c ℕ_Form (@c ExtensionalCardinal<> )
+  // while @c fibonacci 's index column is @c std::size_t (the n-ary
+  // @c iterate FIXME documented in @c :sequences:path ).  The θ
   // predicate compares them via @c ExtensionalCardinal<> 's implicit
   // ctor from @c std::unsigned_integral .
   using EvenPair = std::pair<ℕ_Form, Boolean>;

--- a/src/test/cpp/modules/dedekind/sequences/samples_test.cpp
+++ b/src/test/cpp/modules/dedekind/sequences/samples_test.cpp
@@ -62,25 +62,6 @@ TEST_CASE("fibonacci_of<T> is Form-generic across IsRingIntegral carriers",
   REQUIRE(fib_unsigned.at(7) == 13u);
 }
 
-TEST_CASE(
-    "fibonacci_state's recurrence step is the categorical product algebra",
-    "[sequences][samples][fibonacci][nno]") {
-  // The state pair (F_n, F_{n+1}) at index 7 is (13, 21):
-  //   F_7 = 13, F_8 = 21.
-  // Mechanical witness that the iterate-based recurrence delivers BOTH
-  // projections, not just π₁ — i.e. that the carrier IS the product
-  // ℕ × ℕ at the value level, not only at the IsProduct concept level.
-  const auto state_7 = fibonacci_state.at(7);
-  REQUIRE(state_7.first == 13u);
-  REQUIRE(state_7.second == 21u);
-  // And the next step closes the recurrence loop:
-  //   step(13, 21) = (21, 34) = (F_8, F_9).
-  const auto state_8 = fibonacci_state.at(8);
-  REQUIRE(state_8.first == state_7.second);  // π₁ ∘ step ≡ π₂
-  REQUIRE(state_8.second ==
-          state_7.first + state_7.second);  // π₂ ∘ step ≡ π₁ + π₂
-}
-
 TEST_CASE("as_relation(is_even) graph membership",
           "[sequences][samples][as_relation]") {
   const auto rel = as_relation(is_even);

--- a/src/test/cpp/modules/dedekind/sequences/samples_test.cpp
+++ b/src/test/cpp/modules/dedekind/sequences/samples_test.cpp
@@ -1,0 +1,141 @@
+// ---------------------------------------------------------------------------
+// :sequences:samples — `is_even` and `fibonacci` (#753 §3 page-2).
+//
+// Tests the named §3 page-2 sample pair: their first few values pin the
+// canonical sequences mechanically, their `as_relation` lifts respect
+// the graph predicate (Bourbaki function-as-graph, from #755), and the
+// θ-join via σ∘× exhibits a heterogeneous row (ℕ, 𝔹, ℕ) — the page-2
+// "tuples not lists" beat that the §3 reshape PR's listing will cite.
+//
+// @copyright 2026 The Dedekind Authors
+// Licensed under the Apache License, Version 2.0.
+// ---------------------------------------------------------------------------
+
+#include <catch2/catch_test_macros.hpp>
+#include <cstddef>
+#include <utility>
+
+import dedekind.category;
+import dedekind.sequences;
+import dedekind.sets;
+
+using namespace dedekind::category;
+using namespace dedekind::sequences;
+using namespace dedekind::sets;
+
+TEST_CASE("is_even pins the parity sequence on its first six indices",
+          "[sequences][samples][is_even]") {
+  REQUIRE(is_even.at(0) == Boolean{true});
+  REQUIRE(is_even.at(1) == Boolean{false});
+  REQUIRE(is_even.at(2) == Boolean{true});
+  REQUIRE(is_even.at(3) == Boolean{false});
+  REQUIRE(is_even.at(4) == Boolean{true});
+  REQUIRE(is_even.at(5) == Boolean{false});
+}
+
+TEST_CASE("fibonacci pins the canonical sequence 0, 1, 1, 2, 3, 5, 8, 13",
+          "[sequences][samples][fibonacci]") {
+  // Canonical Fibonacci F_0 = 0, F_1 = 1, F_{n+2} = F_n + F_{n+1}.
+  REQUIRE(fibonacci.at(0) == 0u);
+  REQUIRE(fibonacci.at(1) == 1u);
+  REQUIRE(fibonacci.at(2) == 1u);
+  REQUIRE(fibonacci.at(3) == 2u);
+  REQUIRE(fibonacci.at(4) == 3u);
+  REQUIRE(fibonacci.at(5) == 5u);
+  REQUIRE(fibonacci.at(6) == 8u);
+  REQUIRE(fibonacci.at(7) == 13u);
+}
+
+TEST_CASE(
+    "fibonacci_state's recurrence step is the categorical product algebra",
+    "[sequences][samples][fibonacci][nno]") {
+  // The state pair (F_n, F_{n+1}) at index 7 is (13, 21):
+  //   F_7 = 13, F_8 = 21.
+  // Mechanical witness that the iterate-based recurrence delivers BOTH
+  // projections, not just π₁ — i.e. that the carrier IS the product
+  // ℕ × ℕ at the value level, not only at the IsProduct concept level.
+  const auto state_7 = fibonacci_state.at(7);
+  REQUIRE(state_7.first == 13u);
+  REQUIRE(state_7.second == 21u);
+  // And the next step closes the recurrence loop:
+  //   step(13, 21) = (21, 34) = (F_8, F_9).
+  const auto state_8 = fibonacci_state.at(8);
+  REQUIRE(state_8.first == state_7.second);  // π₁ ∘ step ≡ π₂
+  REQUIRE(state_8.second ==
+          state_7.first + state_7.second);  // π₂ ∘ step ≡ π₁ + π₂
+}
+
+TEST_CASE("as_relation(is_even) graph membership",
+          "[sequences][samples][as_relation]") {
+  const auto rel = as_relation(is_even);
+  // On-graph pairs: (n, is_even(n)).
+  REQUIRE(rel(std::pair<std::size_t, Boolean>{0u, Boolean{true}}));
+  REQUIRE(rel(std::pair<std::size_t, Boolean>{3u, Boolean{false}}));
+  REQUIRE(rel(std::pair<std::size_t, Boolean>{42u, Boolean{true}}));
+  // Off-graph (wrong value at the index): rejected.
+  REQUIRE_FALSE(rel(std::pair<std::size_t, Boolean>{0u, Boolean{false}}));
+  REQUIRE_FALSE(rel(std::pair<std::size_t, Boolean>{3u, Boolean{true}}));
+}
+
+TEST_CASE("as_relation(fibonacci) graph membership",
+          "[sequences][samples][as_relation]") {
+  const auto rel = as_relation(fibonacci);
+  // On-graph: (n, F_n).
+  REQUIRE(rel(std::pair<std::size_t, std::size_t>{0u, 0u}));
+  REQUIRE(rel(std::pair<std::size_t, std::size_t>{7u, 13u}));
+  REQUIRE(rel(std::pair<std::size_t, std::size_t>{10u, 55u}));
+  // Off-graph (wrong value): rejected.
+  REQUIRE_FALSE(rel(std::pair<std::size_t, std::size_t>{7u, 14u}));
+  REQUIRE_FALSE(rel(std::pair<std::size_t, std::size_t>{10u, 21u}));
+}
+
+TEST_CASE("θ-join via σ∘× on (is_even, fibonacci) exhibits a heterogeneous row",
+          "[sequences][samples][theta_join][page2]") {
+  // The §3 page-2 page-anchor: lift both sequences to their graph
+  // relations, take their Cartesian product (×), and select (σ) the
+  // pairs whose index columns agree.  This is Codd's general θ-join
+  // shape, the same posture by which natural_join / zip / LIMIT are
+  // not separately named (per #753).  The output row's type is
+  //   pair<pair<ℕ, 𝔹>, pair<ℕ, ℕ>>
+  // — heterogeneous in the Boolean column, a tuple-of-tuples, NOT a
+  // list of one type.  That heterogeneity is the page-2 beat the
+  // paper §3 listing exhibits.
+  using EvenPair = std::pair<std::size_t, Boolean>;
+  using FibPair = std::pair<std::size_t, std::size_t>;
+  using JoinedRow = std::pair<EvenPair, FibPair>;
+
+  const auto rel_even = as_relation(is_even);
+  const auto rel_fib = as_relation(fibonacci);
+
+  const auto joined = select(cartesian_product(rel_even, rel_fib),
+                             [](const JoinedRow& row) -> bool {
+                               return row.first.first == row.second.first;
+                             });
+
+  SECTION("Diagonal row at n=7: (7, false, 13) is in the join") {
+    // is_even(7) = false, fibonacci(7) = 13 — the canonical paper-citable
+    // row that exhibits the heterogeneous (ℕ, 𝔹, ℕ) shape.
+    REQUIRE(joined(JoinedRow{EvenPair{7u, Boolean{false}}, FibPair{7u, 13u}}));
+  }
+
+  SECTION("Diagonal row at n=8: (8, true, 21) is in the join") {
+    // is_even(8) = true, fibonacci(8) = 21 — a second on-diagonal row,
+    // pinning that the join is not a coincidence at n=7 only.
+    REQUIRE(joined(JoinedRow{EvenPair{8u, Boolean{true}}, FibPair{8u, 21u}}));
+  }
+
+  SECTION("Off-diagonal row (mismatched indices) is rejected") {
+    // is_even(7) = false, fibonacci(8) = 21 — but the indices disagree
+    // (7 ≠ 8), so the θ-predicate vetoes the row.
+    REQUIRE_FALSE(
+        joined(JoinedRow{EvenPair{7u, Boolean{false}}, FibPair{8u, 21u}}));
+  }
+
+  SECTION("Off-graph row (wrong fibonacci value) is rejected") {
+    // The source-predicate veto from as_relation(fibonacci) fires:
+    // fibonacci(7) ≠ 99, so even with matched indices, (7, false, 99)
+    // is off the fibonacci graph.
+    REQUIRE_FALSE(
+        joined(JoinedRow{EvenPair{7u, Boolean{false}}, FibPair{7u, 99u}}));
+  }
+}


### PR DESCRIPTION
## Summary

Ships the §3 page-2 paper-citable substrate plus two boy-scout additions on the neighbourhood we touched. Final form:

1. ✅ **`:sequences:samples`** — named `is_even : Path<Boolean>` and `fibonacci_of<T> : Path<T>` for the §3 page-2 join exhibit. Fibonacci is **one line**: `iterate(std::plus<T>{}, T(0u), T(1u))`. The Boolean codomain on `is_even` exhibits the heterogeneous `(ℕ, 𝔹, ℕ)` θ-join row.
2. ✅ **`:sequences:path` n-ary `iterate(op, seeds...)`** — captures the "binary op applied recursively to a sliding window" structural pattern that recurs across the codebase (Fibonacci, Lucas, Tribonacci, GCD-via-Euclid, linear recurrences of any order). Lives alongside the existing `iterate(seed, step)` — back-compat preserved.
3. ✅ **`:category:morphism` `operator>>` `Arrow >> lambda` adapter** — auto-wraps a bare RHS lambda via `arrow<F::Codomain>(λ)`. Tightens chain call sites.

This is the page-2 anchor PR for the §3 reshape trajectory:
- ✅ #755 — substrate (`as_relation` lift + `IsRingIntegral` gate) — merged at `4ee1a6c5`
- → **this PR** — `:sequences:samples` (`is_even`, `fibonacci_of`) + boy-scout iterate/adapter additions
- → §3 paper reshape PR — four-step progression in `paper.tex`, 6pp → 2pp main body

## What lands

### `:sequences:samples` (page-2 anchor proper)

| Surface | What | Locus |
|---|---|---|
| `is_even : Path<Boolean>` | The parity sequence. Boolean codomain → heterogeneous `(ℕ, 𝔹, ℕ)` rows under θ-join. | `:sequences:samples` |
| `fibonacci_of<T> : Path<T>` | `iterate(std::plus<T>{}, T(0u), T(1u))`. Parameterised over `IsRingIntegral T` with `requires { T(0u); T(1u); }`. | `:sequences:samples` |
| `fibonacci` | Named-default `fibonacci_of<std::size_t>` reference for paper citation. | `:sequences:samples` |

### `:sequences:path` n-ary iterate (boy-scout)

```cpp
template <typename Op, typename T, typename... Ts>
  requires (std::convertible_to<Ts, T> && ...) &&
           std::invocable<Op&, T, Ts...> &&
           std::same_as<std::invoke_result_t<Op&, T, Ts...>, T>
constexpr Path<T> iterate(Op op, T seed_0, Ts... more_seeds);
```

Call-site examples:
```cpp
iterate(std::plus<size_t>{}, size_t{0}, size_t{1})              // Fibonacci
iterate([](size_t a, size_t b, size_t c){ return a+b+c; },
        size_t{0}, size_t{0}, size_t{1})                         // Tribonacci
iterate([](size_t a, size_t b){ return 2*b + a; }, 0u, 1u)       // Pell
```

Zero explicit type parameters at the call site (everything deduces from the seeds).

### `:category:morphism` `Arrow >> lambda` adapter (boy-scout)

```cpp
arrow<int, int>(succ) >> [](const int& x){ return x * 2; };
//  ^ IsArrow                ^ bare lambda, auto-wrapped
```

Symmetric `lambda >> Arrow` adapter intentionally **not** shipped — a polymorphic lambda LHS has no fixed Domain.

## Tests

- **`samples_test.cpp`**: 6 test cases — `is_even` parity, `fibonacci` first 8 values, parametric `fibonacci_of<unsigned int>`, `as_relation` lifts of both sequences, **θ-join row at n=7 → `(7, false, 13)`** (heterogeneous).
- **`path_test.cpp` n-ary iterate suite**: 5 SECTIONs — Fibonacci to F_9=34, Tribonacci to T_8=24, Pell to P_6=70, n=1 NNO reduction, carrier deduction sanity.
- **`morphism_test.cpp` adapter suite**: 3 SECTIONs — basic `Arrow >> lambda`, chained double-fire, codomain-differs-from-domain.

## Why this scope (boy-scouted, not scope-creep)

The PR was scoped to "page-2 anchor" but the design discussion surfaced two adjacent primitives that:
- **Are load-bearing for paper §3 page-2's claim** — the n-ary iterate makes "fibonacci = `iterate(+, 0, 1)`" the citable form, sharper than a lambda-step OR a `fanout(snd, uncurry(+))` decomposition would be
- **Serve consumers beyond fibonacci** — n-ary iterate generalises three existing call sites (`mandelbrot.cppm`, `convergence.cppm`, `galois.cppm`) that today use the binary `iterate(seed, step)` form; the `Arrow >> lambda` adapter tightens any chain call site
- **Don't expand into speculative surface** — the broader CT combinator family (`fst`, `snd`, `fanout`, `curry`, `uncurry`) is **explicitly deferred** to a follow-up issue, with the design discussion captured

## Deferred to follow-up issues

- 🔜 **`:category:combinators` family** — `fst`, `snd`, `curry`, `uncurry`, `fanout` as named CT primitives. The polymorphism-friction discussion is captured for follow-up.
- 🔜 **Domain-specific relational predicates at `:sets:relational`** — `column_match<i>` / `key_eq<i>` etc. for tightening join predicates like `row.first.first == row.second.first`.
- 🔜 **Retire the binary `iterate(seed, step)` form** — once n-ary stabilises, migrate the three existing call sites and delete the binary overload.

## Test plan

- [x] `make compile` clean
- [x] `make test` — all 15 test suites pass
- [x] `make format` clean
- [ ] CI green on `build-and-deploy`, `Analyze (actions/c-cpp/python)`, `CodeQL`, `codecov`

## Issue routing

Closes part of #753 (the page-2 existential anchor slice). The §3 reshape PR is the next slice and depends on this landing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)